### PR TITLE
Doc: Add doc to useInterpret() in index.md

### DIFF
--- a/packages/xstate-react/README.md
+++ b/packages/xstate-react/README.md
@@ -141,7 +141,7 @@ const [state, send] = useActor(customActor, (actor) => {
 
 ### `useInterpret(machine, options?, observer?)`
 
-A React hook that returns the `service` created from the `machine` with the `options`, if specified. It also sets up a subscription to the `service` with the `observer`, if provided.
+A React hook that returns the `service` created from the `machine` with the `options`, if specified. It also sets up a subscription to the `service` with the `observer`, if provided. It starts the service and runs it for the lifetime of the component. Similar to using `useMachine`, but with an observer.
 
 _Since 1.3.0_
 


### PR DESCRIPTION
To clarify that `useInterpret` works with component lifecycles (like `useMachine` does), and how it compares to `useMachine`.
Had to dig into #1915 and aea4a2f to figure out the difference between `useInterpret` and `useMachine`. Realised the only difference was the observer, since `useInterpret` was previously named more clearly as `useMachineObserver`.