### PR TITLE
React Suspense Support via useSuspensefulGetter Hook

### DIFF
--- a/packages/xstate-react/src/index.ts
+++ b/packages/xstate-react/src/index.ts
@@ -3,3 +3,4 @@ export { useService } from './useService';
 export { useActor } from './useActor';
 export { useInterpret } from './useInterpret';
 export { useSelector } from './useSelector';
+export { useSuspensefulGetter, Resource } from './useSuspensefulGetter';

--- a/packages/xstate-react/src/useSuspensefulGetter.ts
+++ b/packages/xstate-react/src/useSuspensefulGetter.ts
@@ -1,0 +1,75 @@
+import { useRef, useEffect } from 'react';
+import { State, EventObject, Typestate } from 'xstate';
+
+type Resolver = (value: undefined) => void;
+type EmptyPromise = Promise<undefined>;
+type SuspenseState<TResult> =
+  | {
+      promise: EmptyPromise;
+      resolve: Resolver;
+      status: 'loading';
+      result: null;
+    }
+  | {
+      promise: EmptyPromise;
+      resolve: Resolver;
+      status: 'resolved';
+      result: TResult;
+    };
+
+export interface Resource<TResult> {
+  read(): never | TResult;
+}
+
+export function useSuspensefulGetter<
+  TContext,
+  TEvent extends EventObject,
+  TStateSchema,
+  TTypeState extends Typestate<TContext>,
+  TGetterReturn
+>(
+  state: State<TContext, TEvent, TStateSchema, TTypeState>,
+  condition: (
+    state: State<TContext, TEvent, TStateSchema, TTypeState>
+  ) => boolean,
+  getter: (
+    state: State<TContext, TEvent, TStateSchema, TTypeState>
+  ) => TGetterReturn
+): Resource<TGetterReturn> {
+  let resolveValue: Resolver;
+  const promise: EmptyPromise = new Promise((resolve) => {
+    resolveValue = resolve;
+  });
+
+  const ref = useRef<SuspenseState<TGetterReturn>>({
+    promise,
+    // @ts-ignore
+    resolve: resolveValue,
+    status: 'loading',
+    result: null
+  });
+
+  useEffect(() => {
+    if (ref.current.status === 'resolved') {
+      ref.current.result = getter(state);
+    }
+  }, [ref.current.status, state, getter]);
+
+  if (condition(state)) {
+    ref.current.status = 'resolved';
+    ref.current.result = getter(state);
+    ref.current.resolve(undefined);
+  }
+
+  return {
+    read(): never | TGetterReturn {
+      switch (ref.current.status) {
+        case 'resolved':
+          return ref.current.result;
+        case 'loading':
+        default:
+          throw ref.current.promise;
+      }
+    }
+  };
+}


### PR DESCRIPTION
This PR adds the feature discussed in #1746 with type definitions and documentation.

## Changes

* Added `useSuspensefulGetter.ts`
* Exported useSuspensefulGetter and Resource out of `index.js`
* Added documentation for `useSuspensefulGetter`

## To-Do

- [ ] Adding tests
- [ ] Add changeset

Hopefully, Suspense tests aren't too different from normal React tests. I'm going to try to write the tests without updating the React dev dependency but if they simply don't work in React 16, I will probably need to update the React dev dependency if that's okay