### PR TITLE
Fixed an issue that caused sending the same event multiple times to the inspector for restarted services

### DIFF
--- a/.changeset/dry-carpets-dream.md
+++ b/.changeset/dry-carpets-dream.md
@@ -1,0 +1,5 @@
+---
+'@xstate/inspect': patch
+---
+
+Fixed an issue that caused sending the same event multiple times to the inspector for restarted services.


### PR DESCRIPTION
This builds on top of https://github.com/statelyai/xstate/pull/3198 so it should be merged after it lands on the main branch