### PR TITLE
Fixed an issue with functions used as inline actions not always receiving the correct arguments when used with `preserveActionOrder`

### DIFF
--- a/.changeset/olive-lies-confess.md
+++ b/.changeset/olive-lies-confess.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with functions used as inline actions not always receiving the correct arguments when used with `preserveActionOrder`.

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -698,15 +698,18 @@ export function resolveActions<TContext, TEvent extends EventObject>(
             break;
           }
           default:
-            const resolvedActionObject = toActionObject(
+            let resolvedActionObject = toActionObject(
               actionObject,
               machine.options.actions
             );
             const { exec } = resolvedActionObject;
             if (exec && preservedContexts) {
               const contextIndex = preservedContexts.length - 1;
-              resolvedActionObject.exec = (_ctx, ...args) => {
-                exec?.(preservedContexts[contextIndex], ...args);
+              resolvedActionObject = {
+                ...resolvedActionObject,
+                exec: (_ctx, ...args) => {
+                  exec(preservedContexts[contextIndex], ...args);
+                }
               };
             }
             return resolvedActionObject;

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1556,6 +1556,32 @@ describe('assign action order', () => {
     expect(captured).toEqual([0, 1, 2]);
   });
 
+  it('should capture correct context values on subsequent transitions', () => {
+    let captured: number[] = [];
+
+    const machine = createMachine<{ counter: number }>({
+      context: {
+        counter: 0
+      },
+      on: {
+        EV: {
+          actions: [
+            assign({ counter: (ctx) => ctx.counter + 1 }),
+            (ctx) => captured.push(ctx.counter)
+          ]
+        }
+      },
+      preserveActionOrder: true
+    });
+
+    const service = interpret(machine).start();
+
+    service.send('EV');
+    service.send('EV');
+
+    expect(captured).toEqual([1, 2]);
+  });
+
   it.each([undefined, false])(
     'should prioritize assign actions when .preserveActionOrder = %i',
     (preserveActionOrder) => {


### PR DESCRIPTION
fixes #2643 

Sadly, I've noticed this back in July: https://github.com/statelyai/xstate/pull/2430#discussion_r675512313 and even implemented this test back then: https://github.com/statelyai/xstate/commit/c49e058e094c4d565b95668a6cbad5b609158d78 but I've used that as an argument against that linked PR while not realizing that this is already broken on the `main` branch 😢 