### PR TITLE
Fix compat issue between useSpawn in @xstate/react and XState version

### DIFF
--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -9,7 +9,7 @@ import {
 } from './types';
 import { isMachine, mapContext, toInvokeSource } from './utils';
 import * as serviceScope from './serviceScope';
-import { ActorRef, BaseActorRef } from '.';
+import { ActorRef, BaseActorRef } from './types';
 
 export interface Actor<
   TContext = any,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,4 +75,3 @@ export {
 };
 
 export * from './types';
-export { spawnBehavior as __spawnBehavior } from './behaviors';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -75,3 +75,4 @@ export {
 };
 
 export * from './types';
+export { spawnBehavior as __spawnBehavior } from './behaviors';

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -15,26 +15,7 @@ import { MaybeLazy } from './types';
 import useConstant from './useConstant';
 import { UseMachineOptions } from './useMachine';
 import { useReactEffectActions } from './useReactEffectActions';
-
-// copied from core/src/utils.ts
-// it avoids a breaking change between this package and XState which is its peer dep
-function toObserver<T>(
-  nextHandler: Observer<T> | ((value: T) => void),
-  errorHandler?: (error: any) => void,
-  completionHandler?: () => void
-): Observer<T> {
-  if (typeof nextHandler === 'object') {
-    return nextHandler;
-  }
-
-  const noop = () => void 0;
-
-  return {
-    next: nextHandler,
-    error: errorHandler || noop,
-    complete: completionHandler || noop
-  };
-}
+import { toObserver } from './xstateCoreCopies';
 
 export function useInterpret<
   TContext,

--- a/packages/xstate-react/src/useSpawn.ts
+++ b/packages/xstate-react/src/useSpawn.ts
@@ -1,10 +1,6 @@
-import { ActorRef, Behavior, EventObject } from 'xstate';
-import * as XState from 'xstate';
+import { ActorRef, EventObject } from 'xstate';
 import useConstant from './useConstant';
