### PR TITLE
Fixed compatibility with Skypack

### DIFF
--- a/.changeset/short-eels-cough.md
+++ b/.changeset/short-eels-cough.md
@@ -1,0 +1,10 @@
+---
+'xstate': patch
+'@xstate/graph': patch
+'@xstate/inspect': patch
+'@xstate/react': patch
+'@xstate/scxml': patch
+'@xstate/vue': patch
+---
+
+Fixed compatibility with Skypack by exporting some shared utilities from root entry of XState and consuming them directly in other packages (this avoids accessing those things using deep imports and thus it avoids creating those compatibility problems).

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -16,7 +16,7 @@ import {
   SimpleEventsOf
 } from './types';
 import { EMPTY_ACTIVITY_MAP } from './constants';
-import { matchesState, keys, isString, warn } from './utils';
+import { matchesState, isString, warn } from './utils';
 import { StateNode } from './StateNode';
 import { getMeta, nextEvents } from './stateUtils';
 import { initEvent } from './actions';
@@ -40,8 +40,8 @@ export function stateValuesEqual(
     return a === b;
   }
 
-  const aKeys = keys(a as StateValueMap);
-  const bKeys = keys(b as StateValueMap);
+  const aKeys = Object.keys(a as StateValueMap);
+  const bKeys = Object.keys(b as StateValueMap);
 
   return (
     aKeys.length === bKeys.length &&
@@ -295,7 +295,7 @@ export class State<
     if (isString(stateValue)) {
       return [stateValue];
     }
-    const valueKeys = keys(stateValue);
+    const valueKeys = Object.keys(stateValue);
 
     return valueKeys.concat(
       ...valueKeys.map((key) =>

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -10,7 +10,6 @@ import {
   mapFilterValues,
   nestedPath,
   toArray,
-  keys,
   isBuiltInEvent,
   partition,
   updateHistoryValue,
@@ -331,7 +330,7 @@ class StateNode<
       this.config.type ||
       (this.config.parallel
         ? 'parallel'
-        : this.config.states && keys(this.config.states).length
+        : this.config.states && Object.keys(this.config.states).length
         ? 'compound'
         : this.config.history
         ? 'history'
@@ -643,7 +642,7 @@ class StateNode<
           return { ...transition, event: eventType };
         })
       : flatten(
-          keys(afterConfig).map((delay, i) => {
+          Object.keys(afterConfig).map((delay, i) => {
             const configTransition = afterConfig[delay];
             const resolvedTransition = isString(configTransition)
               ? { target: configTransition }
@@ -707,7 +706,7 @@ class StateNode<
         : [this, this.states[stateValue]];
     }
 
-    const subStateKeys = keys(stateValue);
+    const subStateKeys = Object.keys(stateValue);
     const subStateNodes: Array<
       StateNode<
         TContext,
@@ -785,7 +784,7 @@ class StateNode<
     state: State<TContext, TEvent>,
     _event: SCXML.Event<TEvent>
   ): StateTransition<TContext, TEvent> | undefined {
-    const subStateKeys = keys(stateValue);
+    const subStateKeys = Object.keys(stateValue);
 
     const stateNode = this.getStateNode(subStateKeys[0]);
     const next = stateNode._transition(
@@ -807,7 +806,7 @@ class StateNode<
   ): StateTransition<TContext, TEvent> | undefined {
     const transitionMap: Record<string, StateTransition<TContext, TEvent>> = {};
 
-    for (const subStateKey of keys(stateValue)) {
+    for (const subStateKey of Object.keys(stateValue)) {
       const subStateValue = stateValue[subStateKey];
 
       if (!subStateValue) {
@@ -821,7 +820,7 @@ class StateNode<
       }
     }
 
-    const stateTransitions = keys(transitionMap).map(
+    const stateTransitions = Object.keys(transitionMap).map(
       (key) => transitionMap[key]
     );
     const enabledTransitions = flatten(
@@ -838,7 +837,7 @@ class StateNode<
     const entryNodes = flatten(stateTransitions.map((t) => t.entrySet));
 
     const configuration = flatten(
-      keys(transitionMap).map((key) => transitionMap[key].configuration)
+      Object.keys(transitionMap).map((key) => transitionMap[key].configuration)
     );
 
     return {
@@ -848,7 +847,7 @@ class StateNode<
       configuration,
       source: state,
       actions: flatten(
-        keys(transitionMap).map((key) => {
+        Object.keys(transitionMap).map((key) => {
           return transitionMap[key].actions;
         })
       )
@@ -865,7 +864,7 @@ class StateNode<
     }
 
     // hierarchical node
-    if (keys(stateValue).length === 1) {
+    if (Object.keys(stateValue).length === 1) {
       return this.transitionCompoundNode(stateValue, state, _event);
     }
 
@@ -976,7 +975,7 @@ class StateNode<
 
     const nodes: Array<StateNode<TContext, any, TEvent, any, any, any>> = [];
     let marker:
-      | StateNode<TContext, any, TEvent, any, any>
+      | StateNode<TContext, any, TEvent, any, any, any>
       | undefined = childStateNode;
 
     while (marker && marker !== this) {
@@ -1556,7 +1555,7 @@ class StateNode<
 
           return stateValue;
         }
-        if (!keys(stateValue).length) {
+        if (!Object.keys(stateValue).length) {
           return this.initialStateValue || {};
         }
 
@@ -1771,7 +1770,7 @@ class StateNode<
   private historyValue(
     relativeStateValue?: StateValue | undefined
   ): HistoryValue | undefined {
-    if (!keys(this.states).length) {
+    if (!Object.keys(this.states).length) {
       return undefined;
     }
 
@@ -1848,7 +1847,7 @@ class StateNode<
    */
   public get stateIds(): string[] {
     const childStateIds = flatten(
-      keys(this.states).map((stateKey) => {
+      Object.keys(this.states).map((stateKey) => {
         return this.states[stateKey].stateIds;
       })
     );
@@ -1866,7 +1865,7 @@ class StateNode<
     const events = new Set(this.ownEvents);
 
     if (states) {
-      for (const stateId of keys(states)) {
+      for (const stateId of Object.keys(states)) {
         const state = states[stateId];
         if (state.states) {
           for (const event of state.events) {
@@ -1994,7 +1993,7 @@ class StateNode<
       } = this.config.on;
 
       onConfig = flatten(
-        keys(strictTransitionConfigs)
+        Object.keys(strictTransitionConfigs)
           .map((key) => {
             if (!IS_PRODUCTION && key === NULL_EVENT) {
               warn(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,28 +1,28 @@
-import { matchesState } from './utils';
-import { mapState } from './mapState';
-import { StateNode } from './StateNode';
-import { State } from './State';
-import { Machine, createMachine } from './Machine';
-import { Actor, toActorRef } from './Actor';
 import * as actions from './actions';
+import { Actor, toActorRef } from './Actor';
 import {
   interpret,
   Interpreter,
-  spawn,
-  InterpreterStatus
+  InterpreterStatus,
+  spawn
 } from './interpreter';
+import { createMachine, Machine } from './Machine';
+import { mapState } from './mapState';
 import { matchState } from './match';
 import { createSchema, t } from './schema';
-
-const { assign, send, sendParent, sendUpdate, forwardTo, doneInvoke } = actions;
-
+import { State } from './State';
+import { StateNode } from './StateNode';
+export { spawnBehavior } from './behaviors';
+export { XStateDevInterface } from './devTools';
+export * from './typegenTypes';
+export * from './types';
+export { matchesState, toEventObject, toObserver, toSCXMLEvent } from './utils';
 export {
   Actor,
   toActorRef,
   Machine,
   StateNode,
   State,
-  matchesState,
   mapState,
   actions,
   assign,
@@ -41,8 +41,7 @@ export {
   t
 };
 
-export * from './types';
-export * from './typegenTypes';
+const { assign, send, sendParent, sendUpdate, forwardTo, doneInvoke } = actions;
 
 declare global {
   interface SymbolConstructor {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -44,7 +44,6 @@ import {
   isPromiseLike,
   mapContext,
   warn,
-  keys,
   isArray,
   isFunction,
   isString,
@@ -350,7 +349,7 @@ export class Interpreter<
     if (this.state.configuration && isDone) {
       // get final child state node
       const finalChildStateNode = state.configuration.find(
-        (sn) => sn.type === 'final' && sn.parent === this.machine
+        (sn) => sn.type === 'final' && sn.parent === (this.machine as any)
       );
 
       const doneData =
@@ -584,7 +583,7 @@ export class Interpreter<
     });
 
     // Cancel all delayed events
-    for (const key of keys(this.delayedEventsMap)) {
+    for (const key of Object.keys(this.delayedEventsMap)) {
       this.clock.clearTimeout(this.delayedEventsMap[key]);
     }
 

--- a/packages/core/src/mapState.ts
+++ b/packages/core/src/mapState.ts
@@ -1,4 +1,4 @@
-import { matchesState, keys } from './utils';
+import { matchesState } from './utils';
 
 export function mapState(
   stateMap: { [stateId: string]: any },
@@ -6,7 +6,7 @@ export function mapState(
 ) {
   let foundStateId;
 
-  for (const mappedStateId of keys(stateMap)) {
+  for (const mappedStateId of Object.keys(stateMap)) {
     if (
       matchesState(mappedStateId, stateId) &&
       (!foundStateId || stateId.length > foundStateId.length)

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -8,7 +8,7 @@ import {
   ChooseCondition
 } from './types';
 import { AnyStateMachine, Machine } from './index';
-import { mapValues, keys, isString } from './utils';
+import { mapValues, isString } from './utils';
 import * as actions from './actions';
 
 function getAttribute(
@@ -102,7 +102,7 @@ const evaluateExecutableContent = <
   body: string
 ) => {
   const datamodel = context
-    ? keys(context)
+    ? Object.keys(context)
         .map((key) => `const ${key} = context['${key}'];`)
         .join('\n')
     : '';

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1,6 +1,6 @@
 import { EventObject, StateValue } from './types';
 import { StateNode } from './StateNode';
-import { keys, flatten } from './utils';
+import { flatten } from './utils';
 
 type Configuration<TC, TE extends EventObject> = Iterable<
   StateNode<TC, any, TE>
@@ -18,7 +18,7 @@ export const isLeafNode = (
 export function getChildren<TC, TE extends EventObject>(
   stateNode: StateNode<TC, any, TE>
 ): Array<StateNode<TC, any, TE>> {
-  return keys(stateNode.states).map((key) => stateNode.states[key]);
+  return Object.keys(stateNode.states).map((key) => stateNode.states[key]);
 }
 
 export function getAllStateNodes<TC, TE extends EventObject>(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -36,10 +36,6 @@ import { State } from './State';
 import { Actor } from './Actor';
 import { AnyStateMachine } from '.';
 
-export function keys<T extends object>(value: T): Array<keyof T & string> {
-  return Object.keys(value) as Array<keyof T & string>;
-}
-
 export function matchesState(
   parentStateId: StateValue,
   childStateId: StateValue,
@@ -61,7 +57,7 @@ export function matchesState(
     return parentStateValue in childStateValue;
   }
 
-  return keys(parentStateValue).every((key) => {
+  return Object.keys(parentStateValue).every((key) => {
     if (!(key in childStateValue)) {
       return false;
     }
@@ -163,19 +159,28 @@ export function pathToStateValue(statePath: string[]): StateValue {
   return value;
 }
 
-export function mapValues<T, P, O extends { [key: string]: T }>(
+export function mapValues<P, O extends Record<string, unknown>>(
   collection: O,
   iteratee: (item: O[keyof O], key: keyof O, collection: O, i: number) => P
-): { [key in keyof O]: P } {
-  const result: Partial<{ [key in keyof O]: P }> = {};
+): { [key in keyof O]: P };
+export function mapValues(
+  collection: Record<string, unknown>,
+  iteratee: (
+    item: unknown,
+    key: string,
+    collection: Record<string, unknown>,
+    i: number
+  ) => unknown
+) {
+  const result: Record<string, unknown> = {};
 
-  const collectionKeys = keys(collection);
+  const collectionKeys = Object.keys(collection);
   for (let i = 0; i < collectionKeys.length; i++) {
     const key = collectionKeys[i];
     result[key] = iteratee(collection[key], key, collection, i);
   }
 
-  return result as { [key in keyof O]: P };
+  return result;
 }
 
 export function mapFilterValues<T, P>(
@@ -185,7 +190,7 @@ export function mapFilterValues<T, P>(
 ): { [key: string]: P } {
   const result: { [key: string]: P } = {};
 
-  for (const key of keys(collection)) {
+  for (const key of Object.keys(collection)) {
     const item = collection[key];
 
     if (!predicate(item)) {
@@ -243,7 +248,7 @@ export function toStatePaths(stateValue: StateValue | undefined): string[][] {
   }
 
   const result = flatten(
-    keys(stateValue).map((key) => {
+    Object.keys(stateValue).map((key) => {
       const subStateValue = stateValue[key];
 
       if (
@@ -431,7 +436,7 @@ export function updateContext<TContext, TEvent extends EventObject>(
         if (isFunction(assignment)) {
           partialUpdate = assignment(acc, _event.data, meta);
         } else {
-          for (const key of keys(assignment)) {
+          for (const key of Object.keys(assignment)) {
             const propAssignment = assignment[key];
 
             partialUpdate[key] = isFunction(propAssignment)
@@ -481,18 +486,6 @@ export function isFunction(value: any): value is Function {
 export function isString(value: any): value is string {
   return typeof value === 'string';
 }
-
-// export function memoizedGetter<T, TP extends { prototype: object }>(
-//   o: TP,
-//   property: string,
-//   getter: () => T
-// ): void {
-//   Object.defineProperty(o.prototype, property, {
-//     get: getter,
-//     enumerable: false,
-//     configurable: false
-//   });
-// }
 
 export function toGuard<TContext, TEvent extends EventObject>(
   condition?: Condition<TContext, TEvent>,
@@ -544,11 +537,7 @@ export const interopSymbols = {
 };
 
 export function isMachine(value: any): value is AnyStateMachine {
-  try {
-    return '__xstatenode' in value;
-  } catch (e) {
-    return false;
-  }
+  return !!value && '__xstatenode' in value;
 }
 
 export function isActor(value: any): value is Actor {

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -8,7 +8,6 @@ import {
   AnyEventObject,
   AnyStateMachine
 } from 'xstate';
-import { flatten, keys } from 'xstate/lib/utils';
 import {
   StatePathsMap,
   StatePaths,
@@ -20,6 +19,10 @@ import {
   AnyStateNode,
   StatePath
 } from './types';
+
+function flatten<T>(array: Array<T | T[]>): T[] {
+  return ([] as T[]).concat(...array);
+}
 
 export function toEventObject<TEvent extends EventObject>(
   event: Event<TEvent>
@@ -41,7 +44,7 @@ export function getStateNodes(
   stateNode: AnyStateNode | AnyStateMachine
 ): AnyStateNode[] {
   const { states } = stateNode;
-  const nodes = keys(states).reduce((accNodes, stateKey) => {
+  const nodes = Object.keys(states).reduce((accNodes, stateKey) => {
     const childStateNode = states[stateKey];
     const childStateNodes = getStateNodes(childStateNode);
 
@@ -209,7 +212,7 @@ export function getShortestPaths<
   while (unvisited.size > 0) {
     for (const vertex of unvisited) {
       const [weight] = weightMap.get(vertex)!;
-      for (const event of keys(adjacency[vertex])) {
+      for (const event of Object.keys(adjacency[vertex])) {
         const nextSegment = adjacency[vertex][event];
         const nextVertex = optionsWithDefaults.stateSerializer(
           nextSegment.state
@@ -301,7 +304,7 @@ export function getSimplePaths<
         segments: [...path]
       });
     } else {
-      for (const subEvent of keys(adjacency[fromStateSerial])) {
+      for (const subEvent of Object.keys(adjacency[fromStateSerial])) {
         const nextSegment = adjacency[fromStateSerial][subEvent];
 
         if (!nextSegment) {
@@ -328,7 +331,7 @@ export function getSimplePaths<
   const initialStateSerial = stateSerializer(machine.initialState);
   stateMap.set(initialStateSerial, machine.initialState);
 
-  for (const nextStateSerial of keys(adjacency)) {
+  for (const nextStateSerial of Object.keys(adjacency)) {
     util(machine.initialState, nextStateSerial);
   }
 
@@ -343,7 +346,7 @@ export function getSimplePathsAsArray<
   options?: ValueAdjMapOptions<TContext, TEvent>
 ): Array<StatePaths<TContext, TEvent>> {
   const result = getSimplePaths(machine, options);
-  return keys(result).map((key) => result[key]);
+  return Object.keys(result).map((key) => result[key]);
 }
 
 export function toDirectedGraph(

--- a/packages/xstate-inspect/examples/server.ts
+++ b/packages/xstate-inspect/examples/server.ts
@@ -1,6 +1,6 @@
 import WebSocket from 'ws';
 import { createMachine, interpret, send } from 'xstate';
-import { toSCXMLEvent } from 'xstate/lib/utils';
+import { toSCXMLEvent } from 'xstate';
 import { inspect } from '@xstate/inspect/lib/server';
 
 inspect({

--- a/packages/xstate-inspect/src/browser.ts
+++ b/packages/xstate-inspect/src/browser.ts
@@ -1,14 +1,16 @@
 import {
   ActorRef,
-  Interpreter,
-  interpret,
-  EventObject,
   EventData,
+  EventObject,
+  interpret,
+  Interpreter,
   Observer,
-  toActorRef
+  toActorRef,
+  toEventObject,
+  toObserver,
+  toSCXMLEvent,
+  XStateDevInterface
 } from 'xstate';
-import { XStateDevInterface } from 'xstate/lib/devTools';
-import { toSCXMLEvent, toEventObject, toObserver } from 'xstate/lib/utils';
 import { createInspectMachine, InspectMachineEvent } from './inspectMachine';
 import { stringifyMachine, stringifyState } from './serialize';
 import type {

--- a/packages/xstate-inspect/src/inspectMachine.ts
+++ b/packages/xstate-inspect/src/inspectMachine.ts
@@ -1,5 +1,11 @@
-import { createMachine, assign, SCXML, ActorRef, Interpreter } from 'xstate';
-import { XStateDevInterface } from 'xstate/lib/devTools';
+import {
+  createMachine,
+  assign,
+  SCXML,
+  ActorRef,
+  Interpreter,
+  XStateDevInterface
+} from 'xstate';
 import { stringifyMachine, stringifyState } from './serialize';
 import { ReceiverEvent, Replacer } from './types';
 

--- a/packages/xstate-inspect/src/server.ts
+++ b/packages/xstate-inspect/src/server.ts
@@ -5,10 +5,10 @@ import {
   EventObject,
   interpret,
   Interpreter,
-  toActorRef
+  toActorRef,
+  toEventObject,
+  toSCXMLEvent
 } from 'xstate';
-import { toEventObject, toSCXMLEvent } from 'xstate/lib/utils';
-
 import { createInspectMachine, InspectMachineEvent } from './inspectMachine';
 import { Inspector, Replacer } from './types';
 import { stringify } from './utils';

--- a/packages/xstate-inspect/src/types.ts
+++ b/packages/xstate-inspect/src/types.ts
@@ -1,11 +1,11 @@
 import type {
   ActorRef,
-  SCXML,
   AnyInterpreter,
+  AnyState,
   AnyStateMachine,
-  AnyState
+  SCXML
 } from 'xstate';
-import { XStateDevInterface } from 'xstate/lib/devTools';
+import { XStateDevInterface } from 'xstate';
 import { InspectMachineEvent } from './inspectMachine';
 
 export type MaybeLazy<T> = T | (() => T);

--- a/packages/xstate-react/src/useSpawn.ts
+++ b/packages/xstate-react/src/useSpawn.ts
@@ -1,5 +1,5 @@
 import { ActorRef, Behavior, EventObject } from 'xstate';
-import { spawnBehavior } from 'xstate/lib/behaviors';
+import { spawnBehavior } from 'xstate';
 import useConstant from './useConstant';
 
 /**

--- a/packages/xstate-scxml/src/index.ts
+++ b/packages/xstate-scxml/src/index.ts
@@ -6,7 +6,10 @@ import {
   ActionType,
   AnyStateMachine
 } from 'xstate';
-import { flatten } from 'xstate/lib/utils';
+
+function flatten<T>(array: Array<T | T[]>): T[] {
+  return ([] as T[]).concat(...array);
+}
 
 function cleanAttributes(attributes: Attributes): Attributes {
   for (const key of Object.keys(attributes)) {

--- a/packages/xstate-scxml/test/fixtures/assign-current-small-step/test1.ts
+++ b/packages/xstate-scxml/test/fixtures/assign-current-small-step/test1.ts
@@ -1,5 +1,6 @@
-import { Machine, assign } from 'xstate';
-import { log } from 'xstate/lib/actions';
+import { Machine, assign, actions } from 'xstate';
+
+const { log } = actions;
 
 export default Machine<any>({
   initial: 'a',

--- a/packages/xstate-scxml/test/fixtures/assign/assign_invalid.ts
+++ b/packages/xstate-scxml/test/fixtures/assign/assign_invalid.ts
@@ -1,5 +1,6 @@
-import { Machine, assign } from 'xstate';
-import { log } from 'xstate/lib/actions';
+import { Machine, assign, actions } from 'xstate';
+
+const { log } = actions;
 
 export default Machine<any>({
   initial: 'uber',

--- a/packages/xstate-vue/src/useSpawn.ts
+++ b/packages/xstate-vue/src/useSpawn.ts
@@ -1,5 +1,4 @@
-import { ActorRef, Behavior, EventObject } from 'xstate';
-import { spawnBehavior } from 'xstate/lib/behaviors';
+import { ActorRef, Behavior, EventObject, spawnBehavior } from 'xstate';
 
 /**
  * Vue composable that spawns an `ActorRef` with the specified `behavior`.


### PR DESCRIPTION
Basically, I just removed `keys` as we can easily use `Object.keys`. I've also inlined `flatten` into other packages since it's a one-liner.

Other things that caused "deopts" were moved to the root entry of XState, you can check out what exports have been added