### PR TITLE
Revert "Version Packages"

### DIFF
--- a/.changeset/breezy-countries-tap.md
+++ b/.changeset/breezy-countries-tap.md
@@ -1,0 +1,14 @@
+---
+'xstate': minor
+---
+
+Actors can now be spawned directly in the initial `machine.context` using lazy initialization, avoiding the need for intermediate states and unsafe typings for immediately spawned actors:
+
+```ts
+const machine = createMachine<{ ref: ActorRef<SomeEvent> }>({
+  context: () => ({
+    ref: spawn(anotherMachine, 'some-id') // spawn immediately!
+  })
+  // ...
+});
+```

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,20 +1,5 @@
 # xstate
 
-## 4.21.0
-
-### Minor Changes
-
-- [`f9bcea2c`](https://github.com/davidkpiano/xstate/commit/f9bcea2ce909ac59fcb165b352a7b51a8b29a56d) [#2366](https://github.com/davidkpiano/xstate/pull/2366) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Actors can now be spawned directly in the initial `machine.context` using lazy initialization, avoiding the need for intermediate states and unsafe typings for immediately spawned actors:
-
-  ```ts
-  const machine = createMachine<{ ref: ActorRef<SomeEvent> }>({
-    context: () => ({
-      ref: spawn(anotherMachine, 'some-id') // spawn immediately!
-    })
-    // ...
-  });
-  ```
-
 ## 4.20.2
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xstate",
-  "version": "4.21.0",
+  "version": "4.20.2",
   "description": "Finite State Machines and Statecharts for the Modern Web.",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/packages/xstate-scxml/package.json
+++ b/packages/xstate-scxml/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "xml-js": "^1.6.11",
-    "xstate": "^4.21.0"
+    "xstate": "^4.20.2"
   },
   "devDependencies": {
     "@scion-scxml/test-framework": "^2.0.15",


### PR DESCRIPTION
Reverts statelyai/xstate#2369 since there was a problem with release workflow being skipped after the repository migration to the statelyai organization