### PR TITLE
Add a failing test for context composition using multiple `provide` calls

### DIFF
--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -146,7 +146,7 @@ describe('machine', () => {
     });
   });
 
-  describe('machine.withConfig', () => {
+  describe('machine.provide', () => {
     it('should override guards and actions', () => {
       const differentMachine = configMachine.provide({
         actions: {
@@ -207,6 +207,14 @@ describe('machine', () => {
       const machine = createMachine({});
 
       expect(machine.initialState.context).toEqual({});
+    });
+
+    it('should compose context provided using multiple subsequent `provide` calls', () => {
+      const machine1 = createMachine<any>({ context: { a: 1 } });
+      const machine2 = machine1.provide({ context: { b: 2 } });
+      const machine3 = machine2.provide({ context: { c: 3 } });
+
+      expect(machine3.initialState.context).toEqual({ a: 1, b: 2, c: 3 });
     });
   });
 


### PR DESCRIPTION
When working on this PR: https://github.com/statelyai/xstate/pull/2522 and comparing the implementation with the `next` branch I've noticed that this doesn't work properly. I didn't have time to dig into this more but hopefully, this shouldn't be too hard to fix - I'm opening this so we don't lose track of it.