### PR TITLE
[@xstate/react] Fix import in `useSpawn(...)`

### DIFF
--- a/.changeset/eleven-dancers-study.md
+++ b/.changeset/eleven-dancers-study.md
@@ -2,4 +2,4 @@
 '@xstate/react': patch
 ---
 
-An internal issue where the `spawnBehavior` import was broken internally has been fixed.
+An internal issue where the `spawnBehavior` import for the `useSpawn(...)` hook was broken internally has been fixed.

--- a/.changeset/eleven-dancers-study.md
+++ b/.changeset/eleven-dancers-study.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+An internal issue where the `spawnBehavior` import was broken internally has been fixed.

--- a/packages/xstate-react/src/useSpawn.ts
+++ b/packages/xstate-react/src/useSpawn.ts
@@ -1,5 +1,5 @@
 import { ActorRef, Behavior, EventObject } from 'xstate';
-import { spawnBehavior } from 'xstate/src/behaviors';
+import { spawnBehavior } from 'xstate/lib/behaviors';
 import useConstant from './useConstant';
 
 /**


### PR DESCRIPTION
An internal issue where the `spawnBehavior` import for the `useSpawn(...)` hook was broken internally has been fixed.

@Andarist FYI