### PR TITLE
Export createModel from index.ts

### DIFF
--- a/.changeset/loud-onions-tickle.md
+++ b/.changeset/loud-onions-tickle.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+exports creaetModel from index.ts

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,4 +74,6 @@ export {
   createSchema
 };
 
+export { createModel } from './model';
+
 export * from './types';


### PR DESCRIPTION
Given how common it is to `createModel` if using TypeScript, it'd be nice if it were exported off of index.ts like `createMachine`.