### PR TITLE
Fixed compatibility of `Interpreter` with older versions of TypeScript

### DIFF
--- a/.changeset/sweet-snakes-remember.md
+++ b/.changeset/sweet-snakes-remember.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed compatibility of `Interpreter` with older versions of TypeScript. This ensures that our interpreters can correctly be consumed by functions expecting `ActorRef` interface (like for example `useSelector`).

--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -4,6 +4,8 @@ import { terser } from 'rollup-plugin-terser';
 import rollupReplace from 'rollup-plugin-replace';
 import fileSize from 'rollup-plugin-filesize';
 import glob from 'fast-glob';
+import path from 'path';
+import fs from 'fs';
 
 const createTsPlugin = ({ declaration = true, target } = {}) =>
   typescript({
@@ -30,7 +32,32 @@ const createNpmConfig = ({ input, output }) => ({
   input,
   output,
   preserveModules: true,
-  plugins: [createTsPlugin(), createBabelPlugin()]
+  plugins: [
+    createTsPlugin(),
+    createBabelPlugin(),
+    /** @ts-ignore [symbolObservable] creates problems who are on older versions of TS, remove this plugin when we drop support for TS@<4.3 */
+    {
+      writeBundle(outputOptions, bundle) {
+        const [, dtsAsset] = Object.entries(bundle).find(
+          ([fileName]) => fileName === 'interpreter.d.ts'
+        );
+
+        const dtsPath = path.join(
+          __dirname,
+          outputOptions.dir,
+          'interpreter.d.ts'
+        );
+
+        fs.writeFileSync(
+          dtsPath,
+          dtsAsset.source.replace(
+            '[symbolObservable]():',
+            '[Symbol.observable]():'
+          )
+        );
+      }
+    }
+  ]
 });
 
 const createUmdConfig = ({ input, output, target = undefined }) => ({

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -112,7 +112,6 @@ export enum InterpreterStatus {
   Stopped
 }
 
-/** @ts-ignore [symbolObservable] creates problems for people without `skipLibCheck` who are on older versions of TS, remove this comment when we drop support for TS@<4.3 */
 export class Interpreter<
   // tslint:disable-next-line:max-classes-per-file
   TContext,
@@ -1372,7 +1371,6 @@ export class Interpreter<
     };
   }
 
-  /** @ts-ignore this creates problems for people without `skipLibCheck` who are on older versions of TS, remove this comment when we drop support for TS@<4.3 */
   public [symbolObservable](): InteropSubscribable<
     State<TContext, TEvent, TStateSchema, TTypestate, TResolvedTypesMeta>
   > {


### PR DESCRIPTION
attempt 3 to solve the Symbol-related mess, fixes #3141