### PR TITLE
Revert "`activities` should be `optional`"

### DIFF
--- a/.changeset/optional-activities.md
+++ b/.changeset/optional-activities.md
@@ -1,5 +1,0 @@
----
-"xstate": patch
----
-
-`activities` should be `optional` because it has been deprecated.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -680,7 +680,7 @@ export interface StateNodeDefinition<
   /**
    * @deprecated
    */
-  activities?: Array<ActivityDefinition<TContext, TEvent>>;
+  activities: Array<ActivityDefinition<TContext, TEvent>>;
   meta: any;
   order: number;
   data?: FinalStateNodeConfig<TContext, TEvent>['data'];


### PR DESCRIPTION
Reverts statelyai/xstate#2751

I'm unsure if this change has been sound. We can, of course, make this optional at the type level but in reality this property is **always** defined on the `StateNodeDefinition` object (that is returned from the `stateNode.definition` getter):
https://github.com/statelyai/xstate/blob/c1503b1219d995ebf0f45de46036c5a1d7e6442f/packages/core/src/StateNode.ts#L522

A side note is that the value fallback (`|| []`) is actually redundant because `this.activities` is always an array:
https://github.com/statelyai/xstate/blob/c1503b1219d995ebf0f45de46036c5a1d7e6442f/packages/core/src/StateNode.ts#L442-L444

cc @huan