### PR TITLE
Demo a flaw of self.send API

### DIFF
--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -18,7 +18,8 @@ import {
   doneInvoke,
   escalate,
   forwardTo,
-  raise
+  raise,
+  respond
 } from '../src/actions';
 import { interval } from 'rxjs';
 import { map, take } from 'rxjs/operators';
@@ -2748,6 +2749,28 @@ describe('invoke', () => {
 
           expect(self.getSnapshot().context.count).toEqual(42);
           done();
+        }
+      }
+    });
+
+    interpret(machine).start();
+  });
+
+  it('parent should be able to respond to events sent using `self.send`', (done) => {
+    const machine = createMachine({
+      invoke: {
+        src: (_ctx, _e, { self }) => (_callback, onReceive) => {
+          self.send({ type: 'PING' });
+
+          onReceive((ev) => {
+            expect(ev.type).toBe('PONG');
+            done();
+          });
+        }
+      },
+      on: {
+        PING: {
+          actions: respond({ type: 'PONG' })
         }
       }
     });


### PR DESCRIPTION
It seems to me that a basic example such as this should work. 

I've done some research in Akka to understand better how this is handled there and from what I understand sending is usually **bound** to the current actor. And this is also related to why [I've originally found `self` to be a confusing name](https://github.com/statelyai/xstate/pull/2776#discussion_r773076005) for this feature.

Let's consider a very basic example:
```js
const machine = createMachine({
  invoke: {
    id: 'myChild',
    src: (_ctx, _e, { self }) => () => {
      // this is an implementation of the actor
      // I would expect "self" to refer here to that actor (to `myChild`)
      // but at the moment it refers to its parent
    },
  },
});
```

Note: in Akka there are both `context.self` and `context.parent` and I think that it sort of proves my point that what currently got introduced as `self` is actually not an equivalent of `context.self` but rather an equivalent of (sort of) `context.parent`.

Let's also take a close look at how communication is usually done in Scala:
```scala
someActor ! someMsg
```
This is known as "tell" and is basically the same thing as "sending" in our terminology. In fact, this is just a sugar syntax for the `tell` method.

So let's desugar this. One could think that this is the same as:
```scala
someActor.tell(someMsg)
```
but that is not true and that has some serious implications associated to it. In fact, this should be translated like this:
```scala
someActor.tell(someMsg, currentActor)
```

So why does this matter? It's very important for the failing test that I've added here. If we go with the first, incorrect, translation then it becomes impossible to assign correct `origin` to the sending operation because in JavaScript there is no way for us to know where and how our `ref.send` has been executed. All such calls are "contextless" when it comes to the runtime semantics.

In fact, this is somewhat interesting, in Scala the whole "currentActor" is an **implicit** argument (provided based on the used `implicit` language keyword and the compilator).

This allows for messages to be sent with the "corrent" `origin` - because every `tell` operation is associated, implicitly, with that sender.

If I understand this correctly, and there is non-zero chance that I'm wrong, `tell` can be used in arbitrary manner. The second argument, that is usually used implicitly, can be provided explicitly and there is no validation for the sender and the sendee (they are just some refs). This is also how `forward` is implemented in Akka:
```scala
def forward(message: Any)(implicit context: ActorContext) = tell(message, context.sender())
```
where the `context.sender` returns the "origin"/sender of the currently processed message. So if we form an actor hierarchy like this:
```
A > B > C > D
```
and we send from D to its parent and if C and B would forward the message to their respective parents then the message received by A would have `context.sender()` equal to D.

So while it's possible to use an arbitrary sender information when sending a message to an actor - that's only possible with the desugared `tell` method and I believe that Akka users interact mostly with the `!` syntax where this is not possible and the sender information is set automatically, based on the context/scope of the sender function etc.

Ok, that's all nice and dandy - but what does it have to do with us? It informs us about constraints/requirements that we should consider. For instance, it feels like something like this would allow for preserving the sender information in a better way:
```js
self.send(msg, parent)
```
The point is - that with this API the `send` is always "bound" to the current actor because it's the method available on it. The downside is that parent, as the target, has to be provided explicitly here. But this API allows us to send messages from the "current" actor - to any actor (if we only obtain reference to it).

And, of course, we could still provide a specialized `parent` ref to actors that would have the sender information already "bound" to it. The question is - should we expose such? It would increase the memory usage but it would do that to allow performing a very common operation in an easier way (so it's not essential, but would certainly improve DX for many people). An additional downside of this approach would be that we couldnt create the "parent" ref once and share it among invoked children - because each `parent.send` would have to be bound, implicitly, to the current child. While this is not a big problem in itself - I find it a little bit problematic that this wouldnt be true `m.childA.parent === m.childB.parent`. Having reference equality here could be quite useful and is semantically appealing.

Ok, what about arbitrary actorRef sharing? I don't see how we can fight against that (at least without a linter). I don't see how we could "hide" the `send` method from arbitrary access while allowing it to be used in the context of an actor. And I don't think that splitting this into 2 concepts (a ref used for "external" communication and an internal ref) would make this any better - because one could always just share the internal ref (the one with `send` method) and we can't do anything about it. The only thing that we could do is to enforce "origin" to be always, explicitly, provided. That wouuld become a chore very quickly since we'd have to enforce this:
```js
// well, in this variant `send` wouldnt have to be put on self, it could come from anywhere
self.send(msg, parent, self)
```

This gets a little bit fuzzy, but with this concept the `send` method gets somewhat flipped on its head (when comparing to what we currently have). That is because `send` is now used to `send` FROM and not TO. So I'm not super sure if that's a good thing, but I believe that the sender/origin problem is real and we should bikeshed all of the possibilities. Maybe actorRefs shouldnt have `send` method at all? and they only would come with `sendTo`? This would allow us to use different semantics for this and for the `Interpreter.prototype.send`.