### PR TITLE
Alternative solution for #3177 that adds no runtime overhead

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -872,13 +872,6 @@ export class Interpreter<
         } else {
           if (sendAction.to) {
             this.sendTo(sendAction._event, sendAction.to);
-          } else if (sendAction.sendType === 'forward') {
-            // Expected to forward to an actor
-            warn(
-              false,
-              `Attempted to forward event "${sendAction.event.type}" to undefined actor`
-            );
-            break;
           } else {
             this.send(
               (sendAction as SendActionObject<TContext, TEvent, TEvent>)._event

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1256,7 +1256,6 @@ export interface SendAction<
   event: TSentEvent | SendExpr<TContext, TEvent, TSentEvent>;
   delay?: number | string | DelayExpr<TContext, TEvent>;
   id: string | number;
-  sendType?: 'send' | 'forward';
 }
 
 export interface SendActionObject<
@@ -1311,7 +1310,6 @@ export interface SendActionOptions<TContext, TEvent extends EventObject> {
   id?: string | number;
   delay?: number | string | DelayExpr<TContext, TEvent>;
   to?: string | ExprWithMeta<TContext, TEvent, string | number | ActorRef<any>>;
-  sendType?: 'send' | 'forward';
 }
 
 export interface CancelAction extends ActionObject<any, any> {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1256,8 +1256,9 @@ describe('forwardTo()', () => {
 
     const service = interpret(machine).start();
 
-    // This is testing for an infinite loop
-    service.send('TEST');
+    expect(() => service.send('TEST')).toThrowErrorMatchingInlineSnapshot(
+      `"Attempted to forward event to undefined actor. This risks an infinite loop in the sender."`
+    );
   });
 });
 


### PR DESCRIPTION
This is an alternative approach to the one taken in https://github.com/statelyai/xstate/pull/3178. This solution only validates that during the development and requires no extra code for the production (as the development-only branch gets stripped down).

This solution here tries to balance the improved DX with the bundlesize concerns