### PR TITLE
Add description property to state and transition

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -252,6 +252,8 @@ class StateNode<
 
   public __xstatenode: true = true;
 
+  public description?: string;
+
   private __cache = {
     events: undefined as Array<TEvent['type']> | undefined,
     relativeValue: new Map() as Map<StateNode<TContext>, StateValue>,
@@ -323,6 +325,7 @@ class StateNode<
       ? this.machine.schema
       : (this.config as MachineConfig<TContext, TStateSchema, TEvent>).schema ??
         ({} as this['schema']);
+    this.description = this.config.description;
 
     if (!IS_PRODUCTION) {
       warn(
@@ -519,7 +522,8 @@ class StateNode<
       meta: this.meta,
       order: this.order || -1,
       data: this.doneData,
-      invoke: this.invoke
+      invoke: this.invoke,
+      description: this.description
     };
   }
 

--- a/packages/core/src/machine.schema.json
+++ b/packages/core/src/machine.schema.json
@@ -5,14 +5,12 @@
     "actionObject": {
       "type": "object",
       "properties": {
-        "type": { "type": "string" },
-        "exec": {
-          "oneOf": [
-            { "type": "string" },
-            { "$ref": "#/definitions/functionObject" }
-          ]
+        "type": {
+          "type": "string",
+          "definition": "The action type"
         }
       },
+      "additionalProperties": true,
       "required": ["type"]
     },
     "baseStateNode": {
@@ -30,6 +28,10 @@
         },
         "order": {
           "$ref": "#/definitions/order"
+        },
+        "description": {
+          "type": "string",
+          "description": "The description of the state node, in Markdown"
         }
       },
       "required": ["id", "key", "type"]
@@ -198,34 +200,37 @@
         "^.*$": {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "actions": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/actionObject"
-                }
-              },
-              "cond": {
-                "type": "object"
-              },
-              "eventType": {
-                "type": "string"
-              },
-              "source": {
-                "type": "string"
-              },
-              "target": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": ["actions", "eventType", "source", "target"]
+            "$ref": "#/definitions/transitionObject"
           }
         }
       }
+    },
+    "transitionObject": {
+      "type": "object",
+      "properties": {
+        "actions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/actionObject"
+          }
+        },
+        "cond": {
+          "type": "object"
+        },
+        "eventType": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "target": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": ["actions", "eventType", "source", "target"]
     },
     "invokeObject": {
       "type": "object",
@@ -293,7 +298,10 @@
       "$ref": "#/definitions/transitionsObject"
     },
     "transitions": {
-      "type": "array"
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/transitionObject"
+      }
     },
     "entry": {
       "type": "array"

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -222,6 +222,7 @@ export interface TransitionConfig<TContext, TEvent extends EventObject> {
   internal?: boolean;
   target?: TransitionTarget<TContext, TEvent>;
   meta?: Record<string, any>;
+  description?: string;
 }
 
 export interface TargetTransitionConfig<TContext, TEvent extends EventObject>
@@ -647,6 +648,10 @@ export interface StateNodeConfig<
    * @default false
    */
   preserveActionOrder?: boolean;
+  /**
+   * A description of the state node, rendered in Markdown
+   */
+  description?: string;
 }
 
 export interface StateNodeDefinition<
@@ -674,6 +679,7 @@ export interface StateNodeDefinition<
   order: number;
   data?: FinalStateNodeConfig<TContext, TEvent>['data'];
   invoke: Array<InvokeDefinition<TContext, TEvent>>;
+  description?: string;
 }
 
 export type AnyStateNodeDefinition = StateNodeDefinition<any, any, any>;

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -160,3 +160,32 @@ describe('transition meta data', () => {
     `);
   });
 });
+
+describe('state description', () => {
+  it('state node should have its description', () => {
+    const machine = createMachine({
+      initial: 'test',
+      states: {
+        test: {
+          description: 'This is a test'
+        }
+      }
+    });
+
+    expect(machine.states.test.description).toEqual('This is a test');
+  });
+});
+
+describe('transition description', () => {
+  it('state node should have its description', () => {
+    const machine = createMachine({
+      on: {
+        EVENT: {
+          description: 'This is a test'
+        }
+      }
+    });
+
+    expect(machine.on['EVENT'][0].description).toEqual('This is a test');
+  });
+});


### PR DESCRIPTION
This PR adds `description` as a top-level property for state nodes and transitions:

```js
const machine = createMachine({
  // ...
  states: {
    active: {
      // ...
      description: 'The task is in progress',
      on: {
        DEACTIVATE: {
          // ...
          description: 'Deactivates the task'
        }
      }
    }
  }
});
```