### PR TITLE
docs: add warning for transient state nodes

### DIFF
--- a/docs/guides/statenodes.md
+++ b/docs/guides/statenodes.md
@@ -213,6 +213,12 @@ const timeOfDayService = interpret(timeOfDayMachine
 
 <iframe src="https://xstate.js.org/viz/?gist=ca6a3f84f585c3e9cd6aadc3ae00b886&embed=1"></iframe>
 
+::: warning
+The event object of a transition to a transient state is not available in the conditions or actions
+defined under the null event. In the example above, `isBeforeNoon` and `isBeforeSix` would receive `{ type: '' }` as the
+second parameter, not the initial event type and data that transitioned to `unknown`.
+:::
+
 ## State Node Meta Data
 
 Meta data, which is static data that describes relevant properties of any [state node](./statenodes.md), can be specified on the `.meta` property of the state node:


### PR DESCRIPTION
I shot myself in the foot with transient state nodes, thinking that the event that originates a transition is available in all conditions and actions defined in the null event.

This is probably obvious for some, but I think it's a good warning to have in the docs.