### PR TITLE
refactor: :label: stronger types for `StateValue` when using Typegen

### DIFF
--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -24,9 +24,9 @@ import { IS_PRODUCTION } from './environment';
 import { TypegenDisabled, TypegenEnabled } from './typegenTypes';
 import { BaseActionObject, Prop } from './types';
 
-export function stateValuesEqual(
-  a: StateValue | undefined,
-  b: StateValue | undefined
+export function stateValuesEqual<TResolvedTypesMeta = TypegenDisabled>(
+  a: StateValue<TResolvedTypesMeta> | undefined,
+  b: StateValue<TResolvedTypesMeta> | undefined
 ): boolean {
   if (a === b) {
     return true;
@@ -92,7 +92,7 @@ export class State<
   TTypestate extends Typestate<TContext> = { value: any; context: TContext },
   TResolvedTypesMeta = TypegenDisabled
 > {
-  public value: StateValue;
+  public value: StateValue<TResolvedTypesMeta>;
   public context: TContext;
   public historyValue?: HistoryValue | undefined;
   public history?: State<
@@ -253,7 +253,7 @@ export class State<
    * @param events Internal event queue. Should be empty with run-to-completion semantics.
    * @param configuration
    */
-  constructor(config: StateConfig<TContext, TEvent>) {
+  constructor(config: StateConfig<TContext, TEvent, TResolvedTypesMeta>) {
     this.value = config.value;
     this.context = config.context;
     this._event = config._event;
@@ -288,10 +288,7 @@ export class State<
    * @param stateValue
    * @param delimiter The character(s) that separate each subpath in the string state node path.
    */
-  public toStrings(
-    stateValue: StateValue = this.value,
-    delimiter: string = '.'
-  ): string[] {
+  public toStrings(stateValue = this.value, delimiter: string = '.'): string[] {
     if (isString(stateValue)) {
       return [stateValue];
     }
@@ -338,8 +335,8 @@ export class State<
     TTypestate,
     TResolvedTypesMeta
   > & { value: TSV };
-  public matches(parentStateValue: StateValue): any {
-    return matchesState(parentStateValue as StateValue, this.value);
+  public matches(parentStateValue: StateValue<TResolvedTypesMeta>): any {
+    return matchesState(parentStateValue, this.value);
   }
 
   /**

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -782,7 +782,7 @@ class StateNode<
 
     return next;
   }
-  private transitionCompoundNode<TResolvedTypesMeta>(
+  private transitionCompoundNode(
     stateValue: StateValue<TResolvedTypesMeta>,
     state: State<TContext, TEvent>,
     _event: SCXML.Event<TEvent>
@@ -802,7 +802,7 @@ class StateNode<
 
     return next;
   }
-  private transitionParallelNode<TResolvedTypesMeta>(
+  private transitionParallelNode(
     stateValue: StateValue<TResolvedTypesMeta>,
     state: State<TContext, TEvent>,
     _event: SCXML.Event<TEvent>
@@ -856,7 +856,7 @@ class StateNode<
       )
     };
   }
-  private _transition<TResolvedTypesMeta>(
+  private _transition(
     stateValue: StateValue<TResolvedTypesMeta>,
     state: State<TContext, TEvent, any, any, any>,
     _event: SCXML.Event<TEvent>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1494,8 +1494,12 @@ export interface StateLike<TContext> {
   _event: SCXML.Event<EventObject>;
 }
 
-export interface StateConfig<TContext, TEvent extends EventObject> {
-  value: StateValue;
+export interface StateConfig<
+  TContext,
+  TEvent extends EventObject,
+  TResolvedTypesMeta = TypegenDisabled
+> {
+  value: StateValue<TResolvedTypesMeta>;
   context: TContext;
   _event: SCXML.Event<TEvent>;
   _sessionid: string | null;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -176,8 +176,11 @@ export interface StateValueMap {
  * - For a child atomic state node, this is a string, e.g., `"pending"`.
  * - For complex state nodes, this is an object, e.g., `{ success: "someChildState" }`.
  */
-export type StateValue = string | StateValueMap;
-
+export type StateValue<
+  TResolvedTypesMeta = TypegenDisabled
+> = TResolvedTypesMeta extends TypegenEnabled
+  ? Prop<Prop<TResolvedTypesMeta, 'resolved'>, 'matchesStates'>
+  : string | StateValueMap;
 export interface HistoryValue {
   states: Record<string, HistoryValue | undefined>;
   current: StateValue | undefined;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -35,14 +35,15 @@ import { StateNode } from './StateNode';
 import { State } from './State';
 import { Actor } from './Actor';
 import { AnyStateMachine } from '.';
+import { TypegenDisabled } from './typegenTypes';
 
 export function keys<T extends object>(value: T): Array<keyof T & string> {
   return Object.keys(value) as Array<keyof T & string>;
 }
 
-export function matchesState(
-  parentStateId: StateValue,
-  childStateId: StateValue,
+export function matchesState<TResolvedTypesMeta = TypegenDisabled>(
+  parentStateId: StateValue<TResolvedTypesMeta>,
+  childStateId: StateValue<TResolvedTypesMeta>,
   delimiter: string = STATE_DELIMITER
 ): boolean {
   const parentStateValue = toStateValue(parentStateId, delimiter);
@@ -122,8 +123,8 @@ export function isStateLike(state: any): state is StateLike<any> {
   );
 }
 
-export function toStateValue(
-  stateValue: StateLike<any> | StateValue | string[],
+export function toStateValue<TResolvedTypesMeta = TypegenDisabled>(
+  stateValue: StateLike<any> | StateValue<TResolvedTypesMeta> | string[],
   delimiter: string
 ): StateValue {
   if (isStateLike(stateValue)) {


### PR DESCRIPTION
Demo of `state.value` having loose types while using Typegen: https://codesandbox.io/s/github/brunocrosier/test-xstate-typegen

![image](https://user-images.githubusercontent.com/18399089/170355449-425717d8-519e-448a-b3ae-1f538db4d97c.png)

Borrowing the type from: https://github.com/statelyai/xstate/blob/main/packages/core/src/State.ts#L321