### PR TITLE
Widened the *From utility types to allow extracting from factory functions

### DIFF
--- a/.changeset/chatty-ads-applaud.md
+++ b/.changeset/chatty-ads-applaud.md
@@ -17,7 +17,7 @@ type Event = EventsFrom<typeof makeMachine>;
 
 This also works for models, behaviours, and other actor types.
 
-The previous method for doing this was a good bit uglier:
+The previous method for doing this was a good bit more verbose:
 
 ```ts
 const makeMachine = () => createMachine({});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,7 +2,6 @@ import { StateNode } from './StateNode';
 import { State } from './State';
 import { Interpreter, Clock } from './interpreter';
 import { Model } from './model.types';
-import { createMachine } from './Machine';
 
 export type EventType = string;
 export type ActionType = string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -828,9 +828,11 @@ export interface StateMachine<
   ): StateMachine<TContext, TStateSchema, TEvent, TTypestate>;
 }
 
-export type StateFrom<
-  TMachine extends StateMachine<any, any, any>
-> = ReturnType<TMachine['transition']>;
+export type StateFrom<T> = T extends StateMachine<any, any, any>
+  ? ReturnType<T['transition']>
+  : T extends (...args: any[]) => StateMachine<any, any, any>
+  ? ReturnType<ReturnType<T>['transition']>
+  : never;
 
 export interface ActionMap<TContext, TEvent extends EventObject> {
   onEntry: Array<Action<TContext, TEvent>>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,7 @@ import { StateNode } from './StateNode';
 import { State } from './State';
 import { Interpreter, Clock } from './interpreter';
 import { Model } from './model.types';
+import { createMachine } from './Machine';
 
 export type EventType = string;
 export type ActionType = string;
@@ -1394,31 +1395,53 @@ export type SpawnedActorRef<
   TEmitted = any
 > = ActorRef<TEvent, TEmitted>;
 
-export type ActorRefFrom<
-  T extends StateMachine<any, any, any> | Promise<any> | Behavior<any>
-> = T extends StateMachine<infer TContext, any, infer TEvent, infer TTypestate>
-  ? ActorRef<TEvent, State<TContext, TEvent, any, TTypestate>> & {
-      /**
-       * @deprecated Use `.getSnapshot()` instead.
-       */
-      state: State<TContext, TEvent, any, TTypestate>;
-    }
+export type ActorRefWithDeprecatedState<
+  TContext,
+  TEvent extends EventObject,
+  TTypestate extends Typestate<TContext>
+> = ActorRef<TEvent, State<TContext, TEvent, any, TTypestate>> & {
+  /**
+   * @deprecated Use `.getSnapshot()` instead.
+   */
+  state: State<TContext, TEvent, any, TTypestate>;
+};
+
+export type ActorRefFrom<T> = T extends StateMachine<
+  infer TContext,
+  any,
+  infer TEvent,
+  infer TTypestate
+>
+  ? ActorRefWithDeprecatedState<TContext, TEvent, TTypestate>
+  : T extends (
+      ...args: any[]
+    ) => StateMachine<infer TContext, any, infer TEvent, infer TTypestate>
+  ? ActorRefWithDeprecatedState<TContext, TEvent, TTypestate>
   : T extends Promise<infer U>
   ? ActorRef<never, U>
   : T extends Behavior<infer TEvent1, infer TEmitted>
+  ? ActorRef<TEvent1, TEmitted>
+  : T extends (...args: any[]) => Behavior<infer TEvent1, infer TEmitted>
   ? ActorRef<TEvent1, TEmitted>
   : never;
 
 export type AnyInterpreter = Interpreter<any, any, any, any>;
 
-export type InterpreterFrom<
-  T extends StateMachine<any, any, any, any>
-> = T extends StateMachine<
+export type InterpreterFrom<T> = T extends StateMachine<
   infer TContext,
   infer TStateSchema,
   infer TEvent,
   infer TTypestate
 >
+  ? Interpreter<TContext, TStateSchema, TEvent, TTypestate>
+  : T extends (
+      ...args: any[]
+    ) => StateMachine<
+      infer TContext,
+      infer TStateSchema,
+      infer TEvent,
+      infer TTypestate
+    >
   ? Interpreter<TContext, TStateSchema, TEvent, TTypestate>
   : never;
 
@@ -1441,19 +1464,33 @@ export interface Behavior<TEvent extends EventObject, TEmitted = any> {
 
 export type EmittedFrom<T> = T extends ActorRef<any, infer TEmitted>
   ? TEmitted
+  : T extends (...args: any[]) => ActorRef<any, infer TEmitted>
+  ? TEmitted
   : T extends Behavior<any, infer TEmitted>
   ? TEmitted
+  : T extends (...args: any[]) => Behavior<any, infer TEmitted>
+  ? TEmitted
   : T extends ActorContext<any, infer TEmitted>
+  ? TEmitted
+  : T extends (...args: any[]) => ActorContext<any, infer TEmitted>
   ? TEmitted
   : never;
 
 export type EventFrom<T> = T extends StateMachine<any, any, infer TEvent, any>
   ? TEvent
+  : T extends (...args: any[]) => StateMachine<any, any, infer TEvent, any>
+  ? TEvent
   : T extends Model<any, infer TEvent, any, any>
+  ? TEvent
+  : T extends (...args: any[]) => Model<any, infer TEvent, any, any>
   ? TEvent
   : T extends State<any, infer TEvent, any, any>
   ? TEvent
+  : T extends (...args: any[]) => State<any, infer TEvent, any, any>
+  ? TEvent
   : T extends Interpreter<any, any, infer TEvent, any>
+  ? TEvent
+  : T extends (...args: any[]) => Interpreter<any, infer TEvent, any, any>
   ? TEvent
   : never;
 
@@ -1464,10 +1501,18 @@ export type ContextFrom<T> = T extends StateMachine<
   any
 >
   ? TContext
+  : T extends (...args: any[]) => StateMachine<infer TContext, any, any, any>
+  ? TContext
   : T extends Model<infer TContext, any, any, any>
+  ? TContext
+  : T extends (...args: any[]) => Model<infer TContext, any, any, any>
   ? TContext
   : T extends State<infer TContext, any, any, any>
   ? TContext
+  : T extends (...args: any[]) => State<infer TContext, any, any, any>
+  ? TContext
   : T extends Interpreter<infer TContext, any, any, any>
+  ? TContext
+  : T extends (...args: any[]) => Interpreter<infer TContext, any, any, any>
   ? TContext
   : never;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -828,7 +828,11 @@ export interface StateMachine<
   ): StateMachine<TContext, TStateSchema, TEvent, TTypestate>;
 }
 
-export type StateFrom<T> = T extends StateMachine<any, any, any>
+export type StateFrom<
+  T extends
+    | StateMachine<any, any, any, any>
+    | ((...args: any[]) => StateMachine<any, any, any, any>)
+> = T extends StateMachine<any, any, any>
   ? ReturnType<T['transition']>
   : T extends (...args: any[]) => StateMachine<any, any, any>
   ? ReturnType<ReturnType<T>['transition']>
@@ -1428,7 +1432,11 @@ export type ActorRefFrom<T> = T extends StateMachine<
 
 export type AnyInterpreter = Interpreter<any, any, any, any>;
 
-export type InterpreterFrom<T> = T extends StateMachine<
+export type InterpreterFrom<
+  T extends
+    | StateMachine<any, any, any, any>
+    | ((...args: any[]) => StateMachine<any, any, any, any>)
+> = T extends StateMachine<
   infer TContext,
   infer TStateSchema,
   infer TEvent,

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -78,7 +78,7 @@ describe('interpreter', () => {
       let entryCalled = 0;
       let promiseSpawned = 0;
 
-      const machine = createMachine<any>({
+      const machine = createMachine<any, any, any>({
         initial: 'idle',
         context: {
           actor: undefined
@@ -1931,7 +1931,7 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
         }
       });
 
-      const formMachine = createMachine<any>({
+      const formMachine = createMachine<any, any, any>({
         id: 'form',
         initial: 'idle',
         context: {},

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -556,7 +556,7 @@ describe('transient states (eventless transitions)', () => {
   });
 
   it('should work with transient transition on root', (done) => {
-    const machine = createMachine<any, any>({
+    const machine = createMachine<any, any, any>({
       id: 'machine',
       initial: 'first',
       context: { count: 0 },
@@ -594,7 +594,7 @@ describe('transient states (eventless transitions)', () => {
   });
 
   it('should work with transient transition on root (with `always`)', (done) => {
-    const machine = createMachine<any, any>({
+    const machine = createMachine<any, any, any>({
       id: 'machine',
       initial: 'first',
       context: { count: 0 },


### PR DESCRIPTION
Copied from changeset:

Widened the *From utility types to allow extracting from factory functions.

This allows for:

```ts
const makeMachine = () => createMachine({});

type Interpreter = InterpreterFrom<typeof makeMachine>;
type Actor = ActorRefFrom<typeof makeMachine>;
type Context = ContextFrom<typeof makeMachine>;
type Event = EventsFrom<typeof makeMachine>;
```

This also works for models, behaviours, and other actor types.