### PR TITLE
Update public roadmap in docs

### DIFF
--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -25,6 +25,7 @@ What we’re working on right now. Features planned for April - June 2022.
 - Feature parity with XState
 - Authentication bug fixes
 - Welcome emails
+- Entity snapping
 - Inline editing
 - Simulation mode
 - Markdown descriptions

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -25,7 +25,7 @@ What we’re working on right now. Features planned for April - June 2022.
 - Feature parity with XState
 - Authentication bug fixes
 - Welcome emails
-- Entity snapping
+- Entity snapping improvements
 - Inline editing
 - Simulation mode
 - Markdown descriptions

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -1,5 +1,5 @@
 ---
-reviewed: 2022-03-22
+reviewed: 2022-04-05
 styleGuideVersion: 0
 ---
 
@@ -7,20 +7,11 @@ styleGuideVersion: 0
 
 A roadmap for what Stately is working on for XState and Stately tools.
 
-## In Progress
+[Read about our latest updates on the Stately blog](https://stately.ai/blog).
 
-What we’re working on right now.
+## In Progress, Q2 2022
 
-### Editor
-
-- Bug fixes
-- Discover page
-- Inline implementations
-- Entity snapping
-
-## Upcoming Q2 2022
-
-Features planned for April - June 2022.
+What we’re working on right now. Features planned for April - June 2022.
 
 ### XState
 
@@ -28,7 +19,9 @@ Features planned for April - June 2022.
 
 ### Editor
 
-- Billing and Teams
+- Bug fixes
+- Discover page
+- Billing and Teams, including private machines
 - Feature parity with XState
 - Authentication bug fixes
 - Welcome emails
@@ -86,4 +79,4 @@ We prioritize features based on your feedback. Please let us know if you have fe
 
 ---
 
-Last updated: March 22, 2022.
+Last updated: April 5, 2022.

--- a/docs/updates/2022-04-05.md
+++ b/docs/updates/2022-04-05.md
@@ -1,0 +1,15 @@
+---
+title: 'Added French translation'
+date: 2022-04-05
+description: 'Thanks to @chlbri, we now have a French translation of the XState docs. You can access the translation using the Languages dropdown menu in the top navigation of the site.'
+reviewed: 2022-04-05
+styleGuideVersion: 0
+updateType: docs
+---
+
+<h1>{{ $frontmatter.title }}</h1>
+<p class="date">{{ new Date($frontmatter.date).toLocaleString('en-US',{ month:'long', day:'numeric', year:'numeric' }) }}</p>
+
+Thanks to [@chlbri](https://github.com/chlbri), we now have a [French translation of the XState docs](/docs/zh/). You can access the translation using the Languages dropdown menu in the top navigation of the site.
+
+If you want to contribute a translation of the XState docs, please go ahead and [make a pull request](https://github.com/statelyai/xstate/pulls), or chat to the Stately team in [our Discord community](https://discord.gg/xstate).


### PR DESCRIPTION
As we’re now in Q2, I’ve updated the roadmap.

- Added a link to the blog for updates on new features
- Updated titles to reflect current quarter
- Specified that the work on teams and billing includes private machines (as we get asked this a lot)

Also added an update post about the French translation.