### PR TITLE
[core] Add failing test for general `model.assign(...)` actions

### DIFF
--- a/packages/core/test/model.test.ts
+++ b/packages/core/test/model.test.ts
@@ -41,6 +41,11 @@ describe('createModel', () => {
       'updateName'
     );
 
+    // Action that can take any event
+    const clearName = userModel.assign({
+      name: ''
+    });
+
     const machine = createMachine<UserContext, UserEvent>({
       context: userModel.initialContext,
       initial: 'active',
@@ -58,6 +63,9 @@ describe('createModel', () => {
                   age: e.value
                 };
               })
+            },
+            anotherEvent: {
+              actions: clearName
             }
           }
         }


### PR DESCRIPTION
This PR demonstrates the failure for transitions to accept general `model.assign(...)` functions with the following characteristics:

1. Are defined _outside_ of the machine definition
2. Can accept any event

Potentially addressed by https://github.com/statelyai/xstate/pull/2690