### PR TITLE
Improved type safety for `spawn`ed actors

### DIFF
--- a/.changeset/lemon-penguins-relax.md
+++ b/.changeset/lemon-penguins-relax.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Improved type safety for `spawn`ed actors. Accidentally incompatible actors were being assignable to a context.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -140,7 +140,7 @@ export type BaseAction<
   TAction extends BaseActionObject
 > =
   | SimpleActionsOf<TAction>['type']
-  | TAction
+  | (string extends TAction['type'] ? never : TAction)
   | RaiseAction<any>
   | SendAction<TContext, TEvent, any>
   | AssignAction<TContext, TEvent>

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -531,4 +531,36 @@ describe('spawn', () => {
       spawnChild: () => spawn(createChild())
     });
   });
+
+  it('incompatible actor ref should not be accepted within assign actions', () => {
+    const child = createMachine({
+      schema: {
+        context: {} as {
+          counter: number;
+        }
+      }
+    });
+
+    const otherChild = createMachine({
+      schema: {
+        context: {} as {
+          title: string;
+        }
+      }
+    });
+
+    createMachine({
+      schema: {
+        context: {} as {
+          myChild: ActorRefFrom<typeof child>;
+        }
+      },
+      // @ts-expect-error
+      entry: assign({
+        myChild: () => {
+          return spawn(otherChild);
+        }
+      })
+    });
+  });
 });


### PR DESCRIPTION
This is sort of a followup to https://github.com/statelyai/xstate/pull/3087 , I couldn't quite repro the problem back then with a bare `createMachine` call and it was haunting me cause I had to add this somewhat unusual test within that PR.

I've figured out **why** the `createMachine` variant was not erroring correctly and here is a PR to fix this.