### PR TITLE
Refactor use of createMachine with models

### DIFF
--- a/examples/react-tic-tac-toe/package.json
+++ b/examples/react-tic-tac-toe/package.json
@@ -9,7 +9,7 @@
     "@xstate/react": "^1.3.4",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
-    "xstate": "^4.20.0"
+    "xstate": "^4.23.1"
   },
   "devDependencies": {
     "@types/react": "^17.0.0",

--- a/examples/react-tic-tac-toe/pnpm-lock.yaml
+++ b/examples/react-tic-tac-toe/pnpm-lock.yaml
@@ -8,13 +8,13 @@ specifiers:
   react-dom: ^17.0.0
   typescript: ^4.1.2
   vite: ^2.3.8
-  xstate: ^4.20.0
+  xstate: ^4.23.1
 
 dependencies:
-  '@xstate/react': 1.3.4_232b9385f3ff363a3a1bb2e5da30bf5c
+  '@xstate/react': 1.3.4_c52e199845f673f7e83f3c17a0acc316
   react: 17.0.2
   react-dom: 17.0.2_react@17.0.2
-  xstate: 4.20.0
+  xstate: 4.23.1
 
 devDependencies:
   '@types/react': 17.0.11
@@ -46,7 +46,7 @@ packages:
     resolution: {integrity: sha512-EaCxbanVeyxDRTQBkdLb3Bvl/HK7PBK6UJjsSixB0iHKoWxE5uu2Q/DgtpOhPIojN0Zl1whvOd7PoHs2P0s5eA==}
     dev: true
 
-  /@xstate/react/1.3.4_232b9385f3ff363a3a1bb2e5da30bf5c:
+  /@xstate/react/1.3.4_c52e199845f673f7e83f3c17a0acc316:
     resolution: {integrity: sha512-uKbKriFYjgeqMeEAqOv8IWRM8WBx5i/4pMPGpqo58wd7sInhFmmK6HWfV7eX3nD/vJPfxWielNMxAUCUdVh1pA==}
     peerDependencies:
       '@xstate/fsm': ^1.0.0
@@ -61,7 +61,7 @@ packages:
       react: 17.0.2
       use-isomorphic-layout-effect: 1.1.1_189cc19b8edfe5959338b863f6e5c247
       use-subscription: 1.5.1_react@17.0.2
-      xstate: 4.20.0
+      xstate: 4.23.1
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -226,6 +226,6 @@ packages:
       fsevents: 2.3.2
     dev: true
 
-  /xstate/4.20.0:
-    resolution: {integrity: sha512-u5Ou1CMo/oWApasmv1TYTHgj38k69DJdTqQdBBwt+/ooNhPJQiSIKTB3Y3HvX0h5tulwfSo6xAwZgBgjRsK3LA==}
+  /xstate/4.23.1:
+    resolution: {integrity: sha512-8ZoCe8d6wDSPfkep+GBgi+fKAdMyXcaizoNf5FKceEhlso4+9n1TeK6oviaDsXZ3Z5O8xKkJOxXPNuD4cA9LCw==}
     dev: false

--- a/examples/react-tic-tac-toe/src/ticTacToe.machine.ts
+++ b/examples/react-tic-tac-toe/src/ticTacToe.machine.ts
@@ -1,8 +1,5 @@
-import {
-  createModel,
-  ModelContextFrom,
-  ModelEventsFrom
-} from 'xstate/lib/model';
+import { createModel } from 'xstate/lib/model';
+import { ContextFrom, EventFrom } from 'xstate';
 
 type Player = 'x' | 'o';
 
@@ -22,14 +19,18 @@ const model = createModel(
 );
 
 const isValidMove = (
-  ctx: ModelContextFrom<typeof model>,
-  e: ModelEventsFrom<typeof model> & { type: 'PLAY' }
+  context: ContextFrom<typeof model>,
+  event: EventFrom<typeof model>
 ) => {
-  return ctx.board[e.value] === null;
+  if (event.type !== 'PLAY') {
+    return false;
+  }
+
+  return context.board[event.value] === null;
 };
 
-function checkWin(ctx: ModelContextFrom<typeof model>) {
-  const { board } = ctx;
+function checkWin(context: ContextFrom<typeof model>) {
+  const { board } = context;
   const winningLines = [
     [0, 1, 2],
     [3, 4, 5],
@@ -58,10 +59,12 @@ function checkWin(ctx: ModelContextFrom<typeof model>) {
       return true;
     }
   }
+
+  return false;
 }
 
-function checkDraw(ctx: ModelContextFrom<typeof model>) {
-  return ctx.moves === 9;
+function checkDraw(context: ContextFrom<typeof model>) {
+  return context.moves === 9;
 }
 
 export const ticTacToeMachine = model.createMachine(
@@ -106,21 +109,22 @@ export const ticTacToeMachine = model.createMachine(
   },
   {
     actions: {
+      // @ts-ignore (will be fixed in next minor version)
       updateBoard: model.assign(
         {
-          board: (ctx, e) => {
-            const updatedBoard = [...ctx.board];
-            updatedBoard[e.value] = ctx.player;
+          board: (context, event) => {
+            const updatedBoard = [...context.board];
+            updatedBoard[event.value] = context.player;
             return updatedBoard;
           },
-          moves: (ctx) => ctx.moves + 1,
-          player: (ctx) => (ctx.player === 'x' ? 'o' : 'x')
+          moves: (context) => context.moves + 1,
+          player: (context) => (context.player === 'x' ? 'o' : 'x')
         },
         'PLAY'
       ),
       resetGame: model.reset(),
-      setWinner: model.assign({
-        winner: (ctx) => (ctx.player === 'x' ? 'o' : 'x')
+      setWinner: model.assign<'PLAY' | 'RESET'>({
+        winner: (context) => (context.player === 'x' ? 'o' : 'x')
       })
     },
     guards: {

--- a/examples/react-tic-tac-toe/src/ticTacToe.machine.ts
+++ b/examples/react-tic-tac-toe/src/ticTacToe.machine.ts
@@ -1,4 +1,3 @@
-import { createMachine } from 'xstate';
 import {
   createModel,
   ModelContextFrom,
@@ -65,7 +64,7 @@ function checkDraw(ctx: ModelContextFrom<typeof model>) {
   return ctx.moves === 9;
 }
 
-export const ticTacToeMachine = createMachine<typeof model>(
+export const ticTacToeMachine = model.createMachine(
   {
     initial: 'playing',
     context: model.initialContext,

--- a/examples/todo-mvc-react/src/App.jsx
+++ b/examples/todo-mvc-react/src/App.jsx
@@ -6,7 +6,7 @@ function App() {
     <>
       <Todos />
 
-      <footer class="info">
+      <footer className="info">
         <p>Double-click to edit a todo</p>
         <p>
           Template by <a href="http://sindresorhus.com">Sindre Sorhus</a>

--- a/examples/todo-mvc-react/src/todo.machine.ts
+++ b/examples/todo-mvc-react/src/todo.machine.ts
@@ -36,7 +36,7 @@ export const createTodoMachine = ({
   title: string;
   completed: boolean;
 }) => {
-  return createMachine<typeof todoModel>(
+  return todoModel.createMachine(
     {
       id: 'todo',
       initial: 'reading',

--- a/examples/todo-mvc-react/src/todo.machine.ts
+++ b/examples/todo-mvc-react/src/todo.machine.ts
@@ -1,4 +1,4 @@
-import { createMachine, sendParent, EventFrom } from 'xstate';
+import { sendParent, EventFrom } from 'xstate';
 import { createModel } from 'xstate/lib/model';
 
 const todoModel = createModel(

--- a/examples/todo-mvc-react/src/todos.machine.ts
+++ b/examples/todo-mvc-react/src/todos.machine.ts
@@ -1,5 +1,5 @@
 import { createModel } from 'xstate/lib/model';
-import { createMachine, spawn, ActorRef, EventFrom } from 'xstate';
+import { spawn, ActorRef, EventFrom } from 'xstate';
 import { createTodoMachine } from './todo.machine';
 
 import { nanoid } from 'nanoid';
@@ -43,7 +43,7 @@ type TodosEvents = EventFrom<typeof todosModel>[keyof EventFrom<
   typeof todosModel
 >];
 
-export const todosMachine = createMachine<typeof todosModel>({
+export const todosMachine = todosModel.createMachine({
   id: 'todos',
   context: todosModel.initialContext,
   initial: 'loading',

--- a/examples/todo-mvc-svelte/src/todo.machine.ts
+++ b/examples/todo-mvc-svelte/src/todo.machine.ts
@@ -32,7 +32,7 @@ export const createTodoMachine = ({
   title: string;
   completed: boolean;
 }) => {
-  return createMachine<typeof todoModel>(
+  return todoModel.createMachine(
     {
       id: 'todo',
       initial: 'reading',

--- a/examples/todo-mvc-svelte/src/todo.machine.ts
+++ b/examples/todo-mvc-svelte/src/todo.machine.ts
@@ -1,4 +1,4 @@
-import { createMachine, sendParent } from 'xstate';
+import { sendParent } from 'xstate';
 import { createModel } from 'xstate/lib/model';
 
 const todoModel = createModel(

--- a/examples/todo-mvc-svelte/src/todos.machine.ts
+++ b/examples/todo-mvc-svelte/src/todos.machine.ts
@@ -39,7 +39,7 @@ const todosModel = createModel(
   }
 );
 
-export const todosMachine = createMachine<typeof todosModel>({
+export const todosMachine = todosModel.createMachine({
   id: 'todos',
   context: todosModel.initialContext,
   initial: 'loading',

--- a/examples/todo-mvc-svelte/src/todos.machine.ts
+++ b/examples/todo-mvc-svelte/src/todos.machine.ts
@@ -1,4 +1,4 @@
-import { createMachine, spawn, ActorRef } from 'xstate';
+import { spawn, ActorRef } from 'xstate';
 import { createModel } from 'xstate/lib/model';
 import { createTodoMachine } from './todo.machine';
 

--- a/examples/todo-mvc-vue/package.json
+++ b/examples/todo-mvc-vue/package.json
@@ -12,7 +12,7 @@
     "todomvc-app-css": "^2.4.1",
     "todomvc-common": "^1.0.5",
     "vue": "^3.0.5",
-    "xstate": "^4.20.1"
+    "xstate": "^4.23.1"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^1.2.3",

--- a/examples/todo-mvc-vue/pnpm-lock.yaml
+++ b/examples/todo-mvc-vue/pnpm-lock.yaml
@@ -12,16 +12,16 @@ specifiers:
   vite: ^2.3.8
   vue: ^3.0.5
   vue-tsc: ^0.2.0
-  xstate: ^4.20.1
+  xstate: ^4.23.1
 
 dependencies:
   '@xstate/inspect': 0.4.1
-  '@xstate/vue': 0.6.0_vue@3.1.1+xstate@4.20.1
+  '@xstate/vue': 0.6.0_vue@3.1.1+xstate@4.23.1
   nanoid: 3.1.23
   todomvc-app-css: 2.4.1
   todomvc-common: 1.0.5
   vue: 3.1.1
-  xstate: 4.20.1
+  xstate: 4.23.1
 
 devDependencies:
   '@vitejs/plugin-vue': 1.2.3_@vue+compiler-sfc@3.1.2
@@ -358,7 +358,7 @@ packages:
       fast-safe-stringify: 2.0.7
     dev: false
 
-  /@xstate/vue/0.6.0_vue@3.1.1+xstate@4.20.1:
+  /@xstate/vue/0.6.0_vue@3.1.1+xstate@4.23.1:
     resolution: {integrity: sha512-4Z7gamAHE1qd47OuCMYdgIRF6PH8ZA4M9fhYu28C/OnU9Ffu+df8gG5Nplww8f3ICTqVV4UsbcfQGWOFPOMa+A==}
     peerDependencies:
       '@xstate/fsm': ^1.0.0
@@ -371,7 +371,7 @@ packages:
         optional: true
     dependencies:
       vue: 3.1.1
-      xstate: 4.20.1
+      xstate: 4.23.1
     dev: false
 
   /acorn/7.4.1:
@@ -2585,8 +2585,8 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /xstate/4.20.1:
-    resolution: {integrity: sha512-oLqFEYKUG3Y4t3Pg5tb7ZXz2kZcrRA1inrEVfzDVf1JoBb+KGpKlNaLzxF5bE7swo0xcc8H+B/gdPb1feyO1gg==}
+  /xstate/4.23.1:
+    resolution: {integrity: sha512-8ZoCe8d6wDSPfkep+GBgi+fKAdMyXcaizoNf5FKceEhlso4+9n1TeK6oviaDsXZ3Z5O8xKkJOxXPNuD4cA9LCw==}
     dev: false
 
   /xtend/4.0.2:

--- a/examples/todo-mvc-vue/src/todoItem.machine.ts
+++ b/examples/todo-mvc-vue/src/todoItem.machine.ts
@@ -32,7 +32,7 @@ export const createTodoMachine = ({
   title: string;
   completed: boolean;
 }) => {
-  return createMachine<typeof todoModel>(
+  return todoModel.createMachine(
     {
       id: 'todo',
       initial: 'reading',

--- a/examples/todo-mvc-vue/src/todoItem.machine.ts
+++ b/examples/todo-mvc-vue/src/todoItem.machine.ts
@@ -1,4 +1,4 @@
-import { createMachine, sendParent } from 'xstate';
+import { sendParent } from 'xstate';
 import { createModel } from 'xstate/lib/model';
 
 const todoModel = createModel(

--- a/examples/todo-mvc-vue/src/todos.machine.ts
+++ b/examples/todo-mvc-vue/src/todos.machine.ts
@@ -38,7 +38,7 @@ const todosModel = createModel(
   }
 );
 
-export const todosMachine = createMachine<typeof todosModel>({
+export const todosMachine = todosModel.createMachine({
   id: 'todos',
   context: todosModel.initialContext,
   initial: 'loading',

--- a/examples/todo-mvc-vue/src/todos.machine.ts
+++ b/examples/todo-mvc-vue/src/todos.machine.ts
@@ -1,4 +1,4 @@
-import { createMachine, spawn, ActorRef } from 'xstate';
+import { spawn, ActorRef } from 'xstate';
 import { nanoid } from 'nanoid';
 import { createTodoMachine } from './todoItem.machine';
 import { createModel } from 'xstate/lib/model';

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -259,7 +259,7 @@ describe('createModel', () => {
       }
     );
 
-    createMachine<typeof model>({
+    model.createMachine({
       context: model.initialContext,
       entry: [
         model.actions.custom(),
@@ -351,7 +351,7 @@ describe('createModel', () => {
       }
     );
 
-    createMachine<typeof model>(
+    model.createMachine(
       {
         context: {}
       },
@@ -464,7 +464,7 @@ describe('createModel', () => {
     const toggleModel = createModel({ count: 0 });
 
     // @ts-expect-error
-    const m = createMachine<typeof toggleModel>({
+    createMachine<typeof toggleModel>({
       id: 'machine',
       initial: 'inactive',
       // missing context:
@@ -504,7 +504,7 @@ describe('createModel', () => {
       { type: 'fooAction' }
     >({ count: 0 });
 
-    createMachine<typeof model>({
+    model.createMachine({
       context: model.initialContext,
       initial: 'a',
       states: {


### PR DESCRIPTION
This PR refactors use of `createMachine<typeof model>` to `model.createMachine` (preferred)