### PR TITLE
doc: v5 contributor local dev setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,8 +4,79 @@ Thank you for your interest in contributing to XState! This project is made poss
 
 ## Environment
 
-- Ensure you have the latest version of Node and Yarn.
-- Run `yarn` to install all needed dev dependencies.
+### Local `xstate-monorepo` clone and install
+
+To setup a local development environment for XState
+
+    NOTE: These instructions are for V5 that now uses yarn as the package manager
+
+1. Ensure you have the latest version of Node and Yarn.
+2. Clone an xstate repo locally and checkout appropriate branch (for V5 `git checkout next`) - (see making changes)
+3. Run `yarn` to install all needed dev dependencies for the xstate-monorepo.
+
+eg:
+
+```bash
+XSTATE_LOCAL_DEV="/workspaces/xstate-dev-local" #where the local xstate-monorepo is located
+XSTATE_BRANCH="next" # change to the appropriate branch required
+GIT_USER="statelyai" # change to the appropriate fork
+git clone https://github.com/$GIT_USER/xstate.git XSTATE_LOCAL_DEV
+cd $XSTATE_LOCAL_DEV
+git checkout $XSTATE_BRANCH
+yarn
+```
+
+### Project use of local development `xstate-monorepo`
+
+Should you want to develop a project against this XState development environment do
+`yarn add link:<YOUR_LOCAL_CLONED_ROOT>/packages/core` which installs a symlink to the xstate core in you local development package, This is on your local file system as above
+
+eg:
+
+```bash
+#Execute these in a root project folder
+XSTATE_LOCAL_DEV="/workspaces/xstate-dev-local" #where the local xstate-monorepo is located
+MY_PROJECT="myFirstXStatePrj"
+mkdir $MY_PROJECT
+cd $MY_PROJECT
+yarn init -y
+# Link in the
+yarn add link:$XSTATE_LOCAL_DEV/packages/core # link to the local xstate-monorepo core
+# make an example node script
+echo "
+import pkg from 'xstate';
+const { createMachine, interpret } = pkg;
+const lightMachine = createMachine({
+    id: 'light',
+    initial: 'green',
+    states: {
+      green: { on: { TIMER: 'yellow' } },
+      yellow: { on: { TIMER: 'red' } },
+      red: {
+        initial: 'walk',
+        states: {
+          walk: {},
+          wait: {},
+          stop: {}
+        },
+        on: {
+          TIMER: [
+            {
+              target: 'green',
+              in: { red: 'stop' }
+            }
+          ]
+        }
+      }
+    }
+  });
+
+const walkState = lightMachine.transition('red.walk', 'TIMER');
+console.log(walkState);
+" > example1.mjs
+#execute this example script
+node example1.mjs
+```
 
 ## Making Changes
 
@@ -23,6 +94,8 @@ Pull requests are encouraged. If you want to add a feature or fix a bug:
 PRs are reviewed promptly and merged in within a day or two (or even within an hour), if everything looks good.
 
 ## Setup
+
+###
 
 ### Building
 


### PR DESCRIPTION
This PR is a brief supporting guide to cloning a local  xstate-monorepo V5 ( pre ALPHA) to use in a development project supporting XState. 

Looking through the various docs and community locations it is not  immediately evident where XState Contributor / Developer guides are homed ?  

The repo `CONTRIBUTING.MD` appears to be the only location. 

As a first time contributor and rather green JS/TS developer I found it took significant good learning to setup a local instance. Whilst I understand this V5 is preAlpha and that documentation usually lags. I am hoping I can assist in making it easier to contribute with this doc PR. Please amend, suggest  or if OK accept this PR for supporting future contributors.

# General Observations on Contrib/Dev Guides
I don't see any mentions of a Contrib/Dev Guide in https://github.com/statelyai/xstate/discussions/552  is this discussion still open ?
I do see a recent discord note on Contributors Guide https://discord.com/channels/795785288994652170/799416890841628713/838407403384471562 , I will be happy to contribute first time experiences to any of these

I feel that  https://xstate.js.org/docs, could have some content for Contributor Guidance, without polluting how to use XState as documented in Tutorials and Recipe's.  

The link in https://xstate.js.org/docs to https://github.com/davidkpiano/xstate/discussions possibly should have pinned a discussion on Contributor Guidance maybe just some FAQ geared towards Contributors ?

