### PR TITLE
Add back export of keys

### DIFF
--- a/.changeset/kind-waves-provide.md
+++ b/.changeset/kind-waves-provide.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The `keys()` utility function export, which was removed in #3089, is now added back, as older versions of XState libraries may depend on it still. See #3106 for more details.

--- a/.changeset/kind-waves-provide.md
+++ b/.changeset/kind-waves-provide.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-The `keys()` utility function export, which was removed in #3089, is now added back, as older versions of XState libraries may depend on it still. See #3106 for more details.
+The `keys()` utility function export, which was removed in [#3089](https://github.com/statelyai/xstate/issues/3089), is now added back, as older versions of XState libraries may depend on it still. See [#3106](https://github.com/statelyai/xstate/issues/3106) for more details.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -36,6 +36,10 @@ import { State } from './State';
 import { Actor } from './Actor';
 import { AnyStateMachine } from '.';
 
+export function keys<T extends object>(value: T): Array<keyof T & string> {
+  return Object.keys(value) as Array<keyof T & string>;
+}
+
 export function matchesState(
   parentStateId: StateValue,
   childStateId: StateValue,


### PR DESCRIPTION
Fixes #3106

The reason that the removal of `keys()` broke the above issue is because various XState tools depend on the `keys()` function to be exported from XState, but it was removed in the newest version.