### PR TITLE
Link more proper PRs/commits to some generated changelog entries

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,13 +6,13 @@
 
 - [#2819](https://github.com/statelyai/xstate/pull/2819) [`0d51d33cd`](https://github.com/statelyai/xstate/commit/0d51d33cd6dc6ab876a5554788300282d03fa5d1) Thanks [@simonihmig](https://github.com/simonihmig)! - Support `globalThis` in `getGlobal()` for better compatibility
 
-* [#2830](https://github.com/statelyai/xstate/pull/2830) [`75627edaf`](https://github.com/statelyai/xstate/commit/75627edaf401be1b964f8210f98f40de307671c4) Thanks [@davidkpiano](https://github.com/davidkpiano)! - XState is now compatible with TypeScript version 4.5.
+* [#2828](https://github.com/statelyai/xstate/pull/2828) [`c0ef3e8`](https://github.com/statelyai/xstate/commit/c0ef3e882c688e6beefb196a3293ec71b65625e3) Thanks [@davidkpiano](https://github.com/davidkpiano)! - XState is now compatible with TypeScript version 4.5.
 
 ## 4.26.0
 
 ### Minor Changes
 
-- [#2676](https://github.com/statelyai/xstate/pull/2676) [`1ff4f7976`](https://github.com/statelyai/xstate/commit/1ff4f797653bdf58eb2c3a7e27aeae24cf4dd2b8) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `description` property is a new top-level property for state nodes and transitions, that lets you provide text descriptions:
+- [#2672](https://github.com/statelyai/xstate/pull/2672) [`8e1d05d`](https://github.com/statelyai/xstate/commit/8e1d05dcafab0d1c8a63b07694b3f208850b0b4b) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `description` property is a new top-level property for state nodes and transitions, that lets you provide text descriptions:
 
   ```ts
   const machine = createMachine({
@@ -106,10 +106,10 @@
 
   model.createMachine({
     // `ctx` was of type `any`
-    entry: ctx => {},
+    entry: (ctx) => {},
     exit: assign({
       // `ctx` was of type `unknown`
-      foo: ctx => 42
+      foo: (ctx) => 42
     })
   });
   ```
@@ -285,11 +285,11 @@
   const machine = createMachine({
     context: { count: 0 },
     entry: [
-      ctx => console.log(ctx.count), // 0
-      assign({ count: ctx => ctx.count + 1 }),
-      ctx => console.log(ctx.count), // 1
-      assign({ count: ctx => ctx.count + 1 }),
-      ctx => console.log(ctx.count) // 2
+      (ctx) => console.log(ctx.count), // 0
+      assign({ count: (ctx) => ctx.count + 1 }),
+      (ctx) => console.log(ctx.count), // 1
+      assign({ count: (ctx) => ctx.count + 1 }),
+      (ctx) => console.log(ctx.count) // 2
     ],
     preserveActionOrder: true
   });
@@ -298,11 +298,11 @@
   const machine = createMachine({
     context: { count: 0 },
     entry: [
-      ctx => console.log(ctx.count), // 2
-      assign({ count: ctx => ctx.count + 1 }),
-      ctx => console.log(ctx.count), // 2
-      assign({ count: ctx => ctx.count + 1 }),
-      ctx => console.log(ctx.count) // 2
+      (ctx) => console.log(ctx.count), // 2
+      assign({ count: (ctx) => ctx.count + 1 }),
+      (ctx) => console.log(ctx.count), // 2
+      assign({ count: (ctx) => ctx.count + 1 }),
+      (ctx) => console.log(ctx.count) // 2
     ]
     // preserveActionOrder: false
   });
@@ -501,7 +501,7 @@
   });
 
   const service = interpret(machine)
-    .onTransition(state => {
+    .onTransition((state) => {
       // Read promise value synchronously
       const resolvedValue = state.context.promiseRef?.getSnapshot();
       // => undefined (if promise not resolved yet)
@@ -581,7 +581,7 @@
     context: { value: 42 },
     on: {
       INC: {
-        actions: assign({ value: ctx => ctx.value + 1 })
+        actions: assign({ value: (ctx) => ctx.value + 1 })
       }
     }
   });
@@ -841,7 +841,7 @@
 
   ```js
   // ...
-  actions: stop(context => context.someActor);
+  actions: stop((context) => context.someActor);
   ```
 
 ### Patch Changes
@@ -1079,10 +1079,10 @@
   ```js
   entry: [
     choose([
-      { cond: ctx => ctx > 100, actions: raise('TOGGLE') },
+      { cond: (ctx) => ctx > 100, actions: raise('TOGGLE') },
       {
         cond: 'hasMagicBottle',
-        actions: [assign(ctx => ({ counter: ctx.counter + 1 }))]
+        actions: [assign((ctx) => ({ counter: ctx.counter + 1 }))]
       },
       { actions: ['fallbackAction'] }
     ])


### PR DESCRIPTION
I've noticed that those were not mentioned correctly because changeset files were created in separate PRs from the PRs that actually introduced those changes.