### PR TITLE
[v5] Improve memoization

### DIFF
--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -121,7 +121,7 @@ export class StateMachine<
       _machine: this
     });
 
-    this.root.initialize();
+    this.root._initialize();
 
     this.states = this.root.states; // TODO: remove!
     this.events = this.root.events;

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -20,7 +20,6 @@ import { IS_PRODUCTION } from './environment';
 import { STATE_DELIMITER } from './constants';
 import {
   getConfiguration,
-  getAllStateNodes,
   resolveMicroTransition,
   macrostep,
   toState,
@@ -122,15 +121,10 @@ export class StateMachine<
       _machine: this
     });
 
-    this.states = this.root.states; // TOOD: remove!
-    this.events = this.root.events;
-  }
+    this.root.initialize();
 
-  public _init(): void {
-    if (this.root.__cache.transitions) {
-      return;
-    }
-    getAllStateNodes(this.root).forEach((stateNode) => stateNode.on);
+    this.states = this.root.states; // TODO: remove!
+    this.events = this.root.events;
   }
 
   /**
@@ -258,8 +252,6 @@ export class StateMachine<
    * entering the initial state.
    */
   public get initialState(): State<TContext, TEvent, TTypestate> {
-    this._init();
-
     const nextState = resolveMicroTransition(this, [], this.first, undefined);
     return macrostep(nextState, null as any, this);
   }
@@ -268,8 +260,6 @@ export class StateMachine<
    * Returns the initial `State` instance, with reference to `self` as an `ActorRef`.
    */
   public getInitialState(): State<TContext, TEvent, TTypestate> {
-    this._init();
-
     const nextState = resolveMicroTransition(this, [], this.first, undefined);
     return macrostep(nextState, null as any, this) as State<
       TContext,

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -196,11 +196,11 @@ export class StateNode<
     this.tags = toArray(config.tags);
   }
 
-  public initialize() {
+  public _initialize() {
     this.transitions = formatTransitions(this);
 
     Object.keys(this.states).forEach((key) => {
-      this.states[key].initialize();
+      this.states[key]._initialize();
     });
   }
 

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -124,8 +124,6 @@ export class StateNode<
 
   public description?: string;
 
-  private __initial?: InitialTransitionDefinition<TContext, TEvent>;
-
   public tags: string[] = [];
   public transitions!: Array<TransitionDefinition<TContext, TEvent>>;
 

--- a/packages/core/src/memo.ts
+++ b/packages/core/src/memo.ts
@@ -1,0 +1,29 @@
+import type { StateNode } from '.';
+
+const stateNodeMap = new WeakMap<StateNode, any>();
+
+export function getMemo<T>(
+  stateNode: StateNode<any, any>,
+  key: string
+): T | undefined {
+  return stateNodeMap.get(stateNode)?.[key];
+}
+
+export function memo<T>(
+  stateNode: StateNode<any, any>,
+  key: string,
+  fn: () => T
+): T {
+  let memoizedData = stateNodeMap.get(stateNode);
+
+  if (!memoizedData || !memoizedData[key]) {
+    memoizedData = {
+      ...memoizedData,
+      [key]: fn()
+    };
+
+    stateNodeMap.set(stateNode, memoizedData);
+  }
+
+  return memoizedData[key];
+}

--- a/packages/core/src/memo.ts
+++ b/packages/core/src/memo.ts
@@ -1,17 +1,13 @@
-import type { StateNode } from '.';
-
-const cache = new WeakMap<StateNode, any>();
+const cache = new WeakMap<any, any>();
 
 export function memo<T>(object: any, key: string, fn: () => T): T {
   let memoizedData = cache.get(object);
 
-  if (!memoizedData || !memoizedData[key]) {
-    memoizedData = {
-      ...memoizedData,
-      [key]: fn()
-    };
-
+  if (!memoizedData) {
+    memoizedData = { [key]: fn() };
     cache.set(object, memoizedData);
+  } else if (!(key in memoizedData)) {
+    memoizedData[key] = fn();
   }
 
   return memoizedData[key];

--- a/packages/core/src/memo.ts
+++ b/packages/core/src/memo.ts
@@ -1,20 +1,9 @@
 import type { StateNode } from '.';
 
-const stateNodeMap = new WeakMap<StateNode, any>();
+const cache = new WeakMap<StateNode, any>();
 
-export function getMemo<T>(
-  stateNode: StateNode<any, any>,
-  key: string
-): T | undefined {
-  return stateNodeMap.get(stateNode)?.[key];
-}
-
-export function memo<T>(
-  stateNode: StateNode<any, any>,
-  key: string,
-  fn: () => T
-): T {
-  let memoizedData = stateNodeMap.get(stateNode);
+export function memo<T>(object: any, key: string, fn: () => T): T {
+  let memoizedData = cache.get(object);
 
   if (!memoizedData || !memoizedData[key]) {
     memoizedData = {
@@ -22,7 +11,7 @@ export function memo<T>(
       [key]: fn()
     };
 
-    stateNodeMap.set(stateNode, memoizedData);
+    cache.set(object, memoizedData);
   }
 
   return memoizedData[key];


### PR DESCRIPTION
This PR introduces internal `memo(...)` and `getMemo(...)` functions that obviate the `__cache` stuff in a more GC-friendly way.

No changeset; internal only.