### PR TITLE
Bring back the global type declaration for the `Symbol.observable` to fix consuming projects that do not use `skipLibCheck`

### DIFF
--- a/.changeset/orange-pans-study.md
+++ b/.changeset/orange-pans-study.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Bring back the global type declaration for the `Symbol.observable` to fix consuming projects that do not use `skipLibCheck`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -77,3 +77,9 @@ export {
 };
 
 export * from './types';
+
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}


### PR DESCRIPTION
fixes #2950

I rly dislike that we are affecting a global thing here - stuff like that causes me harm in the past on several occasions. The risk here is somewhat low but I still dislike the sole notion of doing this 😉

This Symbol is just a „pseudo” standard - it was part of the ES Observable proposal but that never moved far in the standards process. I sympathize with Evan You here: https://github.com/vuejs/core/pull/968#issuecomment-614655701

A funny thing is that… Rx Observables don’t include this property **at the type level** and they dont pass their own `InteropObservable` type-level „check” (although I’ve deduced this from their code and im not sure if I’ve verified this in an actual project, I was playing around with that yesterday and would have to recheck that to be absolutely sure about this)