### PR TITLE
[core] Add potential fix for failing `state.can` test

### DIFF
--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -343,17 +343,24 @@ export class State<
      * The state will change from this event if:
      * - There are entry actions
      * - There are exit actions
-     * - There are transitions in which either the target has changed or there are transition actions
+     * - There are transitions in which either the targets have changed or there are transition actions
      */
-    return (
+    if (
       transitionData.entrySet.some((sn) => sn.onEntry.length > 0) ||
-      transitionData.exitSet.some((sn) => sn.onExit.length > 0) ||
-      !!transitionData.transitions.some((t) => {
-        return (
-          (t.target && t.target.length > 0 && t.target[0] !== t.source) ||
-          t.actions.length > 0
-        );
-      })
-    );
+      transitionData.exitSet.some((sn) => sn.onExit.length > 0)
+    ) {
+      return true;
+    }
+
+    for (const t of transitionData.transitions) {
+      if (t.actions.length) {
+        return true;
+      }
+      if (t.target?.some((target) => !this.configuration.includes(target))) {
+        return true;
+      }
+    }
+
+    return false;
   }
 }

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -335,21 +335,25 @@ export class State<
 
     const transitionData = this.machine?.getTransitionData(this, event);
 
+    if (!transitionData) {
+      return false;
+    }
+
     /**
      * The state will change from this event if:
      * - There are entry actions
      * - There are exit actions
      * - There are transitions in which either the target has changed or there are transition actions
      */
-    return !transitionData
-      ? false
-      : transitionData.entrySet.some((sn) => sn.onEntry.length > 0) ||
-          transitionData.exitSet.some((sn) => sn.onExit.length > 0) ||
-          !!transitionData?.transitions.some((t) => {
-            return (
-              (t.target && t.target.length > 0 && t.target[0] !== t.source) ||
-              t.actions.length > 0
-            );
-          });
+    return (
+      transitionData.entrySet.some((sn) => sn.onEntry.length > 0) ||
+      transitionData.exitSet.some((sn) => sn.onExit.length > 0) ||
+      !!transitionData.transitions.some((t) => {
+        return (
+          (t.target && t.target.length > 0 && t.target[0] !== t.source) ||
+          t.actions.length > 0
+        );
+      })
+    );
   }
 }

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -321,7 +321,7 @@ export class State<
   }
 
   /**
-   * Determines whether sending the `event` will cause a transition
+   * Determines whether sending the `event` will cause a non-forbidden transition
    * to be selected, even if the transitions have no actions nor
    * change the state value.
    *
@@ -338,6 +338,12 @@ export class State<
 
     const transitionData = this.machine?.getTransitionData(this, event);
 
-    return !!transitionData?.transitions.length;
+    return (
+      !!transitionData?.transitions.length &&
+      // Check that at least one transition is not forbidden
+      transitionData.transitions.some(
+        (t) => t.target !== undefined || t.actions.length
+      )
+    );
   }
 }

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -321,7 +321,10 @@ export class State<
   }
 
   /**
-   * Determines whether sending the `event` will cause a transition.
+   * Determines whether sending the `event` will cause a transition
+   * to be selected, even if the transitions have no actions nor
+   * change the state value.
+   *
    * @param event The event to test
    * @returns Whether the event will cause a transition
    */
@@ -335,32 +338,6 @@ export class State<
 
     const transitionData = this.machine?.getTransitionData(this, event);
 
-    if (!transitionData) {
-      return false;
-    }
-
-    /**
-     * The state will change from this event if:
-     * - There are entry actions
-     * - There are exit actions
-     * - There are transitions in which either the targets have changed or there are transition actions
-     */
-    if (
-      transitionData.entrySet.some((sn) => sn.onEntry.length > 0) ||
-      transitionData.exitSet.some((sn) => sn.onExit.length > 0)
-    ) {
-      return true;
-    }
-
-    for (const t of transitionData.transitions) {
-      if (t.actions.length) {
-        return true;
-      }
-      if (t.target?.some((target) => !this.configuration.includes(target))) {
-        return true;
-      }
-    }
-
-    return false;
+    return !!transitionData?.transitions.length;
   }
 }

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -848,7 +848,6 @@ describe('State', () => {
     });
 
     it('should return true when non-first parallel region changes value', () => {
-      let executed = false;
       const machine = createMachine({
         type: 'parallel',
         states: {
@@ -878,9 +877,12 @@ describe('State', () => {
 
       const { initialState } = machine;
 
-      expect(initialState.can('EVENT')).toBeTruthy();
+      expect(machine.transition(undefined, { type: 'EVENT' }).value).toEqual({
+        a: 'a1',
+        b: 'b2'
+      });
 
-      expect(executed).toBeFalsy();
+      expect(initialState.can('EVENT')).toBeTruthy();
     });
   });
 

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -875,14 +875,35 @@ describe('State', () => {
         }
       });
 
-      const { initialState } = machine;
+      expect(machine.initialState.can('EVENT')).toBeTruthy();
+    });
 
