### PR TITLE
Pass events with type `xstate.*` through the inspector to the receiver

### DIFF
--- a/.changeset/fair-eggs-rule.md
+++ b/.changeset/fair-eggs-rule.md
@@ -1,0 +1,5 @@
+---
+'@xstate/inspect': minor
+---
+
+Bypass events with type `xstate.*` to pass through xstate/inspect to the receiver

--- a/packages/xstate-inspect/src/browser.ts
+++ b/packages/xstate-inspect/src/browser.ts
@@ -135,7 +135,7 @@ export function inspect(
   window.addEventListener('message', messageHandler);
 
   window.addEventListener('unload', () => {
-    inspectService.send({ type: 'unload' });
+    inspectService.send({ type: 'inspector.restart' });
   });
 
   devTools.onRegister((service) => {

--- a/packages/xstate-inspect/src/inspectMachine.ts
+++ b/packages/xstate-inspect/src/inspectMachine.ts
@@ -55,7 +55,7 @@ export function createInspectMachine(
               service?.send(scxmlEventObject);
             }
           },
-          unload: {
+          'inspector.restart': {
             actions: (ctx) => {
               ctx.client!.send({ type: 'xstate.disconnect' });
             }

--- a/packages/xstate-inspect/src/types.ts
+++ b/packages/xstate-inspect/src/types.ts
@@ -64,7 +64,7 @@ export type ParsedReceiverEvent =
       sessionId: string;
     }
   | { type: 'service.event'; event: SCXML.Event<any>; sessionId: string }
-  | { type: 'xstate.disconnect' };
+  | { type: 'xstate.disconnect' }
 
 export type InspectReceiver = ActorRef<ReceiverCommand, ParsedReceiverEvent>;
 

--- a/packages/xstate-inspect/src/types.ts
+++ b/packages/xstate-inspect/src/types.ts
@@ -63,7 +63,8 @@ export type ParsedReceiverEvent =
       state: State<any, any>;
       sessionId: string;
     }
-  | { type: 'service.event'; event: SCXML.Event<any>; sessionId: string };
+  | { type: 'service.event'; event: SCXML.Event<any>; sessionId: string }
+  | { type: 'xstate.disconnect' };
 
 export type InspectReceiver = ActorRef<ReceiverCommand, ParsedReceiverEvent>;
 

--- a/packages/xstate-inspect/src/utils.ts
+++ b/packages/xstate-inspect/src/utils.ts
@@ -23,7 +23,8 @@ export function isReceiverEvent(event: any): event is ReceiverEvent {
     if (
       typeof event === 'object' &&
       'type' in event &&
-      (event.type as string).startsWith('service.')
+      ((event.type as string).startsWith('service.') ||
+        (event.type as string).startsWith('xstate.'))
     ) {
       return true;
     }


### PR DESCRIPTION
The primary reasoning behind this PR is to allow `xstate.disconnect` to be received by the devtools receiver. This is useful in cases in which we want to locally re-interpret an inspected machine. One of such cases is embedded inspected machines in blogs where you want to reset the machine to the initial state.