### PR TITLE
Improve `model.assign` inference in some cases by using separate overloads

### DIFF
--- a/.changeset/proud-ghosts-hear.md
+++ b/.changeset/proud-ghosts-hear.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Improve `model.assign` inference in some cases by using separate overloads

--- a/packages/core/src/model.types.ts
+++ b/packages/core/src/model.types.ts
@@ -28,12 +28,15 @@ export interface Model<
   TModelCreators = void
 > {
   initialContext: TContext;
-  assign: <TEventType extends TEvent['type'] = TEvent['type']>(
+  assign(
+    assigner: Assigner<TContext, TEvent> | PropertyAssigner<TContext, TEvent>
+  ): AssignAction<TContext, TEvent>;
+  assign<TEventType extends TEvent['type']>(
     assigner:
       | Assigner<TContext, ExtractEvent<TEvent, TEventType>>
       | PropertyAssigner<TContext, ExtractEvent<TEvent, TEventType>>,
     eventType?: TEventType
-  ) => AssignAction<TContext, ExtractEvent<TEvent, TEventType>>;
+  ): AssignAction<TContext, ExtractEvent<TEvent, TEventType>>;
   events: Prop<TModelCreators, 'events'>;
   actions: Prop<TModelCreators, 'actions'>;
   reset: () => AssignAction<TContext, any>;


### PR DESCRIPTION
This is related to this weird case: https://www.loom.com/share/51f67097b6ca43b790ce5c215b2a63ae

I've found out that by putting less stress on the inference algorithm we can sometimes achieve better results. Overloads in our codebase are sometimes a little bit hard to get right - there are sensitive to declaration order and can lead to cryptic errors. I think this specific case is a good candidate for using overloads though. Unless we can think of a scenario when the first overload shouldn't be preferred and when the second one should be chosen instead then this should be OK to go in.

EDIT:// disregard what I have just said. If anything - overloads can make it harder to infer stuff correctly.