### PR TITLE
Duplicate state resolution

### DIFF
--- a/.changeset/friendly-countries-smash.md
+++ b/.changeset/friendly-countries-smash.md
@@ -1,5 +1,0 @@
----
-'xstate': patch
----
-
-Update tests and documentation to exclude redundant calls of resolveState() immediately before starting an interpreted service.

--- a/.changeset/friendly-countries-smash.md
+++ b/.changeset/friendly-countries-smash.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Update tests and documentation to exclude redundant calls of resolveState() immediately before starting an interpreted service.

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -280,7 +280,7 @@ try {
 }
 ```
 
-State can be restored using the static `State.create(...)` method and resolved using the public `machine.resolveState(...)` method:
+State can be restored using the static `State.create(...)` method:
 
 ```js
 import { State, interpret } from 'xstate';
@@ -292,18 +292,15 @@ const stateDefinition =
 
 // Use State.create() to restore state from a plain object
 const previousState = State.create(stateDefinition);
-
-// Use machine.resolveState() to resolve the state definition to a new State instance relative to the machine
-const resolvedState = myMachine.resolveState(previousState);
 ```
 
-You can then interpret the machine from this resolved state by passing the `State` into the `.start(...)` method of the interpreted service:
+You can then interpret the machine from this state by passing the `State` into the `.start(...)` method of the interpreted service:
 
 ```js
 // ...
 
 // This will start the service at the specified State
-const service = interpret(myMachine).start(resolvedState);
+const service = interpret(myMachine).start(previousState);
 ```
 
 This will also maintain and restore previous [history states](./history.md) and ensures that `.events` and `.nextEvents` represent the correct values.

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -163,10 +163,9 @@ describe('interpreter', () => {
       // saves state and recreate it
       const recreated = JSON.parse(JSON.stringify(nextState));
       const previousState = State.create(recreated);
-      const resolvedState = lightMachine.resolveState(previousState);
 
       const service = interpret(lightMachine);
-      service.start(resolvedState);
+      service.start(previousState);
     });
   });
 


### PR DESCRIPTION
This PR removes redundant `resolveState()` invocations from the interpreter tests and the "Persisting State" section of the docs. See https://github.com/statelyai/xstate/discussions/2811.