### PR TITLE
[@xstate/test][@xstate/graph] Fix `getAdjacencyMap` to ignore transitions for events not explicitly passed into the `options.events` 

### DIFF
--- a/.changeset/cool-colts-jam.md
+++ b/.changeset/cool-colts-jam.md
@@ -1,0 +1,6 @@
+---
+'@xstate/graph': major
+'@xstate/test': minor
+---
+
+`getAdjacencyMap` will now only process events that are passed into `options.events`. Previously, it would attempt to process every event per state, and if there wasn't a case in the `options.events` then a payload-less event would be created -- which is problematic for events that required a payload and could lead to an invalid `context`. The consequence of this change is that `options.events` must always be explicitly passed into `getAdjacencyMap` (see test changes).

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -130,17 +130,15 @@ export function getAdjacencyMap<
       nextEvents.map((nextEvent) => {
         const getNextEvents = events[nextEvent];
 
-        if (!getNextEvents) {
-          return [{ type: nextEvent }];
-        }
-
         if (typeof getNextEvents === 'function') {
           return getNextEvents(state);
         }
 
         return getNextEvents;
       })
-    ).map((event) => toEventObject(event));
+    )
+      .filter(Boolean)
+      .map((event) => toEventObject(event));
 
     for (const event of potentialEvents) {
       let nextState: State<TContext, TEvent>;

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -158,21 +158,42 @@ describe('@xstate/graph', () => {
 
   describe('getShortestPaths()', () => {
     it('should return a mapping of shortest paths to all states', () => {
-      const paths = getShortestPaths(lightMachine) as any;
+      const paths = getShortestPaths(lightMachine, {
+        events: {
+          TIMER: [{ type: 'TIMER' }],
+          POWER_OUTAGE: [{ type: 'POWER_OUTAGE' }],
+          PUSH_BUTTON: [{ type: 'PUSH_BUTTON' }],
+          PED_COUNTDOWN: [{ type: 'PED_COUNTDOWN' }]
+        }
+      });
 
       expect(paths).toMatchSnapshot('shortest paths');
     });
 
     it('should return a mapping of shortest paths to all states (parallel)', () => {
-      const paths = getShortestPaths(parallelMachine) as any;
+      const paths = getShortestPaths(parallelMachine, {
+        events: {
+          1: [{ type: '1' }],
+          2: [{ type: '2' }],
+          3: [{ type: '3' }]
+        }
+      });
+
       expect(paths).toMatchSnapshot('shortest paths parallel');
     });
 
     it('the initial state should have a zero-length path', () => {
+      const paths = getShortestPaths(lightMachine, {
+        events: {
+          TIMER: [{ type: 'TIMER' }],
+          POWER_OUTAGE: [{ type: 'POWER_OUTAGE' }],
+          PUSH_BUTTON: [{ type: 'PUSH_BUTTON' }],
+          PED_COUNTDOWN: [{ type: 'PED_COUNTDOWN' }]
+        }
+      });
+
       expect(
-        getShortestPaths(lightMachine)[
-          JSON.stringify(lightMachine.initialState.value)
-        ].paths[0].segments
+        paths[JSON.stringify(lightMachine.initialState.value)].paths[0].segments
       ).toHaveLength(0);
     });
 
@@ -209,7 +230,14 @@ describe('@xstate/graph', () => {
 
   describe('getSimplePaths()', () => {
     it('should return a mapping of arrays of simple paths to all states', () => {
-      const paths = getSimplePaths(lightMachine) as any;
+      const paths = getSimplePaths(lightMachine, {
+        events: {
+          TIMER: [{ type: 'TIMER' }],
+          POWER_OUTAGE: [{ type: 'POWER_OUTAGE' }],
+          PUSH_BUTTON: [{ type: 'PUSH_BUTTON' }],
+          PED_COUNTDOWN: [{ type: 'PED_COUNTDOWN' }]
+        }
+      });
 
       expect(paths).toMatchSnapshot('simple paths');
     });
@@ -223,24 +251,49 @@ describe('@xstate/graph', () => {
     });
 
     it('should return a mapping of simple paths to all states (parallel)', () => {
-      const paths = getSimplePaths(parallelMachine);
+      const paths = getSimplePaths(parallelMachine, {
+        events: {
+          1: [{ type: '1' }],
+          2: [{ type: '2' }],
+          3: [{ type: '3' }]
+        }
+      });
       expect(paths).toMatchSnapshot('simple paths parallel');
     });
 
     it('should return multiple paths for equivalent transitions', () => {
-      const paths = getSimplePaths(equivMachine);
+      const paths = getSimplePaths(equivMachine, {
+        events: {
+          FOO: [{ type: 'FOO' }],
+          BAR: [{ type: 'BAR' }]
+        }
+      });
+
       expect(paths).toMatchSnapshot('simple paths equal transitions');
     });
 
     it('should return a single empty path for the initial state', () => {
-      expect(getSimplePaths(lightMachine)['"green"'].paths).toHaveLength(1);
-      expect(
-        getSimplePaths(lightMachine)['"green"'].paths[0].segments
-      ).toHaveLength(0);
-      expect(getSimplePaths(equivMachine)['"a"'].paths).toHaveLength(1);
-      expect(
-        getSimplePaths(equivMachine)['"a"'].paths[0].segments
-      ).toHaveLength(0);
+      const lightMachinePaths = getSimplePaths(lightMachine, {
+        events: {
+          TIMER: [{ type: 'TIMER' }],
+          POWER_OUTAGE: [{ type: 'POWER_OUTAGE' }],
+          PUSH_BUTTON: [{ type: 'PUSH_BUTTON' }],
+          PED_COUNTDOWN: [{ type: 'PED_COUNTDOWN' }]
+        }
+      });
+
+      expect(lightMachinePaths['"green"'].paths).toHaveLength(1);
+      expect(lightMachinePaths['"green"'].paths[0].segments).toHaveLength(0);
+
+      const equivMachinePaths = getSimplePaths(equivMachine, {
+        events: {
+          FOO: [{ type: 'FOO' }],
+          BAR: [{ type: 'BAR' }]
+        }
+      });
+
+      expect(equivMachinePaths['"a"'].paths).toHaveLength(1);
+      expect(equivMachinePaths['"a"'].paths[0].segments).toHaveLength(0);
     });
 
     it('should return value-based paths', () => {
@@ -287,7 +340,14 @@ describe('@xstate/graph', () => {
 
   describe('getSimplePathsAsArray()', () => {
     it('should return an array of shortest paths to all states', () => {
-      const pathsArray = getSimplePathsAsArray(lightMachine);
+      const pathsArray = getSimplePathsAsArray(lightMachine, {
+        events: {
+          TIMER: [{ type: 'TIMER' }],
+          POWER_OUTAGE: [{ type: 'POWER_OUTAGE' }],
+          PUSH_BUTTON: [{ type: 'PUSH_BUTTON' }],
+          PED_COUNTDOWN: [{ type: 'PED_COUNTDOWN' }]
+        }
+      });
 
       expect(Array.isArray(pathsArray)).toBeTruthy();
       expect(pathsArray).toMatchSnapshot('simple paths array');

--- a/packages/xstate-test/src/index.ts
+++ b/packages/xstate-test/src/index.ts
@@ -63,9 +63,11 @@ export class TestModel<TTestContext, TContext> {
   public getShortestPathPlans(
     options?: Partial<ValueAdjMapOptions<TContext, any>>
   ): Array<TestPlan<TTestContext, TContext>> {
+    const events = getEventSamples<TTestContext>(this.options.events);
+
     const shortestPaths = getShortestPaths(this.machine, {
       ...options,
-      events: getEventSamples<TTestContext>(this.options.events)
+      events
     }) as StatePathsMap<TContext, any>;
 
     return this.getTestPlans(shortestPaths);
@@ -408,12 +410,15 @@ function getEventSamples<T>(eventsOptions: TestModelOptions<T>['events']) {
 
   Object.keys(eventsOptions).forEach((key) => {
     const eventConfig = eventsOptions[key];
+
     if (typeof eventConfig === 'function') {
-      return [
+      result[key] = [
         {
           type: key
         }
       ];
+
+      return;
     }
 
     result[key] = eventConfig.cases

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -571,7 +571,10 @@ describe('state limiting', () => {
       }
     });
 
-    const testModel = createModel(machine);
+    const testModel = createModel(machine).withEvents({
+      INC: () => {}
+    });
+
     const testPlans = testModel.getShortestPathPlans({
       filter: (state) => {
         return state.context.count < 5;
@@ -632,7 +635,10 @@ describe('plan description', () => {
     }
   });
 
-  const testModel = createModel(machine);
+  const testModel = createModel(machine).withEvents({
+    NEXT: () => {},
+    DONE: () => {}
+  });
   const testPlans = testModel.getShortestPathPlans();
 
   it('should give a description for every plan', () => {


### PR DESCRIPTION
Wasn't entirely sure what the changeset should be -- this could be considered a breaking change, despite the original behavior being flawed.

Basically, `getAdjacencyMap` would always attempt to find adjacencies for **every** transition. It would first look in the `options.events` to determine the payload, but if none was found, then it would create a payload-less event and use that to find adjacencies.

This is problematic for a couple reasons:
1. We can't assume events can be run without a payload
2. The adjacency map is far more expensive to compute when you only need adjacencies for a subset of events (eg: `getPathFromEvents`

There are a couple threads in discord related to this:

**Expensive adjacency map**
https://discord.com/channels/795785288994652170/809564635614150686/943109510040551424

**getPlanFromEvents tried unwanted transitions**
https://discord.com/channels/795785288994652170/809564635614150686/943823319625519124

Anyway, curious to see what people think!