### PR TITLE
Generate a test plan from a sequence of events

### DIFF
--- a/.changeset/dull-bats-hug.md
+++ b/.changeset/dull-bats-hug.md
@@ -1,0 +1,5 @@
+---
+'@xstate/test': minor
+---
+
+Add getPlanFromEvents to generate a test plan with a single path from an explicitly defined sequence of events.

--- a/.changeset/four-rivers-shave.md
+++ b/.changeset/four-rivers-shave.md
@@ -1,0 +1,5 @@
+---
+'@xstate/graph': minor
+---
+
+Add getPathFromEvents to generate a path from a sequence of events.

--- a/docs/packages/xstate-graph/index.md
+++ b/docs/packages/xstate-graph/index.md
@@ -288,6 +288,81 @@ console.log(simplePaths);
 // };
 ```
 
+### `getPathFromEvents(machine, events)`
+
+**Arguments**
+
+- `machine` - the [`Machine`](https://xstate.js.org/docs/guides/machines.html) to traverse
+- `events` - the sequence of events to generate a path from
+
+Returns a path object with the following keys:
+
+- `state` - the target [`State`](https://xstate.js.org/docs/guides/states.html)
+- `segments` - an array of objects with the following shape:
+  - `state` - the [`State`](https://xstate.js.org/docs/guides/states.html) of the segment
+  - `event` - the event object that transitions the `machine` from the state to the next state in the path
+
+import { createMachine } from 'xstate';
+import { getSimplePaths } from '@xstate/graph';
+
+```js
+const feedbackMachine = createMachine({
+  id: 'feedback',
+  initial: 'question',
+  states: {
+    question: {
+      on: {
+        CLICK_GOOD: 'thanks',
+        CLICK_BAD: 'form',
+        CLOSE: 'closed',
+        ESC: 'closed'
+      }
+    },
+    form: {
+      on: {
+        SUBMIT: 'thanks',
+        CLOSE: 'closed',
+        ESC: 'closed'
+      }
+    },
+    thanks: {
+      on: {
+        CLOSE: 'closed',
+        ESC: 'closed'
+      }
+    },
+    closed: {
+      type: 'final'
+    }
+  }
+});
+
+const path = getPathFromEvents(feedbackMachine, [
+  { type: 'CLICK_GOOD' },
+  { type: 'SUBMIT' },
+  { type: 'CLOSE },
+]);
+
+console.log(path);
+// => {
+//   state: { value: 'closed' },
+//   segments: [
+//     {
+//       state: { value: 'question' },
+//       event: { type: 'CLICK_GOOD' },
+//     },
+//     {
+//       state: { value: 'form' },
+//       event: { type: 'SUBMIT' },
+//     },
+//     {
+//       state: { value: 'thanks' },
+//       event: { type: 'CLOSE' },
+//     },
+//   ],
+// }
+```
+
 ### `toDirectedGraph(machine)`
 
 Converts a `machine` to a directed graph structure.

--- a/docs/packages/xstate-graph/index.md
+++ b/docs/packages/xstate-graph/index.md
@@ -302,10 +302,10 @@ Returns a path object with the following keys:
   - `state` - the [`State`](https://xstate.js.org/docs/guides/states.html) of the segment
   - `event` - the event object that transitions the `machine` from the state to the next state in the path
 
+```js
 import { createMachine } from 'xstate';
 import { getSimplePaths } from '@xstate/graph';
 
-```js
 const feedbackMachine = createMachine({
   id: 'feedback',
   initial: 'question',

--- a/docs/packages/xstate-graph/index.md
+++ b/docs/packages/xstate-graph/index.md
@@ -340,7 +340,7 @@ const feedbackMachine = createMachine({
 const path = getPathFromEvents(feedbackMachine, [
   { type: 'CLICK_GOOD' },
   { type: 'SUBMIT' },
-  { type: 'CLOSE },
+  { type: 'CLOSE' }
 ]);
 
 console.log(path);

--- a/docs/packages/xstate-test/index.md
+++ b/docs/packages/xstate-test/index.md
@@ -185,10 +185,10 @@ Returns an array of testing plans based on the simple paths from the test model'
 
 ### `testModel.getPlanFromEvents(events, options)`
 
-| Argument         | Type               | Description                                                                         |
-| ---------------- | ------------------ | ----------------------------------------------------------------------------------- |
-| `events`         | EventObject[]      | The sequence of events to create the plan                                           |
-| `options.target` | { target: string } | An object with a `target` property that should match the target state of the events |
+| Argument  | Type               | Description                                                                         |
+| --------- | ------------------ | ----------------------------------------------------------------------------------- |
+| `events`  | EventObject[]      | The sequence of events to create the plan                                           |
+| `options` | { target: string } | An object with a `target` property that should match the target state of the events |
 
 Returns an array with a single testing plan with a single path generated from the `events`.
 

--- a/docs/packages/xstate-test/index.md
+++ b/docs/packages/xstate-test/index.md
@@ -183,6 +183,17 @@ Returns an array of testing plans based on the simple paths from the test model'
 | -------- | -------- | -------------------------------------------------------------------------------------------------------------- |
 | `filter` | function | Takes in the `state` and returns `true` if the state should be traversed, or `false` if traversal should stop. |
 
+### `testModel.getPlanFromEvents(events, options)`
+
+| Argument         | Type               | Description                                                                         |
+| ---------------- | ------------------ | ----------------------------------------------------------------------------------- |
+| `events`         | EventObject[]      | The sequence of events to create the plan                                           |
+| `options.target` | { target: string } | An object with a `target` property that should match the target state of the events |
+
+Returns an array with a single testing plan with a single path generated from the `events`.
+
+Throws an error if the last entered state does not match the `options.target`.
+
 ### `testModel.testCoverage(options?)`
 
 Tests that all state nodes were covered (traversed) in the exected tests.

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -8,6 +8,7 @@ import {
   AnyEventObject
 } from 'xstate';
 import { flatten, keys } from 'xstate/lib/utils';
+import { StatePath } from '.';
 import {
   StatePathsMap,
   StatePaths,
@@ -380,4 +381,67 @@ export function toDirectedGraph(stateNode: StateNode): DirectedGraphNode {
   };
 
   return graph;
+}
+
+export function getPathFromEvents<
+  TContext = DefaultContext,
+  TEvent extends EventObject = EventObject
+>(
+  machine: StateMachine<TContext, any, TEvent>,
+  events: Array<TEvent>
+): StatePath<TContext, TEvent> {
+  const optionsWithDefaults = getValueAdjMapOptions<TContext, TEvent>({
+    events: events.reduce((events, event) => {
+      events[event.type] ??= [];
+      events[event.type].push(event);
+      return events;
+    }, {})
+  });
+
+  const { stateSerializer, eventSerializer } = optionsWithDefaults;
+
+  if (!machine.states) {
+    return {
+      state: machine.initialState,
+      segments: [],
+      weight: 0
+    };
+  }
+
+  const adjacency = getAdjacencyMap(machine, optionsWithDefaults);
+  const stateMap = new Map<string, State<TContext, TEvent>>();
+  const path: Segments<TContext, TEvent> = [];
+
+  const initialStateSerial = stateSerializer(machine.initialState);
+  stateMap.set(initialStateSerial, machine.initialState);
+
+  let stateSerial = initialStateSerial;
+  let state = machine.initialState;
+  for (const event of events) {
+    path.push({
+      state: stateMap.get(stateSerial)!,
+      event
+    });
+
+    const eventSerial = eventSerializer(event);
+    const nextSegment = adjacency[stateSerial][eventSerial];
+
+    if (!nextSegment) {
+      throw new Error(
+        `Invalid transition from ${stateSerial} with ${eventSerial}`
+      );
+    }
+
+    const nextStateSerial = stateSerializer(nextSegment.state);
+    stateMap.set(nextStateSerial, nextSegment.state);
+
+    stateSerial = nextStateSerial;
+    state = nextSegment.state;
+  }
+
+  return {
+    state,
+    segments: path,
+    weight: path.length
+  };
 }

--- a/packages/xstate-graph/src/index.ts
+++ b/packages/xstate-graph/src/index.ts
@@ -1,5 +1,6 @@
 import {
   getStateNodes,
+  getPathFromEvents,
   getSimplePaths,
   getShortestPaths,
   serializeEvent,
@@ -9,6 +10,7 @@ import {
 
 export {
   getStateNodes,
+  getPathFromEvents,
   getSimplePaths,
   getShortestPaths,
   serializeEvent,

--- a/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
+++ b/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
@@ -1,5 +1,379 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`@xstate/graph getPathFromEvents() should return a path to the last entered state by the event sequence: path from events 1`] = `
+Object {
+  "segments": Array [
+    Object {
+      "event": Object {
+        "type": "TIMER",
+      },
+      "state": Object {
+        "_event": Object {
+          "$$type": "scxml",
+          "data": Object {
+            "type": "xstate.init",
+          },
+          "name": "xstate.init",
+          "type": "external",
+        },
+        "_sessionid": null,
+        "actions": Array [],
+        "activities": Object {},
+        "changed": undefined,
+        "children": Object {},
+        "context": undefined,
+        "done": false,
+        "event": Object {
+          "type": "xstate.init",
+        },
+        "events": Array [],
+        "history": undefined,
+        "historyValue": undefined,
+        "matches": [Function],
+        "meta": Object {},
+        "tags": Array [],
+        "toStrings": [Function],
+        "value": "green",
+      },
+    },
+    Object {
+      "event": Object {
+        "type": "TIMER",
+      },
+      "state": Object {
+        "_event": Object {
+          "$$type": "scxml",
+          "data": Object {
+            "type": "TIMER",
+          },
+          "name": "TIMER",
+          "type": "external",
+        },
+        "_sessionid": null,
+        "actions": Array [],
+        "activities": Object {},
+        "changed": true,
+        "children": Object {},
+        "context": undefined,
+        "done": false,
+        "event": Object {
+          "type": "TIMER",
+        },
+        "events": Array [],
+        "history": Object {
+          "_event": Object {
+            "$$type": "scxml",
+            "data": Object {
+              "type": "xstate.init",
+            },
+            "name": "xstate.init",
+            "type": "external",
+          },
+          "_sessionid": null,
+          "actions": Array [],
+          "activities": Object {},
+          "changed": undefined,
+          "children": Object {},
+          "context": undefined,
+          "done": false,
+          "event": Object {
+            "type": "xstate.init",
+          },
+          "events": Array [],
+          "historyValue": undefined,
+          "matches": [Function],
+          "meta": Object {},
+          "tags": Array [],
+          "toStrings": [Function],
+          "value": "green",
+        },
+        "historyValue": Object {
+          "current": "yellow",
+          "states": Object {
+            "green": undefined,
+            "red": Object {
+              "current": "walk",
+              "states": Object {
+                "flashing": undefined,
+                "stop": undefined,
+                "wait": undefined,
+                "walk": undefined,
+              },
+            },
+            "yellow": undefined,
+          },
+        },
+        "matches": [Function],
+        "meta": Object {},
+        "tags": Array [],
+        "toStrings": [Function],
+        "value": "yellow",
+      },
+    },
+    Object {
+      "event": Object {
+        "type": "TIMER",
+      },
+      "state": Object {
+        "_event": Object {
+          "$$type": "scxml",
+          "data": Object {
+            "type": "TIMER",
+          },
+          "name": "TIMER",
+          "type": "external",
+        },
+        "_sessionid": null,
+        "actions": Array [],
+        "activities": Object {},
+        "changed": true,
+        "children": Object {},
+        "context": undefined,
+        "done": false,
+        "event": Object {
+          "type": "TIMER",
+        },
+        "events": Array [],
+        "history": Object {
+          "_event": Object {
+            "$$type": "scxml",
+            "data": Object {
+              "type": "TIMER",
+            },
+            "name": "TIMER",
+            "type": "external",
+          },
+          "_sessionid": null,
+          "actions": Array [],
+          "activities": Object {},
+          "changed": true,
+          "children": Object {},
+          "context": undefined,
+          "done": false,
+          "event": Object {
+            "type": "TIMER",
+          },
+          "events": Array [],
+          "historyValue": Object {
+            "current": "yellow",
+            "states": Object {
+              "green": undefined,
+              "red": Object {
+                "current": "walk",
+                "states": Object {
+                  "flashing": undefined,
+                  "stop": undefined,
+                  "wait": undefined,
+                  "walk": undefined,
+                },
+              },
+              "yellow": undefined,
+            },
+          },
+          "matches": [Function],
+          "meta": Object {},
+          "tags": Array [],
+          "toStrings": [Function],
+          "value": "yellow",
+        },
+        "historyValue": Object {
+          "current": Object {
+            "red": "walk",
+          },
+          "states": Object {
+            "green": undefined,
+            "red": Object {
+              "current": "walk",
+              "states": Object {
+                "flashing": undefined,
+                "stop": undefined,
+                "wait": undefined,
+                "walk": undefined,
+              },
+            },
+            "yellow": undefined,
+          },
+        },
+        "matches": [Function],
+        "meta": Object {},
+        "tags": Array [],
+        "toStrings": [Function],
+        "value": Object {
+          "red": "walk",
+        },
+      },
+    },
+    Object {
+      "event": Object {
+        "type": "POWER_OUTAGE",
+      },
+      "state": Object {
+        "_event": Object {
+          "$$type": "scxml",
+          "data": Object {
+            "type": "TIMER",
+          },
+          "name": "TIMER",
+          "type": "external",
+        },
+        "_sessionid": null,
+        "actions": Array [],
+        "activities": Object {},
+        "changed": true,
+        "children": Object {},
+        "context": undefined,
+        "done": false,
+        "event": Object {
+          "type": "TIMER",
+        },
+        "events": Array [],
+        "history": Object {
+          "_event": Object {
+            "$$type": "scxml",
+            "data": Object {
+              "type": "TIMER",
+            },
+            "name": "TIMER",
+            "type": "external",
+          },
+          "_sessionid": null,
+          "actions": Array [],
+          "activities": Object {},
+          "changed": true,
+          "children": Object {},
+          "context": undefined,
+          "done": false,
+          "event": Object {
+            "type": "TIMER",
+          },
+          "events": Array [],
+          "historyValue": Object {
+            "current": Object {
+              "red": "walk",
+            },
+            "states": Object {
+              "green": undefined,
+              "red": Object {
+                "current": "walk",
+                "states": Object {
+                  "flashing": undefined,
+                  "stop": undefined,
+                  "wait": undefined,
+                  "walk": undefined,
+                },
+              },
+              "yellow": undefined,
+            },
+          },
+          "matches": [Function],
+          "meta": Object {},
+          "tags": Array [],
+          "toStrings": [Function],
+          "value": Object {
+            "red": "walk",
+          },
+        },
+        "historyValue": Object {
+          "current": "green",
+          "states": Object {
+            "green": undefined,
+            "red": Object {
+              "current": "walk",
+              "states": Object {
+                "flashing": undefined,
+                "stop": undefined,
+                "wait": undefined,
+                "walk": undefined,
+              },
+            },
+            "yellow": undefined,
+          },
+        },
+        "matches": [Function],
+        "meta": Object {},
+        "tags": Array [],
+        "toStrings": [Function],
+        "value": "green",
+      },
+    },
+  ],
+  "state": Object {
+    "_event": Object {
+      "$$type": "scxml",
+      "data": Object {
+        "type": "POWER_OUTAGE",
+      },
+      "name": "POWER_OUTAGE",
+      "type": "external",
+    },
+    "_sessionid": null,
+    "actions": Array [],
+    "activities": Object {},
+    "changed": true,
+    "children": Object {},
+    "context": undefined,
+    "done": false,
+    "event": Object {
+      "type": "POWER_OUTAGE",
+    },
+    "events": Array [],
+    "history": Object {
+      "_event": Object {
+        "$$type": "scxml",
+        "data": Object {
+          "type": "xstate.init",
+        },
+        "name": "xstate.init",
+        "type": "external",
+      },
+      "_sessionid": null,
+      "actions": Array [],
+      "activities": Object {},
+      "changed": undefined,
+      "children": Object {},
+      "context": undefined,
+      "done": false,
+      "event": Object {
+        "type": "xstate.init",
+      },
+      "events": Array [],
+      "historyValue": undefined,
+      "matches": [Function],
+      "meta": Object {},
+      "tags": Array [],
+      "toStrings": [Function],
+      "value": "green",
+    },
+    "historyValue": Object {
+      "current": Object {
+        "red": "flashing",
+      },
+      "states": Object {
+        "green": undefined,
+        "red": Object {
+          "current": "flashing",
+          "states": Object {
+            "flashing": undefined,
+            "stop": undefined,
+            "wait": undefined,
+            "walk": undefined,
+          },
+        },
+        "yellow": undefined,
+      },
+    },
+    "matches": [Function],
+    "meta": Object {},
+    "tags": Array [],
+    "toStrings": [Function],
+    "value": Object {
+      "red": "flashing",
+    },
+  },
+  "weight": 4,
+}
+`;
+
 exports[`@xstate/graph getShortestPaths() should represent conditional paths based on context: shortest paths conditional 1`] = `
 Object {
   "\\"bar\\" | {\\"id\\":\\"foo\\"}": Object {

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -1,6 +1,7 @@
 import { Machine, StateNode, createMachine } from 'xstate';
 import {
   getStateNodes,
+  getPathFromEvents,
   getSimplePaths,
   getShortestPaths,
   toDirectedGraph
@@ -290,6 +291,28 @@ describe('@xstate/graph', () => {
 
       expect(Array.isArray(pathsArray)).toBeTruthy();
       expect(pathsArray).toMatchSnapshot('simple paths array');
+    });
+  });
+
+  describe('getPathFromEvents()', () => {
+    it('should return a path to the last entered state by the event sequence', () => {
+      const path = getPathFromEvents(lightMachine, [
+        { type: 'TIMER' },
+        { type: 'TIMER' },
+        { type: 'TIMER' },
+        { type: 'POWER_OUTAGE' }
+      ]);
+
+      expect(path).toMatchSnapshot('path from events');
+    });
+
+    it('should throw when an invalid event sequence is provided', () => {
+      expect(() =>
+        getPathFromEvents(lightMachine, [
+          { type: 'TIMER' },
+          { type: 'INVALID_EVENT' }
+        ])
+      ).toThrow();
     });
   });
 

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -117,12 +117,14 @@ export class TestModel<TTestContext, TContext> {
       );
     }
 
-    return this.getTestPlans({
+    const plans = this.getTestPlans({
       [JSON.stringify(path.state.value)]: {
         state: path.state,
         paths: [path]
       }
     });
+
+    return plans[0];
   }
 
   public getSimplePathPlans(

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -106,7 +106,7 @@ export class TestModel<TTestContext, TContext> {
   public getPlanFromEvents(
     events: Array<EventObject>,
     { target }: { target: StateValue }
-  ) {
+  ): TestPlan<TTestContext, TContext> {
     const path = getPathFromEvents<TContext>(this.machine, events);
 
     if (!path.state.matches(target)) {

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  getPathFromEvents,
   getShortestPaths,
   getSimplePaths,
   getStateNodes,
@@ -100,6 +101,28 @@ export class TestModel<TTestContext, TContext> {
         ? (plan) => stateValue(plan.state)
         : (plan) => plan.state.matches(stateValue);
     return testPlans.filter(predicate);
+  }
+
+  public getPlanFromEvents(
+    events: Array<EventObject>,
+    { target }: { target: StateValue }
+  ) {
+    const path = getPathFromEvents<TContext>(this.machine, events);
+
+    if (!path.state.matches(target)) {
+      throw new Error(
+        `The last state ${JSON.stringify(
+          (path.state as any).value
+        )} does not match the target: ${JSON.stringify(target)}`
+      );
+    }
+
+    return this.getTestPlans({
+      [JSON.stringify(path.state.value)]: {
+        state: path.state,
+        paths: [path]
+      }
+    });
   }
 
   public getSimplePathPlans(

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -186,6 +186,43 @@ describe('testing a model (simplePathsTo)', () => {
     });
 });
 
+describe('testing a model (getPlanFromEvents)', () => {
+  dieHardModel
+    .getPlanFromEvents(
+      [
+        { type: 'FILL_5' },
+        { type: 'POUR_5_TO_3' },
+        { type: 'EMPTY_3' },
+        { type: 'POUR_5_TO_3' },
+        { type: 'FILL_5' },
+        { type: 'POUR_5_TO_3' }
+      ],
+      {
+        target: 'success'
+      }
+    )
+    .forEach((plan) => {
+      describe(`reaches state ${JSON.stringify(
+        plan.state.value
+      )} (${JSON.stringify(plan.state.context)})`, () => {
+        plan.paths.forEach((path) => {
+          it(path.description, () => {
+            const testJugs = new Jugs();
+            return path.test({ jugs: testJugs });
+          });
+        });
+      });
+    });
+
+  it('should throw if the target does not match the last entered state', () => {
+    expect(() => {
+      dieHardModel.getPlanFromEvents([{ type: 'FILL_5' }], {
+        target: 'success'
+      });
+    }).toThrow();
+  });
+});
+
 describe('path.test()', () => {
   const plans = dieHardModel.getSimplePathPlansTo((state) => {
     return state.matches('success') && state.context.three === 0;

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -187,32 +187,30 @@ describe('testing a model (simplePathsTo)', () => {
 });
 
 describe('testing a model (getPlanFromEvents)', () => {
-  dieHardModel
-    .getPlanFromEvents(
-      [
-        { type: 'FILL_5' },
-        { type: 'POUR_5_TO_3' },
-        { type: 'EMPTY_3' },
-        { type: 'POUR_5_TO_3' },
-        { type: 'FILL_5' },
-        { type: 'POUR_5_TO_3' }
-      ],
-      {
-        target: 'success'
-      }
-    )
-    .forEach((plan) => {
-      describe(`reaches state ${JSON.stringify(
-        plan.state.value
-      )} (${JSON.stringify(plan.state.context)})`, () => {
-        plan.paths.forEach((path) => {
-          it(path.description, () => {
-            const testJugs = new Jugs();
-            return path.test({ jugs: testJugs });
-          });
-        });
+  const plan = dieHardModel.getPlanFromEvents(
+    [
+      { type: 'FILL_5' },
+      { type: 'POUR_5_TO_3' },
+      { type: 'EMPTY_3' },
+      { type: 'POUR_5_TO_3' },
+      { type: 'FILL_5' },
+      { type: 'POUR_5_TO_3' }
+    ],
+    {
+      target: 'success'
+    }
+  );
+
+  describe(`reaches state ${JSON.stringify(plan.state.value)} (${JSON.stringify(
+    plan.state.context
+  )})`, () => {
+    plan.paths.forEach((path) => {
+      it(path.description, () => {
+        const testJugs = new Jugs();
+        return path.test({ jugs: testJugs });
       });
     });
+  });
 
   it('should throw if the target does not match the last entered state', () => {
     expect(() => {


### PR DESCRIPTION
The goal of this PR is to use a test model by "manually" defining a sequence of events as opposed to generating them with `getSimplePathPlans`/`getShortestPathPlans`.

```js
dieHardModel.getPlanFromEvents(
  [
    { type: 'FILL_5' },
    { type: 'POUR_5_TO_3' },
    { type: 'EMPTY_3' },
    { type: 'POUR_5_TO_3' },
    { type: 'FILL_5' },
    { type: 'POUR_5_TO_3' }
  ],
  {
    target: 'success'
  }
)
```

This PR adds a `getPathFromEvents(machine, events): StatePath` function which is used by a new method `testModel.getPlanFromEvents(events, options): TestPlan`.