### PR TITLE
feat(core/behaviors): add stop callback

### DIFF
--- a/packages/core/src/behaviors.ts
+++ b/packages/core/src/behaviors.ts
@@ -89,7 +89,7 @@ export function fromPromise<T>(
         }
       );
 
-      return initialState;
+      return { state: initialState };
     }
   };
 }
@@ -104,6 +104,7 @@ export function spawnBehavior<TEvent extends EventObject, TEmitted>(
   options: SpawnBehaviorOptions = {}
 ): ActorRef<TEvent, TEmitted> {
   let state = behavior.initialState;
+  let stop: (() => void) | undefined;
   const observers = new Set<Observer<TEmitted>>();
   const mailbox: TEvent[] = [];
   let flushing = false;
@@ -138,7 +139,8 @@ export function spawnBehavior<TEvent extends EventObject, TEmitted>(
           observers.delete(observer);
         }
       };
-    }
+    },
+    stop: () => stop?.()
   });
 
   const actorCtx = {
@@ -148,7 +150,9 @@ export function spawnBehavior<TEvent extends EventObject, TEmitted>(
     observers
   };
 
-  state = behavior.start ? behavior.start(actorCtx) : state;
+  if (behavior.start) {
+    ({ state, stop } = behavior.start(actorCtx));
+  }
 
   return actor;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1423,10 +1423,10 @@ export type InterpreterFrom<
   : never;
 
 export interface ActorContext<TEvent extends EventObject, TEmitted> {
-  parent?: ActorRef<any, any>;
-  self: ActorRef<TEvent, TEmitted>;
   id: string;
+  self: ActorRef<TEvent, TEmitted>;
   observers: Set<Observer<TEmitted>>;
+  parent?: ActorRef<any, any>;
 }
 
 export interface Behavior<TEvent extends EventObject, TEmitted = any> {
@@ -1436,12 +1436,8 @@ export interface Behavior<TEvent extends EventObject, TEmitted = any> {
     actorCtx: ActorContext<TEvent, TEmitted>
   ) => TEmitted;
   initialState: TEmitted;
-  start?: (
-    actorCtx: ActorContext<TEvent, TEmitted>
-  ) => {
-    state: TEmitted;
-    stop?: () => void;
-  };
+  start?: (actorCtx: ActorContext<TEvent, TEmitted>) => TEmitted;
+  stop?: (actorCtx: ActorContext<TEvent, TEmitted>) => TEmitted;
 }
 
 export type EmittedFrom<T> = T extends ActorRef<any, infer TEmitted>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1436,7 +1436,12 @@ export interface Behavior<TEvent extends EventObject, TEmitted = any> {
     actorCtx: ActorContext<TEvent, TEmitted>
   ) => TEmitted;
   initialState: TEmitted;
-  start?: (actorCtx: ActorContext<TEvent, TEmitted>) => TEmitted;
+  start?: (
+    actorCtx: ActorContext<TEvent, TEmitted>
+  ) => {
+    state: TEmitted;
+    stop?: () => void;
+  };
 }
 
 export type EmittedFrom<T> = T extends ActorRef<any, infer TEmitted>


### PR DESCRIPTION
To build out more complicated behaviors I think we need to have to ability for behaviors to know when they are stopped, similar to invoked callbacks.

I would like this functionally to build out some helpers located [here](https://github.com/ChrisShank/xstate-behaviors). I have been using invoked callbacks so far, but the more I think about it the more I think I need to use the behavior API.