### PR TITLE
Fixed an issue in the `EmittedFrom` type helper that could prevent it from inferring the desired type from some service

### DIFF
--- a/.changeset/popular-wolves-tap.md
+++ b/.changeset/popular-wolves-tap.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue in the `EmittedFrom` type helper that could prevent it from inferring the desired type from some services.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1799,7 +1799,7 @@ export interface Behavior<TEvent extends EventObject, TEmitted = any> {
 }
 
 export type EmittedFrom<T> = ReturnTypeOrValue<T> extends infer R
-  ? R extends ActorRef<infer _, infer TEmitted>
+  ? R extends ActorRef<any, infer TEmitted>
     ? TEmitted
     : R extends Behavior<infer _, infer TEmitted>
     ? TEmitted

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1799,7 +1799,9 @@ export interface Behavior<TEvent extends EventObject, TEmitted = any> {
 }
 
 export type EmittedFrom<T> = ReturnTypeOrValue<T> extends infer R
-  ? R extends ActorRef<any, infer TEmitted>
+  ? R extends Interpreter<infer _, infer __, infer ___, infer ____, infer _____>
+    ? R['initialState']
+    : R extends ActorRef<infer _, infer TEmitted>
     ? TEmitted
     : R extends Behavior<infer _, infer TEmitted>
     ? TEmitted

--- a/packages/core/test/typeHelpers.test.ts
+++ b/packages/core/test/typeHelpers.test.ts
@@ -2,6 +2,7 @@ import {
   assign,
   ContextFrom,
   createMachine,
+  EmittedFrom,
   EventFrom,
   interpret,
   MachineOptionsFrom,
@@ -366,5 +367,40 @@ describe('StateValueFrom', () => {
     function matches(_value: StateValueFrom<typeof machine>) {}
 
     matches('just anything');
+  });
+});
+
+describe('EmittedFrom', () => {
+  it('should return state type from a service that has concrete event type', () => {
+    const service = interpret(
+      createMachine({
+        schema: {
+          events: {} as { type: 'FOO' }
+        }
+      })
+    );
+
+    function acceptState(_state: EmittedFrom<typeof service>) {}
+
+    acceptState(service.initialState);
+    // @ts-expect-error
+    acceptState("isn't any");
+  });
+
+  it('should return state from a service created based on a model without any concrete events', () => {
+    const service = interpret(
+      createModel(
+        {},
+        {
+          // this empty obj is important for this test case
+        }
+      ).createMachine({})
+    );
+
+    function acceptState(_state: EmittedFrom<typeof service>) {}
+
+    acceptState(service.initialState);
+    // @ts-expect-error
+    acceptState("isn't any");
   });
 });


### PR DESCRIPTION
fixes the issue reported here: https://discord.com/channels/795785288994652170/809564589880639548/974402582393024562