### PR TITLE
Add basic Roadmap page

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -274,6 +274,7 @@ module.exports = {
       {
         title: 'News and Useful Links',
         children: [
+          '/roadmap/',
           '/updates/',
           [
             'https://github.com/statelyai/xstate/blob/main/CODE_OF_CONDUCT.md',

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,0 +1,89 @@
+---
+reviewed: 2022-03-22
+styleGuideVersion: 0
+---
+
+# Roadmap
+
+A roadmap for what Stately is working on for XState and Stately tools.
+
+## In Progress
+
+What we’re working on right now.
+
+### Editor
+
+- Bug fixes
+- Discover page
+- Inline implementations
+- Entity snapping
+
+## Upcoming Q2 2022
+
+Features planned for April - June 2022.
+
+### XState
+
+- XState v5 Alpha
+
+### Editor
+
+- Billing and Teams
+- Feature parity with XState
+- Authentication bug fixes
+- Welcome emails
+- Inline editing
+- Simulation mode
+- Markdown descriptions
+- Workflow creation
+
+### Documentation
+
+- Stately tools visibility
+- Update and rework
+
+## Later
+
+Features planned for the future.
+
+### XState
+
+- Typegen improvements
+
+### Editor
+
+- Profiles
+- Systems
+- Exporting
+- Help button
+- External machines
+- Guarded transitions
+- Persistence
+- Context menu
+- Undo + Redo
+- Reordering
+- Save modal
+- Open graph images
+- Copy paste
+- Keyboard shortcuts
+- VSCode sync
+- Settings page
+- Machine improvements
+- Selection improvements
+- Inspect mode
+- Node resizing
+- Routing
+- Command palette
+- Collaborative editing
+
+### Documentation
+
+- Internationalization improvements
+
+## Got feedback or a suggestion?
+
+We prioritize features based on your feedback. Please let us know if you have feedback or suggestions in [our GitHub Discussions](https://github.com/statelyai/xstate/discussions), [our Discord](https://discord.gg/xstate) or on [Twitter](https://twitter.com/statelyai).
+
+---
+
+Last updated: March 22, 2022.

--- a/docs/updates/2022-03-24.md
+++ b/docs/updates/2022-03-24.md
@@ -1,0 +1,15 @@
+---
+title: 'Added Roadmap'
+date: 2022-03-24
+description: 'We now have a Roadmap page in the “News and Useful Links” section. The Roadmap describes what Stately is working on for XState and Stately tools.'
+reviewed: 2022-03-24
+styleGuideVersion: 0
+updateType: docs
+---
+
+<h1>{{ $frontmatter.title }}</h1>
+<p class="date">{{ new Date($frontmatter.date).toLocaleString('en-US',{ month:'long', day:'numeric', year:'numeric' }) }}</p>
+
+We now have a [Roadmap page](/docs/roadmap/) in the “News and Useful Links” section. The Roadmap describes what Stately is working on for XState and Stately tools.
+
+We prioritize features based on your feedback. Please let us know if you have feedback or suggestions in [our GitHub Discussions](https://github.com/statelyai/xstate/discussions), [our Discord](https://discord.gg/xstate) or on [Twitter](https://twitter.com/statelyai).


### PR DESCRIPTION
A basic Roadmap reflecting our internal Roadmap items. Later on we can make it fancy, but this is the basic content.

Some of them are reworded slightly (based on their issues) for clarity.

Please review considering:
- Is this everything we want to include?
- Should anything here not be included?
- Does grouping by “In Progress”, “Upcoming Q2 2022” and “Later” make sense?