### PR TITLE
Fixed an issue with `state.hasTag(someTag)` crashing when the `state` was rehydrated

### DIFF
--- a/.changeset/modern-pugs-leave.md
+++ b/.changeset/modern-pugs-leave.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with `state.hasTag('someTag')` crashing when the `state` was rehydrated.

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -248,7 +248,9 @@ export class State<
     this.transitions = config.transitions;
     this.children = config.children;
     this.done = !!config.done;
-    this.tags = config.tags ?? new Set();
+    this.tags =
+      (Array.isArray(config.tags) ? new Set(config.tags) : config.tags) ??
+      new Set();
 
     Object.defineProperty(this, 'nextEvents', {
       get: () => {

--- a/packages/core/test/rehydration.test.ts
+++ b/packages/core/test/rehydration.test.ts
@@ -1,0 +1,21 @@
+import { createMachine, interpret, State } from '../src';
+
+describe('rehydration', () => {
+  it('should be able to use `hasTag` on the rehydrated state', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          tags: 'foo'
+        }
+      }
+    });
+
+    const persistedState = JSON.stringify(machine.initialState);
+    const restoredState = State.create(JSON.parse(persistedState));
+
+    const service = interpret(machine).start(restoredState);
+
+    expect(service.state.hasTag('foo')).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixed an issue reported on Discord here: 
https://discord.com/channels/795785288994652170/877294461682602055/878204024803975210