### PR TITLE
docs: Typings for the context and the service

### DIFF
--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -63,33 +63,13 @@ Using `useInterpret` returns a service, which is a static reference to the runni
 
 #### Usage with typescript
 
-To have the strict typings with typescript for your service, you could use the generic `InterpreterFrom` from the `xstate`.
+The return type from `useInterpret` could be created by the generic `InterpreterFrom` from the `xstate`.
 
 ```typescript
-import { createContext, FC } from 'react';
-import { useInterpret } from '@xstate/react';
 import { InterpreterFrom } from 'xstate';
-import { authMachine } from './authMachine';
 
-export type AuthService = InterpreterFrom<typeof authMachine>;
-
-export interface GlobalStateContextType {
-  authService: AuthService;
-}
-
-export const GlobalStateContext = createContext<GlobalStateContextType>(
-  {} as GlobalStateContextType
-);
-
-export const GlobalStateProvider: FC = (props) => {
-  const authService = useInterpret(authMachine);
-
-  return (
-    <GlobalStateContext.Provider value={{ authService }}>
-      {props.children}
-    </GlobalStateContext.Provider>
-  );
-};
+type AuthService = InterpreterFrom<typeof authMachine>;
+const authService: AuthService = useInterpret(authMachine);
 ```
 
 ### Utilizing context

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -61,16 +61,7 @@ export const GlobalStateProvider = (props) => {
 
 Using `useInterpret` returns a service, which is a static reference to the running machine which can be subscribed to. This value never changes, so we don't need to worry about wasted re-renders.
 
-#### Usage with typescript
-
-The return type from `useInterpret` could be created by the generic `InterpreterFrom` from the `xstate`.
-
-```typescript
-import { InterpreterFrom } from 'xstate';
-
-type AuthService = InterpreterFrom<typeof authMachine>;
-const authService: AuthService = useInterpret(authMachine);
-```
+> For Typescript, you can create the context as `createContext({} as InterpreterFrom<typeof authMachine>);` to ensure strong typings.
 
 ### Utilizing context
 
@@ -131,9 +122,15 @@ export const SomeComponent = (props) => {
   // Get `send()` method from a service
   const { send } = globalServices.authService;
 
-   return <>
-      {isLoggedIn && <button type="button" onClick={() => send('LOG_OUT')}>Logout</button>}
-   </>;
+  return (
+    <>
+      {isLoggedIn && (
+        <button type="button" onClick={() => send('LOG_OUT')}>
+          Logout
+        </button>
+      )}
+    </>
+  );
 };
 ```
 

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -46,13 +46,7 @@ import React, { createContext } from 'react';
 import { useInterpret } from '@xstate/react';
 import { authMachine } from './authMachine';
 
-export type AuthService = InterpreterFrom<typeof authMachine>;
-
-export interface GlobalStateContextType {
-  authService: AuthService;
-}
-
-export const GlobalStateContext = createContext<GlobalStateContextType>({} as GlobalStateContextType);
+export const GlobalStateContext = createContext({});
 
 export const GlobalStateProvider = (props) => {
   const authService = useInterpret(authMachine);
@@ -66,6 +60,37 @@ export const GlobalStateProvider = (props) => {
 ```
 
 Using `useInterpret` returns a service, which is a static reference to the running machine which can be subscribed to. This value never changes, so we don't need to worry about wasted re-renders.
+
+#### Usage with typescript
+
+To have the strict typings with typescript for your service, you could use the generic `InterpreterFrom` from the `xstate`.
+
+```typescript
+import { createContext, FC } from 'react';
+import { useInterpret } from '@xstate/react';
+import { InterpreterFrom } from 'xstate';
+import { authMachine } from './authMachine';
+
+export type AuthService = InterpreterFrom<typeof authMachine>;
+
+export interface GlobalStateContextType {
+  authService: AuthService;
+}
+
+export const GlobalStateContext = createContext<GlobalStateContextType>(
+  {} as GlobalStateContextType
+);
+
+export const GlobalStateProvider: FC = (props) => {
+  const authService = useInterpret(authMachine);
+
+  return (
+    <GlobalStateContext.Provider value={{ authService }}>
+      {props.children}
+    </GlobalStateContext.Provider>
+  );
+};
+```
 
 ### Utilizing context
 

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -46,7 +46,13 @@ import React, { createContext } from 'react';
 import { useInterpret } from '@xstate/react';
 import { authMachine } from './authMachine';
 
-export const GlobalStateContext = createContext({});
+export type AuthService = InterpreterFrom<typeof authMachine>;
+
+export interface GlobalStateContextType {
+  authService: AuthService;
+}
+
+export const GlobalStateContext = createContext<GlobalStateContextType>({} as GlobalStateContextType);
 
 export const GlobalStateProvider = (props) => {
   const authService = useInterpret(authMachine);


### PR DESCRIPTION
This PR will properly type the context.
With such way we could inform the users how to properly type our service, since right now it is not clear that we could use the generic `InterpreterFrom<>`