### PR TITLE
Added turborepo

### DIFF
--- a/.github/actions/ci-checks/action.yml
+++ b/.github/actions/ci-checks/action.yml
@@ -9,9 +9,6 @@ runs:
     - name: Test
       run: yarn test
       shell: bash
-      env:
-        TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
-        TURBO_TEAM: statelyai
 
     - name: Svelte Check
       run: yarn --cwd packages/xstate-svelte svelte-check

--- a/.github/actions/ci-checks/action.yml
+++ b/.github/actions/ci-checks/action.yml
@@ -7,8 +7,11 @@ runs:
       shell: bash
 
     - name: Test
-      run: yarn test --silent
+      run: yarn test
       shell: bash
+      env:
+        TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        TURBO_TEAM: statelyai
 
     - name: Svelte Check
       run: yarn --cwd packages/xstate-svelte svelte-check

--- a/.github/actions/ci-checks/action.yml
+++ b/.github/actions/ci-checks/action.yml
@@ -10,7 +10,7 @@ runs:
       run: yarn test
       shell: bash
       env:
-        TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+        TURBO_TOKEN: '${{ secrets.TURBO_TOKEN }}'
         TURBO_TEAM: statelyai
 
     - name: Svelte Check

--- a/.github/actions/ci-checks/action.yml
+++ b/.github/actions/ci-checks/action.yml
@@ -7,9 +7,5 @@ runs:
       shell: bash
 
     - name: Test
-      run: yarn test
-      shell: bash
-
-    - name: Svelte Check
-      run: yarn --cwd packages/xstate-svelte svelte-check
+      run: yarn turbo run test svelte-check
       shell: bash

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,3 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/ci-setup
       - uses: ./.github/actions/ci-checks
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: statelyai

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,9 @@ jobs:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/ci-setup
       - uses: ./.github/actions/ci-checks
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: statelyai
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postinstall": "manypkg check",
     "clean:packages": "yarn workspaces run clean",
     "build": "tsc -b ./tsconfig.monorepo.json",
-    "test": "jest",
+    "test": "turbo run test",
     "test:core": "npm test --prefix packages/core",
     "dev": "node ./scripts/dev.js",
     "changeset": "changeset",
@@ -52,6 +52,7 @@
     "ts-jest": "^26.5.6",
     "tslib": "^2.3.1",
     "tslint": "^5.11.0",
+    "turbo": "^1.2.9",
     "typescript": "^4.5.2",
     "webpack-dev-middleware": "^3.6.0"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "baseBranch": "origin/main",
