### PR TITLE
`@xstate/react`: Correct machine reference in the `useInterpret` hook

### DIFF
--- a/.changeset/long-icons-pull.md
+++ b/.changeset/long-icons-pull.md
@@ -1,0 +1,37 @@
+---
+'@xstate/react': patch
+---
+
+Correct reference to the machine in `useInterpret` hook.
+Make sure a warning is shown in the console in the development mode when machine reference is updated during the hook lifecycle. This usually happens when machine options are dependent on external values and they're passed via `withConfig`.
+
+```js
+const machine = createMachine({
+  initial: 'foo',
+  context: { id: 1 },
+  states: {
+    foo: {
+      on: {
+        CHECK: {
+          target: 'bar',
+          cond: 'hasOverflown'
+        }
+      }
+    },
+    bar: {}
+  }
+});
+
+const [id, setId] = useState(1);
+const [current, send] = useMachine(
+  machine.withConfig({
+    guards: {
+      hasOverflown: () => id > 1 // id is a reference to an outside value
+    }
+  })
+);
+
+// later when id updates
+setId(2);
+// Now the reference to `machine.withConfig` from above is updated but in the guard, the id value is still stale (id=1).
+```

--- a/.changeset/long-icons-pull.md
+++ b/.changeset/long-icons-pull.md
@@ -3,7 +3,7 @@
 ---
 
 Correct reference to the machine in `useInterpret` hook.
-Make sure a warning is shown in the console in the development mode when machine reference is updated during the hook lifecycle. This usually happens when machine options are dependent on external values and they're passed via `withConfig`.
+Fixed a regression with a development-only warning not being shown when a machine reference is updated during the hook lifecycle. This usually happens when machine options are dependent on external values and they're passed via `withConfig`.
 
 ```js
 const machine = createMachine({

--- a/.changeset/long-icons-pull.md
+++ b/.changeset/long-icons-pull.md
@@ -2,6 +2,9 @@
 '@xstate/react': patch
 ---
 
+author: @farskid
+author: @Andarist 
+
 Fixed a regression with a development-only warning not being shown when a machine reference is updated during the hook lifecycle. This usually happens when machine options are dependent on external values and they're passed via `withConfig`.
 
 ```js

--- a/.changeset/long-icons-pull.md
+++ b/.changeset/long-icons-pull.md
@@ -2,7 +2,6 @@
 '@xstate/react': patch
 ---
 
-Correct reference to the machine in `useInterpret` hook.
 Fixed a regression with a development-only warning not being shown when a machine reference is updated during the hook lifecycle. This usually happens when machine options are dependent on external values and they're passed via `withConfig`.
 
 ```js

--- a/.changeset/long-icons-pull.md
+++ b/.changeset/long-icons-pull.md
@@ -32,5 +32,5 @@ const [current, send] = useMachine(
 
 // later when id updates
 setId(2);
-// Now the reference to `machine.withConfig` from above is updated but in the guard, the id value is still stale (id=1).
+// Now the reference passed to `useMachine` (the result of `machine.withConfig`) is updated but the interpreted machine stays the same. So the guard is still the previous one that got passed to the `useMachine` initially, and it closes over the stale `id`.
 ```

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -59,7 +59,7 @@ export function useInterpret<
   ) {
     const [initialMachine] = useState(machine);
 
-    if (machine !== initialMachine) {
+    if (getMachine !== initialMachine) {
       console.warn(
         'Machine given to `useMachine` has changed between renders. This is not supported and might lead to unexpected results.\n' +
           'Please make sure that you pass the same Machine as argument each time.'

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -163,5 +163,9 @@ describe('useInterpret', () => {
     getByRole('button').click();
 
     expect(console.warn).toHaveBeenCalledTimes(1);
+    expect((console.warn as jest.Mock).mock.calls[0][0]).toMatchInlineSnapshot(`
+      "Machine given to \`useMachine\` has changed between renders. This is not supported and might lead to unexpected results.
+      Please make sure that you pass the same Machine as argument each time."
+    `);
   });
 });

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -3,7 +3,12 @@ import { createMachine } from 'xstate';
 import { render, cleanup, fireEvent } from '@testing-library/react';
 import { useInterpret, useMachine } from '../src';
 
-afterEach(cleanup);
+const originalConsoleWarn = console.warn;
+
+afterEach(() => {
+  cleanup();
+  console.warn = originalConsoleWarn;
+});
 
 describe('useInterpret', () => {
   it('observer should be called with initial state', (done) => {
@@ -112,7 +117,7 @@ describe('useInterpret', () => {
     expect(actual).toEqual([1, 42]);
   });
 
-  it('should warn when machine reference is updated during the hook lifecycle', async () => {
+  it('should warn when machine reference is updated during the hook lifecycle', () => {
     console.warn = jest.fn();
     const machine = createMachine({
       initial: 'foo',
@@ -153,9 +158,9 @@ describe('useInterpret', () => {
       );
     };
 
-    const { findByRole } = render(<App />);
+    const { getByRole } = render(<App />);
 
-    (await findByRole('button')).click();
+    getByRole('button').click();
 
     expect(console.warn).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
This PR:
- Makes sure we target the correct machine reference in `useInterpret`
- Makes sure the warning is shown when machine reference updates

TODO:
- [x] Add changeset