### PR TITLE
[core] Fix race condition when stopping child of initializing parent machine

### DIFF
--- a/.changeset/large-crabs-serve.md
+++ b/.changeset/large-crabs-serve.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-A race condition occurred when a grandchild service is immediately stopped and the child service tried to remove it from its undefined state; this has been fixed, and the race condition no longer occurs. See https://github.com/statelyai/xstate/issues/2507 for details.
+A race condition occurred when a child service is immediately stopped and the parent service tried to remove it from its undefined state; this has been fixed, and the race condition no longer occurs. See https://github.com/statelyai/xstate/issues/2507 for details.

--- a/.changeset/large-crabs-serve.md
+++ b/.changeset/large-crabs-serve.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+A race condition occurred when a grandchild service is immediately stopped and the child service tried to remove it from its undefined state; this has been fixed, and the race condition no longer occurs. See https://github.com/statelyai/xstate/issues/2507 for details.

--- a/.changeset/large-crabs-serve.md
+++ b/.changeset/large-crabs-serve.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-A race condition occurred when a child service is immediately stopped and the parent service tried to remove it from its undefined state; this has been fixed, and the race condition no longer occurs. See https://github.com/statelyai/xstate/issues/2507 for details.
+A race condition occurred when a child service is immediately stopped and the parent service tried to remove it from its undefined state (during its own initialization). This has been fixed, and the race condition no longer occurs. See [this issue](https://github.com/statelyai/xstate/issues/2507) for details.

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -1013,8 +1013,8 @@ export class Interpreter<
 
     childService
       .onDone((doneEvent) => {
-        this.send(toSCXMLEvent(doneEvent as any, { origin: childService.id }));
         this.removeChild(childService.id);
+        this.send(toSCXMLEvent(doneEvent as any, { origin: childService.id }));
       })
       .start();
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -932,11 +932,12 @@ export class Interpreter<
   }
 
   private removeChild(childId: string): void {
-    this.scheduler.schedule(() => {
-      this.children.delete(childId);
-      this.forwardTo.delete(childId);
-      delete this.state.children[childId];
-    });
+    this.children.delete(childId);
+    this.forwardTo.delete(childId);
+
+    // this.state might not exist at the time this is called,
+    // such as when a child is added then removed while initializing the state
+    delete this.state?.children[childId];
   }
 
   private stopChild(childId: string): void {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -1011,8 +1011,12 @@ export class Interpreter<
 
     childService
       .onDone((doneEvent) => {
-        this.removeChild(childService.id);
-        this.send(toSCXMLEvent(doneEvent as any, { origin: childService.id }));
+        this.scheduler.schedule(() => {
+          this.removeChild(childService.id);
+          this.send(
+            toSCXMLEvent(doneEvent as any, { origin: childService.id })
+          );
+        });
       })
       .start();
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -932,10 +932,11 @@ export class Interpreter<
   }
 
   private removeChild(childId: string): void {
-    this.children.delete(childId);
-    this.forwardTo.delete(childId);
-
-    delete this.state.children[childId];
+    this.scheduler.schedule(() => {
+      this.children.delete(childId);
+      this.forwardTo.delete(childId);
+      delete this.state.children[childId];
+    });
   }
 
   private stopChild(childId: string): void {
@@ -1011,12 +1012,8 @@ export class Interpreter<
 
     childService
       .onDone((doneEvent) => {
-        this.scheduler.schedule(() => {
-          this.removeChild(childService.id);
-          this.send(
-            toSCXMLEvent(doneEvent as any, { origin: childService.id })
-          );
-        });
+        this.send(toSCXMLEvent(doneEvent as any, { origin: childService.id }));
+        this.removeChild(childService.id);
       })
       .start();
 

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1164,7 +1164,7 @@ describe('actors', () => {
     }).not.toThrow();
   });
 
