### PR TITLE
Parent sibling state access

### DIFF
--- a/.changeset/breezy-poems-hang.md
+++ b/.changeset/breezy-poems-hang.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Transition to a sibling of a parent state

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -99,13 +99,13 @@ import { Actor, createInvocableActor } from './Actor';
 const NULL_EVENT = '';
 const STATE_IDENTIFIER = '#';
 const WILDCARD = '*';
-const SIBLING_STATE_IDENTIFIER = '^';
+const PARENT_SIBLING_STATE_IDENTIFIER = '^';
 
 const EMPTY_OBJECT = {};
 
 const isStateId = (str: string) => str[0] === STATE_IDENTIFIER;
-const isSiblingStateReference = (str: string) =>
-  str[0] === SIBLING_STATE_IDENTIFIER;
+const isParentSiblingStateReference = (str: string) =>
+  str[0] === PARENT_SIBLING_STATE_IDENTIFIER;
 const createDefaultOptions = <TContext>(): MachineOptions<TContext, any> => ({
   actions: {},
   guards: {},
@@ -1341,11 +1341,11 @@ class StateNode<
   }
 
   /**
-   * Gives a possibility to jump out from state and set one of the state siblings
+   * Gives a possibility to jump out from state and set one of the parent state siblings
    *
-   * @param statePath The string or string array sibling path to the state node. The prefix "^" is removed.
+   * @param statePath The string or string array parent sibling path to the state node. The prefix "^" is removed.
    */
-  public getSiblingStateNodeByPath(
+  public getParentSiblingStateNodeByPath(
     statePath: string | string[]
   ): StateNode<TContext, any, TEvent> {
     let stateNode: StateNode<TContext, any, TEvent> | undefined;
@@ -1356,7 +1356,7 @@ class StateNode<
 
     if (!stateNode) {
       throw new Error(
-        `Sibling state node '^${statePath}' does not exist on machine '${this.id}'`
+        `Parent sibling state node '^${statePath}' does not exist on machine '${this.id}'`
       );
     }
 
@@ -1371,9 +1371,12 @@ class StateNode<
   public getStateNodeByPath(
     statePath: string | string[]
   ): StateNode<TContext, any, TEvent> {
-    if (typeof statePath === 'string' && isSiblingStateReference(statePath)) {
+    if (
+      typeof statePath === 'string' &&
+      isParentSiblingStateReference(statePath)
+    ) {
       try {
-        return this.getSiblingStateNodeByPath(statePath.slice(1));
+        return this.getParentSiblingStateNodeByPath(statePath.slice(1));
       } catch (e) {
         // try id or individual paths
         // throw e;

--- a/packages/core/test/parentSibling.test.ts
+++ b/packages/core/test/parentSibling.test.ts
@@ -47,7 +47,7 @@ const idMachine = Machine({
   }
 });
 
-describe('State node sibling state selector', () => {
+describe('Parent sibling state selector', () => {
   const expected = {
     A: {
       NEXT: 'A.dot'

--- a/packages/core/test/sibling.test.ts
+++ b/packages/core/test/sibling.test.ts
@@ -1,0 +1,67 @@
+import { testAll } from './utils';
+import { Machine } from '../src';
+
+const idMachine = Machine({
+  initial: 'A',
+  states: {
+    A: {
+      initial: 'foo',
+      states: {
+        foo: {
+          initial: 'bar',
+          states: {
+            bar: {
+              on: {
+                NEXT: '^dot'
+              }
+            }
+          }
+        },
+        dot: {
+          on: {
+            NEXT: '^B'
+          }
+        }
+      }
+    },
+    B: {
+      initial: 'foo',
+      states: {
+        foo: {
+          initial: 'baz',
+          states: {
+            baz: {
+              on: {
+                NEXT: '^dot'
+              }
+            }
+          }
+        },
+        dot: {
+          on: {
+            NEXT: '^A.foo.bar'
+          }
+        }
+      }
+    }
+  }
+});
+
+describe('State node sibling state selector', () => {
+  const expected = {
+    A: {
+      NEXT: 'A.dot'
+    },
+    'A.dot': {
+      NEXT: 'B'
+    },
+    B: {
+      NEXT: 'B.dot'
+    },
+    'B.dot': {
+      NEXT: 'A.foo.bar'
+    }
+  };
+
+  testAll(idMachine, expected);
+});


### PR DESCRIPTION
Using YAML with anchors as a machine declaration is a pain, when you are forced to jump to state on totally different level. This MR solves problem with aliased nodes, which cannot have ID (because of duplication) and allows set state from parent states collection. 

If you have better/more descriptive naming proposition we should change it. 

In relation to: https://github.com/davidkpiano/xstate/issues/52