-
-if (process.env.NODE_ENV === 'development' && !('__spawnBehavior' in XState)) {
-  throw new Error('`useSpawn` requires at least xstate@4.22.1');
-}
+import { spawnBehavior, Behavior } from './xstateCoreCopies';
 
 /**
  * React hook that spawns an `ActorRef` with the specified `behavior`.
@@ -17,7 +13,7 @@ export function useSpawn<TState, TEvent extends EventObject>(
   behavior: Behavior<TEvent, TState>
 ): ActorRef<TEvent, TState> {
   const actorRef = useConstant(() => {
-    return XState.__spawnBehavior(behavior);
+    return spawnBehavior(behavior);
   });
 
   return actorRef;

--- a/packages/xstate-react/src/useSpawn.ts
+++ b/packages/xstate-react/src/useSpawn.ts
@@ -1,6 +1,10 @@
 import { ActorRef, Behavior, EventObject } from 'xstate';
-import { spawnBehavior } from 'xstate/lib/behaviors';
+import * as XState from 'xstate';
 import useConstant from './useConstant';
+
+if (process.env.NODE_ENV === 'development' && !('__spawnBehavior' in XState)) {
+  throw new Error('`useSpawn` requires at least xstate@4.22.1');
+}
 
 /**
  * React hook that spawns an `ActorRef` with the specified `behavior`.
@@ -13,7 +17,7 @@ export function useSpawn<TState, TEvent extends EventObject>(
   behavior: Behavior<TEvent, TState>
 ): ActorRef<TEvent, TState> {
   const actorRef = useConstant(() => {
-    return spawnBehavior(behavior);
+    return XState.__spawnBehavior(behavior);
   });
 
   return actorRef;

--- a/packages/xstate-react/src/xstateCoreCopies.ts
+++ b/packages/xstate-react/src/xstateCoreCopies.ts
@@ -1,0 +1,120 @@
+// everything in this file is copied from the core's source code
+// it avoids a breaking change between this package and XState which is its peer dep
+import { ActorRef, EventObject } from 'xstate';
+
+interface ActorContext<TEvent extends EventObject, TEmitted> {
+  parent?: ActorRef<any, any>;
+  self: ActorRef<TEvent, TEmitted>;
+  id: string;
+  observers: Set<Observer<TEmitted>>;
+}
+
+export interface Behavior<TEvent extends EventObject, TEmitted = any> {
+  transition: (
+    state: TEmitted,
+    event: TEvent,
+    actorCtx: ActorContext<TEvent, TEmitted>
+  ) => TEmitted;
+  initialState: TEmitted;
+  start?: (actorCtx: ActorContext<TEvent, TEmitted>) => TEmitted;
+}
+
+export function toObserver<T>(
+  nextHandler: Observer<T> | ((value: T) => void),
+  errorHandler?: (error: any) => void,
+  completionHandler?: () => void
+): Observer<T> {
+  if (typeof nextHandler === 'object') {
+    return nextHandler;
+  }
+
+  const noop = () => void 0;
+
+  return {
+    next: nextHandler,
+    error: errorHandler || noop,
+    complete: completionHandler || noop
+  };
+}
+
+interface SpawnBehaviorOptions {
+  id?: string;
+  parent?: ActorRef<any>;
+}
+
+interface Observer<T> {
+  next: (value: T) => void;
+  error: (err: any) => void;
+  complete: () => void;
+}
+
+interface BaseActorRef<TEvent extends EventObject> {
+  send: (event: TEvent) => void;
+}
+
+function toActorRef<
+  TEvent extends EventObject,
+  TEmitted = any,
+  TActorRefLike extends BaseActorRef<TEvent> = BaseActorRef<TEvent>
+>(actorRefLike: TActorRefLike): ActorRef<TEvent, TEmitted> {
+  return {
+    subscribe: () => ({ unsubscribe: () => void 0 }),
+    id: 'anonymous',
+    getSnapshot: () => undefined,
+    ...actorRefLike
+  };
+}
+
+export function spawnBehavior<TEvent extends EventObject, TEmitted>(
+  behavior: Behavior<TEvent, TEmitted>,
+  options: SpawnBehaviorOptions = {}
+): ActorRef<TEvent, TEmitted> {
+  let state = behavior.initialState;
+  const observers = new Set<Observer<TEmitted>>();
+  const mailbox: TEvent[] = [];
+  let flushing = false;
+
+  const flush = () => {
+    if (flushing) {
+      return;
+    }
+    flushing = true;
+    while (mailbox.length > 0) {
+      const event = mailbox.shift()!;
+      state = behavior.transition(state, event, actorCtx);
+      observers.forEach((observer) => observer.next(state));
+    }
+    flushing = false;
+  };
+
+  const actor = toActorRef({
+    id: options.id,
+    send: (event: TEvent) => {
+      mailbox.push(event);
+      flush();
+    },
+    getSnapshot: () => state,
+    subscribe: (next, handleError?, complete?) => {
+      const observer = toObserver(next, handleError, complete);
+      observers.add(observer);
+      observer.next(state);
+
+      return {
+        unsubscribe: () => {
+          observers.delete(observer);
+        }
+      };
+    }
+  });
+
+  const actorCtx = {
+    parent: options.parent,
+    self: actor,
+    id: options.id || 'anonymous',
+    observers
+  };
+
+  state = behavior.start ? behavior.start(actorCtx) : state;
+
+  return actor;
+}


### PR DESCRIPTION
fixes https://github.com/statelyai/xstate/issues/2410

⚠️ this is not rly an ideal solution because we'll end up with the same problem when any user updates `@xstate/react` without updating `xstate`. The best solution would be to move `spawnBehavior` to a new package (`@xstate/private-do-not-use` or something) and add it as a dependency to both `xstate` and `@xstate/react`. This is the only solution that I can think of that would be compatible with any combination of upgrades. Thoughts?

Moral of the story: peer deps are hard 😬 