### PR TITLE
Optimize path deduplication algorithm

### DIFF
--- a/packages/xstate-test/src/TestModel.ts
+++ b/packages/xstate-test/src/TestModel.ts
@@ -18,7 +18,7 @@ import {
   coversAllStates,
   coversAllTransitions
 } from './coverage';
-import { addDedupToPlanGenerator } from './dedupPathPlans';
+import { planGeneratorWithDedup } from './dedupPathPlans';
 import type {
   CriterionResult,
   GetPlansOptions,
@@ -89,7 +89,7 @@ export class TestModel<TState, TEvent extends EventObject> {
   public getPlans(
     options?: GetPlansOptions<TState, TEvent>
   ): Array<StatePlan<TState, TEvent>> {
-    const planGenerator = addDedupToPlanGenerator<TState, TEvent>(
+    const planGenerator = planGeneratorWithDedup<TState, TEvent>(
       options?.planGenerator || TestModel.defaults.planGenerator
     );
     const plans = planGenerator(this.behavior, this.resolveOptions(options));

--- a/packages/xstate-test/test/plans.test.ts
+++ b/packages/xstate-test/test/plans.test.ts
@@ -1,4 +1,4 @@
-import { configure, createTestModel } from '../src';
+import { createTestModel } from '../src';
 import { coversAllStates } from '../src/coverage';
 import { createTestMachine } from '../src/machine';
 


### PR DESCRIPTION
This PR optimizes the path deduplication algorithm by:

- Checking paths in path length order descending
- Checking event sequences from the start instead of `.includes()` - for state machines, the subpath must be considered from the initial state, since events "A, B, C" can result in a completely different state traversal in the middle of a state machine rather than at the start

This greatly reduces the number of comparisons made.