### PR TITLE
Added a runtime warning for "unreachable" `onDone` for parallel states

### DIFF
--- a/.changeset/olive-tools-greet.md
+++ b/.changeset/olive-tools-greet.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Added a runtime warning for "unreachable" `onDone` for parallel states. For it to have an effect all of its children states must have a final substate.


### PR DESCRIPTION
⚠️ I haven't really tested this yet - just created this in a moment so we don't forget about it. Gonna add a test for this when I get a chance to get back to it. 

Created "in response" to: https://github.com/davidkpiano/xstate/discussions/2003