### PR TITLE
[core] Add `AnyState` and `AnyStateMachine`

### DIFF
--- a/.changeset/clean-cobras-exist.md
+++ b/.changeset/clean-cobras-exist.md
@@ -1,0 +1,14 @@
+---
+'xstate': patch
+---
+
+The `AnyStateMachine` type is now available, which can be used to express any state machine created from `createMachine(...)`:
+
+```ts
+import type { AnyStateMachine } from 'xstate';
+
+// A function that takes in any state machine
+function visualizeMachine(machine: AnyStateMachine) {
+  // (exercise left to reader)
+}
+```

--- a/.changeset/clean-cobras-exist.md
+++ b/.changeset/clean-cobras-exist.md
@@ -2,13 +2,17 @@
 'xstate': patch
 ---
 
-The `AnyStateMachine` type is now available, which can be used to express any state machine created from `createMachine(...)`:
+The `AnyState` and `AnyStateMachine` types are now available, which can be used to express any state and state machine, respectively:
 
 ```ts
-import type { AnyStateMachine } from 'xstate';
+import type { AnyState, AnyStateMachine } from 'xstate';
 
 // A function that takes in any state machine
 function visualizeMachine(machine: AnyStateMachine) {
   // (exercise left to reader)
+}
+
+function logState(state: AnyState) {
+  // ...
 }
 ```