-      expect(machine.transition(undefined, { type: 'EVENT' }).value).toEqual({
-        a: 'a1',
-        b: 'b2'
+    it('should return true when transition targets a state that is already part of the current configuration but the final state value changes', () => {
+      const machine = createMachine({
+        initial: 'a',
+        states: {
+          a: {
+            id: 'foo',
+            initial: 'a1',
+            states: {
+              a1: {
+                on: {
+                  NEXT: 'a2'
+                }
+              },
+              a2: {
+                on: {
+                  NEXT: '#foo'
+                }
+              }
+            }
+          }
+        }
       });
 
-      expect(initialState.can('EVENT')).toBeTruthy();
+      const nextState = machine.transition(undefined, { type: 'NEXT' });
+
+      expect(nextState.can({ type: 'NEXT' })).toBeTruthy();
     });
   });
 

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -650,7 +650,7 @@ describe('State', () => {
       expect(machine.initialState.can({ type: 'NEXT' })).toBe(true);
     });
 
-    it('should return false for an external self-transition without actions', () => {
+    it('should return true for an external self-transition without actions', () => {
       const machine = createMachine({
         initial: 'a',
         states: {
@@ -662,7 +662,7 @@ describe('State', () => {
         }
       });
 
-      expect(machine.initialState.can({ type: 'EV' })).toBe(false);
+      expect(machine.initialState.can({ type: 'EV' })).toBe(true);
     });
 
     it('should return true for an external self-transition with reentry action', () => {
@@ -716,7 +716,7 @@ describe('State', () => {
       expect(machine.initialState.can({ type: 'EV' })).toBe(true);
     });
 
-    it('should return false for a forbidden transition', () => {
+    it('should return true for a defined transition without a target', () => {
       const machine = createMachine({
         initial: 'a',
         states: {
@@ -728,7 +728,7 @@ describe('State', () => {
         }
       });
 
-      expect(machine.initialState.can({ type: 'EV' })).toBe(false);
+      expect(machine.initialState.can({ type: 'EV' })).toBe(true);
     });
 
     it('should return false for an unknown event', () => {

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -716,7 +716,7 @@ describe('State', () => {
       expect(machine.initialState.can({ type: 'EV' })).toBe(true);
     });
 
-    it('should return true for a defined transition without a target', () => {
+    it('should return false for a forbidden transition', () => {
       const machine = createMachine({
         initial: 'a',
         states: {
@@ -728,7 +728,7 @@ describe('State', () => {
         }
       });
 
-      expect(machine.initialState.can({ type: 'EV' })).toBe(true);
+      expect(machine.initialState.can({ type: 'EV' })).toBe(false);
     });
 
     it('should return false for an unknown event', () => {

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -858,7 +858,7 @@ describe('State', () => {
                 id: 'foo',
                 on: {
                   // first region doesn't change value here
-                  EVENT: ['#foo', '#bar']
+                  EVENT: { target: ['#foo', '#bar'] }
                 }
               }
             }

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -846,6 +846,42 @@ describe('State', () => {
 
       expect(executed).toBeFalsy();
     });
+
+    it('should return true when non-first parallel region changes value', () => {
+      let executed = false;
+      const machine = createMachine({
+        type: 'parallel',
+        states: {
+          a: {
+            initial: 'a1',
+            states: {
+              a1: {
+                id: 'foo',
+                on: {
+                  // first region doesn't change value here
+                  EVENT: ['#foo', '#bar']
+                }
+              }
+            }
+          },
+          b: {
+            initial: 'b1',
+            states: {
+              b1: {},
+              b2: {
+                id: 'bar'
+              }
+            }
+          }
+        }
+      });
+
+      const { initialState } = machine;
+
+      expect(initialState.can('EVENT')).toBeTruthy();
+
+      expect(executed).toBeFalsy();
+    });
   });
 
   describe('.hasTag', () => {


### PR DESCRIPTION
This PR potentially fixes #2837, but reveals another problem in which transitions with multiple targets might be incorrect, preventing this fix from working.