### PR TITLE
Increased width for visualizer img in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ send('TOGGLE'); // 'inactive'
 
 **[:new: Preview and simulate your statecharts in the xstate visualizer (beta)!](https://bit.ly/xstate-viz)**
 
-<a href="https://bit.ly/xstate-viz" title="xstate visualizer"><img src="https://i.imgur.com/fOMJKDZ.png" alt="xstate visualizer" width="300" /></a>
+<a href="https://bit.ly/xstate-viz" title="xstate visualizer"><img src="https://i.imgur.com/fOMJKDZ.png" alt="xstate visualizer" width="800" /></a>
 
 ## 3rd-Party Usage
 


### PR DESCRIPTION
Not sure if targeting the right base repo.

Small change. The visualizer image was hard to see at such a small resolution. 

(It's also outdated—tried to make a new one, but realized it might have to be hosted on designated Imgur account)

Great work with XState!