### PR TITLE
Align send functionality for `spawnBehavior` with interpreted machine

### DIFF
--- a/.changeset/smooth-ducks-judge.md
+++ b/.changeset/smooth-ducks-judge.md
@@ -1,0 +1,13 @@
+---
+'xstate': patch
+---
+
+Adds support for calling `send` with a string as the event type to `spawnBehavior`.
+This aligns actors that are spawned from behavior with actors that are spawned from machines.
+
+```typescript
+const actor = spawnBehavior(/* ... */);
+
+actor.send('test'); // Will be converted to an event object {type: "test"}
+actor.send({ ŧype: 'test' }); // Continuous to work as before
+```

--- a/.changeset/smooth-ducks-judge.md
+++ b/.changeset/smooth-ducks-judge.md
@@ -9,5 +9,5 @@ This aligns actors that are spawned from behavior with actors that are spawned f
 const actor = spawnBehavior(/* ... */);
 
 actor.send('test'); // Will be converted to an event object {type: "test"}
-actor.send({ ŧype: 'test' }); // Continuous to work as before
+actor.send({ type: 'test' }); // Continues to work as before
 ```

--- a/packages/core/src/behaviors.ts
+++ b/packages/core/src/behaviors.ts
@@ -103,7 +103,7 @@ export function spawnBehavior<TEvent extends EventObject, TEmitted>(
   behavior: Behavior<TEvent, TEmitted>,
   options: SpawnBehaviorOptions = {}
 ): ActorRef<TEvent, TEmitted> {
-  const id = options.id ?? 'anonymous';
+  const id = options.id || 'anonymous';
   let state = behavior.initialState;
   const observers = new Set<Observer<TEmitted>>();
   const mailbox: TEvent[] = [];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1403,7 +1403,7 @@ export type ExtractEvent<
 > = TEvent extends { type: TEventType } ? TEvent : never;
 
 export interface BaseActorRef<TEvent extends EventObject> {
-  send: Sender<TEvent>;
+  send: (event: TEvent) => void;
 }
 
 export interface ActorRef<TEvent extends EventObject, TEmitted = any>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -259,6 +259,14 @@ export interface ActivityDefinition<TContext, TEvent extends EventObject>
 
 export type Sender<TEvent extends EventObject> = (event: Event<TEvent>) => void;
 
+/**
+ * Restrictive {@link Sender} that prevents the string shorthand from being
+ * usable when the event contains a payload.
+ */
+export type RestrictiveSender<TEvent extends EventObject> = (
+  event: TEvent | ExtractWithSimpleSupport<TEvent>['type']
+) => void;
+
 type ExcludeType<A> = { [K in Exclude<keyof A, 'type'>]: A[K] };
 
 type ExtractExtraParameters<A, T> = A extends { type: T }
@@ -1408,7 +1416,7 @@ export interface BaseActorRef<TEvent extends EventObject> {
 
 export interface ActorRef<TEvent extends EventObject, TEmitted = any>
   extends Subscribable<TEmitted> {
-  send: Sender<TEvent>; // TODO: this should just be TEvent
+  send: RestrictiveSender<TEvent>; // TODO: this should just be TEvent
   id: string;
   getSnapshot: () => TEmitted | undefined;
   stop?: () => void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1403,7 +1403,7 @@ export type ExtractEvent<
 > = TEvent extends { type: TEventType } ? TEvent : never;
 
 export interface BaseActorRef<TEvent extends EventObject> {
-  send: (event: TEvent) => void;
+  send: Sender<TEvent>;
 }
 
 export interface ActorRef<TEvent extends EventObject, TEmitted = any>

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -477,6 +477,22 @@ describe('communicating with spawned actors', () => {
 
     actor.send('test_event');
   });
+
+  it('should produce a type error if a string is sent for an event with payload', () => {
+    const actor = spawnBehavior<
+      { type: 'test'; other: number } | { type: 'test2' },
+      null
+    >({
+      initialState: null,
+      transition: (state) => state
+    });
+
+    // Works because "test2" does not expect a payload
+    actor.send('test2');
+
+    // @ts-expect-error "test" expects a payload
+    actor.send('test');
+  });
 });
 
 describe('actors', () => {

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -469,7 +469,6 @@ describe('communicating with spawned actors', () => {
     const actor = spawnBehavior({
       initialState: null,
       transition: (state, event: { type: 'test_event' }) => {
-        // event string should be translated to an event object when the behavior is called
         expect(event).toStrictEqual({ type: 'test_event' });
 
         return state;

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -21,7 +21,7 @@ import {
 } from '../src/actions';
 import { interval, EMPTY } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { fromPromise } from '../src/behaviors';
+import { fromPromise, spawnBehavior } from '../src/behaviors';
 
 describe('spawning machines', () => {
   const todoMachine = Machine({
@@ -461,6 +461,22 @@ describe('communicating with spawned actors', () => {
     });
 
     parentService.start();
+  });
+
+  it('should be possible to send event strings to spawned behavior', () => {
+    expect.assertions(1);
+
+    const actor = spawnBehavior({
+      initialState: null,
+      transition: (state, event: { type: 'test_event' }) => {
+        // event string should be translated to an event object when the behavior is called
+        expect(event).toStrictEqual({ type: 'test_event' });
+
+        return state;
+      }
+    });
+
+    actor.send('test_event');
   });
 });
 


### PR DESCRIPTION
This PR fixes #2706.

Actors that are spawned with `spawnBehavior` are typed as `ActorRefs`. This means that they should support the `Sender` type, i.e. `send("event")`.  However, a behavior normally expects event objects so string events are ignored. This PR fixes the problem by converting string events to event objects before they are passed to the spawned behavior in `spawnBehavior`, which is equivalent to the functionality in the interpreter. 