### PR TITLE
[core] Do not warn of missing implementation for built-in actions

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -923,7 +923,7 @@ export class Interpreter<
         }
         break;
       default:
-        if (!IS_PRODUCTION) {
+        if (!IS_PRODUCTION && !action.type.startsWith('xstate.')) {
           warn(
             false,
             `No implementation found for action type '${action.type}'`


### PR DESCRIPTION
Fixes #1792

(no easy way to test warnings)