### PR TITLE
Support `globalThis` in `getGlobal()` for better compatibility

### DIFF
--- a/.changeset/hungry-jokes-shake.md
+++ b/.changeset/hungry-jokes-shake.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Support `globalThis` in `getGlobal()` for better compatibility

--- a/packages/core/src/devTools.ts
+++ b/packages/core/src/devTools.ts
@@ -16,6 +16,9 @@ export interface XStateDevInterface {
 
 // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis
 export function getGlobal() {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
   if (typeof self !== 'undefined') {
     return self;
   }


### PR DESCRIPTION
`globalThis` is the actual ECMAScript standard for the global object, so this should be returned by `getGlobal()` when available. The existing code (taken from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) is good as a *replacement* when `globalThis` is not available, but when it is, we should return it directly! See a [similar example in Ember.js](https://github.com/emberjs/ember.js/blob/7b9584bf688c9e5a31447fa690b938ac89d3e656/packages/loader/lib/index.js#L7-L16).

This fixes a real world issue I had when running `xstate` in a rather exotic environment (GraalVM running JS inside a Java server), which correctly supports `globalThis`, but does *not* support `global` (which is node.js specific!) or `self`.

