### PR TITLE
Call `Inspector`'s `subscribe` callback immediately with the current state at the subscription time

### DIFF
--- a/.changeset/forty-chicken-train.md
+++ b/.changeset/forty-chicken-train.md
@@ -1,0 +1,5 @@
+---
+'@xstate/inspect': minor
+---
+
+`Inspector`'s `subscribe` callback will now get immediately called with the current state at the subscription time.

--- a/packages/xstate-inspect/src/browser.ts
+++ b/packages/xstate-inspect/src/browser.ts
@@ -203,6 +203,7 @@ export function inspect(
       const observer = toObserver(next, onError, onComplete);
 
       listeners.add(observer);
+      observer.next(inspectService.state);
 
       return {
         unsubscribe: () => {


### PR DESCRIPTION
As requested last week. I wonder though if this really should be exposed like that - this is exposing the `inspectMachine`'s state as part of the public API. It could mean that any change to it could be considered a breaking change.