### PR TITLE
Changed behaviour of guards/actions/services in options of useMachine

### DIFF
--- a/.changeset/eight-eggs-press.md
+++ b/.changeset/eight-eggs-press.md
@@ -1,0 +1,35 @@
+---
+'@xstate/react': minor
+---
+
+Changed the behaviour of guards, delays and activities when declared as options in `useMachine`/`useInterpret`.
+
+Previously, guards could not reference external props, because they would not be updated when the props changed. For instance:
+
+```tsx
+const Modal = (props) => {
+  useMachine(modalMachine, {
+    guards: {
+      isModalOpen: () => props.isOpen
+    }
+  });
+};
+```
+
+When the component is created, `props.isOpen` would be checked and evaluated to the initial value. But if the guard is evaluated at any other time, it will not respond to the props' changed value.
+
+This is not true of actions/services. This will work as expected:
+
+```tsx
+const Modal = (props) => {
+  useMachine(modalMachine, {
+    actions: {
+      consoleLogModalOpen: () => {
+        console.log(props.isOpen);
+      }
+    }
+  });
+};
+```
+
+This change brings guards, delays and activities into line with actions and services.

--- a/.changeset/eight-eggs-press.md
+++ b/.changeset/eight-eggs-press.md
@@ -32,4 +32,6 @@ const Modal = (props) => {
 };
 ```
 
-This change brings guards, delays and activities into line with actions and services.
+This change brings guards and delays into line with actions and services.
+
+⚠️ **NOTE:** Whenever possible, use data from within `context` rather than external data in your guards and delays.

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -119,28 +119,18 @@ export function useInterpret<
     };
   }, []);
 
-  // Make sure actions and services are kept updated when they change.
+  // Make sure options are kept updated when they change.
   // This mutation assignment is safe because the service instance is only used
   // in one place -- this hook's caller.
   useIsomorphicLayoutEffect(() => {
-    Object.assign(service.machine.options.actions, actions);
-  }, [actions]);
-
-  useIsomorphicLayoutEffect(() => {
-    Object.assign(service.machine.options.services, services);
-  }, [services]);
-
-  useIsomorphicLayoutEffect(() => {
-    Object.assign(service.machine.options.guards, guards);
-  }, [guards]);
-
-  useIsomorphicLayoutEffect(() => {
-    Object.assign(service.machine.options.delays, delays);
-  }, [delays]);
-
-  useIsomorphicLayoutEffect(() => {
-    Object.assign(service.machine.options.activities, activities);
-  }, [activities]);
+    Object.assign(service.machine.options, {
+      actions,
+      guards,
+      activities,
+      services,
+      delays
+    });
+  }, [actions, guards, activities, services, delays]);
 
   useReactEffectActions(service);
 

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -130,6 +130,18 @@ export function useInterpret<
     Object.assign(service.machine.options.services, services);
   }, [services]);
 
+  useIsomorphicLayoutEffect(() => {
+    Object.assign(service.machine.options.guards, guards);
+  }, [guards]);
+
+  useIsomorphicLayoutEffect(() => {
+    Object.assign(service.machine.options.delays, delays);
+  }, [delays]);
+
+  useIsomorphicLayoutEffect(() => {
+    Object.assign(service.machine.options.activities, activities);
+  }, [activities]);
+
   useReactEffectActions(service);
 
   return service;


### PR DESCRIPTION
Changed the behaviour of guards, delays and activities when declared as options in `useMachine`/`useInterpret`.

Previously, guards could not reference external props, because they would not be updated when the props changed. For instance:

```tsx
const Modal = (props) => {
  useMachine(modalMachine, {
    guards: {
      isModalOpen: () => props.isOpen
    }
  });
};
```

When the component is created, `props.isOpen` would be checked and evaluated to the initial value. But if the guard is evaluated at any other time, it will not respond to the props' changed value.

This is not true of actions/services. This will work as expected:

```tsx
const Modal = (props) => {
  useMachine(modalMachine, {
    actions: {
      consoleLogModalOpen: () => {
        console.log(props.isOpen);
      }
    }
  });
};
```

This change brings guards, delays and activities into line with actions and services.