### PR TITLE
[core] Add support for handling communication errors

### DIFF
--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -8,7 +8,8 @@ import {
   MachineOptions,
   StateMachine,
   StateSchema,
-  Typestate
+  Typestate,
+  ErrorEventObject
 } from './types';
 
 /**
@@ -47,6 +48,8 @@ export function Machine<
   ) as StateMachine<TContext, TStateSchema, TEvent>;
 }
 
+type AllEvents<TEvent extends EventObject> = TEvent | ErrorEventObject;
+
 export function createMachine<
   TContext,
   TEvent extends EventObject = AnyEventObject,
@@ -54,7 +57,7 @@ export function createMachine<
 >(
   config: TContext extends Model<any, any, any, any>
     ? 'Model type no longer supported as generic type. Please use `model.createMachine(...)` instead.'
-    : MachineConfig<TContext, any, TEvent>,
+    : MachineConfig<TContext, any, AllEvents<TEvent>>,
   options?: Partial<MachineOptions<TContext, TEvent>>
 ): StateMachine<TContext, any, TEvent, TTypestate>;
 export function createMachine<

--- a/packages/core/src/actionTypes.ts
+++ b/packages/core/src/actionTypes.ts
@@ -15,6 +15,7 @@ export const init = ActionTypes.Init;
 export const invoke = ActionTypes.Invoke;
 export const errorExecution = ActionTypes.ErrorExecution;
 export const errorPlatform = ActionTypes.ErrorPlatform;
+export const errorCommunication = ActionTypes.ErrorCommunication;
 export const error = ActionTypes.ErrorCustom;
 export const update = ActionTypes.Update;
 export const choose = ActionTypes.Choose;

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -56,7 +56,13 @@ import {
 import { State } from './State';
 import { StateNode } from './StateNode';
 import { IS_PRODUCTION } from './environment';
-import { ActorRef, EventFrom, StopAction, StopActionObject } from '.';
+import {
+  ActorRef,
+  ErrorCommunicationEvent,
+  EventFrom,
+  StopAction,
+  StopActionObject
+} from '.';
 
 export { actionTypes };
 
@@ -527,13 +533,27 @@ export function doneInvoke(id: string, data?: any): DoneEvent {
   return eventObject as DoneEvent;
 }
 
-export function error(id: string, data?: any): ErrorPlatformEvent & string {
+export function error(
+  id: string,
+  message?: string
+): ErrorPlatformEvent & string {
   const type = `${ActionTypes.ErrorPlatform}.${id}`;
-  const eventObject = { type, data };
+  const eventObject = { type, message, data: message };
 
   eventObject.toString = () => type;
 
   return eventObject as ErrorPlatformEvent & string;
+}
+
+export function communicationError(
+  message?: string
+): ErrorCommunicationEvent & string {
+  const type = ActionTypes.ErrorCommunication;
+  const eventObject = { type, message, data: message };
+
+  eventObject.toString = () => type;
+
+  return eventObject as ErrorCommunicationEvent & string;
 }
 
 export function pure<TContext, TEvent extends EventObject>(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -576,7 +576,10 @@ export interface StateNodeConfig<
    *
    * This is equivalent to defining a `[done(id)]` transition on this state node's `on` property.
    */
-  onDone?: string | SingleOrArray<TransitionConfig<TContext, DoneEventObject>> | undefined;
+  onDone?:
+    | string
+    | SingleOrArray<TransitionConfig<TContext, DoneEventObject>>
+    | undefined;
   /**
    * The mapping (or array) of delays (in milliseconds) to their potential transition(s).
    * The delayed transitions are taken after the specified delay in an interpreter.
@@ -919,14 +922,24 @@ export interface DoneInvokeEvent<TData> extends EventObject {
   data: TData;
 }
 
-export interface ErrorExecutionEvent extends EventObject {
-  src: string;
-  type: ActionTypes.ErrorExecution;
-  data: any;
+export interface ErrorEventObject extends EventObject {
+  /**
+   * @deprecated Use `.message` instead.
+   */
+  data?: any;
+  message?: string;
 }
 
-export interface ErrorPlatformEvent extends EventObject {
-  data: any;
+export interface ErrorExecutionEvent extends ErrorEventObject {
+  type: 'error.execution';
+}
+
+export interface ErrorPlatformEvent extends ErrorEventObject {
+  type: 'error.platform';
+}
+
+export interface ErrorCommunicationEvent extends ErrorEventObject {
+  type: 'error.communication';
 }
 
 export interface DoneEventObject extends EventObject {


### PR DESCRIPTION
This PR adds support for handling communication errors when the targets of events sent between actors does not exist:

```js
// ...
entry: sendParent('SOME_EVENT'), // pretend the parent does not exist...
on: {
  'error.communication': {
    actions: (_, e) => { console.log(e.message); }  // this will happen instead of an error being thrown
  }
}
```

If there is no `'error.communication'` transition, then an error will be thrown (existing behavior).