### PR TITLE
Removed states, events from testmodel, removed cases from events

### DIFF
--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -173,7 +173,8 @@ export function getAdjacencyMap<TMachine extends AnyStateMachine>(
 const defaultMachineStateOptions: TraversalOptions<State<any, any>, any> = {
   serializeState: serializeMachineState,
   serializeEvent,
-  getEvents: (state) => {
+  eventCases: {},
+  getEvents: (_eventCases, state) => {
     return state.nextEvents.map((type) => ({ type }));
   }
 };
@@ -420,7 +421,7 @@ interface AdjMap<TState, TEvent> {
   };
 }
 
-export function performDepthFirstTraversal<TState, TEvent>(
+export function performDepthFirstTraversal<TState, TEvent extends EventObject>(
   behavior: SimpleBehavior<TState, TEvent>,
   options: TraversalOptions<TState, TEvent>
 ): AdjMap<TState, TEvent> {
@@ -428,6 +429,7 @@ export function performDepthFirstTraversal<TState, TEvent>(
   const {
     serializeState,
     getEvents,
+    eventCases,
     traversalLimit: limit
   } = resolveTraversalOptions(options);
   const adj: AdjMap<TState, TEvent> = {};
@@ -452,7 +454,7 @@ export function performDepthFirstTraversal<TState, TEvent>(
       transitions: {}
     };
 
-    const events = getEvents(state);
+    const events = getEvents(eventCases, state);
 
     for (const subEvent of events) {
       const nextState = transition(state, subEvent);
@@ -472,7 +474,7 @@ export function performDepthFirstTraversal<TState, TEvent>(
   return adj;
 }
 
-function resolveTraversalOptions<TState, TEvent>(
+function resolveTraversalOptions<TState, TEvent extends EventObject>(
   traversalOptions?: Partial<TraversalOptions<TState, TEvent>>,
   defaultOptions?: TraversalOptions<TState, TEvent>
 ): Required<TraversalOptions<TState, TEvent>> {
@@ -487,6 +489,7 @@ function resolveTraversalOptions<TState, TEvent>(
     visitCondition: (state, event, vctx) => {
       return vctx.vertices.has(serializeState(state, event));
     },
+    eventCases: {},
     getEvents: () => [],
     traversalLimit: Infinity,
     ...defaultOptions,

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -174,7 +174,7 @@ const defaultMachineStateOptions: TraversalOptions<State<any, any>, any> = {
   serializeState: serializeMachineState,
   serializeEvent,
   eventCases: {},
-  getEvents: (_eventCases, state) => {
+  getEvents: (state) => {
     return state.nextEvents.map((type) => ({ type }));
   }
 };
@@ -454,7 +454,7 @@ export function performDepthFirstTraversal<TState, TEvent extends EventObject>(
       transitions: {}
     };
 
-    const events = getEvents(eventCases, state);
+    const events = getEvents(state, eventCases);
 
     for (const subEvent of events) {
       const nextState = transition(state, subEvent);

--- a/packages/xstate-graph/src/types.ts
+++ b/packages/xstate-graph/src/types.ts
@@ -162,7 +162,7 @@ export interface TraversalOptions<TState, TEvent extends EventObject>
     vctx: VisitedContext<TState, TEvent>
   ) => boolean;
   filter?: (state: TState, event: TEvent) => boolean;
-  getEvents?: (cases: EventCaseMap<TState, TEvent>, state: TState) => TEvent[];
+  getEvents?: (state: TState, cases: EventCaseMap<TState, TEvent>) => TEvent[];
   /**
    * The maximum number of traversals to perform when calculating
    * the state transition adjacency map.

--- a/packages/xstate-test/src/machine.ts
+++ b/packages/xstate-test/src/machine.ts
@@ -97,10 +97,7 @@ export function createTestModel<TMachine extends AnyStateMachine>(
           executeAction(action, state);
         });
       },
-      getEvents: (
-        eventCases: EventCaseMap<StateFrom<TMachine>, EventFrom<TMachine>>,
-        state
-      ) =>
+      getEvents: (state, eventCases) =>
         flatten(
           state.nextEvents.map((eventType) => {
             const eventCaseGenerator = eventCases?.[eventType];

--- a/packages/xstate-test/src/machine.ts
+++ b/packages/xstate-test/src/machine.ts
@@ -1,4 +1,4 @@
-import { EventCaseMap, serializeState, SimpleBehavior } from '@xstate/graph';
+import { serializeState, SimpleBehavior } from '@xstate/graph';
 import {
   ActionObject,
   AnyEventObject,

--- a/packages/xstate-test/src/machine.ts
+++ b/packages/xstate-test/src/machine.ts
@@ -1,4 +1,4 @@
-import { serializeState, SimpleBehavior } from '@xstate/graph';
+import { EventCaseMap, serializeState, SimpleBehavior } from '@xstate/graph';
 import {
   ActionObject,
   AnyEventObject,
@@ -15,7 +15,6 @@ import { TestModel } from './TestModel';
 import {
   TestMachineConfig,
   TestMachineOptions,
-  TestModelEventConfig,
   TestModelOptions
 } from './types';
 import { flatten } from './utils';
@@ -93,25 +92,18 @@ export function createTestModel<TMachine extends AnyStateMachine>(
           ? state.configuration.includes(machine.getStateNodeById(key))
           : state.matches(key);
       },
-      states: {
-        '*': testStateFromMeta
-      },
       execute: (state) => {
         state.actions.forEach((action) => {
           executeAction(action, state);
         });
       },
-      getEvents: (state) =>
+      getEvents: (
+        eventCases: EventCaseMap<StateFrom<TMachine>, EventFrom<TMachine>>,
+        state
+      ) =>
         flatten(
           state.nextEvents.map((eventType) => {
-            const eventConfig = options?.events?.[eventType];
-            const eventCaseGenerator =
-              typeof eventConfig === 'function'
-                ? undefined
-                : (eventConfig?.cases as TestModelEventConfig<
-                    any,
-                    any
-                  >['cases']);
+            const eventCaseGenerator = eventCases?.[eventType];
 
             const cases = eventCaseGenerator
               ? Array.isArray(eventCaseGenerator)

--- a/packages/xstate-test/src/testUtils.ts
+++ b/packages/xstate-test/src/testUtils.ts
@@ -1,15 +1,21 @@
 import { TestModel } from './TestModel';
-import { TestPath } from './types';
+import { TestParam, TestPath } from './types';
 
-const testModel = async (model: TestModel<any, any>) => {
+const testModel = async (
+  model: TestModel<any, any>,
+  params: TestParam<any, any>
+) => {
   for (const path of model.getPaths()) {
-    await path.test();
+    await path.test(params);
   }
 };
 
-const testPaths = async (paths: TestPath<any, any>[]) => {
+const testPaths = async (
+  paths: TestPath<any, any>[],
+  params: TestParam<any, any>
+) => {
   for (const path of paths) {
-    await path.test();
+    await path.test(params);
   }
 };
 

--- a/packages/xstate-test/src/utils.ts
+++ b/packages/xstate-test/src/utils.ts
@@ -26,6 +26,7 @@ export function formatPathTestResult(
     serializeState: (state, _event) =>
       simpleStringify(state) as SerializedState,
     serializeEvent: (event) => simpleStringify(event) as SerializedEvent,
+    eventCases: {},
     ...options
   };
 

--- a/packages/xstate-test/test/events.test.ts
+++ b/packages/xstate-test/test/events.test.ts
@@ -17,19 +17,16 @@ describe('events', () => {
           },
           b: {}
         }
-      }),
-      {
-        events: {
-          EVENT: {
-            exec: () => {
-              executed = true;
-            }
-          }
-        }
-      }
+      })
     );
 
-    await testUtils.testModel(testModel);
+    await testUtils.testModel(testModel, {
+      events: {
+        EVENT: () => {
+          executed = true;
+        }
+      }
+    });
 
     expect(executed).toBe(true);
   });
@@ -48,17 +45,16 @@ describe('events', () => {
           },
           b: {}
         }
-      }),
-      {
-        events: {
-          EVENT: () => {
-            executed = true;
-          }
-        }
-      }
+      })
     );
 
-    await testUtils.testModel(testModel);
+    await testUtils.testModel(testModel, {
+      events: {
+        EVENT: () => {
+          executed = true;
+        }
+      }
+    });
 
     expect(executed).toBe(true);
   });

--- a/packages/xstate-test/test/paths.test.ts
+++ b/packages/xstate-test/test/paths.test.ts
@@ -44,7 +44,7 @@ describe('testModel.testPaths(...)', () => {
 
     const paths = testModel.getPaths({
       pathGenerator: (behavior, options) => {
-        const events = options.getEvents?.({}, behavior.initialState) ?? [];
+        const events = options.getEvents?.(behavior.initialState, {}) ?? [];
 
         const nextState = behavior.transition(behavior.initialState, events[0]);
         return [

--- a/packages/xstate-test/test/paths.test.ts
+++ b/packages/xstate-test/test/paths.test.ts
@@ -44,7 +44,7 @@ describe('testModel.testPaths(...)', () => {
 
     const paths = testModel.getPaths({
       pathGenerator: (behavior, options) => {
-        const events = options.getEvents?.(behavior.initialState) ?? [];
+        const events = options.getEvents?.({}, behavior.initialState) ?? [];
 
         const nextState = behavior.transition(behavior.initialState, events[0]);
         return [
@@ -62,7 +62,7 @@ describe('testModel.testPaths(...)', () => {
       }
     });
 
-    await testUtils.testPaths(paths);
+    await testUtils.testPaths(paths, {});
   });
 
   describe('When the machine only has one path', () => {

--- a/packages/xstate-test/test/states.test.ts
+++ b/packages/xstate-test/test/states.test.ts
@@ -23,26 +23,25 @@ describe('states', () => {
             }
           }
         }
-      }),
-      {
-        states: {
-          a: (state) => {
-            testedStateValues.push(state.value);
-          },
-          b: (state) => {
-            testedStateValues.push(state.value);
-          },
-          'b.b1': (state) => {
-            testedStateValues.push(state.value);
-          },
-          'b.b2': (state) => {
-            testedStateValues.push(state.value);
-          }
-        }
-      }
+      })
     );
 
-    await testUtils.testModel(testModel);
+    await testUtils.testModel(testModel, {
+      states: {
+        a: (state) => {
+          testedStateValues.push(state.value);
+        },
+        b: (state) => {
+          testedStateValues.push(state.value);
+        },
+        'b.b1': (state) => {
+          testedStateValues.push(state.value);
+        },
+        'b.b2': (state) => {
+          testedStateValues.push(state.value);
+        }
+      }
+    });
 
     expect(testedStateValues).toMatchInlineSnapshot(`
       Array [
@@ -88,26 +87,25 @@ describe('states', () => {
             }
           }
         }
-      }),
-      {
-        states: {
-          '#state_a': (state) => {
-            testedStateValues.push(state.value);
-          },
-          '#state_b': (state) => {
-            testedStateValues.push(state.value);
-          },
-          '#state_b1': (state) => {
-            testedStateValues.push(state.value);
-          },
-          '#state_b2': (state) => {
-            testedStateValues.push(state.value);
-          }
-        }
-      }
+      })
     );
 
-    await testUtils.testModel(testModel);
+    await testUtils.testModel(testModel, {
+      states: {
+        '#state_a': (state) => {
+          testedStateValues.push(state.value);
+        },
+        '#state_b': (state) => {
+          testedStateValues.push(state.value);
+        },
+        '#state_b1': (state) => {
+          testedStateValues.push(state.value);
+        },
+        '#state_b2': (state) => {
+          testedStateValues.push(state.value);
+        }
+      }
+    });
 
     expect(testedStateValues).toMatchInlineSnapshot(`
       Array [

--- a/packages/xstate-test/test/sync.test.ts
+++ b/packages/xstate-test/test/sync.test.ts
@@ -13,46 +13,26 @@ const machine = createMachine({
   }
 });
 
-const promiseStateModel = createTestModel(machine, {
-  states: {
-    a: async () => {},
-    b: () => {}
-  },
-  events: {
-    EVENT: () => {}
-  }
-});
+const promiseStateModel = createTestModel(machine);
 
-const promiseEventModel = createTestModel(machine, {
-  states: {
-    a: () => {},
-    b: () => {}
-  },
-  events: {
-    EVENT: {
-      exec: async () => {}
-    }
-  }
-});
+const promiseEventModel = createTestModel(machine);
 
-const syncModel = createTestModel(machine, {
-  states: {
-    a: () => {},
-    b: () => {}
-  },
-  events: {
-    EVENT: {
-      exec: () => {}
-    }
-  }
-});
+const syncModel = createTestModel(machine);
 
 describe('.testPathSync', () => {
   it('Should error if it encounters a promise in a state', () => {
     expect(() =>
-      promiseStateModel
-        .getPaths()
-        .forEach((path) => promiseStateModel.testPathSync(path))
+      promiseStateModel.getPaths().forEach((path) =>
+        promiseStateModel.testPathSync(path, {
+          states: {
+            a: async () => {},
+            b: () => {}
+          },
+          events: {
+            EVENT: () => {}
+          }
+        })
+      )
     ).toThrowError(
       `The test for 'a' returned a promise - did you mean to use the sync method?`
     );
@@ -60,9 +40,17 @@ describe('.testPathSync', () => {
 
   it('Should error if it encounters a promise in an event', () => {
     expect(() =>
-      promiseEventModel
-        .getPaths()
-        .forEach((path) => promiseEventModel.testPathSync(path))
+      promiseEventModel.getPaths().forEach((path) =>
+        promiseEventModel.testPathSync(path, {
+          states: {
+            a: () => {},
+            b: () => {}
+          },
+          events: {
+            EVENT: async () => {}
+          }
+        })
+      )
     ).toThrowError(
       `The event 'EVENT' returned a promise - did you mean to use the sync method?`
     );
@@ -70,7 +58,17 @@ describe('.testPathSync', () => {
 
   it('Should succeed if it encounters no promises', () => {
     expect(() =>
-      syncModel.getPaths().forEach((path) => syncModel.testPathSync(path))
+      syncModel.getPaths().forEach((path) =>
+        syncModel.testPathSync(path, {
+          states: {
+            a: () => {},
+            b: () => {}
+          },
+          events: {
+            EVENT: () => {}
+          }
+        })
+      )
     ).not.toThrow();
   });
 });

--- a/packages/xstate-test/test/testModel.test.ts
+++ b/packages/xstate-test/test/testModel.test.ts
@@ -15,7 +15,7 @@ describe('custom test models', () => {
         }
       },
       {
-        getEvents: (_cases, state) => {
+        getEvents: (state) => {
           if (state % 2 === 0) {
             return [{ type: 'even' }];
           }
@@ -44,7 +44,7 @@ describe('custom test models', () => {
         }
       },
       {
-        getEvents: (_cases, state) => {
+        getEvents: (state) => {
           if (state % 2 === 0) {
             return [{ type: 'even' }];
           }

--- a/packages/xstate-test/test/testModel.test.ts
+++ b/packages/xstate-test/test/testModel.test.ts
@@ -15,7 +15,7 @@ describe('custom test models', () => {
         }
       },
       {
-        getEvents: (cases, state) => {
+        getEvents: (_cases, state) => {
           if (state % 2 === 0) {
             return [{ type: 'even' }];
           }
@@ -44,7 +44,7 @@ describe('custom test models', () => {
         }
       },
       {
-        getEvents: (cases, state) => {
+        getEvents: (_cases, state) => {
           if (state % 2 === 0) {
             return [{ type: 'even' }];
           }

--- a/packages/xstate-test/test/testModel.test.ts
+++ b/packages/xstate-test/test/testModel.test.ts
@@ -15,7 +15,7 @@ describe('custom test models', () => {
         }
       },
       {
-        getEvents: (state) => {
+        getEvents: (cases, state) => {
           if (state % 2 === 0) {
             return [{ type: 'even' }];
           }
@@ -44,21 +44,11 @@ describe('custom test models', () => {
         }
       },
       {
-        getEvents: (state) => {
+        getEvents: (cases, state) => {
           if (state % 2 === 0) {
             return [{ type: 'even' }];
           }
           return [{ type: 'odd' }];
-        },
-        states: {
-          even: (state) => {
-            testedStateKeys.push('even');
-            expect(state % 2).toBe(0);
-          },
-          odd: (state) => {
-            testedStateKeys.push('odd');
-            expect(state % 2).toBe(1);
-          }
         },
         stateMatcher: (state, key) => {
           if (key === 'even') {
@@ -74,7 +64,18 @@ describe('custom test models', () => {
 
     const paths = model.getShortestPathsTo((state) => state === 1);
 
-    await testUtils.testPaths(paths);
+    await testUtils.testPaths(paths, {
+      states: {
+        even: (state) => {
+          testedStateKeys.push('even');
+          expect(state % 2).toBe(0);
+        },
+        odd: (state) => {
+          testedStateKeys.push('odd');
+          expect(state % 2).toBe(1);
+        }
+      }
+    });
 
     expect(testedStateKeys).toContain('even');
     expect(testedStateKeys).toContain('odd');


### PR DESCRIPTION
We decided that having `states` and `events` in the test model means you have closure issues.

However, having `cases` only run on `paths` mean they were excluded from path generation.