### PR TITLE
Fix @xstate/inspect crash with circular state object (see #2373)

### DIFF
--- a/.changeset/dirty-birds-sniff.md
+++ b/.changeset/dirty-birds-sniff.md
@@ -1,0 +1,5 @@
+---
+'@xstate/inspect': patch
+---
+
+Fix crash when sending circular state objects (#2373).

--- a/packages/xstate-inspect/src/server.ts
+++ b/packages/xstate-inspect/src/server.ts
@@ -131,14 +131,6 @@ export function inspect(options: ServerInspectorOptions): Inspector {
         sessionId: service.sessionId
       });
     });
-
-    service.subscribe((state) => {
-      inspectService.send({
-        type: 'service.state',
-        state: JSON.stringify(state),
-        sessionId: service.sessionId
-      });
-    });
   });
 
   const inspector: Inspector = {


### PR DESCRIPTION
As discussed in #2373, there appears to be a redundant call to `service.subscribe` in the `@xstate/inspect` code.

This PR removes the duplicate call, which used the `JSON.stringify` method instead of the circular object-safe `stringify` utility method that already exists in the package.