### PR TITLE
feat: add event meta to test machine event execution

### DIFF
--- a/.changeset/fifty-ants-deliver.md
+++ b/.changeset/fifty-ants-deliver.md
@@ -1,0 +1,6 @@
+---
+'@xstate/graph': minor
+'@xstate/test': patch
+---
+
+Adding event meta to the arguments for a test event execution. This should allow more flexibility for reusing the same event execution logic with a different config. For example, filling out multiple fields with random text where the only thing that changes is the input selector.

--- a/docs/packages/xstate-test/index.md
+++ b/docs/packages/xstate-test/index.md
@@ -135,6 +135,7 @@ Provides testing details for each event. Each key in `eventsMap` is an object wh
 - `exec` (function): Function that executes the events. It is given two arguments:
   - `testContext` (any): any contextual testing data
   - `event` (EventObject): the event sent by the testing model
+  - `eventMeta` (undefined | Record<string, any>): Any metadata in the transition object of the event
 - `cases?` (EventObject[]): the sample event objects for this event type that can be sent by the testing model.
 
 **Example**

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -153,9 +153,13 @@ export function getAdjacencyMap<
         (!filter || filter(nextState)) &&
         stateHash !== stateSerializer(nextState)
       ) {
+        const meta = nextState.transitions.find(
+          (transition) => transition.eventType === event.type
+        )?.meta;
         adjacency[stateHash][eventSerializer(event)] = {
           state: nextState,
-          event
+          event,
+          eventMeta: meta
         };
 
         findAdjacencies(nextState);
@@ -246,7 +250,8 @@ export function getShortestPaths<
               state,
               segments: statePathMap[fromState].paths[0].segments.concat({
                 state: stateMap.get(fromState)!,
-                event: deserializeEventString(fromEvent!) as TEvent
+                event: deserializeEventString(fromEvent!) as TEvent,
+                eventMeta: adjacency[fromState][fromEvent!].eventMeta
               }),
               weight
             }

--- a/packages/xstate-graph/src/types.ts
+++ b/packages/xstate-graph/src/types.ts
@@ -61,6 +61,7 @@ export interface AdjacencyMap<TContext, TEvent extends EventObject> {
     {
       state: State<TContext, TEvent>;
       event: TEvent;
+      eventMeta?: Record<string, any>;
     }
   >;
 }
@@ -103,6 +104,7 @@ export interface Segment<TContext, TEvent extends EventObject> {
    * The event to be taken from the specified state.
    */
   event: TEvent;
+  eventMeta?: Record<string, any>;
 }
 
 export type Segments<TContext, TEvent extends EventObject> = Array<

--- a/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
+++ b/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
@@ -11,6 +11,7 @@ Object {
               "id": "whatever",
               "type": "EVENT",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -189,6 +190,7 @@ Object {
             "event": Object {
               "type": "STATE",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -656,6 +658,7 @@ Object {
             "event": Object {
               "type": "2",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -882,6 +885,7 @@ Object {
             "event": Object {
               "type": "3",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -1403,6 +1407,7 @@ Object {
             "event": Object {
               "type": "TIMER",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -1589,6 +1594,7 @@ Object {
             "event": Object {
               "type": "POWER_OUTAGE",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -1783,6 +1789,7 @@ Object {
             "event": Object {
               "type": "TIMER",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -1876,6 +1883,7 @@ Object {
             "event": Object {
               "type": "TIMER",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -1923,6 +1931,7 @@ Object {
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -1974,6 +1983,7 @@ Object {
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -2131,6 +2141,7 @@ Object {
             "event": Object {
               "type": "TIMER",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -2224,6 +2235,7 @@ Object {
             "event": Object {
               "type": "TIMER",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -2271,6 +2283,7 @@ Object {
             "event": Object {
               "type": "PED_COUNTDOWN",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -2433,6 +2446,7 @@ Object {
             "event": Object {
               "type": "TIMER",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",
@@ -2526,6 +2540,7 @@ Object {
             "event": Object {
               "type": "TIMER",
             },
+            "eventMeta": undefined,
             "state": Object {
               "_event": Object {
                 "$$type": "scxml",

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -380,6 +380,30 @@ describe('@xstate/graph', () => {
 
       expect(adj).toHaveProperty('"second" | {"count":10}');
     });
+    it('should pass event meta via function', () => {
+      const machine = createMachine<{ count: number }, { type: 'EVENT' }>({
+        initial: 'first',
+        context: {
+          count: 0
+        },
+        states: {
+          first: {
+            on: {
+              EVENT: {
+                target: 'second',
+                meta: { someMeta: 'value' }
+              }
+            }
+          },
+          second: {}
+        }
+      });
+
+      const adj = getAdjacencyMap(machine);
+      expect(
+        adj['"first" | {"count":0}']['{"type":"EVENT"}']
+      ).toHaveProperty('eventMeta', { someMeta: 'value' });
+    });
   });
 
   describe('toDirectedGraph', () => {

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -19,6 +19,8 @@ import {
   CoverageOptions
 } from './types';
 
+export * from './types';
+
 /**
  * Creates a test model that represents an abstract model of a
  * system under test (SUT).
@@ -130,7 +132,8 @@ export class TestModel<TTestContext, TContext> {
             ...segment,
             description: getDescription(segment.state),
             test: (testContext) => this.testState(segment.state, testContext),
-            exec: (testContext) => this.executeEvent(segment.event, testContext)
+            exec: (testContext) =>
+              this.executeEvent(segment.event, testContext, segment.eventMeta)
           };
         });
 
@@ -299,11 +302,15 @@ export class TestModel<TTestContext, TContext> {
     return testEvent.exec;
   }
 
-  public async executeEvent(event: EventObject, testContext: TTestContext) {
+  public async executeEvent(
+    event: EventObject,
+    testContext: TTestContext,
+    meta?: Record<string, any>
+  ) {
     const executor = this.getEventExecutor(event);
 
     if (executor) {
-      await executor(testContext, event);
+      await executor(testContext, event, meta);
     }
   }
 

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -97,7 +97,11 @@ export type EventExecutor<T> = (
   /**
    * The represented event that will be triggered when executed
    */
-  event: EventObject
+  event: EventObject,
+  /**
+   * The meta object on the Event transition definition
+   */
+  meta?: Record<string, any>
 ) => Promise<any> | void;
 
 export interface TestEventConfig<TTestContext> {


### PR DESCRIPTION
I have a use case where I wanted to check that the maximum length validation of a lot of fields was respected.

One other thing I slipped in was re-exporting the types file from @xstate/test - this is really useful when trying to build wrappers or utility functions around @xstate/test in strict typescript environments.

Thinking about it, there may be a better way of doing this (and I have a workaround) but I spent the time making the change before I realised that so thought I'd submit the MR anyway as it might be more useful in some other case.