### PR TITLE
Remove `.toString()` method on action objects

### DIFF
--- a/.changeset/dry-kangaroos-roll.md
+++ b/.changeset/dry-kangaroos-roll.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-The custom `.toString()` method on action objects is now removed. See #2488
+The custom `.toString()` method on action objects is now removed which improves performance in larger applications (see [#2488](https://github.com/statelyai/xstate/discussions/2488) for more context).

--- a/.changeset/dry-kangaroos-roll.md
+++ b/.changeset/dry-kangaroos-roll.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The custom `.toString()` method on action objects is now removed. See #2488

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -116,13 +116,6 @@ export function toActionObject<TContext, TEvent extends EventObject>(
       actionObject = action as ActionObject<TContext, TEvent>;
     }
   }
-
-  Object.defineProperty(actionObject, 'toString', {
-    value: () => actionObject.type,
-    enumerable: false,
-    configurable: true
-  });
-
   return actionObject;
 }
 

--- a/packages/core/test/deep.test.ts
+++ b/packages/core/test/deep.test.ts
@@ -97,7 +97,7 @@ describe('deep transitions', () => {
     it('should exit all substates when superstates exits (A_EVENT)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'A_EVENT')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
       expect(actual).toEqual(expected);
     });
@@ -105,7 +105,7 @@ describe('deep transitions', () => {
     it('should exit substates and superstates when exiting (B_EVENT)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'B_EVENT')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
       expect(actual).toEqual(expected);
     });
@@ -113,7 +113,7 @@ describe('deep transitions', () => {
     it('should exit substates and superstates when exiting (C_EVENT)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'C_EVENT')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
       expect(actual).toEqual(expected);
     });
@@ -121,7 +121,7 @@ describe('deep transitions', () => {
     it('should exit superstates when exiting (D_EVENT)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'D_EVENT')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
       expect(actual).toEqual(expected);
     });
@@ -129,7 +129,7 @@ describe('deep transitions', () => {
     it('should exit substate when machine handles event (MACHINE_EVENT)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'MACHINE_EVENT')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = ['EXIT_D', 'EXIT_C', 'EXIT_B', 'EXIT_A'];
       expect(actual).toEqual(expected);
     });
@@ -148,7 +148,7 @@ describe('deep transitions', () => {
     it('should exit deep and enter deep (A_S)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'A_S')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = DBCAPQRS;
       expect(actual).toEqual(expected);
     });
@@ -156,7 +156,7 @@ describe('deep transitions', () => {
     it('should exit deep and enter deep (D_P)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'D_P')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = DBCAPQRS;
       expect(actual).toEqual(expected);
     });
@@ -164,7 +164,7 @@ describe('deep transitions', () => {
     it('should exit deep and enter deep (A_P)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'A_P')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = DBCAPQRS;
       expect(actual).toEqual(expected);
     });
@@ -172,7 +172,7 @@ describe('deep transitions', () => {
     it('should exit deep and enter deep (D_S)', () => {
       const actual = deepMachine
         .transition(deepMachine.initialState, 'D_S')
-        .actions.map((a) => `${a}`);
+        .actions.map((a) => a.type);
       const expected = DBCAPQRS;
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
This method was undocumented and unused (except incorrectly in tests), and removing this improves performance.

Fixes #2488