### PR TITLE
Add doc for useInterpret() in index.md

### DIFF
--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -141,7 +141,7 @@ const [state, send] = useActor(customActor, (actor) => {
 
 ### `useInterpret(machine, options?, observer?)`
 
-A React hook that returns the `service` created from the `machine` with the `options`, if specified. It also sets up a subscription to the `service` with the `observer`, if provided. It starts the service and runs it for the lifetime of the component. Similar to using `useMachhine`, but with an observer.
+A React hook that returns the `service` created from the `machine` with the `options`, if specified. It also sets up a subscription to the `service` with the `observer`, if provided. It starts the service and runs it for the lifetime of the component. Similar to using `useMachine`, but with an observer.
 
 _Since 1.3.0_
 

--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -141,7 +141,7 @@ const [state, send] = useActor(customActor, (actor) => {
 
 ### `useInterpret(machine, options?, observer?)`
 
-A React hook that returns the `service` created from the `machine` with the `options`, if specified. It also sets up a subscription to the `service` with the `observer`, if provided.
+A React hook that returns the `service` created from the `machine` with the `options`, if specified. It also sets up a subscription to the `service` with the `observer`, if provided. It starts the service and runs it for the lifetime of the component. Similar to using `useMachhine`, but with an observer.
 
 _Since 1.3.0_
 


### PR DESCRIPTION
To clarify that `useInterpret` works with component lifecycles (like `useMachine` does), and how it compares to `useMachine`.
Had to dig into https://github.com/statelyai/xstate/pull/1915 and https://github.com/statelyai/xstate/pull/1915/commits/aea4a2faf7b695593ee0939b7dc099f21e5bb7c6 to figure out the difference between `useInterpret` and `useMachine`. Realised the only difference was the observer, since `useInterpret` was previously named more clearly as `useMachineObserver`.