### PR TITLE
fix: return empty context from event.type protective code

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -248,7 +248,7 @@ The reason this errors is because inside the `consoleLogData` function, we don't
 createMachine<Context, Event>(machine, {
   actions: {
     consoleLogData: (context, event) => {
-      if (event.type !== 'EVENT_WITH_FLAG') return
+      if (event.type !== 'EVENT_WITH_FLAG') return {}
       // No more error at .flag!
       console.log(event.flag);
     };


### PR DESCRIPTION
It seems the TS compiler is complaining about the return value. A simple return is not allowed.
Returning and empty object hash works though.