### PR TITLE
improve exporting of 'actions'

### DIFF
--- a/.changeset/flat-dolls-suffer.md
+++ b/.changeset/flat-dolls-suffer.md
@@ -2,4 +2,4 @@
 'xstate': minor
 ---
 
-improve exporting of 'actions'
+All actions are now available in the `actions` variable when importing: `import { actions } from 'xstate'`

--- a/.changeset/flat-dolls-suffer.md
+++ b/.changeset/flat-dolls-suffer.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+improve exporting of 'actions'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,26 +4,7 @@ import { StateNode } from './StateNode';
 import { State } from './State';
 import { Machine, createMachine } from './Machine';
 import { Actor } from './Actor';
-import {
-  raise,
-  send,
-  sendParent,
-  sendTo,
-  sendUpdate,
-  log,
-  cancel,
-  start,
-  stop,
-  assign,
-  after,
-  done,
-  respond,
-  doneInvoke,
-  forwardTo,
-  escalate,
-  choose,
-  pure
-} from './actions';
+import * as actions from './actions';
 import {
   interpret,
   Interpreter,
@@ -33,25 +14,7 @@ import {
 import { matchState } from './match';
 import { createSchema } from './schema';
 
-const actions = {
-  raise,
-  send,
-  sendParent,
-  sendTo,
-  sendUpdate,
-  log,
-  cancel,
-  start,
-  stop,
-  assign,
-  after,
-  done,
-  respond,
-  forwardTo,
-  escalate,
-  choose,
-  pure
-};
+const { assign, send, sendParent, sendUpdate, forwardTo, doneInvoke } = actions;
 
 export {
   Actor,


### PR DESCRIPTION
Hello xstate team :wave: 

I [asked a question](https://discord.com/channels/795785288994652170/799416943324823592/929512618157285447) some time ago if there are any functions that can retrieve the event names for done/error of services but the answer: 
![image](https://user-images.githubusercontent.com/4054185/151081738-d8752c2e-16ab-4583-bfac-0f833a134070.png)

DIdn't seem to work. I realised later that some of exports from the `actions.ts` file aren't actually exported properly. Especially the ones we're after e.g. `doneInvoke` and `error`.

So this the change I'm making to improve how actions are exported. I don't think I've broken any exports but now everything that's exported from `actions.ts` is now exposed. Let me know if this not the right fix and I can change this to only export the ones we need and were assumed to be exported.

Cheers!
Satya