### PR TITLE
Fixed an issue with states coming from `model.createMachine` resulting in contexts of type `any` after type refinements

### DIFF
--- a/.changeset/warm-spies-cry.md
+++ b/.changeset/warm-spies-cry.md
@@ -1,0 +1,12 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with states coming from `model.createMachine` resulting in contexts of type `any` after type refinements such as here:
+
+```ts
+// `state.context` became `any` erroneously
+if (state.matches('inactive')) {
+  console.log(state.context.count);
+}
+```

--- a/.changeset/warm-spies-cry.md
+++ b/.changeset/warm-spies-cry.md
@@ -2,7 +2,7 @@
 'xstate': patch
 ---
 
-Fixed an issue where, when using `model.createMachine`, state context was incorrectly inferred as `any` after refinement with `.matches(...)`, e.g.
+Fixed an issue where, when using `model.createMachine`, state's context was incorrectly inferred as `any` after refinement with `.matches(...)`, e.g.
 
 ```ts
 // `state.context` became `any` erroneously

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -19,6 +19,12 @@ import { StateNode } from './StateNode';
 import { getMeta, nextEvents } from './stateUtils';
 import { initEvent } from './actions';
 
+type Equals<A1 extends any, A2 extends any> = (<A>() => A extends A2
+  ? 1
+  : 0) extends <A>() => A extends A1 ? 1 : 0
+  ? 1
+  : 0;
+
 export function stateValuesEqual(
   a: StateValue | undefined,
   b: StateValue | undefined
@@ -293,11 +299,13 @@ export class State<
   public matches<TSV extends TTypestate['value']>(
     parentStateValue: TSV
   ): this is State<
-    (TTypestate extends any
-      ? { value: TSV; context: any } extends TTypestate
-        ? TTypestate
-        : never
-      : never)['context'],
+    Equals<TTypestate, any> extends 1
+      ? TContext
+      : (TTypestate extends any
+          ? { value: TSV; context: any } extends TTypestate
+            ? TTypestate
+            : never
+          : never)['context'],
     TEvent,
     TStateSchema,
     TTypestate

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -19,12 +19,6 @@ import { StateNode } from './StateNode';
 import { getMeta, nextEvents } from './stateUtils';
 import { initEvent } from './actions';
 
-type Equals<A1 extends any, A2 extends any> = (<A>() => A extends A2
-  ? 1
-  : 0) extends <A>() => A extends A1 ? 1 : 0
-  ? 1
-  : 0;
-
 export function stateValuesEqual(
   a: StateValue | undefined,
   b: StateValue | undefined
@@ -299,13 +293,11 @@ export class State<
   public matches<TSV extends TTypestate['value']>(
     parentStateValue: TSV
   ): this is State<
-    Equals<TTypestate, any> extends 1
-      ? TContext
-      : (TTypestate extends any
-          ? { value: TSV; context: any } extends TTypestate
-            ? TTypestate
-            : never
-          : never)['context'],
+    (TTypestate extends any
+      ? { value: TSV; context: any } extends TTypestate
+        ? TTypestate
+        : never
+      : never)['context'],
     TEvent,
     TStateSchema,
     TTypestate

--- a/packages/core/src/model.types.ts
+++ b/packages/core/src/model.types.ts
@@ -32,7 +32,7 @@ export interface Model<
   createMachine: (
     config: MachineConfig<TContext, any, TEvent>,
     implementations?: Partial<MachineOptions<TContext, TEvent>>
-  ) => StateMachine<TContext, any, TEvent, any>;
+  ) => StateMachine<TContext, any, TEvent>;
 }
 
 export type ModelContextFrom<


### PR DESCRIPTION
fixes #2423 

Note that this PR contains 2 separate fixes for the reported issue. Any of them could be removed and the reported issue would still be fixed. I will comment on each one "inline"