### PR TITLE
Added a syncToContext option to useInterpret and useMachine

### DIFF
--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -54,6 +54,12 @@ export interface UseMachineOptions<TContext, TEvent extends EventObject> {
    * start at this state instead of its `initialState`.
    */
   state?: StateConfig<TContext, TEvent>;
+
+  /**
+   * If provided, will be synced with the machine's `context`
+   * every time it changes
+   */
+  syncToContext?: Partial<TContext>;
 }
 
 export function useMachine<


### PR DESCRIPTION
This implementation is exceptionally naive, but it appears to work. I'd love advice on how I can improve this.

- [ ] Add docs
- [ ] Add changeset
- [ ] Improve implementation?
- [ ] https://twitter.com/zhzhng/status/1441032589947518979 - Consider whether to handle dependency changes explicitly, or implicitly