### PR TITLE
Split and reorder resources

### DIFF
--- a/docs/about/resources.md
+++ b/docs/about/resources.md
@@ -23,196 +23,199 @@ Explore a collection of professionally-designed state machines and statecharts i
   - [GitHub - Workshop](https://github.com/kyleshevlin/intro-to-state-machines-and-xstate-workshop)
 - [Egghead - Construct Sturdy UIs with XState](https://egghead.io/courses/construct-sturdy-uis-with-xstate) by [Isaac Mann](https://twitter.com/MannIsaac)
 - [XState Guide](https://examples.bradwoods.io/xstate) by [Brad Woods](https://twitter.com/bradwoodsio)
+- [DevTrends: XState](https://devtrends.io/videos/xstate/) by [Anthony Gore](https://twitter.com/anthonygore)
 
 ## Podcasts
 
-- [🎙 (React Podcast) 5: Finite State Machines with David Khourshid](https://reactpodcast.com/episodes/5)
-- [🎙 (React Podcast) 83: David Khourshid on XState, Statecharts, and the Future of Designer—Coder Collaboration](https://reactpodcast.com/episodes/83)
-- [🎙 (Full Stack Radio) 130: David Khourshid - Building Better UI Components with State Machines](https://fullstackradio.com/130)
-- [🎙 (Chats with Kent) Make Your Apps Resilient Using Finite State Machines With David Khourshid](https://kentcdodds.com/chats-with-kent-podcast/seasons/01/episodes/make-your-apps-resilient-finite-state-machines-with-david-khourshid)
-- [🎙 (React Round-Up) 069: The State Machines in React with David Khourshid](https://devchat.tv/react-round-up/rru-069-the-state-machines-in-react-with-david-khourshid/)
-- [🎙 (ShopTalk Show) 327: Working with State Machines with Jon Bellah and David Khourshid](https://shoptalkshow.com/327-working-state-machines/)
-- [🎙 (Egghead.io Podcast) 11: Introduction To State Machines And XState With Kyle Shevlin](https://egghead.io/podcasts/introduction-to-state-machines-and-xstate-with-kyle-shevlin)
-- [🎙 (Syntax.FM) 206: State Machines, CSS and Animations with David K Piano](https://syntax.fm/show/206/state-machines-css-and-animations-with-david-k-piano)
-- [🎙 (Modern Web) S07E20: Building State Machines using XState with David Khourshid](https://modernweb.podbean.com/e/s07e20-modern-web-podcast-building-state-machines-using-xstate-with-david-khourshid/)
+- [🎙 (Modern Web) S07E20: Building State Machines using XState with David Khourshid](https://modernweb.podbean.com/e/s07e20-modern-web-podcast-building-state-machines-using-xstate-with-david-khourshid/) on 2021-01-20
   - [▶️ Video](https://www.youtube.com/watch?v=uLlQjp5u2KQ)
+- [🎙 (React Podcast) 83: David Khourshid on XState, Statecharts, and the Future of Designer—Coder Collaboration](https://reactpodcast.com/episodes/83) on 2020-02-27
+- [🎙 (Syntax.FM) 206: State Machines, CSS and Animations with David K Piano](https://syntax.fm/show/206/state-machines-css-and-animations-with-david-k-piano) on 2019-12-18
+- [🎙 (Egghead.io Podcast) 11: Introduction To State Machines And XState With Kyle Shevlin](https://egghead.io/podcasts/introduction-to-state-machines-and-xstate-with-kyle-shevlin) on 2019-12-17
+- [🎙 (Full Stack Radio) 130: David Khourshid - Building Better UI Components with State Machines](https://fullstackradio.com/130) on 2019-12-11
+- [🎙 (Chats with Kent) Make Your Apps Resilient Using Finite State Machines With David Khourshid](https://kentcdodds.com/chats-with-kent-podcast/seasons/01/episodes/make-your-apps-resilient-finite-state-machines-with-david-khourshid) on 2019-08-05
+- [🎙 (React Round-Up) 069: The State Machines in React with David Khourshid](https://devchat.tv/react-round-up/rru-069-the-state-machines-in-react-with-david-khourshid/) on 2019-07-09
+- [🎙 (ShopTalk Show) 327: Working with State Machines with Jon Bellah and David Khourshid](https://shoptalkshow.com/327-working-state-machines/) on 2018-09-03
+- [🎙 (React Podcast) 5: Finite State Machines with David Khourshid](https://reactpodcast.com/episodes/5) on 2018-04-03
 
-## Articles and Videos
+## Articles
 
-- [XState - a TypeScript state machine with a lot of features](http://realfiction.net/2019/01/30/xstate-a-typescript-state-machine-with-a-lot-of-features) by Frank Quednau
-- [Creating a Complex IVR System with Ease with XState](https://www.nexmo.com/blog/2019/06/20/creating-a-complex-ivr-system-with-ease-with-xstate-dr) by Yonatan Mevorach
-- [My love letter to XState and statecharts ♥](https://dev.to/timdeschryver/my-love-letter-to-xstate-and-statecharts-287b) by Tim Deschryver
-- [StackOverflow: What is an actual difference between redux and a state machine (e.g. xstate)?](https://stackoverflow.com/questions/54482695/what-is-an-actual-difference-between-redux-and-a-state-machine-e-g-xstate/54521035#54521035)
-- [Hyperapp demo with XState](https://github.com/johnkazer/hyperapp-xstate-demo) by [@johnkazer](https://github.com/johnkazer)
-- [A series of examples showing how to model application state with statechart using xstate](https://github.com/coodoo/xstate-examples) by [@coodoo](https://github.com/coodoo/xstate-examples)
-- [Finite State Machines in React JS using XState](https://www.skcript.com/svr/finite-state-machines-in-react-js-using-xstate/) by [Sooraj Nair](https://www.linkedin.com/in/sooraj-nair-a81543172/)
-- [Vuex + XState](https://medium.com/@brockreece/vuex-xstate-4f9ea23bb24e) by [Brock Reece](https://medium.com/@brockreece)
-- [CodePen - XState Vue Login Page](https://codepen.io/ryanzola/pen/PMwoqe) by [Ryan Zola](https://codepen.io/ryanzola)
-- [▶️ Standing on the Shoulders of Giants. Development with XState](https://www.youtube.com/watch?v=GuzcWkVrqLg) by Brad Woods
-  - [Slides and more](https://www.atlassian.com/atlascamp/watch-sessions/2019/advanced-app-development/standing-on-the-shoulders-of-giants-development-with-xstate)
-- [Getting Started with XState](https://www.vietnguyen.site/getting-started-with-xstate/) by Viet Nguyen
-- [How to Effortlessly Model Async (React) with XState's Invoke](https://medium.com/@tahini/how-to-effortlessly-model-async-react-with-xstates-invoke-4c36dc8547b3) by Matthew Jones
-- [XState 新手教學 - Finite State Machine](https://blog.jerry-hong.com/posts/xstate-tutorials-state-machine/?fbclid=IwAR14AL6nwxR5lb78CSABY18rOm2EA7I5f7uaErgZGC0ISmcJFri0VL91_xA) by Jerry Hong
-- [XState 状态管理](https://blog.zfanw.com/xstate-state-management/) by 陈三
-- [▶️ Aplicaciones React usando XState](https://www.youtube.com/watch?v=9P3sLqSiswE) by Luis César Contreras
-- [Replacing Vuex with XState](https://dev.to/felix/replacing-vuex-with-xstate-3097) by [Felix Guerin](https://dev.to/felix)
-- [Communicating with spawned and invoked XState actors in React](https://itnext.io/communicating-with-spawned-and-invoked-xstate-actors-in-react-999cca56506b) by Ismayil Khayredinov
-- [GitLab - TDDing XState](https://gitlab.com/danbunea/tdding-xstate) by Dan Bunea
-- [GitHub - XState Sample Kit](https://github.com/rjdestigter/xstate-sample-kit) by [@rjdestigter](https://github.com/rjdestigter)
-- [▶️ How to Build a simple React App with XState](https://www.youtube.com/watch?v=g_2lt7bBwpk) by Tim Ermilov
-- [XState: The new opportunity for web development](https://medium.com/yakindu/statecharts-a-new-path-for-the-future-of-web-development-9c8a8fb85717) by [@mschulte](https://medium.com/@mschulte_69595)
-- [Undo/Redo in React Using XState](https://dev.to/robertbroersma/undo-redo-in-react-using-xstate-23j8) by [Robert](https://dev.to/robertbroersma)
-  - [CodeSandbox demo](https://codesandbox.io/s/xstate-undo-redo-i3eiu)
-- [State-driven interfaces with XState](https://blog.logrocket.com/state-driven-interfaces-with-xstate/) by [Brad Woods](https://blog.logrocket.com/author/bradwoods/)
-- [React Single File Components with XState](https://dev.to/robertbroersma/react-single-file-components-with-xstate-19k4) by [Robert](https://dev.to/robertbroersma)
-- [An Introduction to State Machines using XState](https://keyholesoftware.com/2020/03/30/an-introduction-to-state-machines-using-xstate/) by [Mat Warger](https://keyholesoftware.com/author/mwarger/)
-  - [GitHub Demo](https://github.com/in-the-keyhole/xstate-demo)
-- [Webinar - Visualize Application State with XState in JavaScript](https://www.youtube.com/watch?v=GhHh_9I6CXQ) by Dani Akash
-- [Modeling parallel states in XState](https://dev.to/jacobmparis/modelling-parallel-states-in-xstate-3pe0) by [Jacob Paris](https://dev.to/jacobmparis)
-  - [XState Text Formatting Part 2](https://dev.to/jacobmparis/xstate-text-formatting-part-2-32ma)
-- [GitHub - a flipping cards game using XState](https://github.com/lednhatkhanh/xstate-flipping-cards-game) by [@lednhatkhanh](https://github.com/lednhatkhanh)
-  - [Playable demo](https://xstate-flipping-cards-game.now.sh/)
-- [GitHub - A Pac Man game, built with React, TypeScript, MobX, styled-components, and XState](https://github.com/stefanwille/pacman-react)
-  - [Playable demo](https://pacman-react.netlify.app/)
-- [GitHub - a small React, XState and Framer Motion demo](https://github.com/tanem/state-machines-in-react) by [@tanem](https://github.com/tanem)
-- [GitHub - Autocomplete example with XState](https://github.com/krzysztofzuraw/xstate-autocomplete) by [@krzysztofzuraw](https://github.com/krzysztofzuraw)
-- [GitHub - a Markdown Editor in Vue.js and XState](https://github.com/sarahdayan/markdown-editor-vue-xstate) by [Sarah Dayan](https://github.com/sarahdayan)
-  - [Live Demo](https://nifty-yalow-295db4.netlify.app/)
-- [Guidelines for State Machines and XState](https://kyleshevlin.com/guidelines-for-state-machines-and-xstate/) by [Kyle Shevlin](https://kyleshevlin.com)
-- [A simple calculator using React and XState (statecharts)](https://github.com/diegoperezm/react-xstate-calc) by [diegoperezm](https://github.com/diegoperezm)
-- [XState Chart Traffic Lights](https://github.com/howardmann/xstate/tree/master/traffic-light) by [@howardmann](https://github.com/howardmann)
+- [How to model application flows in React with finite state machines and XState](https://engineering.kablamo.com.au/posts/2021/finite-state-machines-and-xstate) by [Andrew McDowell](https://twitter.com/madole) on 2021-07-23
+- [Testing XState machines in your React Native app](https://medium.com/welld-tech/testing-xstate-machines-in-your-react-native-app-236fb01bf5b8) by [Simone D'Avico](https://sdavico.medium.com/) on 2021-07-15
+- [Using XState with Deno](https://gustavosantos.dev/a/using-xstate-with-deno) by [Bruno Quaresma](https://twitter.com/bruno__quaresma) on 2021-06-24
+- [Use an XState Machine with React](https://dev.to/jbranchaud/use-an-xstate-machine-with-react-326i) by [Josh Branchaud](https://twitter.com/jbrancha) on 2021-05-09
+- [XState: Should this be an action, or a service?](https://dev.to/mpocock1/xstate-should-this-be-an-action-or-a-service-2cp0) by [Matt Pocock](https://twitter.com/mpocock1) on 2021-04-30
+- [State Machines: Should this be a state, or in context?](https://dev.to/mpocock1/state-machines-should-this-be-a-state-or-in-context-1d7e) by [Matt Pocock](https://twitter.com/mpocock1) on 2021-04-29
+- [XState: What's the difference between Machine and createMachine?](https://dev.to/mpocock1/xstate-what-s-the-difference-between-machine-and-createmachine-15h1) by [Matt Pocock](https://twitter.com/mpocock1) on 2021-04-28
+- [How to Use Finite State Machines in React](https://www.telerik.com/blogs/how-to-use-finite-state-machines-react) by [Leonardo Maldonado](https://www.telerik.com/blogs/author/leonardo-maldonado) on 2021-03-17
+- [Frontend is Rocket Science – Managing state in any JavaScript Application](https://blog.oddeven.ch/blog/frontend-is-rocket-science-managing-state-in-any-javascript-application/) by [Aleksej Dix](https://twitter.com/aleksejdix) on 2021-02-26
+- [Boost your React application's performance by XState](https://dev.to/alirezavalizade/boost-your-react-application-s-performance-by-xstate-42p8) by [Alireza Valizade](https://dev.to/alirezavalizade) on 2021-02-24
+- [Rsvp to weddings with XState](https://dev.to/droopytersen/rsvp-to-weddings-with-xstate-55nl) by [Andrew Peterson](https://dev.to/droopytersen) on 2021-02-19
+- [An Introduction to XState in TypeScript](https://medium.com/giant-machines/an-introduction-to-xstate-in-typescript-e71c7729ce88) by [Neeraj Khosla](https://medium.com/@n.khosla91) on 2021-02-04
+- [An Introduction to Finite State Machines: Simplifying React State Management with State Machines](https://soshace.com/an-introduction-to-finite-state-machines-simplifying-react-state-management-with-state-machines/) by [Bradley Kofi](https://soshace.com/author/bradstarart/) on 2021-02-02 
+- [Integrate XState with React Native and React Navigation](https://medium.com/welld-tech/integrate-xstate-with-react-native-and-react-navigation-21ead87391da) by [Simone D'Avico](https://sdavico.medium.com/) on 2021-02-02
+- [Infinite Scrolling with Svelte 3, XState and IntersectionObserver](https://dev.to/gcdcoder/infinite-scrolling-with-svelte-3-xstate-and-intersectionobserver-127j) by [Gustavo Castillo](https://dev.to/gcdcoder) on 2021-02-01
+- [Untangle complex flows in your React Native app with XState](https://medium.com/welld-tech/untangle-complex-flows-in-your-react-native-app-with-xstate-1b11d0b8a91f) by [Simone D'Avico](https://sdavico.medium.com/) on 2021-01-14
+- ["Just Use Props": An opinionated guide to React and XState](https://dev.to/mpocock1/just-use-props-an-opinionated-guide-to-react-and-xstate-fc9) by [Matt Pocock](https://dev.to/mpocock1) on 2021-01-11
+- [Creating State Machines in JavaScript with XState](https://nisimdor.medium.com/creating-state-machines-in-javascript-with-xstate-21e1599521be) by [Dor Nisim](https://nisimdor.medium.com/) on 2021-01-10
+- [Future of state management in React with XState](https://blog.jskoneczny.pl/post/future-of-state-management-in-react-with-xstate) by [Jakub Skoneczny](https://blog.jskoneczny.pl/) on 2021-01-05
+- [Learning XState by refactoring an old project](https://fvsch.com/learning-xstate) by [Florens Verschelde](https://fvsch.com/) on 2021-01-01
+- [React context without context, using XState – CodeWithSwiz 14, 15](https://swizec.com/blog/react-context-without-context-using-xstate-codewithswiz-14-15) by [@swizec](https://swizec.com) on 2020-11-10
+- [State Machines Workshop with XState](https://github.com/ooade/state-machines-workshop) by [Ademola (@ooade)](https://github.com/ooade) on 2020-11-06
+- [Tes en Línea: React, TypeScript, XState, fp-ts & CSS Grid (esp)](https://medium.com/codingedgar/tes-en-l%C3%ADnea-react-typescript-xstate-fp-ts-css-grid-esp-1373236189d1) by [Edgar Rodriguez](https://medium.com/@codingedgar) on 2020-10-29
+- [How to write tests for XState](https://swizec.com/blog/how-to-write-tests-for-xstate-codewithswiz-12/) by [@swizec](https://swizec.com) on 2020-10-13
+- [Create-React-App Template with XState](https://github.com/kwdowik/cra-template-xstate) by [Kacper Wdowik](https://github.com/kwdowik) on 2020-10-18
+- [XState Brain Teaser #1 - Auth Flow](https://dev.to/mpocock1/xstate-brain-teaser-1-auth-flow-2jhl) by [Matt Pocock](https://twitter.com/mpocock1) on 2020-10-09
+- [Refactoring a useReducer to XState, Part 1](https://swizec.com/blog/refactoring-a-usereducer-to-xstate-pt1-codewithswiz-11/) by [@swizec](https://swizec.com) on 2020-10-08
+- [How State Machines Saved Our Bacon 🥓](https://www.ianjones.us/xstate-saves-our-bacon) by [Ian Jones](https://www.ianjones.us/) on approximately 2020-10-01
+- [Finite State Machines in React JS using XState JS](https://dev.to/soorajsnblaze333/finite-state-machines-in-react-js-using-xstate-36ho) by [Sooraj](https://dev.to/soorajsnblaze333) on 2020-09-23
+  - [CodeSandbox example](https://codesandbox.io/s/small-sea-t5mce?file=/pages/index.js/)
+- [My First Machine, Getting Started with XState and Angular](https://calebukle.com/blog/my-first-machine-getting-started-with-xstate-and-angular) by [Caleb Ukle](https://calebukle.com) on 2020-09-11
+- [State Machines For Everyone](https://medium.com/well-red/state-machines-for-everyone-part-1-introduction-b7ac9aaf482e) by [Alex Dodge](https://medium.com/@alexmdodge) on 2020-09-08
+- [State machines in Production](https://moduscreate.com/blog/state-machines-in-production/) by [Ivan Kovic](https://twitter.com/kobeljic) on 2020-09-02
+- [Testing XState with React Testing Library](https://dev.to/joepurnell1/testing-xstate-with-react-testing-library-26kh) by [Joe Purnell](https://dev.to/joepurnell1) on 2020-08-27
+- [When your brain is breaking, try XState](https://swizec.com/blog/when-your-brain-is-breaking-try-xstate) by [@swizec](https://swizec.com) on 2020-08-10
+- [Todo App with XState and Vue composition API](https://dev.to/jasmin/todo-app-with-xstate-and-vue-composition-api-52ae) by [Jasmin Virdi](https://dev.to/jasmin) on 2020-08-03
+- [Firebase authentication with XState and Svelte](https://codechips.me/firebase-authentication-with-xstate-and-svelte/) by [@codechips](https://github.com/codechips) on 2020-07-31
+- [SWR-Style Fetching with XState State Machines](https://imfeld.dev/writing/swr_with_xstate) by [Daniel Imfeld](https://imfeld.dev) on 2020-07-21
+- [Hello XState Part 3: Writing my first state machines (and washing my hands)](https://dev.to/ekafyi/hello-xstate-part-3-writing-my-first-state-machines-and-washing-my-hands-for-20-seconds-23p) by by [Eka](https://dev.to/ekafyi) on 2020-07-21
+- [Intro: XState and State Machines (React)](https://medium.com/@d_danailov/intro-sstate-and-state-machines-react-3b873a6a713d) by [Dimitar Danailov](https://medium.com/@d_danailov) on 2020-07-17
+- [XState, React, and TypeScript - how to get it working](https://dev.to/mpocock1/xstate-react-and-typescript-how-to-get-it-working-4p18) by [Matt Pocock](https://dev.to/mpocock1) on 2020-07-17
+- [Hello XState Part 2: Exploring the XState Viz example](https://dev.to/ekafyi/hello-xstate-part-2-exploring-the-xstate-viz-example-1nc1) by [Eka](https://dev.to/ekafyi) on 2020-07-13
+- [Slides - Working with State Machines in Angular](https://slides.com/stli/xstate-angular-nl) with XState by [Stefanos Lignos](https://twitter.com/stefanos_lig) on 2020-07-20
+  - [GitHub - code](https://github.com/codechips/svelte-firebase-auth-xstate-example)
+- [Hello XState Part 1: Learning state machines for frontend web development](https://dev.to/ekafyi/hello-xstate-learning-state-machines-for-frontend-web-development-5bin) by [Eka](https://dev.to/ekafyi) on 2020-07-12
+- [Comparing state machines: XState vs. Robot](https://blog.logrocket.com/comparing-state-machines-xstate-vs-robot/) by [Samaila Bala](https://blog.logrocket.com/author/samailabala/) on 2020-07-09
+- [Starting with State Machines and XState!](https://dev.to/jasmin/starting-with-state-machine-and-xstate-1972) by [Jasmin Virdi](https://dev.to/jasmin) on 2020-07-06
+- [Learn and Apply XState with Vonage Video](https://dev.to/vonagedev/learn-and-apply-xstate-with-vonage-video-5dfg) by [Kelly Andrews](https://dev.to/kellyjandrews) on 2020-07-01
+  - [Article on Nexmo.com](https://www.nexmo.com/blog/2020/07/01/learn-and-apply-xstate-with-vonage-video)
+- [Introduction to XState](https://flaviocopes.com/xstate/) by [Flavio Copes](https://flaviocopes.com/) on 2020-06-26
+- [Multistep form handling with Finite State Machines, Formik and TypeScript](https://thewidlarzgroup.com/multistep-form-xstate-formik/) by Daniel Grychtoł on 2020-06-17
+- [Intro to XState - a true state management library for React](https://medium.com/@pavlo_lompas/intro-to-xstate-a-true-state-management-system-library-for-react-d8c0051c71e4) by [Pavlo Lompas](https://medium.com/@pavlo_lompas) on 2020-06-15
+- [Remake of the 100 squares game](https://onehundred.now.sh/) by [@nikpundik](https://twitter.com/nikpundik) on 2020-06-05
+  - [Tweet with demo](https://twitter.com/nikpundik/status/1268936078737670145)
+- [ThoughtWorks - XState in the Technology Radar for Languages & Frameworks](https://www.thoughtworks.com/radar/languages-and-frameworks/xstate) on 2020-05-19
+- [A front-end journey into XState](https://medium.com/@roberthigdon/a-front-end-journey-into-xstate-d13691b9165d) by [Robert Higdon](https://medium.com/@roberthigdon) on 2020-05-15
+- [GitHub - Stripe Machine Example](https://github.com/JacobParis/stripe-machine-example): An animated stripe checkout using XState and React by [@JacobParis](https://github.com/JacobParis) on 2020-05-08
+- [XState and Svelte: initial setup](https://geoexamples.com/svelte/2020/05/08/xstate-svelte-I.html) by [@rveciana](https://github.com/rveciana) on 2020-05-08
+- [How To Build Finite State Machines using XState and React](https://www.ibrahima-ndaw.com/blog/xstate-react-finite-state-machine/) by [Ibrahima Ndaw](https://www.ibrahima-ndaw.com) on 2020-04-21
+  - [Post on Dev.to](https://dev.to/ibrahima92/how-to-build-finite-state-machines-using-xstate-and-react-1o8g)
+- [XState Minesweeper](https://github.com/lednhatkhanh/xstate-minesweeper) by [@lednhatkhanh](https://github.com/lednhatkhanh/xstate-minesweeper) on 2020-04-16
+  - [Playable demo](https://xstate-minesweeper.now.sh/)
+- [XState Chart Traffic Lights](https://github.com/howardmann/xstate/tree/master/traffic-light) by [@howardmann](https://github.com/howardmann) on 2020-04-16
   - [Demo link](http://xstatetrafficlight.surge.sh/)
   - [XState visualization](https://xstate.js.org/viz/?gist=1b9e1bcf75b1fed19190adc9f39b895e)
-- [XState Minesweeper](https://github.com/lednhatkhanh/xstate-minesweeper) by [@lednhatkhanh](https://github.com/lednhatkhanh/xstate-minesweeper)
-  - [Playable demo](https://xstate-minesweeper.now.sh/)
-- [Tips and tricks of using XState for UI development](https://github.com/farskid/xstate.tips) by [@farskid](https://github.com/farskid)
-  - [Link: XState.Tips](https://xstate.tips/)
-- [Tic-Tac-Toe with Crank, XState, and TypeScript](https://github.com/mwarger/tic-tac-toe-crank-xstate-typescript) by [@warger](https://github.com/mwarger)
-- [How To Build Finite State Machines using XState and React](https://www.ibrahima-ndaw.com/blog/xstate-react-finite-state-machine/) by [Ibrahima Ndaw](https://www.ibrahima-ndaw.com)
-  - [Post on Dev.to](https://dev.to/ibrahima92/how-to-build-finite-state-machines-using-xstate-and-react-1o8g)
-- [GitHub - Practical examples of statechart-based solutions with XState](https://github.com/DevanB/xstate-examples) by [@DevanB](https://github.com/DevanB)
-- [▶️ Improving Application Predictability with XState](https://www.youtube.com/watch?v=MbS2TQj4Xsc) by [Sam Edwards](https://twitter.com/sjoedwards)
-- [A front-end journey into XState](https://medium.com/@roberthigdon/a-front-end-journey-into-xstate-d13691b9165d) by [Robert Higdon](https://medium.com/@roberthigdon)
-- [ThoughtWorks - XState in the Technology Radar for Languages & Frameworks](https://www.thoughtworks.com/radar/languages-and-frameworks/xstate)
-- [XState and Svelte: initial setup](https://geoexamples.com/svelte/2020/05/08/xstate-svelte-I.html)
-- [GitHub - Stripe Machine Example](https://github.com/JacobParis/stripe-machine-example): An animated stripe checkout using XState and React by [@JacobParis](https://github.com/JacobParis)
-- [▶️ Creating a `useAutoSave` Hook - Part 5: Using XState](https://www.youtube.com/watch?v=JPgd1RG-rOk) by [Brooks Lybrand](https://twitter.com/BrooksLybrand)
-  - [CodeSandbox](https://codesandbox.io/s/useautosavefinal-xhsyx?file=/src/useAutoSave-5.js)
-- [▶️ Authentication statechart in XState](https://www.youtube.com/watch?v=lIge4KWq6Xc) by [Brooks Lybrand](https://twitter.com/BrooksLybrand)
-- [Drag & Drop State Machine! Learning XState with David](https://www.youtube.com/watch?v=osaszd2aU9U) on the [Keyframers](https://twitter.com/keyframers)
-- [▶️ Isaac && Zack Code Jam #2: State Machines and XState](https://www.youtube.com/watch?v=emAUbr0XHqg)
-  - [▶️ Part 3](https://www.youtube.com/watch?v=R2vzzuUkjV0)
-- [Improving state representation by using XState in React](https://www.youtube.com/watch?v=hG3UHNCUdzQ) by [Jon Major Condon](https://www.youtube.com/channel/UCQB-QsEnKCvJX4e_ms9XvHA)
-- [Remake of the 100 squares game](https://onehundred.now.sh/) by [@nikpundik](https://twitter.com/nikpundik)
-  - [Tweet with demo](https://twitter.com/nikpundik/status/1268936078737670145)
-- [Intro to XState - a true state management library for React](https://medium.com/@pavlo_lompas/intro-to-xstate-a-true-state-management-system-library-for-react-d8c0051c71e4) by [Pavlo Lompas](https://medium.com/@pavlo_lompas)
-- [Multistep form handling with Finite State Machines, Formik and TypeScript](https://thewidlarzgroup.com/multistep-form-xstate-formik/) by Daniel Grychtoł
-- [CodeSandbox - XState Login & Sign Up Forms](https://codesandbox.io/s/xstate-login-sign-up-forms-yzzoc) by [Jamie Mason](https://github.com/JamieMason)
-- [Introduction to XState](https://flaviocopes.com/xstate/) by [Flavio Copes](https://flaviocopes.com/)
-- [▶️ Autocomplete, XState, and anything in between](https://www.youtube.com/watch?v=7CP-OUcUq2Q) by [Krzysztof Żuraw](https://krzysztofzuraw.com)
-- [▶️ How to add an XState machine conf to a project](https://www.youtube.com/watch?v=A0bLzjQdZPU) by [Diego Perez](https://www.youtube.com/channel/UCxr-10LjbO-CTiPRcCLyRyg)
-- [▶️ Part 1: Tic-tac-toe - Let's build (using JavaScript, React, Cypress and XState)](https://www.youtube.com/watch?v=uVySNh6ud2w)
-  - [▶️ Part 2](https://www.youtube.com/watch?v=LtqTNATLIlY)
-  - [▶️ Part 3](https://www.youtube.com/watch?v=t5WU1oZeBQw)
-- [Learn and Apply XState with Vonage Video](https://dev.to/vonagedev/learn-and-apply-xstate-with-vonage-video-5dfg) by [Kelly Andrews](https://dev.to/kellyjandrews)
-  - [Article on Nexmo.com](https://www.nexmo.com/blog/2020/07/01/learn-and-apply-xstate-with-vonage-video)
-- [Starting with State Machines and XState!](https://dev.to/jasmin/starting-with-state-machine-and-xstate-1972) by [Jasmin Virdi](https://dev.to/jasmin)
-  - [Todo App with XState and Vue composition API](https://dev.to/jasmin/starting-with-state-machine-and-xstate-1972)
-- [Comparing state machines: XState vs. Robot](https://blog.logrocket.com/comparing-state-machines-xstate-vs-robot/) by [Samaila Bala](https://blog.logrocket.com/author/samailabala/)
-- [Hello XState Part 1: Learning state machines for frontend web development](https://dev.to/ekafyi/hello-xstate-learning-state-machines-for-frontend-web-development-5bin) by [Eka](https://dev.to/ekafyi)
-  - [Hello XState Part 2: Exploring the XState Viz example](https://dev.to/ekafyi/hello-xstate-part-2-exploring-the-xstate-viz-example-1nc1)
-  - [Hello XState Part 3: Writing my first state machines (and washing my hands)](https://dev.to/ekafyi/hello-xstate-part-3-writing-my-first-state-machines-and-washing-my-hands-for-20-seconds-23p)
-- [▶️ The Actor Model | XState part 1](https://www.youtube.com/watch?v=4CLdNeetVHw) by [@bisvarup](https://bisvarup.me/)
-  - [CodeSandbox example](https://codesandbox.io/s/ancient-framework-bvw61?file=/src/App.js)
-- [Intro: XState and State Machines (React)](https://medium.com/@d_danailov/intro-sstate-and-state-machines-react-3b873a6a713d) by [Dimitar Danailov](https://medium.com/@d_danailov)
-- [▶️ Learning XState with Lauren](https://www.youtube.com/watch?v=h5H1ZmjMDE4) on Lauren Learns Things
-- [XState, React, and TypeScript - how to get it working](https://dev.to/mpocock1/xstate-react-and-typescript-how-to-get-it-working-4p18) by [Matt Pocock](https://dev.to/mpocock1)
-- [XState Pizza Wizard!](https://www.youtube.com/watch?v=JauJhGTBFsc) by [Jack Herrington](https://github.com/jherr)
-  - [GitHub - Code](https://github.com/jherr/xstate-pizza-orderer)
-- [SWR-Style Fetching with XState State Machines](https://imfeld.dev/writing/swr_with_xstate) by [Daniel Imfeld](https://imfeld.dev)
-- [Slides - Working with State Machines in Angular](https://slides.com/stli/xstate-angular-nl) with XState by [Stefanos Lignos](https://twitter.com/stefanos_lig)
-- [Firebase authentication with XState and Svelte](https://codechips.me/firebase-authentication-with-xstate-and-svelte/) by [@codechips](https://github.com/codechips)
-  - [GitHub - code](https://github.com/codechips/svelte-firebase-auth-xstate-example)
-- [▶️ Model Based Testing with XState | Why It's Great | Part 1](https://www.youtube.com/watch?v=tkxH7o-n9sI) by [John Bales](https://www.youtube.com/channel/UCVYw7ad200ZmvsZ0BVC9YvA)
-  - [▶️ Model Based Testing with XState | The Basics | Part 2](https://www.youtube.com/watch?v=9_dWCweA8Pk)
-  - [▶️ Model Based Testing with XState | Path Generation with Context | Part 3](https://www.youtube.com/watch?v=9gQulfnG7HM)
-- [▶️ Mini Introducción a XState](https://www.youtube.com/watch?v=brMpOOAOUZ4) by [Michell Ayala](https://www.youtube.com/channel/UCBXo5FFDCtNoddUOqZuWX7w)
-  - [▶️ React + XState](https://www.youtube.com/watch?v=Z7LIsZfQ4LU)
-- [Testing XState with React Testing Library](https://dev.to/joepurnell1/testing-xstate-with-react-testing-library-26kh) by [Joe Purnell](https://dev.to/joepurnell1)
-- [▶️ Easy Introduction to XState in React | States, Transitions, Guards, and (Actions](https://www.youtube.com/watch?v=PRwDOSjIFg8) by [Bhargav Ponnapalli](https://www.youtube.com/channel/UC4gKWR53xDzybMwm8Y61ukA)
-- [▶️ State-driven Interfaces with XState](https://www.youtube.com/watch?v=bPUgBHFfQdI) on [Mozilla Indonesia](https://www.youtube.com/channel/UCUwngm8TCj0mhsvKTO2q5fQ)
-- [▶️ Virtual Lunch & Learn: Let's build an app using Svelte, TypeScript, XState and Tailwind](https://www.youtube.com/watch?v=-FiN2Svpk2s) by Anders Bech Mellson
-- [▶️ Refactoring with XState - Part 1](https://www.youtube.com/watch?v=hZ1vaMJnKx0) by [VigsCodes](https://www.youtube.com/channel/UCAFlrYILud3-3MCs8nsDiAA)
-- [State machines in Production](https://moduscreate.com/blog/state-machines-in-production/) by [Ivan Kovic](https://twitter.com/kobeljic)
-- [When your brain is breaking, try XState](https://swizec.com/blog/when-your-brain-is-breaking-try-xstate) by [@swizec](https://swizec.com)
-- [GitHub - Cypress Real-World App](https://github.com/cypress-io/cypress-realworld-app)
-- [State Machines For Everyone](https://medium.com/well-red/state-machines-for-everyone-part-1-introduction-b7ac9aaf482e) by [Alex Dodge](https://medium.com/@alexmdodge)
-- [My First Machine, Getting Started with XState and Angular](https://calebukle.com/blog/my-first-machine-getting-started-with-xstate-and-angular) by [Caleb Ukle](https://calebukle.com)
-- [▶️ Reducing state complexity with XState](https://www.youtube.com/watch?v=CpxL-4oIZPw) by [Kishore](www.github.com/pkishoez)
-- [Finite State Machines in React JS using XState JS](https://dev.to/soorajsnblaze333/finite-state-machines-in-react-js-using-xstate-36ho) by [Sooraj](https://dev.to/soorajsnblaze333)
-- [▶️ Managing UI Complexity with Statecharts (playlist)](https://www.youtube.com/playlist?list=PLsVj0cy-DbErFraf3KeAUbzVl-OKyBZ0-)
-- [How State Machines Saved Our Bacon 🥓](https://www.ianjones.us/xstate-saves-our-bacon) by [Ian Jones](https://www.ianjones.us/)
-- [Refactoring a useReducer to XState, Part 1](https://swizec.com/blog/refactoring-a-usereducer-to-xstate-pt1-codewithswiz-11/) by [@swizec](https://swizec.com)
-- [▶️ XState and React](https://www.youtube.com/watch?v=pclR8Q5mbNI) on [Leniolabs](https://www.youtube.com/channel/UCcRg2Au0LLtEcakG9fg6VXg)
-  - [CodeSandbox example](https://codesandbox.io/s/small-sea-t5mce?file=/pages/index.js/)
-- [How to write tests for XState](https://swizec.com/blog/how-to-write-tests-for-xstate-codewithswiz-12/) by [@swizec](https://swizec.com)
-- [Create-React-App Template with XState](https://github.com/kwdowik/cra-template-xstate) by [Kacper Wdowik](https://github.com/kwdowik)
-- [XState and State Machines in VueJS](https://www.youtube.com/watch?v=8y9wUwJvdGs) by [Constantin Druc](https://www.youtube.com/channel/UCsMdRMBnxIVO0K_YS0KHiMA)
-- [Tes en Línea: React, TypeScript, XState, fp-ts & CSS Grid (esp)](https://medium.com/codingedgar/tes-en-l%C3%ADnea-react-typescript-xstate-fp-ts-css-grid-esp-1373236189d1) by [Edgar Rodriguez](https://medium.com/@codingedgar)
-- [Supervising XState Machines with Redux](https://dev.to/rjdestigter/supervising-xstate-machines-with-redux-277d) by [John de Stigter](https://dev.to/rjdestigter)
-- [Working with non-user asynchronous events in model based tests with XState](https://dev.to/rjdestigter/working-with-non-user-asynchronous-events-in-model-based-tests-with-xstate-58ek) by [John de Stigter](https://dev.to/rjdestigter)
-- [Model based UI tests with XState, Cypress, Puppeteer & more](https://dev.to/rjdestigter/model-based-ui-tests-with-xstate-cypress-puppeteer-more-268d) by [John de Stigter](https://dev.to/rjdestigter)
-- [Thoughts on State Management with XState and ReactJS](https://dev.to/rjdestigter/thoughts-on-state-management-with-xstate-and-reactjs-3d19) by [John de Stigter](https://dev.to/rjdestigter)
-- [▶️ Tutorial of C++ Code Generator for XState State Machine engine](https://www.youtube.com/watch?v=DnuJFUR1SgA) by [Andrew Shuvalov](https://www.youtube.com/channel/UCHFfZT1QM-vnqSZKtrT0e6g)
+- [A simple calculator using React and XState (statecharts)](https://github.com/diegoperezm/react-xstate-calc) by [diegoperezm](https://github.com/diegoperezm) on 2020-04-15
+- [Modeling parallel states in XState](https://dev.to/jacobmparis/modelling-parallel-states-in-xstate-3pe0) by [Jacob Paris](https://dev.to/jacobmparis) on 2020-04-05
+  - [XState Text Formatting Part 2](https://dev.to/jacobmparis/xstate-text-formatting-part-2-32ma)
+- [Guidelines for State Machines and XState](https://kyleshevlin.com/guidelines-for-state-machines-and-xstate/) by [Kyle Shevlin](https://kyleshevlin.com) on 2020-04-03
+- [An Introduction to State Machines using XState](https://keyholesoftware.com/2020/03/30/an-introduction-to-state-machines-using-xstate/) by [Mat Warger](https://keyholesoftware.com/author/mwarger/) on 2020-03-30
+  - [GitHub Demo](https://github.com/in-the-keyhole/xstate-demo)
+- [React Single File Components with XState](https://dev.to/robertbroersma/react-single-file-components-with-xstate-19k4) by [Robert](https://dev.to/robertbroersma) on 2020-03-29
+- [State-driven interfaces with XState](https://blog.logrocket.com/state-driven-interfaces-with-xstate/) by [Brad Woods](https://blog.logrocket.com/author/bradwoods/) on 2020-03-23
+- [Undo/Redo in React Using XState](https://dev.to/robertbroersma/undo-redo-in-react-using-xstate-23j8) by [Robert](https://dev.to/robertbroersma) on 2020-03-22
+  - [CodeSandbox demo](https://codesandbox.io/s/xstate-undo-redo-i3eiu)
+- [Working with non-user asynchronous events in model based tests with XState](https://dev.to/rjdestigter/working-with-non-user-asynchronous-events-in-model-based-tests-with-xstate-58ek) by [John de Stigter](https://dev.to/rjdestigter) on 2020-03-18
+- [Supervising XState Machines with Redux](https://dev.to/rjdestigter/supervising-xstate-machines-with-redux-277d) by [John de Stigter](https://dev.to/rjdestigter) on 2020-03-16
+- [Model based UI tests with XState, Cypress, Puppeteer & more](https://dev.to/rjdestigter/model-based-ui-tests-with-xstate-cypress-puppeteer-more-268d) by [John de Stigter](https://dev.to/rjdestigter) on 2020-03-12
+- [Thoughts on State Management with XState and ReactJS](https://dev.to/rjdestigter/thoughts-on-state-management-with-xstate-and-reactjs-3d19) by [John de Stigter](https://dev.to/rjdestigter) on 2020-03-08
+- [XState: The new opportunity for web development](https://medium.com/yakindu/statecharts-a-new-path-for-the-future-of-web-development-9c8a8fb85717) by [@mschulte](https://medium.com/@mschulte_69595) on 2020-03-05
+- [Communicating with spawned and invoked XState actors in React](https://itnext.io/communicating-with-spawned-and-invoked-xstate-actors-in-react-999cca56506b) by Ismayil Khayredinov on 2020-02-02
+- [Replacing Vuex with XState](https://dev.to/felix/replacing-vuex-with-xstate-3097) by [Felix Guerin](https://dev.to/felix) on 2020-01-28
+- [XState 状态管理](https://blog.zfanw.com/xstate-state-management/) by 陈三 on 2019-12-31
+- [XState 新手教學 - Finite State Machine](https://blog.jerry-hong.com/posts/xstate-tutorials-state-machine/?fbclid=IwAR14AL6nwxR5lb78CSABY18rOm2EA7I5f7uaErgZGC0ISmcJFri0VL91_xA) by Jerry Hong on 2019-12-08
+- [How to Effortlessly Model Async (React) with XState's Invoke](https://medium.com/@tahini/how-to-effortlessly-model-async-react-with-xstates-invoke-4c36dc8547b3) by Matthew Jones on 2019-10-30
+- [Getting Started with XState](https://www.vietnguyen.site/getting-started-with-xstate/) by Viet Nguyen on 2019-10-09
+- [A series of examples showing how to model application state with statechart using xstate](https://github.com/coodoo/xstate-examples) by [@coodoo](https://github.com/coodoo/xstate-examples) on 2019-09-27
+- [Finite State Machines in React JS using XState](https://www.skcript.com/svr/finite-state-machines-in-react-js-using-xstate/) by [Sooraj Nair](https://www.linkedin.com/in/sooraj-nair-a81543172/) on 2019-08-22
+- [Hyperapp demo with XState](https://github.com/johnkazer/hyperapp-xstate-demo) by [@johnkazer](https://github.com/johnkazer) on 2019-07-23
+- [My love letter to XState and statecharts ♥](https://dev.to/timdeschryver/my-love-letter-to-xstate-and-statecharts-287b) by Tim Deschryver on 2019-07-08
+- [Creating a Complex IVR System with Ease with XState](https://www.nexmo.com/blog/2019/06/20/creating-a-complex-ivr-system-with-ease-with-xstate-dr) by Yonatan Mevorach on 2019-06-20
+- [StackOverflow: What is an actual difference between redux and a state machine (e.g. xstate)?](https://stackoverflow.com/questions/54482695/what-is-an-actual-difference-between-redux-and-a-state-machine-e-g-xstate/54521035#54521035) by David Khourshid on 2019-02-04
+- [XState - a TypeScript state machine with a lot of features](http://realfiction.net/2019/01/30/xstate-a-typescript-state-machine-with-a-lot-of-features) by Frank Quednau on 2019-01-30
+- [Vuex + XState](https://medium.com/@brockreece/vuex-xstate-4f9ea23bb24e) by [Brock Reece](https://medium.com/@brockreece) on 2017-09-17
+
+## Videos
+
+- [▶️ Splitting the view and the brains in JS — state machines with XState (in French)](https://www.youtube.com/watch?v=yRB57CDvQuY) by [Aurelien Meunier](https://www.linkedin.com/in/aumeunier) on 2021-06-22
+- [▶️ Front-end state management with XState](https://www.youtube.com/watch?v=Slb6M_rIn0M) by [Amy Pellegrini](https://twitter.com/amyvpellegrini) on 2021-06-09
+- [▶️ Maquinas de estado finito y gráficas de estado en React ](https://www.youtube.com/watch?v=Rm6AMY6-Wqw) by José L Narajo on 2021-03-19
+- [▶️ Use State Machines to Build a Queue for Custom Twitch Overlays — Learn With Jason](https://www.youtube.com/watch?v=UzA5Mvk587M) by [Jason Lengstorf](https://www.youtube.com/channel/UCnty0z0pNRDgnuoirYXnC5A) on 2021-02-26
+- [▶️ Getting Started with XState, React, and Typescript | Part 1](https://www.youtube.com/watch?v=po1YRAk7irY) by [Modus Create](https://www.youtube.com/channel/UCsKwL0-e2eHRNa6Ne99AESw) on 2021-02-18
+- [▶️ Modelling application behaviour with the XState library (in React)](https://www.youtube.com/watch?v=paZ4ImyI1YQ) by [Marc Klefter](https://twitter.com/marcklefter) on 2021-02-11
+- [▶️ Custom Svelte Store: XState as Svelte store](https://www.youtube.com/watch?v=NIfQsc5XAzU) by [lihautan](https://www.youtube.com/channel/UCbmC3HP3FaAFdcZkui8YoMQ) on 2021-02-10
+- [▶️ XState Introduction](https://www.youtube.com/watch?v=clu2bqjk3c0) on [For Those Who Code](https://www.youtube.com/channel/UCS3-MF_4ADqglU2OSly4vIw) on 2021-02-08
+- [▶️ XState - Global state in React](https://www.youtube.com/watch?v=1kJcnFBrk2I) by [Matt Pocock](https://twitter.com/mpocock1) on 2021-02-04
+- [▶️ Finite State Machine on Frontend](https://www.youtube.com/watch?v=gCT-lCYYhf4) by [Eugenia Zigisova](https://twitter.com/jevgeniazi) on 2021-01-20
+- [▶️ Typing XState in Vue 3](https://www.youtube.com/watch?v=7tT45eRmyJE) by [JacoboCode](https://www.youtube.com/channel/UCcE2YngHoargpdjIzkCNY2Q) on 2021-01-18
+- [▶️ Infinite Scrolling con Svelte, IntersectionObserver & XState (en español)](https://www.youtube.com/watch?v=GMXrwrG0cL4) by [GCD Coder](https://www.youtube.com/channel/UCwkisgTJdCx3mNZMaaHAaVA) on 2021-01-13
+- [▶️ Getting Started with XState in Vue 3](https://www.youtube.com/watch?v=g4YnmydXMP8) by [JacoboCode](https://www.youtube.com/channel/UCcE2YngHoargpdjIzkCNY2Q) on 2021-01-05
+- [▶️ Usando XState y React para hacer peticiones HTTP (en español)](https://www.youtube.com/watch?v=Wo-rVyAsz-Q) by [GCD Coder](https://www.youtube.com/channel/UCwkisgTJdCx3mNZMaaHAaVA) on 2020-12-29
+- [▶️ Modeling a Voicemail Widget with XState](https://www.youtube.com/watch?v=D6LzWcV_-14) by [Constantin Druc](https://www.youtube.com/channel/UCsMdRMBnxIVO0K_YS0KHiMA) on 2020-12-20
+- [▶️ React Wednesdays: XState and JavaScript State Machines](https://www.youtube.com/watch?v=1TT2ymkYGyM) on 2020-12-09
+- [▶️ Frontend is Rocket Science - How to use XState in Vue 3 Now!](https://www.youtube.com/watch?v=wRktleOGKS4) by [Aleksej Dix](https://twitter.com/aleksejdix) on 2020-11-06
+- [▶️ Finite State Machines in Vue 3](https://www.youtube.com/watch?v=fT9p9CCSrn8) by [Sarah Dayan](https://twitter.com/frontstuff_io) on 2020-11-06
+- [▶️ Tutorial of C++ Code Generator for XState State Machine engine](https://www.youtube.com/watch?v=DnuJFUR1SgA) by [Andrew Shuvalov](https://www.youtube.com/channel/UCHFfZT1QM-vnqSZKtrT0e6g) on 2020-10-30
   - [▶️ Part 2](https://www.youtube.com/watch?v=8TTfRrmNu0s)
   - [▶️ Part 3](https://www.youtube.com/watch?v=HoH68709Sq8)
   - [GitHub Project](https://github.com/shuvalov-mdb/xstate-cpp-generator)
-- [React context without context, using XState – CodeWithSwiz 14, 15](https://swizec.com/blog/react-context-without-context-using-xstate-codewithswiz-14-15) by [@swizec](https://swizec.com)
-- [State Machines Workshop with XState](https://github.com/ooade/state-machines-workshop) by [Ademola (@ooade)](https://github.com/ooade)
-- [▶️ Finite State Machines in Vue 3](https://www.youtube.com/watch?v=fT9p9CCSrn8) by [Sarah Dayan](https://twitter.com/frontstuff_io)
-- [▶️ Frontend is Rocket Science - How to use XState in Vue 3 Now!](https://www.youtube.com/watch?v=wRktleOGKS4) by [Aleksej Dix](https://twitter.com/aleksejdix)
-- [▶️ React Wednesdays: XState and JavaScript State Machines](https://www.youtube.com/watch?v=1TT2ymkYGyM)
-- [▶️ Declarative and manageable state management with XState](https://www.youtube.com/watch?v=jCbV5aELY6A) on Decoupled Days
-- [▶️ Modeling a Voicemail Widget with XState](https://www.youtube.com/watch?v=D6LzWcV_-14) by [Constantin Druc](https://www.youtube.com/channel/UCsMdRMBnxIVO0K_YS0KHiMA)
-- [XState Brain Teaser #1 - Auth Flow](https://dev.to/mpocock1/xstate-brain-teaser-1-auth-flow-2jhl) by [Matt Pocock](https://twitter.com/mpocock1)
-- [▶️ Learning XState by refactoring an old project](https://fvsch.com/learning-xstate) by [Florens Verschelde](https://fvsch.com/)
-  - [Article](https://fvsch.com/learning-xstate)
-- [Creating State Machines in JavaScript with XState](https://nisimdor.medium.com/creating-state-machines-in-javascript-with-xstate-21e1599521be) by [Dor Nisim](https://nisimdor.medium.com/)
-- ["Just Use Props": An opinionated guide to React and XState](https://dev.to/mpocock1/just-use-props-an-opinionated-guide-to-react-and-xstate-fc9) by [Matt Pocock](https://dev.to/mpocock1)
-- [Usando XState y React para hacer peticiones HTTP (en español)](https://www.youtube.com/watch?v=Wo-rVyAsz-Q) by [GCD Coder](https://www.youtube.com/channel/UCwkisgTJdCx3mNZMaaHAaVA)
-- [Infinite Scrolling con Svelte, IntersectionObserver & XState (en español)](https://www.youtube.com/watch?v=GMXrwrG0cL4) by [GCD Coder](https://www.youtube.com/channel/UCwkisgTJdCx3mNZMaaHAaVA)
-- [▶️ Getting Started with XState in Vue 3](https://www.youtube.com/watch?v=g4YnmydXMP8) by [JacoboCode](https://www.youtube.com/channel/UCcE2YngHoargpdjIzkCNY2Q)
-- [▶️ Typing XState in Vue 3](https://www.youtube.com/watch?v=7tT45eRmyJE) by [JacoboCode](https://www.youtube.com/channel/UCcE2YngHoargpdjIzkCNY2Q)
-- [Infinite Scrolling with Svelte 3, XState and IntersectionObserver](https://dev.to/gcdcoder/infinite-scrolling-with-svelte-3-xstate-and-intersectionobserver-127j) by [Gustavo Castillo](https://dev.to/gcdcoder)
-- [Untangle complex flows in your React Native app with XState](https://medium.com/welld-tech/untangle-complex-flows-in-your-react-native-app-with-xstate-1b11d0b8a91f) by [Simone D'Avico](https://sdavico.medium.com/)
-- [Integrate XState with React Native and React Navigation](https://medium.com/welld-tech/integrate-xstate-with-react-native-and-react-navigation-21ead87391da) by [Simone D'Avico](https://sdavico.medium.com/)
-- [Testing XState machines in your React Native app](https://medium.com/welld-tech/testing-xstate-machines-in-your-react-native-app-236fb01bf5b8) by [Simone D'Avico](https://sdavico.medium.com/)
-- [An Introduction to Finite State Machines: Simplifying React State Management with State Machines](https://soshace.com/an-introduction-to-finite-state-machines-simplifying-react-state-management-with-state-machines/) by [Bradley Kofi](https://soshace.com/author/bradstarart/)
-- [An Introduction to XState in TypeScript](https://medium.com/giant-machines/an-introduction-to-xstate-in-typescript-e71c7729ce88) by [Neeraj Khosla
-  ](https://medium.com/@n.khosla91)
-- [▶️ XState - Global state in React](https://www.youtube.com/watch?v=1kJcnFBrk2I) by [Matt Pocock](https://twitter.com/mpocock1)
-- [▶️ XState Introduction](https://www.youtube.com/watch?v=clu2bqjk3c0) on [For Those Who Code](https://www.youtube.com/channel/UCS3-MF_4ADqglU2OSly4vIw)
-- [Future of state management in React with XState](https://blog.jskoneczny.pl/post/future-of-state-management-in-react-with-xstate) by [Jakub Skoneczny](https://blog.jskoneczny.pl/)
-- [▶️ Custom Svelte Store: XState as Svelte store](https://www.youtube.com/watch?v=NIfQsc5XAzU) by [lihautan](https://www.youtube.com/channel/UCbmC3HP3FaAFdcZkui8YoMQ)
-- [▶️ Finite State Machine on Frontend](https://www.youtube.com/watch?v=gCT-lCYYhf4) by [Eugenia Zigisova](https://twitter.com/jevgeniazi)
-- [#1 Introduction to XState in React](https://blog.imbhargav5.com/1-introduction-to-xstate-in-react) by [Bhargav Ponnapalli](https://blog.imbhargav5.com/)
-- [▶️ Modelling application behaviour with the XState library (in React)](https://www.youtube.com/watch?v=paZ4ImyI1YQ) by [Marc Klefter](https://twitter.com/marcklefter)
-- [Rsvp to weddings with XState](https://dev.to/droopytersen/rsvp-to-weddings-with-xstate-55nl) by [Andrew Peterson](https://dev.to/droopytersen)
+- [▶️ XState and React](https://www.youtube.com/watch?v=pclR8Q5mbNI) on [Leniolabs](https://www.youtube.com/channel/UCcRg2Au0LLtEcakG9fg6VXg) on 2020-10-08
+- [▶️ XState and State Machines in VueJS](https://www.youtube.com/watch?v=8y9wUwJvdGs) by [Constantin Druc](https://www.youtube.com/channel/UCsMdRMBnxIVO0K_YS0KHiMA) on 2020-09-30
+- [▶️ Reducing state complexity with XState](https://www.youtube.com/watch?v=CpxL-4oIZPw) by [Kishore](www.github.com/pkishoez) on 2020-09-21
+- [▶️ Refactoring with XState - Part 1](https://www.youtube.com/watch?v=hZ1vaMJnKx0) by [VigsCodes](https://www.youtube.com/channel/UCAFlrYILud3-3MCs8nsDiAA) on 2020-09-06
+- [▶️ State-driven Interfaces with XState](https://www.youtube.com/watch?v=bPUgBHFfQdI) on [Mozilla Indonesia](https://www.youtube.com/channel/UCUwngm8TCj0mhsvKTO2q5fQ) on 2020-08-30
+- [▶️ Easy Introduction to XState in React | States, Transitions, Guards, and (Actions](https://www.youtube.com/watch?v=PRwDOSjIFg8) by [Bhargav Ponnapalli](https://www.youtube.com/channel/UC4gKWR53xDzybMwm8Y61ukA) on 2020-08-28
+- [▶️ Virtual Lunch & Learn: Let's build an app using Svelte, TypeScript, XState and Tailwind](https://www.youtube.com/watch?v=-FiN2Svpk2s) by Anders Bech Mellson on 2020-08-26
+- [▶️ Mini Introducción a XState](https://www.youtube.com/watch?v=brMpOOAOUZ4) by [Michell Ayala](https://www.youtube.com/channel/UCBXo5FFDCtNoddUOqZuWX7w) on 2020-08-14
+  - [▶️ React + XState](https://www.youtube.com/watch?v=Z7LIsZfQ4LU)
+- [▶️ Model Based Testing with XState | Why It's Great | Part 1](https://www.youtube.com/watch?v=tkxH7o-n9sI) by [John Bales](https://www.youtube.com/channel/UCVYw7ad200ZmvsZ0BVC9YvA) on 2020-08-11
+  - [▶️ Model Based Testing with XState | The Basics | Part 2](https://www.youtube.com/watch?v=9_dWCweA8Pk)
+  - [▶️ Model Based Testing with XState | Path Generation with Context | Part 3](https://www.youtub
+- [▶️ Managing UI Complexity with Statecharts (playlist)](https://www.youtube.com/playlist?list=PLsVj0cy-DbErFraf3KeAUbzVl-OKyBZ0-) on 2020-08-01
+- [▶️ XState Pizza Wizard!](https://www.youtube.com/watch?v=JauJhGTBFsc) by [Jack Herrington](https://github.com/jherr) on 2020-07-22
+- [▶️ Declarative and manageable state management with XState](https://www.youtube.com/watch?v=jCbV5aELY6A) on Decoupled Days on 2020-07-22
+- [▶️ Learning XState with Lauren](https://www.youtube.com/watch?v=h5H1ZmjMDE4) on Lauren Learns Thingse.com/watch?v=9gQulfnG7HM) on 2020-07-17
+- [▶️ The Actor Model | XState part 1](https://www.youtube.com/watch?v=4CLdNeetVHw) by [@bisvarup](https://bisvarup.me/) on 2020-07-15
+  - [CodeSandbox example](https://codesandbox.io/s/ancient-framework-bvw61?file=/src/App.js)
+- [▶️ Part 1: Tic-tac-toe - Let's build (using JavaScript, React, Cypress and XState)](https://www.youtube.com/watch?v=uVySNh6ud2w) by Dane Harnett on 2020-06-28
+  - [▶️ Part 2](https://www.youtube.com/watch?v=LtqTNATLIlY)
+  - [▶️ Part 3](https://www.youtube.com/watch?v=t5WU1oZeBQw)
+- [▶️ How to add an XState machine conf to a project](https://www.youtube.com/watch?v=A0bLzjQdZPU) by [Diego Perez](https://www.youtube.com/channel/UCxr-10LjbO-CTiPRcCLyRyg) on 2020-06-26
+- [▶️ Autocomplete, XState, and anything in between](https://www.youtube.com/watch?v=7CP-OUcUq2Q) by [Krzysztof Żuraw](https://krzysztofzuraw.com) on 2020-06-24
+- [▶️ Creating a `useAutoSave` Hook - Part 5: Using XState](https://www.youtube.com/watch?v=JPgd1RG-rOk) by [Brooks Lybrand](https://twitter.com/BrooksLybrand) on 2020-05-08
+  - [CodeSandbox](https://codesandbox.io/s/useautosavefinal-xhsyx?file=/src/useAutoSave-5.js
+- [▶️ Improving Application Predictability with XState](https://www.youtube.com/watch?v=MbS2TQj4Xsc) by [Sam Edwards](https://twitter.com/sjoedwards) on 2020-04-29
+- [▶️ Webinar - Visualize Application State with XState in JavaScript](https://www.youtube.com/watch?v=GhHh_9I6CXQ) by Dani Akash on 2020-04-02
+- [▶️ Drag & Drop State Machine! Learning XState with David](https://www.youtube.com/watch?v=osaszd2aU9U) on the [Keyframers](https://twitter.com/keyframers) on 2020-03-06
+  - [GitHub - Code](https://github.com/jherr/xstate-pizza-orderer))
+- [▶️ How to Build a simple React App with XState](https://www.youtube.com/watch?v=g_2lt7bBwpk) by Tim Ermilov on 2020-03-04
+- [▶️ Authentication statechart in XState](https://www.youtube.com/watch?v=lIge4KWq6Xc) by [Brooks Lybrand](https://twitter.com/BrooksLybrand) on 2020-02-07
+- [▶️ Aplicaciones React usando XState](https://www.youtube.com/watch?v=9P3sLqSiswE) by Luis César Contreras on 2020-01-21
+- [▶️ Improving state representation by using XState in React](https://www.youtube.com/watch?v=hG3UHNCUdzQ) by [Jon Major Condon](https://www.youtube.com/channel/UCQB-QsEnKCvJX4e_ms9XvHA) on 2019-10-03
+- [▶️ Isaac && Zack Code Jam #2: State Machines and XState](https://www.youtube.com/watch?v=emAUbr0XHqg) on 2019-10-03
+  - [▶️ Part 3](https://www.youtube.com/watch?v=R2vzzuUkjV0)
 - [▶️ XState and State Machines in Vue](https://tallpad.com/series/xstate-misc/episode/1)
-- [Github - XState with React and Angular in Nx Workspace](https://github.com/nartc/nx-state-machine-todos-mvc) by [Chau Tran](https://nartc.me)
-- [Boost your React application's performance by XState](https://dev.to/alirezavalizade/boost-your-react-application-s-performance-by-xstate-42p8) by [Alireza Valizade](https://dev.to/alirezavalizade)
-- [Getting Started with XState, React, and Typescript | Part 1](https://www.youtube.com/watch?v=po1YRAk7irY) by [Modus Create](https://www.youtube.com/channel/UCsKwL0-e2eHRNa6Ne99AESw)
-- [Frontend is Rocket Science – Managing state in any JavaScript Application](https://blog.oddeven.ch/blog/frontend-is-rocket-science-managing-state-in-any-javascript-application/) by [Aleksej Dix](https://twitter.com/aleksejdix)
-- [▶️ Use State Machines to Build a Queue for Custom Twitch Overlays — Learn With Jason](https://www.youtube.com/watch?v=UzA5Mvk587M) by [Jason Lengstorf](https://www.youtube.com/channel/UCnty0z0pNRDgnuoirYXnC5A)
-- [How to Use Finite State Machines in React](https://www.telerik.com/blogs/how-to-use-finite-state-machines-react) by [Leonardo Maldonado](https://www.telerik.com/blogs/author/leonardo-maldonado)
-- [▶️ Maquinas de estado finito y gráficas de estado en React ](https://www.youtube.com/watch?v=Rm6AMY6-Wqw) by José L Narajo
-- [XState: Should this be an action, or a service?](https://dev.to/mpocock1/xstate-should-this-be-an-action-or-a-service-2cp0) by [Matt Pocock](https://twitter.com/mpocock1)
-- [State Machines: Should this be a state, or in context?](https://dev.to/mpocock1/state-machines-should-this-be-a-state-or-in-context-1d7e) by [Matt Pocock](https://twitter.com/mpocock1)
-- [XState: What's the difference between Machine and createMachine?](https://dev.to/mpocock1/xstate-what-s-the-difference-between-machine-and-createmachine-15h1) by [Matt Pocock](https://twitter.com/mpocock1)
-- [Use an XState Machine with React](https://dev.to/jbranchaud/use-an-xstate-machine-with-react-326i) by [Josh Branchaud](https://twitter.com/jbrancha)
-- [▶️ DevTrends: XState](https://devtrends.io/videos/xstate/) by [Anthony Gore](https://twitter.com/anthonygore)
+- [▶️ Standing on the Shoulders of Giants. Development with XState](https://www.youtube.com/watch?v=GuzcWkVrqLg) by Brad Woods on 2019-09-11
+  - [Slides and more](https://www.atlassian.com/atlascamp/watch-sessions/2019/advanced-app-development/standing-on-the-shoulders-of-giants-development-with-xstate)
+
+## Repositories
+
 - [XState: Street Lights with Pedestrian Crossing using Vue.js](https://codesandbox.io/s/stoic-thompson-ktzrl?file=/src/App.vue) by [Kevin Warrington](https://github.com/dubbs)
-- [▶️ Front-end state management with XState](https://www.youtube.com/watch?v=Slb6M_rIn0M) by [Amy Pellegrini](https://twitter.com/amyvpellegrini)
-- [▶️ Splitting the view and the brains in JS — state machines with XState (in French)](https://www.youtube.com/watch?v=yRB57CDvQuY) by [Aurelien Meunier](https://www.linkedin.com/in/aumeunier)
-- [Using XState with Deno](https://gustavosantos.dev/a/using-xstate-with-deno) by [Bruno Quaresma](https://twitter.com/bruno__quaresma)
-- [How to model application flows in React with finite state machines and XState](https://engineering.kablamo.com.au/posts/2021/finite-state-machines-and-xstate) by [Andrew McDowell](https://twitter.com/madole)
+- [CodeSandbox - XState Login & Sign Up Forms](https://codesandbox.io/s/xstate-login-sign-up-forms-yzzoc) by [Jamie Mason](https://github.com/JamieMason)
+- [Tic-Tac-Toe with Crank, XState, and TypeScript](https://github.com/mwarger/tic-tac-toe-crank-xstate-typescript) by [@warger](https://github.com/mwarger) on 2020-04-17
+- [GitHub - Autocomplete example with XState](https://github.com/krzysztofzuraw/xstate-autocomplete) by [@krzysztofzuraw](https://github.com/krzysztofzuraw) on 2020-04-06
+- [Github - XState with React and Angular in Nx Workspace](https://github.com/nartc/nx-state-machine-todos-mvc) by [Chau Tran](https://nartc.me) on 2020-03-08
+- [GitHub - XState Sample Kit](https://github.com/rjdestigter/xstate-sample-kit) by [@rjdestigter](https://github.com/rjdestigter) on 2020-02-17
+- [GitLab - TDDing XState](https://gitlab.com/danbunea/tdding-xstate) by Dan Bunea on 2020-02-13
+- [Tips and tricks of using XState for UI development](https://github.com/farskid/xstate.tips) by [@farskid](https://github.com/farskid) on 2020-01-24
+  - [Link: XState.Tips](https://xstate.tips/)
+- [GitHub - Cypress Real-World App](https://github.com/cypress-io/cypress-realworld-app) on 2020-01-07
+- [GitHub - a flipping cards game using XState](https://github.com/lednhatkhanh/xstate-flipping-cards-game) by [@lednhatkhanh](https://github.com/lednhatkhanh) on 2020-04-21
+  - [Playable demo](https://xstate-flipping-cards-game.now.sh/)
+- [GitHub - a Markdown Editor in Vue.js and XState](https://github.com/sarahdayan/markdown-editor-vue-xstate) by [Sarah Dayan](https://github.com/sarahdayan) on 2020-02-15
+  - [Live Demo](https://nifty-yalow-295db4.netlify.app/)
+- [GitHub - A Pac Man game, built with React, TypeScript, MobX, styled-components, and XState](https://github.com/stefanwille/pacman-react) by [Stefan Wille](https://github.com/stefanwille) on 2019-12-21
+  - [Playable demo](https://pacman-react.netlify.app/)
+- [GitHub - a small React, XState and Framer Motion demo](https://github.com/tanem/state-machines-in-react) by [@tanem](https://github.com/tanem) on 2019-09-29
+- [CodePen - XState Vue Login Page](https://codepen.io/ryanzola/pen/PMwoqe) by [Ryan Zola](https://codepen.io/ryanzola) on 2019-07-19
+- [GitHub - Practical examples of statechart-based solutions with XState](https://github.com/DevanB/xstate-examples) by [@DevanB](https://github.com/DevanB) on 2019-09-07


### PR DESCRIPTION
See https://github.com/statelyai/xstate/discussions/2500.

I've split the Articles and Videos section in Articles, Videos, and Repositories. After that I've added  publication or scheduled dates and reordered every section in reverse chronological order. For now I've not merged the Tutorial section.

There were some dead links that I've removed and some entries couldn't be dated. The dates for the repositories are the dates of the first commit.

Feel free to suggest any changes.