### PR TITLE
Add utility types for typestates

### DIFF
--- a/.changeset/strong-walls-train.md
+++ b/.changeset/strong-walls-train.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Added three utility types to simplify working with typestates: `CombineTypestates`, `CombineTypestateTuples`, and `TypestateContext`

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -158,15 +158,15 @@ The typestates of a machine are specified as the 3rd generic type in `createMach
 **Example:**
 
 ```ts
-import { createMachine, interpret } from 'xstate';
+import {
+  CombineTypestates,
+  TypestateContext,
+  createMachine,
+  interpret
+} from 'xstate';
 
 interface User {
   name: string;
-}
-
-interface UserContext {
-  user?: User;
-  error?: string;
 }
 
 type UserEvent =
@@ -174,26 +174,14 @@ type UserEvent =
   | { type: 'RESOLVE'; user: User }
   | { type: 'REJECT'; error: string };
 
-type UserState =
-  | {
-      value: 'idle';
-      context: UserContext & {
-        user: undefined;
-        error: undefined;
-      };
-    }
-  | {
-      value: 'loading';
-      context: UserContext;
-    }
-  | {
-      value: 'success';
-      context: UserContext & { user: User; error: undefined };
-    }
-  | {
-      value: 'failure';
-      context: UserContext & { user: undefined; error: string };
-    };
+type UserState = CombineTypestates<
+  | { value: 'idle'; context: {} }
+  | { value: 'loading'; context: { user?: User; error?: string } }
+  | { value: 'success'; context: { user: User } }
+  | { value: 'failure'; context: { error: string } }
+>;
+
+type UserContext = TypestateContext<UserState>;
 
 const userMachine = createMachine<UserContext, UserEvent, UserState>({
   id: 'user',
@@ -216,7 +204,7 @@ const userMachine = createMachine<UserContext, UserEvent, UserState>({
 
 const userService = interpret(userMachine);
 
-userService.subscribe(state => {
+userService.subscribe((state) => {
   if (state.matches('success')) {
     // from the UserState typestate, `user` will be defined
     state.context.user.name;


### PR DESCRIPTION
Three utility types to simplify working with typestates:

`CombineTypestates`: Takes a union of typestate objects and returns a new union where each context value has any missing/undefined values from other typestate contexts automatically filled in. Now each individual state only needs to define context fields that are actually relevant to that state. In my opinion, this makes it much easier at a glance to tell what the context value will actually look like. See the simplified example in [typescript.md](https://github.com/davidkpiano/xstate/compare/master...sbking:typestate-utils#diff-6890812557a98693a8ac6553e77fc608R177-R184).

`TypestateContext`: Given a union of typestates, returns a merged object type that represents the aggregate context value with all fields from all union members. Since this can now be inferred from a `CombineTypestates` result, the `createMachine` function should only need two generic parameters instead of three, but I tried to keep this changeset additive-only.

`CombineTypestateTuples`: Like `CombineTypestates`, but takes a union of `[value, context]` tuples instead of a union of `{ value, context }` objects.