### PR TITLE
fix example todo-mvc-react.

### DIFF
--- a/examples/todo-mvc-react/src/todo.machine.ts
+++ b/examples/todo-mvc-react/src/todo.machine.ts
@@ -115,6 +115,7 @@ export const createTodoMachine = ({
           }
         },
         deleted: {
+          type: 'final',
           entry: sendParent((context) => ({
             type: 'TODO.DELETE',
             id: context.id


### PR DESCRIPTION
In this example the Todo final state is not declared `final` indeed I've noticed that Todos `state.children` keep growing while adding /removing Todo items. With just one line the problem get fixed.  
The problem is probably present also into the other todo-mvc examples.