### PR TITLE
Let generics be inferred for `assign()` in fsm

### DIFF
--- a/.changeset/wicked-chicken-chew.md
+++ b/.changeset/wicked-chicken-chew.md
@@ -1,0 +1,5 @@
+---
+'@xstate/fsm': patch
+---
+
+Changed the type of `assign()` so that an explicit generic parameter is not needed for input using `PropertyAssigner` any more.

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -15,11 +15,14 @@ function toArray<T>(item: T | T[] | undefined): T[] {
   return item === undefined ? [] : ([] as T[]).concat(item);
 }
 
-export function assign<TC extends object, TE extends EventObject = EventObject>(
-  assignment:
-    | StateMachine.Assigner<TC, TE>
-    | StateMachine.PropertyAssigner<TC, TE>
-): StateMachine.AssignActionObject<TC, TE> {
+export function assign<
+  TContext extends object,
+  TEvent extends EventObject = EventObject,
+  TAssignment extends StateMachine.Assignment<
+    TContext,
+    TEvent
+  > = StateMachine.Assignment<TContext, TEvent>
+>(assignment: TAssignment): StateMachine.AssignActionObject<TContext, TEvent> {
   return {
     type: ASSIGN_ACTION,
     assignment

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -5,6 +5,7 @@ export enum InterpreterStatus {
 }
 
 export type SingleOrArray<T> = T[] | T;
+
 export interface EventObject {
   type: string;
 }
@@ -29,6 +30,7 @@ export namespace StateMachine {
   > {
     type: string;
     exec?: ActionFunction<TContext, TEvent>;
+
     [key: string]: any;
   }
 
@@ -44,7 +46,7 @@ export namespace StateMachine {
     TEvent extends EventObject
   > extends ActionObject<TContext, TEvent> {
     type: AssignAction;
-    assignment: Assigner<TContext, TEvent> | PropertyAssigner<TContext, TEvent>;
+    assignment: Assignment<TContext, TEvent>;
   }
 
   export type Transition<TContext extends object, TEvent extends EventObject> =
@@ -54,6 +56,7 @@ export namespace StateMachine {
         actions?: SingleOrArray<Action<TContext, TEvent>>;
         cond?: (context: TContext, event: TEvent) => boolean;
       };
+
   export interface State<
     TContext extends object,
     TEvent extends EventObject,
@@ -140,6 +143,10 @@ export namespace StateMachine {
       | ((context: TContext, event: TEvent) => TContext[K])
       | TContext[K];
   };
+
+  export type Assignment<TContext extends object, TEvent extends EventObject> =
+    | Assigner<TContext, TEvent>
+    | PropertyAssigner<TContext, TEvent>;
 }
 
 export interface Typestate<TContext extends object> {

--- a/packages/xstate-fsm/test/fsm.test.ts
+++ b/packages/xstate-fsm/test/fsm.test.ts
@@ -41,7 +41,7 @@ describe('@xstate/fsm', () => {
           'exitGreen',
           assign({ count: (ctx) => ctx.count + 1 }),
           assign({ count: (ctx) => ctx.count + 1 }),
-          assign<LightContext>({ foo: 'static' }),
+          assign({ foo: 'static' }),
           assign({ foo: (ctx) => ctx.foo + '++' })
         ],
         on: {
@@ -52,7 +52,7 @@ describe('@xstate/fsm', () => {
         }
       },
       yellow: {
-        entry: assign<LightContext>({ go: false }),
+        entry: assign({ go: false }),
         on: {
           INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) },
           EMERGENCY: {


### PR DESCRIPTION
The need to pass in the Context as a generic parameter in `assign()` (when using `PropertyAssigner`) feels redundant when we already give the Context to `createMachine` trough `StateMachine.Config`.

This commit changes `assign()` so that the type of the `assignment` parameter in `assign()` is inferred, and then `TContext` is also inferred, and so we don't need an explicit generic parameter when using `PropertyAssigner`.

I also created a new type `Assignment` which is the union of `Assigner` and `PropertyAssigner` to make the new code in `assign` a little bit easier to read.

---

These changes are only to the types, and should not affect the outputted JS-code at all.

There are some new blank lines inserted in *types.ts*. Those come from prettier, so I just left them in.