### PR TITLE
[docs] Remove StateSchema from typescript.md

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -3,21 +3,6 @@
 As XState is written in [TypeScript](https://www.typescriptlang.org/), strongly typing your statecharts is useful and encouraged. Consider this light machine example:
 
 ```typescript
-// The hierarchical (recursive) schema for the states
-interface LightStateSchema {
-  states: {
-    green: {};
-    yellow: {};
-    red: {
-      states: {
-        walk: {};
-        wait: {};
-        stop: {};
-      };
-    };
-  };
-}
-
 // The events that the machine handles
 type LightEvent =
   | { type: 'TIMER' }
@@ -29,7 +14,7 @@ interface LightContext {
   elapsed: number;
 }
 
-const lightMachine = createMachine<LightContext, LightStateSchema, LightEvent>({
+const lightMachine = createMachine<LightContext, LightEvent>({
   key: 'light',
   initial: 'green',
   context: { elapsed: 0 },
@@ -80,10 +65,9 @@ const lightMachine = createMachine<LightContext, LightStateSchema, LightEvent>({
 });
 ```
 
-Providing the context, state schema, and events as generic parameters for the `createMachine()` function may seem tedious (and is completely optional), but gives many advantages:
+Providing the context and events as generic parameters for the `createMachine()` function may seem tedious (and is completely optional), but gives many advantages:
 
 - The context type/interface (`TContext`) is passed on to action `exec` functions, guard `cond` functions, and more. It is also passed to deeply nested states.
-- The state schema type/interface (`TStateSchema`) ensures that only state keys defined on the schema are allowed in the actual config object. Nested state schemas are recursively passed down to their representative child states.
 - The event type (`TEvent`) ensures that only specified events (and built-in XState-specific ones) are used in transition configs. The provided event object shapes are also passed on to action `exec` functions, guard `cond` functions, and more. This can prevent unnecessary `event.somePayload === undefined` checks.
 
 Note if you are seeing this error:
@@ -97,12 +81,12 @@ Ensure that your tsconfig file does not include `"keyofStringsOnly": true,`.
 
 ## Config Objects
 
-The generic types for `MachineConfig<TContext, TSchema, TEvent>` are the same as those for `createMachine<TContext, TSchema, TEvent>`. This is useful when you are defining a machine config object _outside_ of the `createMachine(...)` function, and helps prevent [inference errors](https://github.com/davidkpiano/xstate/issues/310):
+The generic types for `MachineConfig<TContext, any, TEvent>` are the same as those for `createMachine<TContext, TEvent>`. This is useful when you are defining a machine config object _outside_ of the `createMachine(...)` function, and helps prevent [inference errors](https://github.com/davidkpiano/xstate/issues/310):
 
 ```ts
 import { MachineConfig } from 'xstate';
 
-const myMachineConfig: MachineConfig<TContext, TSchema, TEvent> = {
+const myMachineConfig: MachineConfig<TContext, any, TEvent> = {
   id: 'controller',
   initial: 'stopped',
   states: {


### PR DESCRIPTION
As `StateSchema` is going to be deprecated for v5 and is entirely optional, it's best to discourage its use by omission.