### PR TITLE
Fix non-working code example in typescript.md

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -29,7 +29,7 @@ interface LightContext {
   elapsed: number;
 }
 
-const lightMachine = createMachine<LightContext, LightStateSchema, LightEvent>({
+const lightMachine = Machine<LightContext, LightStateSchema, LightEvent>({
   key: 'light',
   initial: 'green',
   context: { elapsed: 0 },


### PR DESCRIPTION
`createMachine` doesn't support this syntax: <LightContext, LightStateSchema, LightEvent>, but `Machine `supports