### PR TITLE
Fixed an issue that has caused `MachineConfig` parametrized with a subset of events not being accepted as part of the `MachineConfig` accepting the whole set of those events

### DIFF
--- a/.changeset/famous-turtles-shave.md
+++ b/.changeset/famous-turtles-shave.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with TypeScript types that has caused `MachineConfig` parametrized with a subset of events not being accepted as part of the `MachineConfig` accepting the whole set of those events.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -257,7 +257,7 @@ class StateNode<
       | Array<TransitionDefinition<TContext, TEvent>>
       | undefined,
     candidates: {} as {
-      [K in TEvent['type'] | NullEvent['type'] | '*']:
+      [K in TEvent['type'] | NullEvent['type'] | '*']?:
         | Array<
             TransitionDefinition<
               TContext,
@@ -520,7 +520,7 @@ class StateNode<
 
     return (this.__cache.on = transitions.reduce((map, transition) => {
       map[transition.eventType] = map[transition.eventType] || [];
-      map[transition.eventType].push(transition as any);
+      map[transition.eventType]!.push(transition as any);
       return map;
     }, {} as TransitionDefinitionMap<TContext, TEvent>));
   }

--- a/packages/core/src/json.ts
+++ b/packages/core/src/json.ts
@@ -49,7 +49,7 @@ export function machineToJSON(stateNode: StateNode): StateNodeConfig {
     entry: stateNode.onEntry,
     exit: stateNode.onExit,
     on: mapValues(stateNode.on, (transition) => {
-      return transition.map((t) => {
+      return transition!.map((t) => {
         return {
           target: t.target ? t.target.map(getStateNodeId) : [],
           source: getStateNodeId(t.source),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -977,7 +977,7 @@ export interface TransitionDefinition<TContext, TEvent extends EventObject>
 }
 
 export type TransitionDefinitionMap<TContext, TEvent extends EventObject> = {
-  [K in TEvent['type'] | NullEvent['type'] | '*']: Array<
+  [K in TEvent['type'] | NullEvent['type'] | '*']?: Array<
     TransitionDefinition<
       TContext,
       K extends TEvent['type'] ? Extract<TEvent, { type: K }> : EventObject

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1,4 +1,10 @@
-import { Machine, assign, createMachine, interpret } from '../src/index';
+import {
+  Machine,
+  assign,
+  createMachine,
+  interpret,
+  MachineConfig
+} from '../src/index';
 import { raise } from '../src/actions';
 
 function noop(_x) {
@@ -384,5 +390,27 @@ describe('Typestates', () => {
       ? service.state.context
       : { result: none, error: 'oops' };
     expect(failed).toEqual({ result: none, error: 'oops' });
+  });
+});
+
+describe('assignability', () => {
+  it('should accept config handling subset of events as part of the whole config handling superset of those events', () => {
+    const EditorConfig: MachineConfig<
+      any,
+      any,
+      { type: 'TOGGLE_ITALIC' } | { type: 'TOGGLE_BOLD' }
+    > = {
+      type: 'parallel',
+      states: {
+        italic: {
+          ...({} as MachineConfig<any, any, { type: 'TOGGLE_ITALIC' }>)
+        },
+        bold: {
+          ...({} as MachineConfig<any, any, { type: 'TOGGLE_BOLD' }>)
+        }
+      }
+    };
+
+    expect(true).toBeTruthy();
   });
 });

--- a/packages/xstate-scxml/src/index.ts
+++ b/packages/xstate-scxml/src/index.ts
@@ -126,7 +126,7 @@ function stateNodeToSCXML(stateNode: StateNode<any, any, any>): XMLElement {
     Object.keys(stateNode.on).map((event) => {
       const transitions = stateNode.on[event];
 
-      return transitions.map((transition) => transitionToSCXML(transition));
+      return transitions!.map((transition) => transitionToSCXML(transition));
     })
   );
 


### PR DESCRIPTION
fixes https://github.com/davidkpiano/xstate/discussions/1603#discussioncomment-117608

