### PR TITLE
[core] Allow any action if action creators are not specified in model

### DIFF
--- a/.changeset/slow-timers-nail.md
+++ b/.changeset/slow-timers-nail.md
@@ -1,0 +1,20 @@
+---
+'xstate': patch
+---
+
+A regression was fixed where actions were being typed as `never` if events were specified in `createModel(...)` but not actions:
+
+```ts
+const model = createModel(
+  {},
+  {
+    events: {}
+  }
+);
+
+model.createMachine({
+  // These actions will cause TS to not compile
+  entry: 'someAction',
+  exit: { type: 'someObjectAction' }
+});
+```

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -22,9 +22,11 @@ export function createModel<
   TComputedEvent = 'events' extends keyof TFinalModelCreators
     ? UnionFromCreatorsReturnTypes<TFinalModelCreators['events']>
     : never,
-  TComputedAction = 'actions' extends keyof TFinalModelCreators
-    ? UnionFromCreatorsReturnTypes<TFinalModelCreators['actions']>
-    : never
+  TComputedAction = 'actions' extends keyof TModelCreators
+    ? 'actions' extends keyof TFinalModelCreators
+      ? UnionFromCreatorsReturnTypes<TFinalModelCreators['actions']>
+      : any
+    : any
 >(
   initialContext: TContext,
   creators: TModelCreators

--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -436,7 +436,14 @@ describe('createModel', () => {
   });
 
   it('should typecheck `createMachine` for model without creators', () => {
-    const toggleModel = createModel({ count: 0 });
+    const toggleModel = createModel(
+      { count: 0 },
+      {
+        events: {
+          TOGGLE: () => ({})
+        }
+      }
+    );
 
     toggleModel.createMachine({
       id: 'machine',
@@ -515,6 +522,24 @@ describe('createModel', () => {
           // @ts-expect-error
           entry: 'barAction'
         }
+      }
+    });
+  });
+
+  it('should allow any action if actions are not specified', () => {
+    const model = createModel(
+      {},
+      {
+        events: {}
+      }
+    );
+
+    model.createMachine({
+      entry: 'someAction',
+      exit: { type: 'someObjectAction' },
+      on: {
+        // @ts-expect-error
+        UNEXPECTED_EVENT: {}
       }
     });
   });


### PR DESCRIPTION
This PR fixes a regression noticed by some users - when they specified `events` but not `actions` in `createModel(...)`, actions would be typed as `never`:

```ts
    const model = createModel(
      {},
      {
        events: {}
      }
    );

    model.createMachine({
      // TS will not compile
      entry: 'someAction',
      exit: { type: 'someObjectAction' },
    });
```

Fixes #2619