### PR TITLE
1276 add timestamp to delayed actions

### DIFF
--- a/.changeset/ninety-olives-arrive.md
+++ b/.changeset/ninety-olives-arrive.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+This change adds a timestamp to the SendAction object, allowing for better understanding and control of delayed Actions

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -251,7 +251,8 @@ export function resolveSend<
     to: resolvedTarget,
     _event: resolvedEvent,
     event: resolvedEvent.data,
-    delay: resolvedDelay
+    delay: resolvedDelay,
+    timestamp: Date.now()
   };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1268,6 +1268,7 @@ export interface SendActionObject<
   event: TSentEvent;
   delay?: number;
   id: string | number;
+  timestamp?: number;
 }
 
 export interface StopAction<TContext, TEvent extends EventObject>

--- a/packages/core/test/after.test.ts
+++ b/packages/core/test/after.test.ts
@@ -35,10 +35,10 @@ describe('delayed transitions', () => {
     expect(nextState.value).toEqual('yellow');
     expect(nextState.actions).toEqual([
       cancel(after(1000, 'light.green')),
-      {
+      expect.objectContaining({
         ...send(after(1000, 'light.yellow'), { delay: 1000 }),
         _event: toSCXMLEvent(after(1000, 'light.yellow'))
-      }
+      })
     ]);
   });
 
@@ -296,5 +296,23 @@ describe('delayed transitions', () => {
 
       expect(sendActions[0].delay).toEqual(undefined);
     });
+  });
+
+  it('the delayed action should provide the timestamp', () => {
+    const machine = createMachine({
+      initial: 'pending',
+      states: {
+        pending: {
+          after: {
+            100: 'started'
+          }
+        },
+        started: {}
+      }
+    });
+
+    const initialState = machine.initialState;
+
+    expect(typeof initialState.actions[0].timestamp).toBe('number');
   });
 });


### PR DESCRIPTION
This change adds a timestamp to the SendAction object, allowing for better understanding and control of delayed Actions