### PR TITLE
Added `InternalEventFrom`

### DIFF
--- a/.changeset/proud-moose-try.md
+++ b/.changeset/proud-moose-try.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Added `InternalEventFrom` that can be used to get union of all declared internal events (such as `xstate.init`, `done.invoke.*` and more) from machines with the typegen data.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,7 +7,8 @@ import {
   TypegenDisabled,
   ResolveTypegenMeta,
   TypegenConstraint,
-  AreAllImplementationsAssumedToBeProvided
+  AreAllImplementationsAssumedToBeProvided,
+  TypegenEnabled
 } from './typegenTypes';
 
 export type AnyFunction = (...args: any[]) => any;
@@ -1838,6 +1839,32 @@ export type EventFrom<
   K extends Prop<TEvent, 'type'> = never,
   TEvent = ResolveEventType<T>
 > = IsNever<K> extends true ? TEvent : Extract<TEvent, { type: K }>;
+
+type __InternalEventFromMachine<
+  TMachine extends AnyStateMachine,
+  TIndexedEvents = TMachine['__TResolvedTypesMeta']['indexedEvents'],
+  TPublicType = TMachine['__TEvent']['type']
+> = Values<
+  string extends TPublicType
+    ? TIndexedEvents
+    : Omit<TIndexedEvents, Cast<TPublicType, string>>
+>;
+
+export type InternalEventFrom<T> = ReturnTypeOrValue<T> extends infer R
+  ? R extends StateMachine<
+      infer _,
+      infer __,
+      infer ___,
+      infer ____,
+      infer _____,
+      infer ______,
+      infer TResolvedTypesMeta
+    >
+    ? TResolvedTypesMeta extends TypegenEnabled
+      ? __InternalEventFromMachine<R>
+      : never
+    : never
+  : never;
 
 export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
   ? R extends StateMachine<


### PR DESCRIPTION
This PR implements what has been suggested by @tom-sherman [here](https://github.com/statelyai/xstate/discussions/3117) and what I've initially prepared in the comment [here](https://github.com/statelyai/xstate/discussions/3117#discussioncomment-2295224).

This is still the subject for bike-shedding etc. I'm opening this as a draft to open a discussion about this. At the very least I'd like to add type tests for this before landing this.