-  it('should not crash on immediate spawned observable completion', () => {
+  it('should not crash on child observable sync completion during self-initialization', () => {
     const createEmptyObservable = (): any => ({
       subscribe(_next, _error, complete) {
         complete();

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1149,7 +1149,7 @@ describe('actors', () => {
 
   it('should not crash on immediate spawned promise completion', () => {
     const parentMachine = createMachine<{
-      child: ActorRef<any> | null;
+      child: ActorRef<never, any> | null;
     }>({
       context: {
         child: null
@@ -1164,14 +1164,14 @@ describe('actors', () => {
     }).not.toThrow();
   });
 
-it('should not crash on immediate spawned observable completion', () => {
+  it('should not crash on immediate spawned observable completion', () => {
     const createEmptyObservable = (): any => ({
       subscribe(_next, _error, complete) {
         complete();
       }
     });
     const parentMachine = createMachine<{
-      child: ActorRef<any> | null;
+      child: ActorRef<never, any> | null;
     }>({
       context: {
         child: null

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1107,7 +1107,7 @@ describe('actors', () => {
   });
 
   // https://github.com/statelyai/xstate/issues/2507
-  it('should not crash on sync child completion during self-initialization', () => {
+  it('should not crash on child machine sync completion during self-initialization', () => {
     const childMachine = createMachine({
       initial: 'idle',
       states: {

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import {
   Machine,
   spawn,

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1147,7 +1147,7 @@ describe('actors', () => {
     }).not.toThrow();
   });
 
-  it('should not crash on immediate spawned promise completion', () => {
+  it('should not crash on immediate spawned promise-like completion', () => {
     const parentMachine = createMachine<{
       child: ActorRef<never, any> | null;
     }>({

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -19,7 +19,7 @@ import {
   forwardTo,
   error
 } from '../src/actions';
-import { interval } from 'rxjs';
+import { interval, EMPTY } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { fromPromise } from '../src/behaviors';
 
@@ -1141,6 +1141,40 @@ describe('actors', () => {
         }
       }
     );
+    const service = interpret(parentMachine);
+    expect(() => {
+      service.start();
+    }).not.toThrow();
+  });
+
+  it('should not crash on immediate spawned promise completion', () => {
+    const parentMachine = createMachine<{
+      child: ActorRef<any> | null;
+    }>({
+      context: {
+        child: null
+      },
+      entry: assign({
+        child: () => spawn(new Promise((res) => res(null)))
+      })
+    });
+    const service = interpret(parentMachine);
+    expect(() => {
+      service.start();
+    }).not.toThrow();
+  });
+
+  it('should not crash on immediate spawned observable completion', () => {
+    const parentMachine = createMachine<{
+      child: ActorRef<any> | null;
+    }>({
+      context: {
+        child: null
+      },
+      entry: assign({
+        child: () => spawn(EMPTY)
+      })
+    });
     const service = interpret(parentMachine);
     expect(() => {
       service.start();

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1107,7 +1107,7 @@ describe('actors', () => {
   });
 
   // https://github.com/statelyai/xstate/issues/2507
-  it('should not crash on sync child completion before stopping', () => {
+  it('should not crash on sync child completion during self-initialization', () => {
     const childMachine = createMachine({
       initial: 'idle',
       states: {

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1155,7 +1155,7 @@ describe('actors', () => {
         child: null
       },
       entry: assign({
-        child: () => spawn(new Promise((res) => res(null)))
+        child: () => spawn({ then: (fn) => fn(null) } as any)
       })
     });
     const service = interpret(parentMachine);

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1147,7 +1147,7 @@ describe('actors', () => {
     }).not.toThrow();
   });
 
-  it('should not crash on immediate spawned promise-like completion', () => {
+  it('should not crash on child promise-like sync completion during self-initialization', () => {
     const parentMachine = createMachine<{
       child: ActorRef<never, any> | null;
     }>({

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -7,8 +7,7 @@ import {
   ActorRefFrom,
   Behavior,
   createMachine,
-  EventObject,
-  actions
+  EventObject
 } from '../src';
 import {
   assign,


### PR DESCRIPTION
This PR fixes #2507 

The problem was a classic race condition:

1. Child machine determining initial state (`this.state` is still `undefined`)
2. Grandchild machine immediately stopping, notifying child machine
3. Child machine trying to remove grandchild from `this.state.children` (remember: `this.state` is still `undefined` at this point) ❌ 

The fix is to _schedule_ the removal of the child, so that it can first complete determining its initial state, so that `this.state` is defined, and then try to remove the child afterward.