### PR TITLE
fix action.exec && action.exec()?

### DIFF
--- a/docs/guides/interpretation.md
+++ b/docs/guides/interpretation.md
@@ -217,7 +217,7 @@ function send(event) {
 
   actions.forEach((action) => {
     // If the action is executable, execute it
-    action.exec && action.exec();
+    typeof action.exec === 'function' && action.exec();
   });
 
   // Notify the listeners


### PR DESCRIPTION
should be `typeof action.exec === 'function' && action.exec();`?

because got an error ("TypeError: action.exec is not a function") on `action.exec && action.exec();`