### PR TITLE
[@xstate/react] Ensure `asEffect*` works with `preserveActionOrder: true`

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -382,11 +382,11 @@ class StateNode<
     // TODO: deprecate (entry)
     this.onEntry = toArray(
       this.config.entry || this.config.onEntry
-    ).map((action) => toActionObject(action));
+    ).map((action) => toActionObject(action, this.machine.options.actions));
     // TODO: deprecate (exit)
     this.onExit = toArray(
       this.config.exit || this.config.onExit
-    ).map((action) => toActionObject(action));
+    ).map((action) => toActionObject(action, this.machine.options.actions));
     this.meta = this.config.meta;
     this.doneData =
       this.type === 'final'
@@ -1858,7 +1858,10 @@ class StateNode<
 
     const transition = {
       ...transitionConfig,
-      actions: toActionObjects(toArray(transitionConfig.actions)),
+      actions: toActionObjects(
+        toArray(transitionConfig.actions),
+        this.machine.options.actions
+      ),
       cond: toGuard(transitionConfig.cond, guards),
       target,
       source: this as any,

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -652,6 +652,11 @@ export function resolveActions<TContext, TEvent extends EventObject>(
               return [];
             }
 
+            const actionObjects = toActionObjects(
+              toArray(matchedActions),
+              machine.options.actions
+            );
+
             const [
               resolvedActionsFromChoose,
               resolvedContextFromChoose
@@ -660,7 +665,7 @@ export function resolveActions<TContext, TEvent extends EventObject>(
               currentState,
               updatedContext,
               _event,
-              toActionObjects(toArray(matchedActions), machine.options.actions),
+              actionObjects,
               preserveActionOrder
             );
             updatedContext = resolvedContextFromChoose;

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -718,7 +718,7 @@ export function resolveActions<TContext, TEvent extends EventObject>(
             if (exec && preservedContexts) {
               const contextIndex = preservedContexts.length - 1;
               resolvedActionObject.exec = (_ctx, ...args) => {
-                exec?.(preservedContexts[contextIndex], ...args);
+                return exec?.(preservedContexts[contextIndex], ...args);
               };
             }
             return resolvedActionObject;

--- a/packages/xstate-react/src/types.ts
+++ b/packages/xstate-react/src/types.ts
@@ -77,18 +77,16 @@ export enum ReactEffectType {
   LayoutEffect = 2
 }
 
-export interface ReactActionFunction<TContext, TEvent extends EventObject> {
-  (
-    context: TContext,
-    event: TEvent,
-    meta: ActionMeta<TContext, TEvent>
-  ): () => void;
-  __effect: ReactEffectType;
-}
+export type ReactActionFunction<TContext, TEvent extends EventObject> = (
+  context: TContext,
+  event: TEvent,
+  meta: ActionMeta<TContext, TEvent>
+) => () => void;
 
 export interface ReactActionObject<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
   exec: ReactActionFunction<TContext, TEvent>;
+  __effect: ReactEffectType;
 }
 
 export interface UseMachineOptions<TContext, TEvent extends EventObject> {

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -10,37 +10,43 @@ import {
   Typestate,
   ActionFunction
 } from 'xstate';
-import { MaybeLazy, ReactActionFunction, ReactEffectType } from './types';
+import {
+  MaybeLazy,
+  ReactActionFunction,
+  ReactActionObject,
+  ReactEffectType
+} from './types';
 import { useInterpret } from './useInterpret';
 
 function createReactActionFunction<TContext, TEvent extends EventObject>(
   exec: ActionFunction<TContext, TEvent>,
   tag: ReactEffectType
-): ReactActionFunction<TContext, TEvent> {
-  const effectExec: unknown = (...args: Parameters<typeof exec>) => {
+): ReactActionObject<TContext, TEvent> {
+  const effectExec: ReactActionFunction<TContext, TEvent> = (
+    ...args: Parameters<typeof exec>
+  ) => {
     // don't execute; just return
     return () => {
       return exec(...args);
     };
   };
 
-  Object.defineProperties(effectExec, {
-    name: { value: `effect:${exec.name}` },
-    __effect: { value: tag }
-  });
-
-  return effectExec as ReactActionFunction<TContext, TEvent>;
+  return {
+    type: `effect:${exec.name}`,
+    __effect: tag,
+    exec: effectExec
+  };
 }
 
 export function asEffect<TContext, TEvent extends EventObject>(
   exec: ActionFunction<TContext, TEvent>
-): ReactActionFunction<TContext, TEvent> {
+): ReactActionObject<TContext, TEvent> {
   return createReactActionFunction(exec, ReactEffectType.Effect);
 }
 
 export function asLayoutEffect<TContext, TEvent extends EventObject>(
   exec: ActionFunction<TContext, TEvent>
-): ReactActionFunction<TContext, TEvent> {
+): ReactActionObject<TContext, TEvent> {
   return createReactActionFunction(exec, ReactEffectType.LayoutEffect);
 }
 

--- a/packages/xstate-react/src/useReactEffectActions.ts
+++ b/packages/xstate-react/src/useReactEffectActions.ts
@@ -37,17 +37,14 @@ export function useReactEffectActions<TContext, TEvent extends EventObject>(
       if (currentState.actions.length) {
         const reactEffectActions = currentState.actions.filter(
           (action): action is ReactActionObject<TContext, TEvent> => {
-            return (
-              typeof action.exec === 'function' &&
-              '__effect' in (action as ReactActionObject<TContext, TEvent>).exec
-            );
+            return typeof action.exec === 'function' && '__effect' in action;
           }
         );
 
         const [effectActions, layoutEffectActions] = partition(
           reactEffectActions,
           (action): action is ReactActionObject<TContext, TEvent> => {
-            return action.exec.__effect === ReactEffectType.Effect;
+            return action.__effect === ReactEffectType.Effect;
           }
         );
 

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -394,6 +394,55 @@ describe('useMachine hook', () => {
     done();
   });
 
+  it('should capture all actions with preserveActionOrder = true', (done) => {
+    let count = 0;
+
+    const machine = createMachine({
+      initial: 'active',
+      states: {
+        active: {
+          on: {
+            EVENT: {
+              actions: asEffect(() => {
+                count++;
+              })
+            }
+          }
+        }
+      },
+      preserveActionOrder: true
+    });
+
+    const App = () => {
+      const [stateCount, setStateCount] = useState(0);
+      const [state, send] = useMachine(machine);
+
+      React.useEffect(() => {
+        send('EVENT');
+        send('EVENT');
+        send('EVENT');
+        send('EVENT');
+      }, []);
+
+      React.useEffect(() => {
+        setStateCount((c) => c + 1);
+      }, [state]);
+
+      return <div data-testid="count">{stateCount}</div>;
+    };
+
+    const { getByTestId } = render(<App />);
+
+    const countEl = getByTestId('count');
+
+    // Component should only rerender twice:
+    // - 1 time for the initial state
+    // - and 1 time for the four (batched) events
+    expect(countEl.textContent).toEqual('2');
+    expect(count).toEqual(4);
+    done();
+  });
+
   it('should capture initial actions', (done) => {
     let count = 0;
 

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -349,7 +349,7 @@ describe('useMachine hook', () => {
   it('should capture all actions', (done) => {
     let count = 0;
 
-    const machine = createMachine<any, { type: 'EVENT' }>({
+    const machine = createMachine({
       initial: 'active',
       states: {
         active: {


### PR DESCRIPTION
This PR refactors effects in `@xstate/react` to use an object instead of a function, so that it works with `preserveActionOrder: true` and also in v5 (currently broken, which this change will fix).