### PR TITLE
[@xstate/react] Improve deprecation warning for send payloads

### DIFF
--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -90,7 +90,7 @@ A [React hook](https://reactjs.org/hooks) that interprets the given `machine` an
 
 In the next major version, `useService(service)` will be replaced with `useActor(service)`. Prefer using the `useActor(service)` hook for services instead, since services are also actors.
 
-Also, keep in mind that only a single argument (the event object) can be sent to `send(eventObject)` from `useActor(...)`. When migrating to `useActor(...)`, refactor `send(...)` calls to use only a single event object:
+Also, keep in mind that only a single argument (the event object) can be sent to `send(eventObject)` from `useActor(...)`. When migrating to `useActor(...)`, refactor `send(...)` calls to use only a single argument (event object or event type string):
 
 ```diff
 const [state, send] = useActor(service);

--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -90,6 +90,15 @@ A [React hook](https://reactjs.org/hooks) that interprets the given `machine` an
 
 In the next major version, `useService(service)` will be replaced with `useActor(service)`. Prefer using the `useActor(service)` hook for services instead, since services are also actors.
 
+Also, keep in mind that only a single argument (the event object) can be sent to `send(eventObject)` from `useActor(...)`. When migrating to `useActor(...)`, refactor `send(...)` calls to use only a single event object:
+
+```diff
+const [state, send] = useActor(service);
+
+-send('CLICK', { x: 0, y: 3 });
++send({ type: 'CLICK', x: 0, y: 3 });
+```
+
 :::
 
 A [React hook](https://reactjs.org/hooks) that subscribes to state changes from an existing [service](https://xstate.js.org/docs/guides/interpretation.html).

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -57,7 +57,7 @@ export function useActor(
 
     if (process.env.NODE_ENV !== 'production' && args.length > 1) {
       console.warn(
-        `Unexpected argument: ${JSON.stringify(
+        `Unexpected payload: ${JSON.stringify(
           (args as any)[1]
         )}. Only a single event object can be sent to actor send() functions.`
       );

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -52,7 +52,17 @@ export function useActor(
   const deferredEventsRef = useRef<EventObject[]>([]);
   const [current, setCurrent] = useState(() => getSnapshot(actorRef));
 
-  const send: Sender<EventObject> = useConstant(() => (event) => {
+  const send: Sender<EventObject> = useConstant(() => (...args) => {
+    const event = args[0];
+
+    if (process.env.NODE_ENV !== 'production' && args.length > 1) {
+      console.warn(
+        `Unexpected argument: ${JSON.stringify(
+          (args as any)[1]
+        )}. Only a single event object can be sent to actor send() functions.`
+      );
+    }
+
     const currentActorRef = actorRefRef.current;
     // If the previous actor is a deferred actor,
     // queue the events so that they can be replayed


### PR DESCRIPTION
This PR adds warnings for unexpected arguments when migrating from `useService(...)` to `useActor(...)`.

The warnings look like this:

![CleanShot 2021-08-08 at 17 30 46](https://user-images.githubusercontent.com/1093738/128646413-d319511b-07f3-4fe2-bb9c-fa510b68ce46.png)

Documentation is also updated. Closes #2412