### PR TITLE
[core] Multiple guards

### DIFF
--- a/.changeset/empty-clocks-rest.md
+++ b/.changeset/empty-clocks-rest.md
@@ -12,4 +12,5 @@ on: {
     target: 'withdrawn'
   }
 }
+// ...
 ```

--- a/.changeset/empty-clocks-rest.md
+++ b/.changeset/empty-clocks-rest.md
@@ -1,0 +1,15 @@
+---
+'xstate': minor
+---
+
+An array of guards can now be specified in a transition's `cond: ...` property. All guards in the array must pass ("and" behavior) for the transition to be taken.
+
+```js
+// ...
+on: {
+  WITHDRAW: {
+    cond: ['isLoggedIn', 'hasMoney'],
+    target: 'withdrawn'
+  }
+}
+```

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -198,7 +198,7 @@ export type TransitionTargets<TContext> = Array<
 >;
 
 export interface TransitionConfig<TContext, TEvent extends EventObject> {
-  cond?: Condition<TContext, TEvent>;
+  cond?: SingleOrArray<Condition<TContext, TEvent>>;
   actions?: Actions<TContext, TEvent>;
   in?: StateValue;
   internal?: boolean;
@@ -576,7 +576,10 @@ export interface StateNodeConfig<
    *
    * This is equivalent to defining a `[done(id)]` transition on this state node's `on` property.
    */
-  onDone?: string | SingleOrArray<TransitionConfig<TContext, DoneEventObject>> | undefined;
+  onDone?:
+    | string
+    | SingleOrArray<TransitionConfig<TContext, DoneEventObject>>
+    | undefined;
   /**
    * The mapping (or array) of delays (in milliseconds) to their potential transition(s).
    * The delayed transitions are taken after the specified delay in an interpreter.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -495,7 +495,7 @@ export function isString(value: any): value is string {
 // }
 
 export function toGuard<TContext, TEvent extends EventObject>(
-  condition?: Condition<TContext, TEvent>,
+  condition?: SingleOrArray<Condition<TContext, TEvent>>,
   guardMap?: Record<string, ConditionPredicate<TContext, TEvent>>
 ): Guard<TContext, TEvent> | undefined {
   if (!condition) {
@@ -515,6 +515,16 @@ export function toGuard<TContext, TEvent extends EventObject>(
       type: DEFAULT_GUARD_TYPE,
       name: condition.name,
       predicate: condition
+    };
+  }
+
+  if (isArray(condition)) {
+    const guards = condition.map((c) => toGuard(c, guardMap));
+    return {
+      type: DEFAULT_GUARD_TYPE,
+      name: guards.map((g) => g?.name).join(' && '),
+      predicate: (ctx, e, meta) =>
+        guards.every((g) => g?.predicate(ctx, e, meta))
     };
   }
 

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -1,4 +1,4 @@
-import { Machine, interpret } from '../src';
+import { Machine, interpret, createMachine } from '../src';
 
 describe('guard conditions', () => {
   type LightMachineCtx = {
@@ -378,5 +378,76 @@ describe('guards - other', () => {
     service.send('EVENT');
 
     expect(service.state.value).toBe('c');
+  });
+});
+
+describe('guards array', () => {
+  it('array of guards can be used as AND guard (inline)', (done) => {
+    const machine = createMachine({
+      initial: 'a',
+      context: {
+        count: 42
+      },
+      states: {
+        a: {
+          on: {
+            EVENT: {
+              cond: [
+                (ctx) => ctx.count * 2 === 84,
+                (ctx) => ctx.count / 2 === 21
+              ],
+              target: 'b'
+            }
+          }
+        },
+        b: {
+          type: 'final'
+        }
+      }
+    });
+
+    interpret(machine)
+      .onDone(() => {
+        done();
+      })
+      .start()
+      .send('EVENT');
+  });
+
+  it('array of guards can be used as AND guard (serialized)', (done) => {
+    const machine = createMachine(
+      {
+        initial: 'a',
+        context: {
+          count: 42
+        },
+        states: {
+          a: {
+            on: {
+              EVENT: {
+                cond: ['double', 'halve'],
+                target: 'b'
+              }
+            }
+          },
+          b: {
+            type: 'final'
+          }
+        }
+      },
+      {
+        guards: {
+          double: (ctx) => ctx.count * 2 === 84,
+          halve: (ctx) => ctx.count / 2 === 21
+        }
+      }
+    );
+
+    interpret(machine)
+      .onDone(() => {
+        done();
+      })
+      .start()
+      .send('EVENT');
   });
 });


### PR DESCRIPTION
This PR introduces the ability to specify guards in an array, where all of them must evaluate to `true` ("and" behavior) for the transition to be taken:

```js
// ...
on: {
  WITHDRAW: {
    cond: ['isLoggedIn', 'hasMoney'],
    target: 'withdrawn'
  }
}
// ...
```
