### PR TITLE
docs(strict): add strict documentation

### DIFF
--- a/docs/guides/machines.md
+++ b/docs/guides/machines.md
@@ -37,9 +37,11 @@ const lightMachine = createMachine({
 });
 ```
 
-The machine config is the same as the [state node config](./statenodes.md), with the addition of the context property:
+The machine config is the same as the [state node config](./statenodes.md), with the addition of the following properties:
 
 - `context` - represents the local "extended state" for all of the machine's nested states. See [the docs for context](./context.md) for more details.
+
+- `strict` - if `true`, any events that are sent to the machine but not accepted (i.e., there doesn't exist any transitions in any state for the given event), an error will be thrown. Defaults to `false`.
 
 ## Options
 


### PR DESCRIPTION
strict mode is reference from https://xstate.js.org/docs/guides/hierarchical.html#events but strict mode docs are missing