### PR TITLE
Fix ContextFrom<T>, EventFrom<T>, EmittedFrom<T>

### DIFF
--- a/.changeset/curvy-snails-wonder.md
+++ b/.changeset/curvy-snails-wonder.md
@@ -1,0 +1,9 @@
+---
+'xstate': patch
+---
+
+The following utility types were previously returning `never` in some unexpected cases, and are now working as expected:
+
+- `ContextFrom<T>`
+- `EventFrom<T>`
+- `EmittedFrom<T>`

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,9 @@ import { State } from './State';
 import { Interpreter, Clock } from './interpreter';
 import { Model } from './model.types';
 
+type AnyFunction = (...args: any[]) => any;
+type ReturnTypeOrValue<T> = T extends AnyFunction ? ReturnType<T> : T;
+
 export type EventType = string;
 export type ActionType = string;
 export type MetaObject = Record<string, any>;
@@ -1471,57 +1474,36 @@ export interface Behavior<TEvent extends EventObject, TEmitted = any> {
   start?: (actorCtx: ActorContext<TEvent, TEmitted>) => TEmitted;
 }
 
-export type EmittedFrom<T> = T extends ActorRef<any, infer TEmitted>
-  ? TEmitted
-  : T extends (...args: any[]) => ActorRef<any, infer TEmitted>
-  ? TEmitted
-  : T extends Behavior<any, infer TEmitted>
-  ? TEmitted
-  : T extends (...args: any[]) => Behavior<any, infer TEmitted>
-  ? TEmitted
-  : T extends ActorContext<any, infer TEmitted>
-  ? TEmitted
-  : T extends (...args: any[]) => ActorContext<any, infer TEmitted>
-  ? TEmitted
+export type EmittedFrom<T> = ReturnTypeOrValue<T> extends infer R
+  ? R extends ActorRef<infer _, infer TEmitted>
+    ? TEmitted
+    : R extends Behavior<infer _, infer TEmitted>
+    ? TEmitted
+    : R extends ActorContext<infer _, infer TEmitted>
+    ? TEmitted
+    : never
   : never;
 
-export type EventFrom<T> = T extends StateMachine<any, any, infer TEvent, any>
-  ? TEvent
-  : T extends (...args: any[]) => StateMachine<any, any, infer TEvent, any>
-  ? TEvent
-  : T extends Model<any, infer TEvent, any, any>
-  ? TEvent
-  : T extends (...args: any[]) => Model<any, infer TEvent, any, any>
-  ? TEvent
-  : T extends State<any, infer TEvent, any, any>
-  ? TEvent
-  : T extends (...args: any[]) => State<any, infer TEvent, any, any>
-  ? TEvent
-  : T extends Interpreter<any, any, infer TEvent, any>
-  ? TEvent
-  : T extends (...args: any[]) => Interpreter<any, infer TEvent, any, any>
-  ? TEvent
+export type EventFrom<T> = ReturnTypeOrValue<T> extends infer R
+  ? R extends StateMachine<infer _, infer __, infer TEvent, infer ____>
+    ? TEvent
+    : R extends Model<infer _, infer TEvent, infer ___, infer ____>
+    ? TEvent
+    : R extends State<infer _, infer TEvent, infer ___, infer ____>
+    ? TEvent
+    : R extends Interpreter<infer _, infer __, infer TEvent, infer ____>
+    ? TEvent
+    : never
   : never;
 
-export type ContextFrom<T> = T extends StateMachine<
-  infer TContext,
-  any,
-  any,
-  any
->
-  ? TContext
-  : T extends (...args: any[]) => StateMachine<infer TContext, any, any, any>
-  ? TContext
-  : T extends Model<infer TContext, any, any, any>
-  ? TContext
-  : T extends (...args: any[]) => Model<infer TContext, any, any, any>
-  ? TContext
-  : T extends State<infer TContext, any, any, any>
-  ? TContext
-  : T extends (...args: any[]) => State<infer TContext, any, any, any>
-  ? TContext
-  : T extends Interpreter<infer TContext, any, any, any>
-  ? TContext
-  : T extends (...args: any[]) => Interpreter<infer TContext, any, any, any>
-  ? TContext
+export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
+  ? R extends StateMachine<infer TContext, infer _, infer __, infer ___>
+    ? TContext
+    : R extends Model<infer TContext, infer _, infer __, infer ___>
+    ? TContext
+    : R extends State<infer TContext, infer _, infer __, infer ___>
+    ? TContext
+    : R extends Interpreter<infer TContext, infer _, infer __, infer ___>
+    ? TContext
+    : never
   : never;

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -544,7 +544,7 @@ describe('createModel', () => {
       }
     );
 
-    const val = (null as unknown) as ContextFrom<typeof model>;
+    const val = ({} as unknown) as ContextFrom<typeof model>;
 
     // expect no type error here
     // with previous ContextFrom behavior, this will not compile
@@ -564,7 +564,7 @@ describe('createModel', () => {
       }
     );
 
-    const val = (null as unknown) as EventFrom<typeof model>;
+    const val = ({} as unknown) as EventFrom<typeof model>;
 
     // expect no type error here
     // with previous ContextFrom behavior, this will not compile

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -1,4 +1,4 @@
-import { createMachine } from '../src';
+import { ContextFrom, createMachine, EventFrom } from '../src';
 import {
   cancel,
   choose,
@@ -534,5 +534,43 @@ describe('createModel', () => {
       // @ts-expect-error
       machine.initialState.context.unknown;
     }
+  });
+
+  it('ContextFrom accepts a model type', () => {
+    const model = createModel(
+      { count: 3 },
+      {
+        events: {}
+      }
+    );
+
+    const val = (null as unknown) as ContextFrom<typeof model>;
+
+    // expect no type error here
+    // with previous ContextFrom behavior, this will not compile
+    val.count;
+
+    // @ts-expect-error (sanity check)
+    val.unknown;
+  });
+
+  it('EventFrom accepts a model type', () => {
+    const model = createModel(
+      { count: 3 },
+      {
+        events: {
+          INC: () => ({})
+        }
+      }
+    );
+
+    const val = (null as unknown) as EventFrom<typeof model>;
+
+    // expect no type error here
+    // with previous ContextFrom behavior, this will not compile
+    val.type;
+
+    // @ts-expect-error (sanity check)
+    val.count;
   });
 });


### PR DESCRIPTION
This PR fixes an issue with the `*From<T>` types returning `never`. This was occurring because doing something like:

```ts
T extends Model<infer T, any, any, any>
```

was not working when `T` was actually `Model<Something, never, never, ...>`, since `never` doesn't extend `any` (I think).

The fix was to do this instead:

```ts
T extends Model<infer T, infer _, infer __, infer ___>
```

This also uses the trick that @Andarist proposed in the previous PR 👏 

Fixes #2600