### PR TITLE
Fixed an issue with context type defined using `schema.context` being sometimes widened based on `config.context`

### DIFF
--- a/.changeset/red-frogs-yell.md
+++ b/.changeset/red-frogs-yell.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with context type defined using `schema.context` being sometimes widened based on `config.context`. If both are given the `schema.context` should always take precedence and should represent the complete type of the context.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,6 +31,7 @@ export type Equals<A1 extends any, A2 extends any> = (<A>() => A extends A2
 export type IsAny<T> = Equals<T, any>;
 export type Cast<A, B> = A extends B ? A : B;
 export type NoInfer<T> = [T][T extends any ? 0 : any];
+export type LowInfer<T> = T & {};
 
 export type EventType = string;
 export type ActionType = string;
@@ -951,7 +952,7 @@ export interface MachineConfig<
   /**
    * The initial context (extended state)
    */
-  context?: TContext | (() => TContext);
+  context?: LowInfer<TContext | (() => TContext)>;
   /**
    * The machine's own version.
    */

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -395,6 +395,25 @@ describe('Typestates', () => {
 });
 
 describe('context', () => {
+  it('should infer context type from `config.context` when there is no `schema.context`', () => {
+    createMachine(
+      {
+        context: {
+          foo: 'test'
+        }
+      },
+      {
+        actions: {
+          someAction: (ctx) => {
+            ((_accept: string) => {})(ctx.foo);
+            // @ts-expect-error
+            ((_accept: number) => {})(ctx.foo);
+          }
+        }
+      }
+    );
+  });
+
   it('should not use actions as possible inference sites', () => {
     createMachine(
       {
@@ -425,6 +444,20 @@ describe('context', () => {
     }
 
     createMachineWithExtras({ counter: 42 });
+  });
+
+  it('should not widen literal types defined in `schema.context` based on `config.context`', () => {
+    createMachine({
+      schema: {
+        context: {} as {
+          literalTest: 'foo' | 'bar';
+        }
+      },
+      context: {
+        // @ts-expect-error
+        literalTest: 'anything'
+      }
+    });
   });
 });
 


### PR DESCRIPTION
fixes #3028