+  "pipeline": {
+    "test": {
+      "outputs": []
+    }
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -4,6 +4,9 @@
   "pipeline": {
     "test": {
       "outputs": []
+    },
+    "svelte-check": {
+      "outputs": []
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8046,6 +8046,90 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+turbo-darwin-64@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-64/-/turbo-darwin-64-1.2.9.tgz#001159794757f77c4b016fc56d045c5e7bfc9510"
+  integrity sha512-rVwDQpi6p0GwTiqSsvtA1b3RvKl8l2y+ElZ3EKGiIIJYZt1D6wBMJoADaZ9uZ/LWkT+WKfAWNtKdwRmuBAOS6g==
+
+turbo-darwin-arm64@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-darwin-arm64/-/turbo-darwin-arm64-1.2.9.tgz#fb19615984d1780fdcdd9e54a607efb46a700e72"
+  integrity sha512-j7NgQHkQWWODw1I/saiqmjjD54uGAEq0qTTtLI3RoLaA+yI+awXmHwsiHRqsvGSyGJlBoKBcbxXkekLf21q3GA==
+
+turbo-freebsd-64@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-64/-/turbo-freebsd-64-1.2.9.tgz#edb2ee840ba80c257068e339d10ac460c1f9fb10"
+  integrity sha512-+tLb3iCOrIeGrcOJZYey5mD9qgNgKYuwRRg6FeX/6TDITvZXcCS50A2uRbaD/PQzQKs1lHcshiCe/DRtbvJ63g==
+
+turbo-freebsd-arm64@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-freebsd-arm64/-/turbo-freebsd-arm64-1.2.9.tgz#aebfb5b07a2dd6e9211fb6d9827c2f2288e2ca73"
+  integrity sha512-gwI8jocTf036kc9GI1BebzftxrkT5pewHPA2iqvAXAJpX01G1x1iGcl8/uIbkbL5hp038nu+l2Kb+lRI96sJuA==
+
+turbo-linux-32@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-linux-32/-/turbo-linux-32-1.2.9.tgz#1462e45776d3ce93c57f2014745e7edb60910a44"
+  integrity sha512-Rm47bIsCHIae/DkXJ58YrWvdh8o4Ug9U4VnTDb9byXrz2B7624ol9XdfpXv429z7LXkQR1+WnwCMwFB4K6DyuQ==
+
+turbo-linux-64@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-linux-64/-/turbo-linux-64-1.2.9.tgz#0eef4a6f6f267b773ea58c4bda86922092eda3eb"
+  integrity sha512-8Gqi+TzEdmOmxxAukU0NO0JlIqdm98C97u9qEsxWrXTFL/xL21gKCixqsBTEO7JOISC4M8VjArxjSsITRbkD5g==
+
+turbo-linux-arm64@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm64/-/turbo-linux-arm64-1.2.9.tgz#57777d356bf74ef2cc284998ef86fe19c77b92c2"
+  integrity sha512-FVIeM7koUtyu1cNAJhPYjb90kL/ICdWoJr4PoZZYnqty5sxLsBg75bVErEDQeDzKQvwXLlcax2lEzHvaSyn/wg==
+
+turbo-linux-arm@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-linux-arm/-/turbo-linux-arm-1.2.9.tgz#2424016fb926143682f9029bd86a8d455979e075"
+  integrity sha512-OS+XCWiGFbuM7UNBVQdVbIJqxhVu9Sr2WxQgDcGZpCYn32yLLPlWDDGL0Cl/EG006J9k+VS1e4OzyM6kfMxS9Q==
+
+turbo-linux-mips64le@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-linux-mips64le/-/turbo-linux-mips64le-1.2.9.tgz#e3bb35f53cb84ff836cf42fc576b6197c92a5e8a"
+  integrity sha512-2zVBnOVivWGpl51qO/lycfw7euM4b04AXYUmhsWkUN3FygIwyNgjuiMU8rxQOlu9VGX8X+WXkX2gfbgTovTeFw==
+
+turbo-linux-ppc64le@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-linux-ppc64le/-/turbo-linux-ppc64le-1.2.9.tgz#130041711579a1b6b3fe774d85c394425d45c0ac"
+  integrity sha512-EGgKyzf8IhodOF32BvE3Zlgbr/dSGuUbemC9RGSuhF1F1PMnP1nYS/t3JWN5QKZU4O2uWiIyLdC/0ZjtcGAcZQ==
+
+turbo-windows-32@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-windows-32/-/turbo-windows-32-1.2.9.tgz#89a0d8463dffba01627d69998bfe6ea5fa975511"
+  integrity sha512-XrMJMUtewlfksBUB0R7Tyw16IoqshVl6f/3R2ccMccddEMcvak0oW03FK9n+Y4F+wyIoJ22AVhu8jMv+HgEehA==
+
+turbo-windows-64@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-windows-64/-/turbo-windows-64-1.2.9.tgz#a55e3f32996ce4a8a538f9667748e7a1129ed10e"
+  integrity sha512-ewhj4MrqcMpW/keag4xG7YRLTJ7PzcqBc6Kc96OGD2qfK/uJV/r7H3Xt09WuYHRWwPgGEeNn8utpqdqbYfCVDw==
+
+turbo-windows-arm64@1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo-windows-arm64/-/turbo-windows-arm64-1.2.9.tgz#3dc635c0031a0998be0322f9a258553f7cb4eb6e"
+  integrity sha512-B8BoNb/yZWAyKwQUbs2+UFzLmOu/WGv/+ADT6SQfI8jOaTenS7Od4bbMsGJT0iXcqv+v8TcWKX83KmQ6gxBQpg==
+
+turbo@^1.2.9:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/turbo/-/turbo-1.2.9.tgz#61257149a2a29966c9941a16e0b5ad88b07b4e79"
+  integrity sha512-aPGzZqmUHE9yx9TS7wcAJnDmXiuQSNXDwU5b1KrgNlFuID18TL443wna79p7k4awmf4Yuhu1cSZIvO+se72iVQ==
+  optionalDependencies:
+    turbo-darwin-64 "1.2.9"
+    turbo-darwin-arm64 "1.2.9"
+    turbo-freebsd-64 "1.2.9"
+    turbo-freebsd-arm64 "1.2.9"
+    turbo-linux-32 "1.2.9"
+    turbo-linux-64 "1.2.9"
+    turbo-linux-arm "1.2.9"
+    turbo-linux-arm64 "1.2.9"
+    turbo-linux-mips64le "1.2.9"
+    turbo-linux-ppc64le "1.2.9"
+    turbo-windows-32 "1.2.9"
+    turbo-windows-64 "1.2.9"
+    turbo-windows-arm64 "1.2.9"
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"


### PR DESCRIPTION
This PR:

1. Adds turborepo to run on `test` and `svelte-check` only (the slowest part of our setup by far)
2. Connects turborepo to Vercel via the `TURBO_TOKEN` to cache the results of our tests

This should speed up our CI significantly by only re-running tests that have already run.