### PR TITLE
Update types.ts to work with --exactOptionalPropertyTypes

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -41,7 +41,7 @@ export interface ActionObject<TContext, TEvent extends EventObject>
   /**
    * The implementation for executing the action.
    */
-  exec?: ActionFunction<TContext, TEvent>;
+  exec?: ActionFunction<TContext, TEvent> | undefined;
 }
 
 export type DefaultContext = Record<string, any> | undefined;
@@ -220,7 +220,7 @@ export interface TransitionConfig<TContext, TEvent extends EventObject> {
   actions?: Actions<TContext, TEvent>;
   in?: StateValue;
   internal?: boolean;
-  target?: TransitionTarget<TContext, TEvent>;
+  target?: TransitionTarget<TContext, TEvent> | undefined;
   meta?: Record<string, any>;
   description?: string;
 }
@@ -594,7 +594,7 @@ export interface StateNodeConfig<
    *
    * This is equivalent to defining a `[done(id)]` transition on this state node's `on` property.
    */
-  onDone?: string | SingleOrArray<TransitionConfig<TContext, DoneEventObject>>;
+  onDone?: string | SingleOrArray<TransitionConfig<TContext, DoneEventObject>> | undefined;
   /**
    * The mapping (or array) of delays (in milliseconds) to their potential transition(s).
    * The delayed transitions are taken after the specified delay in an interpreter.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -695,6 +695,7 @@ export interface AtomicStateNodeConfig<TContext, TEvent extends EventObject>
   initial?: undefined;
   parallel?: false | undefined;
   states?: undefined;
+  onDone?: undefined;
 }
 
 export interface HistoryStateNodeConfig<TContext, TEvent extends EventObject>
@@ -966,7 +967,7 @@ export interface ActivityActionObject<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
   type: ActionTypes.Start | ActionTypes.Stop;
   activity: ActivityDefinition<TContext, TEvent> | undefined;
-  exec: ActionFunction<TContext, TEvent>;
+  exec: ActionFunction<TContext, TEvent> | undefined;
 }
 
 export interface InvokeActionObject<TContext, TEvent extends EventObject>
@@ -1135,7 +1136,7 @@ export interface ChooseAction<TContext, TEvent extends EventObject>
 
 export interface TransitionDefinition<TContext, TEvent extends EventObject>
   extends TransitionConfig<TContext, TEvent> {
-  target: Array<StateNode<TContext, any, TEvent>>;
+  target: Array<StateNode<TContext, any, TEvent>> | undefined;
   source: StateNode<TContext, any, TEvent>;
   actions: Array<ActionObject<TContext, TEvent>>;
   cond?: Guard<TContext, TEvent>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -695,7 +695,6 @@ export interface AtomicStateNodeConfig<TContext, TEvent extends EventObject>
   initial?: undefined;
   parallel?: false | undefined;
   states?: undefined;
-  onDone?: undefined;
 }
 
 export interface HistoryStateNodeConfig<TContext, TEvent extends EventObject>
@@ -967,7 +966,7 @@ export interface ActivityActionObject<TContext, TEvent extends EventObject>
   extends ActionObject<TContext, TEvent> {
   type: ActionTypes.Start | ActionTypes.Stop;
   activity: ActivityDefinition<TContext, TEvent> | undefined;
-  exec: ActionFunction<TContext, TEvent> | undefined;
+  exec: ActionFunction<TContext, TEvent>;
 }
 
 export interface InvokeActionObject<TContext, TEvent extends EventObject>
@@ -1136,7 +1135,7 @@ export interface ChooseAction<TContext, TEvent extends EventObject>
 
 export interface TransitionDefinition<TContext, TEvent extends EventObject>
   extends TransitionConfig<TContext, TEvent> {
-  target: Array<StateNode<TContext, any, TEvent>> | undefined;
+  target: Array<StateNode<TContext, any, TEvent>>;
   source: StateNode<TContext, any, TEvent>;
   actions: Array<ActionObject<TContext, TEvent>>;
   cond?: Guard<TContext, TEvent>;


### PR DESCRIPTION
While I was trying to enable `exactOptionalPropertyTypes` in tsconfig.json, I got tsc errors.
https://github.com/pmndrs/jotai/pull/839

To work around it, it's using a patch now. This is the same fix, without understanding anything.