### PR TITLE
Fixed an issue with `ActorRefFrom` not resolving the typegen metadata from machine types

### DIFF
--- a/.changeset/thin-hounds-kiss.md
+++ b/.changeset/thin-hounds-kiss.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with `ActorRefFrom` not resolving the typegen metadata from machine types given to it. This could sometimes result in types assignability problems, especially when using machine factories and `spawn`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1671,19 +1671,8 @@ export type ActorRefWithDeprecatedState<
   state: State<TContext, TEvent, any, TTypestate, TResolvedTypesMeta>;
 };
 
-export type ActorRefFrom<T> = T extends StateMachine<
-  infer TContext,
-  any,
-  infer TEvent,
-  infer TTypestate,
-  any,
-  any,
-  any
->
-  ? ActorRefWithDeprecatedState<TContext, TEvent, TTypestate>
-  : T extends (
-      ...args: any[]
-    ) => StateMachine<
+export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
+  ? R extends StateMachine<
       infer TContext,
       any,
       infer TEvent,
@@ -1692,18 +1681,17 @@ export type ActorRefFrom<T> = T extends StateMachine<
       any,
       infer TResolvedTypesMeta
     >
-  ? ActorRefWithDeprecatedState<
-      TContext,
-      TEvent,
-      TTypestate,
-      TResolvedTypesMeta
-    >
-  : T extends Promise<infer U>
-  ? ActorRef<never, U>
-  : T extends Behavior<infer TEvent1, infer TEmitted>
-  ? ActorRef<TEvent1, TEmitted>
-  : T extends (...args: any[]) => Behavior<infer TEvent1, infer TEmitted>
-  ? ActorRef<TEvent1, TEmitted>
+    ? ActorRefWithDeprecatedState<
+        TContext,
+        TEvent,
+        TTypestate,
+        TResolvedTypesMeta
+      >
+    : R extends Promise<infer U>
+    ? ActorRef<never, U>
+    : R extends Behavior<infer TEvent, infer TEmitted>
+    ? ActorRef<TEvent, TEmitted>
+    : never
   : never;
 
 export type AnyInterpreter = Interpreter<any, any, any, any, any>;

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -4,7 +4,9 @@ import {
   assign,
   createMachine,
   interpret,
-  StateMachine
+  StateMachine,
+  spawn,
+  ActorRefFrom
 } from '../src/index';
 import { raise } from '../src/actions';
 
@@ -477,6 +479,20 @@ describe('interpreter', () => {
       ((_val: number) => {})(state.context.count);
       // @ts-expect-error
       ((_val: string) => {})(state.context.count);
+    });
+  });
+});
+
+describe('spawn', () => {
+  it('spawned actor ref should be compatible with the result of ActorRefFrom', () => {
+    const createChild = () => createMachine({});
+
+    function createParent(_deps: {
+      spawnChild: () => ActorRefFrom<typeof createChild>;
+    }) {}
+
+    createParent({
+      spawnChild: () => spawn(createChild())
     });
   });
 });


### PR DESCRIPTION
Fixed the second issue reported here: https://github.com/statelyai/xstate/issues/3028