### PR TITLE
Fixed a minor issue with sometimes sending `undefined` state to the inspector

### DIFF
--- a/.changeset/nasty-ways-trade.md
+++ b/.changeset/nasty-ways-trade.md
@@ -1,0 +1,5 @@
+---
+'@xstate/inspect': patch
+---
+
+Fixed a minor issue with sometimes sending `undefined` state to the inspector which resulted in an error being thrown in it when resolving the received state. The problem was very minor as no functionality was broken because of it.

--- a/packages/xstate-inspect/src/browser.ts
+++ b/packages/xstate-inspect/src/browser.ts
@@ -168,6 +168,10 @@ export function inspect(
     };
 
     service.subscribe((state) => {
+      // filter out synchronous notification from within `.start()` call when the `service.state` has not yet been assigned
+      if (state === undefined) {
+        return;
+      }
       inspectService.send({
         type: 'service.state',
         state: stringify(state),


### PR DESCRIPTION
When interpreting machines, when the inspect machine is already in the `connected` state, this makes this `service.event` sent to the inspector right within the `.start()` call:
https://github.com/statelyai/xstate/blob/fb7ea97465dfba0b7ef17edbf327c7c21848c7e8/packages/xstate-inspect/src/browser.ts#L171-L175

but the `service._state` has never been assigned yet up to this point so it's `undefined`. That gets forwarded to the inspector and throws here on `JSON.parse(undefined)`:
https://github.com/statelyai/xstate/blob/fb7ea97465dfba0b7ef17edbf327c7c21848c7e8/packages/xstate-inspect/src/utils.ts#L38