### PR TITLE
Add note on persisted states with spawned machines

### DIFF
--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -261,7 +261,8 @@ const service = interpret(myMachine).start(resolvedState);
 This will also maintain and restore previous [history states](./history.md) and ensures that `.events` and `.nextEvents` represent the correct values.
 
 ::: warning
-Persisting spawned [Actors](./actors.md) isn't yet supported in XState. Until then, you'll need to manually re-spawn actors of your persisted machine.
+Persisting spawned [actors](./actors.md) isn't yet supported in XState.
+:::
 
 ## State Meta Data
 

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -260,6 +260,9 @@ const service = interpret(myMachine).start(resolvedState);
 
 This will also maintain and restore previous [history states](./history.md) and ensures that `.events` and `.nextEvents` represent the correct values.
 
+::: warning
+Persisting spawned [Actors](./actors.md) isn't yet supported in XState. Until then, you'll need to manually re-spawn actors of your persisted machine.
+
 ## State Meta Data
 
 Meta data, which is static data that describes relevant properties of any [state node](./statenodes.md), can be specified on the `.meta` property of the state node:


### PR DESCRIPTION
Adds a note on restoring state with spawned actors. See [discussion in Discord](https://discord.com/channels/795785288994652170/799416943324823592/861979176805597216) for context.

I'd love to point to a canonical issue, discussion or PR on the topic, but couldn't find any. Pointers?