### PR TITLE
allow machines to use sendParent when they are not invoked/spawned

### DIFF
--- a/.changeset/proud-carpets-tap.md
+++ b/.changeset/proud-carpets-tap.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-allow machines to use sendParent when they are not invoked/spawned
+Machines can now use `sendParent(...)` without error, even when they are not invoked/spawned from a parent.

--- a/.changeset/proud-carpets-tap.md
+++ b/.changeset/proud-carpets-tap.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+allow machines to use sendParent when they are not invoked/spawned

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -722,8 +722,7 @@ export class Interpreter<
     event: SCXML.Event<AnyEventObject>,
     to: string | number | ActorRef<any>
   ) => {
-    const isParent =
-      this.parent && (to === SpecialTargets.Parent || this.parent.id === to);
+    const isParent = to === SpecialTargets.Parent || this?.parent?.id === to;
     const target = isParent
       ? this.parent
       : isString(to)

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -979,6 +979,26 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
         }
       }
     });
+
+    const orphanMachine = Machine<Ctx>({
+      id: 'orphan',
+      initial: 'start',
+      context: {
+        password: ''
+      },
+      states: {
+        start: {
+          onEntry: sendParent((ctx) => ({
+            type: 'NEXT',
+            password: ctx.password
+          })),
+          always: 'finish'
+        },
+        finish: {
+          type: 'final'
+        }
+      }
+    });
     // Ctx, any, Events, any
     const parentMachine = createMachine<Ctx, Events>({
       id: 'parent',
@@ -1012,6 +1032,16 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
             expect(state.children).toHaveProperty('child');
             expect(typeof state.children.child.send).toBe('function');
           }
+        })
+        .onDone(() => done())
+        .start();
+    });
+
+    it('should not error if the childMachine uses sendParent when not invoked within a parent machine', (done) => {
+      interpret(orphanMachine)
+        .onTransition((state) => {
+          console.log(state);
+          expect(state.matches('finish')).toBe(true);
         })
         .onDone(() => done())
         .start();

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1040,7 +1040,6 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
     it('should not error if the childMachine uses sendParent when not invoked within a parent machine', (done) => {
       interpret(orphanMachine)
         .onTransition((state) => {
-          console.log(state);
           expect(state.matches('finish')).toBe(true);
         })
         .onDone(() => done())


### PR DESCRIPTION
A machine should be able to call sendParent regardless of whether it is spawned/invoked or run on its own.
This allows greater re-usability of machines.