--- a/docs/packages/xstate-inspect/index.md
+++ b/docs/packages/xstate-inspect/index.md
@@ -92,8 +92,8 @@ You can implement your own inspector by creating a **receiver**. A **receiver** 
   ```ts
   {
     type: 'service.register';
-    machine: StateMachine<any, any, any>;
-    state: State<any, any>;
+    machine: AnyStateMachine;
+    state: AnyState;
     id: string;
     sessionId: string;
     parent?: string;
@@ -115,7 +115,7 @@ You can implement your own inspector by creating a **receiver**. A **receiver** 
   ```ts
   {
     type: 'service.state';
-    state: State<any, any>;
+    state: AnyState;
     sessionId: string;
   }
   ```

--- a/docs/zh/packages/xstate-inspect/index.md
+++ b/docs/zh/packages/xstate-inspect/index.md
@@ -92,8 +92,8 @@ inspect();
   ```ts
   {
     type: 'service.register';
-    machine: StateMachine<any, any, any>;
-    state: State<any, any>;
+    machine: AnyStateMachine;
+    state: AnyState;
     id: string;
     sessionId: string;
     parent?: string;
@@ -115,7 +115,7 @@ inspect();
   ```ts
   {
     type: 'service.state';
-    state: State<any, any>;
+    state: AnyState;
     sessionId: string;
   }
   ```

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -31,7 +31,9 @@ import {
   ActorRefFrom,
   Behavior,
   StopActionObject,
-  Subscription
+  Subscription,
+  AnyState,
+  StateConfig
 } from './types';
 import { State, bindActionToState, isStateConfig } from './State';
 import * as actionTypes from './actionTypes';
@@ -65,7 +67,6 @@ import { registry } from './registry';
 import { getGlobal, registerService } from './devTools';
 import * as serviceScope from './serviceScope';
 import { spawnBehavior } from './behaviors';
-import { StateConfig } from '.';
 import {
   AreAllImplementationsAssumedToBeProvided,
   TypegenDisabled
@@ -1325,7 +1326,7 @@ export class Interpreter<
           {
             name: this.id,
             autoPause: true,
-            stateSanitizer: (state: State<any, any>): object => {
+            stateSanitizer: (state: AnyState): object => {
               return {
                 value: state.value,
                 context: state.context,

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -7,7 +7,7 @@ import {
   DelayExpr,
   ChooseCondition
 } from './types';
-import { Machine, StateMachine } from './index';
+import { AnyStateMachine, Machine } from './index';
 import { mapValues, keys, isString } from './utils';
 import * as actions from './actions';
 
@@ -426,7 +426,7 @@ export interface ScxmlToMachineOptions {
 function scxmlToMachine(
   scxmlJson: XMLElement,
   options: ScxmlToMachineOptions
-): StateMachine<any, any, any, any, any, any, any> {
+): AnyStateMachine {
   const machineElement = scxmlJson.elements!.find(
     (element) => element.name === 'scxml'
   ) as XMLElement;
@@ -462,7 +462,7 @@ function scxmlToMachine(
 export function toMachine(
   xml: string,
   options: ScxmlToMachineOptions
-): StateMachine<any, any, any, any, any, any, any> {
+): AnyStateMachine {
   const json = xml2js(xml) as XMLElement;
   return scxmlToMachine(json, options);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -158,7 +158,7 @@ export type Actions<TContext, TEvent extends EventObject> = SingleOrArray<
   Action<TContext, TEvent>
 >;
 
-export type StateKey = string | State<any>;
+export type StateKey = string | AnyState;
 
 export interface StateValueMap {
   [key: string]: StateValue;
@@ -698,6 +698,8 @@ export interface StateNodeDefinition<
 
 export type AnyStateNodeDefinition = StateNodeDefinition<any, any, any>;
 
+export type AnyState = State<any, any, any, any, any>;
+
 export type AnyStateMachine = StateMachine<any, any, any, any, any, any, any>;
 
 export interface AtomicStateNodeConfig<TContext, TEvent extends EventObject>
@@ -1166,7 +1168,7 @@ export interface DoneEventObject extends EventObject {
 
 export interface UpdateObject extends EventObject {
   id: string | number;
-  state: State<any, any>;
+  state: AnyState;
 }
 
 export type DoneEvent = DoneEventObject & string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -487,7 +487,7 @@ export interface InvokeConfig<TContext, TEvent extends EventObject> {
   src:
     | string
     | InvokeSourceDefinition
-    | StateMachine<any, any, any>
+    | AnyStateMachine
     | InvokeCreator<TContext, TEvent, any>;
   /**
    * If `true`, events sent to the parent service will be forwarded to the invoked service.
@@ -568,9 +568,7 @@ export interface StateNodeConfig<
   /**
    * The services to invoke upon entering this state node. These services will be stopped upon exiting this state node.
    */
-  invoke?: SingleOrArray<
-    InvokeConfig<TContext, TEvent> | StateMachine<any, any, any>
-  >;
+  invoke?: SingleOrArray<InvokeConfig<TContext, TEvent> | AnyStateMachine>;
   /**
    * The mapping of event types to their potential transition(s).
    */
@@ -699,6 +697,9 @@ export interface StateNodeDefinition<
 }
 
 export type AnyStateNodeDefinition = StateNodeDefinition<any, any, any>;
+
+export type AnyStateMachine = StateMachine<any, any, any, any, any, any, any>;
+
 export interface AtomicStateNodeConfig<TContext, TEvent extends EventObject>
   extends StateNodeConfig<TContext, StateSchema, TEvent> {
   initial?: undefined;
@@ -753,7 +754,7 @@ export type DelayFunctionMap<TContext, TEvent extends EventObject> = Record<
 export type ServiceConfig<
   TContext,
   TEvent extends EventObject = AnyEventObject
-> = string | StateMachine<any, any, any> | InvokeCreator<TContext, TEvent>;
+> = string | AnyStateMachine | InvokeCreator<TContext, TEvent>;
 
 export type DelayConfig<TContext, TEvent extends EventObject> =
   | number
@@ -810,7 +811,7 @@ type MachineOptionsServices<
   TInvokeSrcNameMap = Prop<TResolvedTypesMeta, 'invokeSrcNameMap'>
 > = {
   [K in keyof TEventsCausingServices]?:
-    | StateMachine<any, any, any, any, any, any, any>
+    | AnyStateMachine
     | InvokeCreator<
         TContext,
         Cast<Prop<TIndexedEvents, TEventsCausingServices[K]>, EventObject>,
@@ -1065,14 +1066,10 @@ export interface StateMachine<
 }
 
 export type StateFrom<
-  T extends
-    | StateMachine<any, any, any, any, any, any, any>
-    | ((...args: any[]) => StateMachine<any, any, any, any, any, any, any>)
-> = T extends StateMachine<any, any, any, any, any, any, any>
+  T extends AnyStateMachine | ((...args: any[]) => AnyStateMachine)
+> = T extends AnyStateMachine
   ? ReturnType<T['transition']>
-  : T extends (
-      ...args: any[]
-    ) => StateMachine<any, any, any, any, any, any, any>
+  : T extends (...args: any[]) => AnyStateMachine
   ? ReturnType<ReturnType<T>['transition']>
   : never;
 
@@ -1610,7 +1607,7 @@ export interface Subscribable<T> {
 }
 
 export type Spawnable =
-  | StateMachine<any, any, any>
+  | AnyStateMachine
   | PromiseLike<any>
   | InvokeCallback
   | InteropObservable<any>
@@ -1697,9 +1694,7 @@ export type ActorRefFrom<T> = T extends StateMachine<
 export type AnyInterpreter = Interpreter<any, any, any, any, any>;
 
 export type InterpreterFrom<
-  T extends
-    | StateMachine<any, any, any, any, any, any, any>
-    | ((...args: any[]) => StateMachine<any, any, any, any, any, any, any>)
+  T extends AnyStateMachine | ((...args: any[]) => AnyStateMachine)
 > = T extends StateMachine<
   infer TContext,
   infer TStateSchema,
@@ -1725,9 +1720,7 @@ export type InterpreterFrom<
   : never;
 
 export type MachineOptionsFrom<
-  T extends
-    | StateMachine<any, any, any, any, any, any, any>
-    | ((...args: any[]) => StateMachine<any, any, any, any, any, any, any>),
+  T extends AnyStateMachine | ((...args: any[]) => AnyStateMachine),
   TRequireMissingImplementations extends boolean = false
 > = ReturnTypeOrValue<T> extends StateMachine<
   infer TContext,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -11,7 +11,6 @@ import {
   AssignAction,
   Condition,
   Subscribable,
-  StateMachine,
   ConditionPredicate,
   SCXML,
   StateLike,
@@ -35,6 +34,7 @@ import { IS_PRODUCTION } from './environment';
 import { StateNode } from './StateNode';
 import { State } from './State';
 import { Actor } from './Actor';
+import { AnyStateMachine } from '.';
 
 export function keys<T extends object>(value: T): Array<keyof T & string> {
   return Object.keys(value) as Array<keyof T & string>;
@@ -543,7 +543,7 @@ export const interopSymbols = {
   }
 };
 
-export function isMachine(value: any): value is StateMachine<any, any, any> {
+export function isMachine(value: any): value is AnyStateMachine {
   try {
     return '__xstatenode' in value;
   } catch (e) {

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -10,7 +10,8 @@ import {
   EventObject,
   StateValue,
   AnyEventObject,
-  createMachine
+  createMachine,
+  AnyState
 } from '../src';
 import { State } from '../src/State';
 import { log, actionTypes, raise, stop } from '../src/actions';
@@ -216,7 +217,7 @@ describe('interpreter', () => {
 
   describe('send with delay', () => {
     it('can send an event after a delay', () => {
-      const currentStates: Array<State<any>> = [];
+      const currentStates: Array<AnyState> = [];
       const listener = (state) => {
         currentStates.push(state);
 
@@ -631,7 +632,7 @@ describe('interpreter', () => {
   });
 
   it('can cancel a delayed event', () => {
-    let currentState: State<any>;
+    let currentState: AnyState;
     const listener = (state) => (currentState = state);
 
     const service = interpret(lightMachine, {
@@ -943,7 +944,7 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
         }
       });
 
-      let state: State<any>;
+      let state: AnyState;
 
       interpret(raiseMachine)
         .onTransition((s) => {

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -6,7 +6,7 @@ import * as pkgUp from 'pkg-up';
 import { toMachine } from '../src/scxml';
 import { interpret } from '../src/interpreter';
 import { SimulatedClock } from '../src/SimulatedClock';
-import { AnyStateMachine, State } from '../src';
+import { AnyState, AnyStateMachine } from '../src';
 import { pathsToStateValue } from '../src/utils';
 // import { StateValue } from '../src/types';
 // import { Event, StateValue, ActionObject } from '../src/types';
@@ -356,7 +356,7 @@ interface SCIONTest {
 
 async function runW3TestToCompletion(machine: AnyStateMachine): Promise<void> {
   await new Promise<void>((resolve, reject) => {
-    let nextState: State<any>;
+    let nextState: AnyState;
 
     interpret(machine)
       .onTransition((state) => {
@@ -387,7 +387,7 @@ async function runTestToCompletion(
     )
   );
   let done = false;
-  let nextState: State<any> = machine.getInitialState(resolvedStateValue);
+  let nextState: AnyState = machine.getInitialState(resolvedStateValue);
   const service = interpret(machine, {
     clock: new SimulatedClock()
   })

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -6,7 +6,7 @@ import * as pkgUp from 'pkg-up';
 import { toMachine } from '../src/scxml';
 import { interpret } from '../src/interpreter';
 import { SimulatedClock } from '../src/SimulatedClock';
-import { State, StateMachine } from '../src';
+import { AnyStateMachine, State } from '../src';
 import { pathsToStateValue } from '../src/utils';
 // import { StateValue } from '../src/types';
 // import { Event, StateValue, ActionObject } from '../src/types';
@@ -354,9 +354,7 @@ interface SCIONTest {
   }>;
 }
 
-async function runW3TestToCompletion(
-  machine: StateMachine<any, any, any, any, any>
-): Promise<void> {
+async function runW3TestToCompletion(machine: AnyStateMachine): Promise<void> {
   await new Promise<void>((resolve, reject) => {
     let nextState: State<any>;
 
@@ -376,7 +374,7 @@ async function runW3TestToCompletion(
 }
 
 async function runTestToCompletion(
-  machine: StateMachine<any, any, any, any, any>,
+  machine: AnyStateMachine,
   test: SCIONTest
 ): Promise<void> {
   if (!test.events.length && test.initialConfiguration[0] === 'pass') {

--- a/packages/xstate-analytics/src/index.ts
+++ b/packages/xstate-analytics/src/index.ts
@@ -1,8 +1,8 @@
 // hello
 
-import { State } from 'xstate';
+import { AnyState } from 'xstate';
 
-export type StateListener = (state: State<any, any, any, any, any>) => void;
+export type StateListener = (state: AnyState) => void;
 
 interface TransitionsAnalysis {
   count: number;
@@ -26,7 +26,7 @@ interface TransitionAnalysis {
   relativeWeight: number;
 }
 
-const serializeState = (state?: State<any, any>): string => {
+const serializeState = (state?: AnyState): string => {
   if (!state) {
     return '';
   }
@@ -36,7 +36,7 @@ const serializeState = (state?: State<any, any>): string => {
 };
 
 interface AnalyzerOptions {
-  filter: (state: State<any, any>) => boolean;
+  filter: (state: AnyState) => boolean;
   history?: TransitionsAnalysis;
 }
 
@@ -57,7 +57,7 @@ export function createAnalyzer(
     transitions: {}
   };
 
-  return (state: State<any, any>) => {
+  return (state: AnyState) => {
     if (!resolvedOptions.filter(state)) {
       return;
     }

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -68,6 +68,8 @@ export namespace StateMachine {
     ) => this is TState extends { value: TSV } ? TState : never;
   }
 
+  export type AnyState = State<any, any, any>;
+
   export interface Config<
     TContext extends object,
     TEvent extends EventObject,
@@ -102,9 +104,7 @@ export namespace StateMachine {
     ) => State<TContext, TEvent, TState>;
   }
 
-  export type StateListener<T extends State<any, any, any>> = (
-    state: T
-  ) => void;
+  export type StateListener<T extends AnyState> = (state: T) => void;
 
   export interface Service<
     TContext extends object,

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -5,7 +5,8 @@ import {
   Event,
   EventObject,
   StateMachine,
-  AnyEventObject
+  AnyEventObject,
+  AnyStateMachine
 } from 'xstate';
 import { flatten, keys } from 'xstate/lib/utils';
 import {
@@ -37,7 +38,7 @@ const EMPTY_MAP = {};
  * @param stateNode State node to recursively get child state nodes from
  */
 export function getStateNodes(
-  stateNode: AnyStateNode | StateMachine<any, any, any, any, any, any, any>
+  stateNode: AnyStateNode | AnyStateMachine
 ): AnyStateNode[] {
   const { states } = stateNode;
   const nodes = keys(states).reduce((accNodes, stateKey) => {
@@ -346,7 +347,7 @@ export function getSimplePathsAsArray<
 }
 
 export function toDirectedGraph(
-  stateNode: AnyStateNode | StateMachine<any, any, any, any, any, any, any>
+  stateNode: AnyStateNode | AnyStateMachine
 ): DirectedGraphNode {
   const edges: DirectedGraphEdge[] = flatten(
     stateNode.transitions.map((t, transitionIndex) => {

--- a/packages/xstate-inspect/src/serialize.ts
+++ b/packages/xstate-inspect/src/serialize.ts
@@ -1,4 +1,4 @@
-import { AnyStateMachine, State, StateMachine } from 'xstate';
+import { AnyState, AnyStateMachine, State, StateMachine } from 'xstate';
 import { Replacer } from './types';
 import { stringify } from './utils';
 
@@ -20,10 +20,7 @@ export function selectivelyStringify<T extends object>(
   });
 }
 
-export function stringifyState(
-  state: State<any, any>,
-  replacer?: Replacer
-): string {
+export function stringifyState(state: AnyState, replacer?: Replacer): string {
   return selectivelyStringify(state, ['context', 'event', '_event'], replacer);
 }
 

--- a/packages/xstate-inspect/src/serialize.ts
+++ b/packages/xstate-inspect/src/serialize.ts
@@ -1,4 +1,4 @@
-import { State, StateMachine } from 'xstate';
+import { AnyStateMachine, State, StateMachine } from 'xstate';
 import { Replacer } from './types';
 import { stringify } from './utils';
 
@@ -28,7 +28,7 @@ export function stringifyState(
 }
 
 export function stringifyMachine(
-  machine: StateMachine<any, any, any>,
+  machine: AnyStateMachine,
   replacer?: Replacer
 ): string {
   return selectivelyStringify(machine, ['context'], replacer);

--- a/packages/xstate-inspect/src/serialize.ts
+++ b/packages/xstate-inspect/src/serialize.ts
@@ -1,4 +1,4 @@
-import { AnyState, AnyStateMachine, State, StateMachine } from 'xstate';
+import { AnyState, AnyStateMachine } from 'xstate';
 import { Replacer } from './types';
 import { stringify } from './utils';
 

--- a/packages/xstate-inspect/src/types.ts
+++ b/packages/xstate-inspect/src/types.ts
@@ -3,7 +3,8 @@ import type {
   SCXML,
   State,
   StateMachine,
-  AnyInterpreter
+  AnyInterpreter,
+  AnyStateMachine
 } from 'xstate';
 import { XStateDevInterface } from 'xstate/lib/devTools';
 import { InspectMachineEvent } from './inspectMachine';
@@ -60,7 +61,7 @@ export type ReceiverEvent =
 export type ParsedReceiverEvent =
   | {
       type: 'service.register';
-      machine: StateMachine<any, any, any, any, any, any, any>;
+      machine: AnyStateMachine;
       state: State<any, any>;
       id: string;
       sessionId: string;

--- a/packages/xstate-inspect/src/types.ts
+++ b/packages/xstate-inspect/src/types.ts
@@ -1,10 +1,9 @@
 import type {
   ActorRef,
   SCXML,
-  State,
-  StateMachine,
   AnyInterpreter,
-  AnyStateMachine
+  AnyStateMachine,
+  AnyState
 } from 'xstate';
 import { XStateDevInterface } from 'xstate/lib/devTools';
 import { InspectMachineEvent } from './inspectMachine';
@@ -22,8 +21,7 @@ export interface InspectorOptions {
   serialize?: Replacer | undefined;
 }
 
-export interface Inspector
-  extends ActorRef<InspectMachineEvent, State<any, any, any, any, any>> {
+export interface Inspector extends ActorRef<InspectMachineEvent, AnyState> {
   /**
    * Disconnects the inspector.
    */
@@ -62,7 +60,7 @@ export type ParsedReceiverEvent =
   | {
       type: 'service.register';
       machine: AnyStateMachine;
-      state: State<any, any>;
+      state: AnyState;
       id: string;
       sessionId: string;
       parent?: string;
@@ -71,7 +69,7 @@ export type ParsedReceiverEvent =
   | { type: 'service.stop'; sessionId: string }
   | {
       type: 'service.state';
-      state: State<any, any, any, any, any>;
+      state: AnyState;
       sessionId: string;
     }
   | { type: 'service.event'; event: SCXML.Event<any>; sessionId: string };

--- a/packages/xstate-inspect/src/utils.ts
+++ b/packages/xstate-inspect/src/utils.ts
@@ -1,5 +1,5 @@
 import safeStringify from 'fast-safe-stringify';
-import { State, createMachine } from 'xstate';
+import { State, createMachine, AnyState } from 'xstate';
 import { ParsedReceiverEvent, ReceiverEvent } from './types';
 
 export function getLazy<T>(value: T): T extends () => infer R ? R : T {
@@ -37,7 +37,7 @@ export function isReceiverEvent(event: any): event is ReceiverEvent {
   return false;
 }
 
-export function parseState(stateJSON: string): State<any, any> {
+export function parseState(stateJSON: string): AnyState {
   const state = State.create(JSON.parse(stateJSON));
 
   delete state.history;

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 import {
+  AnyStateMachine,
   AreAllImplementationsAssumedToBeProvided,
   InternalMachineOptions,
   interpret,
   InterpreterFrom,
   InterpreterOptions,
   Observer,
-  State,
-  StateMachine
+  State
 } from 'xstate';
 import { MaybeLazy } from './types';
 import useConstant from './useConstant';
@@ -36,7 +36,7 @@ function toObserver<T>(
 }
 
 type RestParams<
-  TMachine extends StateMachine<any, any, any, any, any, any, any>
+  TMachine extends AnyStateMachine
 > = AreAllImplementationsAssumedToBeProvided<
   TMachine['__TResolvedTypesMeta']
 > extends false
@@ -98,9 +98,7 @@ type RestParams<
           ) => void)
     ];
 
-export function useInterpret<
-  TMachine extends StateMachine<any, any, any, any, any, any, any>
->(
+export function useInterpret<TMachine extends AnyStateMachine>(
   getMachine: MaybeLazy<TMachine>,
   ...[options = {}, observerOrListener]: RestParams<TMachine>
 ): InterpreterFrom<TMachine> {

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import {
   ActionFunction,
+  AnyStateMachine,
   AreAllImplementationsAssumedToBeProvided,
   EventObject,
   InternalMachineOptions,
@@ -8,8 +9,7 @@ import {
   InterpreterOptions,
   State,
   StateConfig,
-  StateFrom,
-  StateMachine
+  StateFrom
 } from 'xstate';
 import { MaybeLazy, Prop, ReactActionFunction, ReactEffectType } from './types';
 import { useInterpret } from './useInterpret';
@@ -58,7 +58,7 @@ export interface UseMachineOptions<TContext, TEvent extends EventObject> {
 }
 
 type RestParams<
-  TMachine extends StateMachine<any, any, any, any, any, any, any>
+  TMachine extends AnyStateMachine
 > = AreAllImplementationsAssumedToBeProvided<
   TMachine['__TResolvedTypesMeta']
 > extends false
@@ -83,13 +83,11 @@ type RestParams<
     ];
 
 type UseMachineReturn<
-  TMachine extends StateMachine<any, any, any, any, any, any, any>,
+  TMachine extends AnyStateMachine,
   TInterpreter = InterpreterFrom<TMachine>
 > = [StateFrom<TMachine>, Prop<TInterpreter, 'send'>, TInterpreter];
 
-export function useMachine<
-  TMachine extends StateMachine<any, any, any, any, any, any, any>
->(
+export function useMachine<TMachine extends AnyStateMachine>(
   getMachine: MaybeLazy<TMachine>,
   ...[options = {}]: RestParams<TMachine>
 ): UseMachineReturn<TMachine> {

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -10,7 +10,8 @@ import {
   createMachine,
   send,
   InterpreterFrom,
-  StateFrom
+  StateFrom,
+  AnyState
 } from 'xstate';
 import {
   render,
@@ -69,7 +70,7 @@ describe('useMachine hook', () => {
 
   const Fetcher: React.FC<{
     onFetch: () => Promise<any>;
-    persistedState?: State<any, any, any, any, any>;
+    persistedState?: AnyState;
   }> = ({
     onFetch = () => new Promise((res) => res('some data')),
     persistedState

--- a/packages/xstate-scxml/src/index.ts
+++ b/packages/xstate-scxml/src/index.ts
@@ -1,10 +1,10 @@
 import { js2xml, Element as XMLElement, Attributes } from 'xml-js';
 import {
-  StateMachine,
   ActionObject,
   TransitionDefinition,
   StateNode,
-  ActionType
+  ActionType,
+  AnyStateMachine
 } from 'xstate';
 import { flatten } from 'xstate/lib/utils';
 
@@ -153,7 +153,7 @@ function stateNodeToSCXML(stateNode: StateNode<any, any, any>): XMLElement {
   };
 }
 
-export function toSCXML(machine: StateMachine<any, any, any>): string {
+export function toSCXML(machine: AnyStateMachine): string {
   const { states, initial } = machine;
 
   return js2xml(

--- a/packages/xstate-scxml/test/scxml.test.ts
+++ b/packages/xstate-scxml/test/scxml.test.ts
@@ -1,4 +1,4 @@
-import { Machine, StateMachine, State, interpret } from 'xstate';
+import { Machine, interpret } from 'xstate';
 import { xml2js } from 'xml-js';
 import { transitionToSCXML, toSCXML } from '../src';
 import { toMachine } from 'xstate/lib/scxml';

--- a/packages/xstate-scxml/test/scxml.test.ts
+++ b/packages/xstate-scxml/test/scxml.test.ts
@@ -5,7 +5,7 @@ import { toMachine } from 'xstate/lib/scxml';
 import { pathsToStateValue } from 'xstate/lib/utils';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
 import * as fs from 'fs';
-import { AnyStateMachine } from 'xstate/src';
+import { AnyState, AnyStateMachine } from 'xstate/src';
 
 interface SCIONTest {
   initialConfiguration: string[];
@@ -29,7 +29,7 @@ async function runTestToCompletion(
   const resolvedStateValue = machine.resolve(stateValue);
 
   let done = false;
-  let nextState: State<any> = machine.getInitialState(
+  let nextState: AnyState = machine.getInitialState(
     resolvedStateValue,
     machine.initialState.context
   );

--- a/packages/xstate-scxml/test/scxml.test.ts
+++ b/packages/xstate-scxml/test/scxml.test.ts
@@ -1,11 +1,10 @@
-import { Machine, interpret } from 'xstate';
+import { Machine, interpret, AnyState, AnyStateMachine } from 'xstate';
 import { xml2js } from 'xml-js';
 import { transitionToSCXML, toSCXML } from '../src';
 import { toMachine } from 'xstate/lib/scxml';
 import { pathsToStateValue } from 'xstate/lib/utils';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
 import * as fs from 'fs';
-import { AnyState, AnyStateMachine } from 'xstate/src';
 
 interface SCIONTest {
   initialConfiguration: string[];

--- a/packages/xstate-scxml/test/scxml.test.ts
+++ b/packages/xstate-scxml/test/scxml.test.ts
@@ -5,6 +5,7 @@ import { toMachine } from 'xstate/lib/scxml';
 import { pathsToStateValue } from 'xstate/lib/utils';
 import { SimulatedClock } from 'xstate/lib/SimulatedClock';
 import * as fs from 'fs';
+import { AnyStateMachine } from 'xstate/src';
 
 interface SCIONTest {
   initialConfiguration: string[];
@@ -16,7 +17,7 @@ interface SCIONTest {
 }
 
 async function runTestToCompletion(
-  machine: StateMachine<any, any, any, any, any, any>,
+  machine: AnyStateMachine,
   test: SCIONTest
 ): Promise<void> {
   const stateValue = test.events.length

--- a/packages/xstate-svelte/test/UseMachine.svelte
+++ b/packages/xstate-svelte/test/UseMachine.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  export let persistedState: State<any> | undefined = undefined;
+  export let persistedState: AnyState | undefined = undefined;
 
   import { useMachine } from '../src';
   import { fetchMachine } from './fetchMachine';
-  import type { State } from 'xstate';
+  import type { AnyState } from 'xstate';
 
   const onFetch = () =>
     new Promise((res) => setTimeout(() => res('some data'), 50));

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -1,11 +1,11 @@
-import { EventObject, State, StateNode } from 'xstate';
+import { AnyState, EventObject, State, StateNode } from 'xstate';
 export interface TestMeta<T, TContext> {
   test?: (testContext: T, state: State<TContext, any>) => Promise<void> | void;
   description?: string | ((state: State<TContext, any>) => string);
   skip?: boolean;
 }
 interface TestSegment<T> {
-  state: State<any, any>;
+  state: AnyState;
   event: EventObject;
   description: string;
   test: (testContext: T) => Promise<void>;

--- a/packages/xstate-vue/test/UseMachine.vue
+++ b/packages/xstate-vue/test/UseMachine.vue
@@ -13,7 +13,7 @@
 <script lang="ts">
 import { defineComponent, PropType } from 'vue';
 import { useMachine } from '../src';
-import { createMachine, assign, State } from 'xstate';
+import { createMachine, assign, State, AnyState } from 'xstate';
 
 const context = {
   data: undefined
@@ -47,7 +47,7 @@ const fetchMachine = createMachine<typeof context, any>({
 export default defineComponent({
   props: {
     persistedState: {
-      type: Object as PropType<State<any>>
+      type: Object as PropType<AnyState>
     }
   },
   setup({ persistedState }) {


### PR DESCRIPTION
This PR:
- Adds `AnyState` to represent `State<any, any, ...>`
- Adds `AnyStateMachine` to represent `StateMachine<any, any, ...>`
- Cleans up internal types using the above two types