### PR TITLE
Check if `process` is defined

### DIFF
--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -1,1 +1,4 @@
-export const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+export const IS_PRODUCTION =
+  typeof process !== 'undefined'
+    ? process.env.NODE_ENV === 'production'
+    : false;

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -1,4 +1,4 @@
 export const IS_PRODUCTION =
   typeof process !== 'undefined'
     ? process.env.NODE_ENV === 'production'
-    : false;
+    : true;

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -50,7 +50,10 @@ function toActionObject<TContext extends object, TEvent extends EventObject>(
     : action;
 }
 
-const IS_PRODUCTION = process.env.NODE_ENV === 'production';
+const IS_PRODUCTION =
+  typeof process !== 'undefined'
+    ? process.env.NODE_ENV === 'production'
+    : false;
 
 function createMatcher(value: string) {
   return (stateValue) => value === stateValue;

--- a/packages/xstate-react/src/fsm.ts
+++ b/packages/xstate-react/src/fsm.ts
@@ -9,6 +9,11 @@ import {
 import { useSubscription, Subscription } from 'use-subscription';
 import useConstant from './useConstant';
 
+export const IS_PRODUCTION =
+  typeof process !== 'undefined'
+    ? process.env.NODE_ENV === 'production'
+    : false;
+
 const getServiceState = <
   TContext extends object,
   TEvent extends EventObject = EventObject,
@@ -39,7 +44,7 @@ export function useMachine<
   StateMachine.Service<TContext, TEvent, TState>['send'],
   StateMachine.Service<TContext, TEvent, TState>
 ] {
-  if (process.env.NODE_ENV !== 'production') {
+  if (!IS_PRODUCTION) {
     const [initialMachine] = useState(stateMachine);
 
     if (stateMachine !== initialMachine) {


### PR DESCRIPTION
This PR checks if `process` is defined before reading it. I ran into this when trying to use XState with Cloudflare Durable Objects.

Fixes #787