### PR TITLE
Updated React recipe context typing advice

### DIFF
--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -61,7 +61,7 @@ export const GlobalStateProvider = (props) => {
 
 Using `useInterpret` returns a service, which is a static reference to the running machine which can be subscribed to. This value never changes, so we don't need to worry about wasted re-renders.
 
-> For Typescript, you can create the context as `createContext({} as InterpreterFrom<typeof authMachine>);` to ensure strong typings.
+> For Typescript, you can create the context as `createContext({ authService: {} as InterpreterFrom<typeof authMachine> });` to ensure strong typings.
 
 ### Utilizing context
 


### PR DESCRIPTION
The context value in the [example](https://xstate.js.org/docs/recipes/react.html#global-state-react-context) isn't an interpreter, but contains an interpreter. The type in the accompanying TypeScript note now matches it.
