### PR TITLE
Docs: Add `service.start()` to make example work.

### DIFF
--- a/packages/xstate-inspect/README.md
+++ b/packages/xstate-inspect/README.md
@@ -45,4 +45,5 @@ import { inspect } from '@xstate/inspect';
 // ...
 
 const service = interpret(someMachine, { devTools: true });
+service.start();
 ```


### PR DESCRIPTION
I think adding `service.start()` here would be a good idea, to make the example work.

I didn't come across interpreted machines / services yet, so I was a bit puzzled why it didn't work.