### PR TITLE
Add `assertEventType` helper

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -71,7 +71,8 @@ export {
   spawn,
   doneInvoke,
   createMachine,
-  createSchema
+  createSchema,
+  assertEventType
 };
 
 export * from './types';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-import { matchesState } from './utils';
+import { matchesState, assertEventType } from './utils';
 import { mapState } from './mapState';
 import { StateNode } from './StateNode';
 import { State } from './State';

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -712,3 +712,36 @@ export function toObserver<T>(
     complete: completionHandler || noop
   };
 }
+
+export function assertEventType<
+  TEvent extends EventObject,
+  TType extends TEvent['type']
+>(
+  event: TEvent,
+  type: TType
+): asserts event is Extract<TEvent, { type: TType }>;
+export function assertEventType<
+  TEvent extends EventObject,
+  TTypes extends readonly TEvent['type'][]
+>(
+  event: TEvent,
+  type: TTypes
+): asserts event is Extract<TEvent, { type: TTypes[number] }>;
+export function assertEventType(
+  event: EventObject,
+  type: string | string[]
+): void {
+  if (typeof type === 'string' && event.type !== type) {
+    throw new Error(
+      `Expected event type "${type}", found type "${event.type}"`
+    );
+  }
+
+  if (Array.isArray(type) && !type.includes(event.type)) {
+    throw new Error(
+      `Expected one of event type "${JSON.stringify(type)}", found type "${
+        event.type
+      }"`
+    );
+  }
+}


### PR DESCRIPTION
Adds a helper function that can be used as an invariant to narrow the type of events that are passed to actions, services, guards, etc.