### PR TITLE
Simplify how `Symbol.observable` alias is declared

### DIFF
--- a/packages/core/src/Actor.ts
+++ b/packages/core/src/Actor.ts
@@ -10,7 +10,7 @@ import {
   BaseActorRef
 } from './types';
 import {
-  symbolObservableRef,
+  symbolObservable,
   isMachine,
   mapContext,
   toInvokeSource
@@ -43,7 +43,7 @@ export function createNullActor(id: string): ActorRef<any> {
     toJSON: () => ({
       id
     }),
-    [symbolObservableRef.symbol]: function () {
+    [symbolObservable]: function () {
       return this;
     }
   };
@@ -126,7 +126,7 @@ export function toActorRef<
     subscribe: () => ({ unsubscribe: () => void 0 }),
     id: 'anonymous',
     getSnapshot: () => undefined,
-    [symbolObservableRef.symbol]: function () {
+    [symbolObservable]: function () {
       return this;
     },
     ...actorRefLike

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -58,7 +58,7 @@ import {
   toObserver,
   isActor,
   isBehavior,
-  symbolObservableRef
+  symbolObservable
 } from './utils';
 import { Scheduler } from './scheduler';
 import { Actor, isSpawnedActor, createDeferredActor } from './Actor';
@@ -1166,7 +1166,7 @@ export class Interpreter<
         return { id };
       },
       getSnapshot: () => resolvedData,
-      [symbolObservableRef.symbol]: function () {
+      [symbolObservable]: function () {
         return this;
       }
     };
@@ -1229,7 +1229,7 @@ export class Interpreter<
         return { id };
       },
       getSnapshot: () => emitted,
-      [symbolObservableRef.symbol]: function () {
+      [symbolObservable]: function () {
         return this;
       }
     };
@@ -1270,7 +1270,7 @@ export class Interpreter<
       toJSON() {
         return { id };
       },
-      [symbolObservableRef.symbol]: function () {
+      [symbolObservable]: function () {
         return this;
       }
     };
@@ -1317,7 +1317,7 @@ export class Interpreter<
       toJSON() {
         return { id };
       },
-      [symbolObservableRef.symbol]: function () {
+      [symbolObservable]: function () {
         return this;
       }
     });
@@ -1366,7 +1366,7 @@ export class Interpreter<
     };
   }
 
-  public [symbolObservableRef.symbol](): InteropSubscribable<
+  public [symbolObservable](): InteropSubscribable<
     State<TContext, TEvent, TStateSchema, TTypestate, TResolvedTypesMeta>
   > {
     return this;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -529,16 +529,13 @@ export function isObservable<T>(value: any): value is Subscribable<T> {
   }
 }
 
-const symbolObservable = (() =>
-  (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();
-
-export const symbolObservableRef = {
-  symbol: symbolObservable as Exclude<typeof symbolObservable, string>
-} as const;
+export const symbolObservable: typeof Symbol.observable = (() =>
+  (typeof Symbol === 'function' && Symbol.observable) ||
+  '@@observable')() as any;
 
 // TODO: to be removed in v5, left it out just to minimize the scope of the change and maintain compatibility with older versions of integration paackages
 export const interopSymbols = {
-  [symbolObservableRef.symbol]: function () {
+  [symbolObservable]: function () {
     return this;
   },
   [Symbol.observable]: function () {


### PR DESCRIPTION
Previously I was trying to use `as typeof Symbol.observable` and this didn't work so I've done those weird transformations to achieve the desired effect. However, it turned out that this can be done much simpler with help of the `as any`