### PR TITLE
Allow existing actors in spawn() to be referenced by name

### DIFF
--- a/.changeset/red-parrots-judge.md
+++ b/.changeset/red-parrots-judge.md
@@ -1,0 +1,18 @@
+---
+'xstate': patch
+---
+
+Existing actors can now be identified in `spawn(...)` calls by providing an `id`. This allows them to be referenced by string:
+
+```ts
+const machine = createMachine({
+  context: () => ({
+    someRef: spawn(someExistingRef, 'something')
+  }),
+  on: {
+    SOME_EVENT: {
+      actions: send('AN_EVENT', { to: 'something' })
+    }
+  }
+});
+```

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -946,7 +946,7 @@ export class Interpreter<
     } else if (isFunction(entity)) {
       return this.spawnCallback(entity as InvokeCallback, name);
     } else if (isSpawnedActor(entity)) {
-      return this.spawnActor(entity);
+      return this.spawnActor(entity, name);
     } else if (isObservable<TEvent>(entity)) {
       return this.spawnObservable(entity, name);
     } else if (isMachine(entity)) {
@@ -1180,8 +1180,8 @@ export class Interpreter<
 
     return actor;
   }
-  private spawnActor<T extends ActorRef<any>>(actor: T): T {
-    this.children.set(actor.id, actor);
+  private spawnActor<T extends ActorRef<any>>(actor: T, name: string): T {
+    this.children.set(name, actor);
 
     return actor;
   }

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -367,6 +367,55 @@ describe('communicating with spawned actors', () => {
     parentService.start();
   });
 
+  it('should be able to name existing actors', (done) => {
+    const existingMachine = Machine({
+      initial: 'inactive',
+      states: {
+        inactive: {
+          on: { ACTIVATE: 'active' }
+        },
+        active: {
+          entry: respond('EXISTING.DONE')
+        }
+      }
+    });
+
+    const existingService = interpret(existingMachine).start();
+
+    const parentMachine = createMachine<{
+      existingRef: ActorRef<any> | undefined;
+    }>({
+      initial: 'pending',
+      context: {
+        existingRef: undefined
+      },
+      states: {
+        pending: {
+          entry: assign({
+            existingRef: () => spawn(existingService, 'existing')
+          }),
+          on: {
+            'EXISTING.DONE': 'success'
+          },
+          after: {
+            100: {
+              actions: send('ACTIVATE', { to: 'existing' })
+            }
+          }
+        },
+        success: {
+          type: 'final'
+        }
+      }
+    });
+
+    const parentService = interpret(parentMachine).onDone(() => {
+      done();
+    });
+
+    parentService.start();
+  });
+
   it('should be able to communicate with arbitrary actors if sessionId is known', (done) => {
     const existingMachine = Machine({
       initial: 'inactive',


### PR DESCRIPTION
Existing actors can now be identified in `spawn(...)` calls by providing an `id`. This allows them to be referenced by string:

```ts
const machine = createMachine({
  context: () => ({
    someRef: spawn(someExistingRef, 'something')
  }),
  on: {
    SOME_EVENT: {
      actions: send('AN_EVENT', { to: 'something' })
    }
  }
});
```
