### PR TITLE
fixed "Forward To Action" example

### DIFF
--- a/docs/guides/actions.md
+++ b/docs/guides/actions.md
@@ -462,7 +462,7 @@ const parentMachine = createMachine({
 
 const parentService = interpret(parentMachine).start();
 
-parentService.send({ type: 'ALERT' }, { message: 'hello world' });
+parentService.send({ type: 'ALERT', message: 'hello world' });
 // => alerts "hello world"
 ```
 


### PR DESCRIPTION
it should be `event object` to work because `send()` action creator tooks as second argument `options` object with only `id`, `to` and `delay` properties.