### PR TITLE
Added some internal `@ts-ignore` comments to fix consuming projects that do not use `skipLibCheck`

### DIFF
--- a/.changeset/chilled-ghosts-turn.md
+++ b/.changeset/chilled-ghosts-turn.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Added some internal `@ts-ignore` comments to fix consuming projects that do not use `skipLibCheck`.

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -113,6 +113,7 @@ export enum InterpreterStatus {
   Stopped
 }
 
+/** @ts-ignore [symbolObservable] creates problems for people without `skipLibCheck` who are on older versions of TS, remove this comment when we drop support for TS@<4.3 */
 export class Interpreter<
   // tslint:disable-next-line:max-classes-per-file
   TContext,
@@ -1366,6 +1367,7 @@ export class Interpreter<
     };
   }
 
+  /** @ts-ignore this creates problems for people without `skipLibCheck` who are on older versions of TS, remove this comment when we drop support for TS@<4.3 */
   public [symbolObservable](): InteropSubscribable<
     State<TContext, TEvent, TStateSchema, TTypestate, TResolvedTypesMeta>
   > {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7984,17 +7984,7 @@ ts-jest@^26.5.6:
     semver "7.x"
     yargs-parser "20.x"
 
-tslib@2.1.0, tslib@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
-
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
-  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
-
-tslib@^2.3.1:
+tslib@2.1.0, tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^2.3.1, tslib@~2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==


### PR DESCRIPTION
fixes https://github.com/statelyai/xstate/issues/3081