### PR TITLE
default to new visualizer URL in @xstate/inspect

### DIFF
--- a/.changeset/dirty-icons-grow.md
+++ b/.changeset/dirty-icons-grow.md
@@ -1,0 +1,5 @@
+---
+'@xstate/inspect': minor
+---
+
+update @xstate/inspect URL to the new visualizer on stately.ai

--- a/packages/xstate-inspect/src/browser.ts
+++ b/packages/xstate-inspect/src/browser.ts
@@ -61,7 +61,7 @@ export function createDevTools(): XStateDevInterface {
 }
 
 const defaultInspectorOptions: InspectorOptions = {
-  url: 'https://statecharts.io/inspect',
+  url: 'https://stately.ai/viz',
   iframe: () =>
     document.querySelector<HTMLIFrameElement>('iframe[data-xstate]'),
   devTools: () => {


### PR DESCRIPTION
As requested in #2542, here's a small change to update the URL for the inspector to the new visualizer. After working with the new viz further and seeing some of its issues, like [this one](https://github.com/statelyai/xstate-viz/issues/227), but also some general fragility*, I think my suggestion would be that you publish this change to @xstate/inspect under a @beta or @next tag so that the beta status of the new viz is clear to users? I have suggested this as well in the docs change in #2579.

*Fragility = times when the visualization stopped showing up, just a blank page. Unfortunately I didn't have time to stop and capture the instances when this happened by extracting the machines into sandboxes... but I'll try to find the time in the future.