### PR TITLE
Docs: Fix link to Roadmap in 'Added Roadmap' blog post

### DIFF
--- a/docs/updates/2022-03-24.md
+++ b/docs/updates/2022-03-24.md
@@ -10,6 +10,6 @@ updateType: docs
 <h1>{{ $frontmatter.title }}</h1>
 <p class="date">{{ new Date($frontmatter.date).toLocaleString('en-US',{ month:'long', day:'numeric', year:'numeric' }) }}</p>
 
-We now have a [Roadmap page](/docs/roadmap/) in the “News and Useful Links” section. The Roadmap describes what Stately is working on for XState and Stately tools.
+We now have a [Roadmap page](/roadmap/) in the “News and Useful Links” section. The Roadmap describes what Stately is working on for XState and Stately tools.
 
 We prioritize features based on your feedback. Please let us know if you have feedback or suggestions in [our GitHub Discussions](https://github.com/statelyai/xstate/discussions), [our Discord](https://discord.gg/xstate) or on [Twitter](https://twitter.com/statelyai).


### PR DESCRIPTION
Was randomly browsing the site and noticed that [this blog post](https://xstate.js.org/docs/updates/2022-03-24.html) contained a broken link to the Roadmap (`/docs/docs/roadmap`).

(Note: This change was made through GitHub's editor)