### PR TITLE
Naive jest console message

### DIFF
--- a/.changeset/angry-rice-add.md
+++ b/.changeset/angry-rice-add.md
@@ -1,0 +1,5 @@
+---
+'@xstate/test': minor
+---
+
+update to console messaging

--- a/packages/xstate-test/src/utils.ts
+++ b/packages/xstate-test/src/utils.ts
@@ -78,7 +78,7 @@ export function formatPathTestResult(
 export function getDescription<T, TContext>(state: AnyState): string {
   const contextString =
     state.context === undefined ? '' : `(${JSON.stringify(state.context)})`;
-  const machineDescriptionMessage = state.transitions[0].description
+  const transitionDescription = state.transitions[0].description
     ? `"${state.transitions[0].description}"`
     : '';
 
@@ -102,7 +102,7 @@ export function getDescription<T, TContext>(state: AnyState): string {
   return (
     `state${stateStrings.length === 1 ? '' : 's'} ` +
     stateStrings.join(', ') +
-    ` ${machineDescriptionMessage} ${contextString}`
+    ` ${transitionDescription} ${contextString}`
   ).trim();
 }
 

--- a/packages/xstate-test/src/utils.ts
+++ b/packages/xstate-test/src/utils.ts
@@ -78,6 +78,9 @@ export function formatPathTestResult(
 export function getDescription<T, TContext>(state: AnyState): string {
   const contextString =
     state.context === undefined ? '' : `(${JSON.stringify(state.context)})`;
+  const jestConsoleMessage = state.transitions[0].description
+    ? `"${state.transitions[0].description}"`
+    : '';
 
   const stateStrings = state.configuration
     .filter((sn) => sn.type === 'atomic' || sn.type === 'final')
@@ -99,8 +102,8 @@ export function getDescription<T, TContext>(state: AnyState): string {
   return (
     `state${stateStrings.length === 1 ? '' : 's'} ` +
     stateStrings.join(', ') +
-    ` ${contextString}`.trim()
-  );
+    ` ${jestConsoleMessage} ${contextString}`
+  ).trim();
 }
 
 export function flatten<T>(array: Array<T | T[]>): T[] {

--- a/packages/xstate-test/src/utils.ts
+++ b/packages/xstate-test/src/utils.ts
@@ -78,7 +78,7 @@ export function formatPathTestResult(
 export function getDescription<T, TContext>(state: AnyState): string {
   const contextString =
     state.context === undefined ? '' : `(${JSON.stringify(state.context)})`;
-  const jestConsoleMessage = state.transitions[0].description
+  const machineDescriptionMessage = state.transitions[0].description
     ? `"${state.transitions[0].description}"`
     : '';
 
@@ -102,7 +102,7 @@ export function getDescription<T, TContext>(state: AnyState): string {
   return (
     `state${stateStrings.length === 1 ? '' : 's'} ` +
     stateStrings.join(', ') +
-    ` ${jestConsoleMessage} ${contextString}`
+    ` ${machineDescriptionMessage} ${contextString}`
   ).trim();
 }
 

--- a/packages/xstate-test/src/utils.ts
+++ b/packages/xstate-test/src/utils.ts
@@ -79,7 +79,10 @@ export function getDescription<T, TContext>(state: AnyState): string {
   const contextString =
     state.context === undefined ? '' : `(${JSON.stringify(state.context)})`;
   const transitionDescription = state.transitions[0].description
-    ? `"${state.transitions[0].description}"`
+    ? state.transitions[0].description.trim()
+    : '';
+  const formattedTransitionDescription = transitionDescription
+    ? ' "' + transitionDescription + '"'
     : '';
 
   const stateStrings = state.configuration
@@ -102,7 +105,7 @@ export function getDescription<T, TContext>(state: AnyState): string {
   return (
     `state${stateStrings.length === 1 ? '' : 's'} ` +
     stateStrings.join(', ') +
-    ` ${transitionDescription} ${contextString}`
+    `${formattedTransitionDescription} ${contextString}`
   ).trim();
 }
 

--- a/packages/xstate-test/test/paths.test.ts
+++ b/packages/xstate-test/test/paths.test.ts
@@ -114,6 +114,33 @@ describe('path.description', () => {
       'Reaches state "e": EVENT → EVENT → EVENT_2'
     ]);
   });
+
+  it('Should append a readable description from the machine to the target state path', () => {
+    const machine = createTestMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            EVENT: { target: 'b' }
+          }
+        },
+        b: {
+          on: {
+            EVENT: { description: 'go to c', target: 'c' }
+          }
+        },
+        c: {}
+      }
+    });
+
+    const model = createTestModel(machine);
+
+    const paths = model.getPaths();
+
+    expect(paths.map((path) => path.description)).toEqual([
+      'Reaches state "c" "go to c": EVENT → EVENT'
+    ]);
+  });
 });
 
 describe('transition coverage', () => {

--- a/packages/xstate-test/test/paths.test.ts
+++ b/packages/xstate-test/test/paths.test.ts
@@ -115,32 +115,37 @@ describe('path.description', () => {
     ]);
   });
 
-  it('Should append a readable description from the machine to the target state path', () => {
-    const machine = createTestMachine({
-      initial: 'a',
-      states: {
-        a: {
-          on: {
-            EVENT: { target: 'b' }
-          }
-        },
-        b: {
-          on: {
-            EVENT: { description: 'go to c', target: 'c' }
-          }
-        },
-        c: {}
-      }
-    });
+  it.each([
+    ['Reaches state "c" "go to c": EVENT → EVENT', 'go to c'],
+    ['Reaches state "c" "go to c": EVENT → EVENT', '  go to c  '],
+    ['Reaches state "c": EVENT → EVENT', ' ']
+  ])(
+    'Inserts formatted descriptions between the state and path with spacing and colon',
+    (result, description) => {
+      const machine = createTestMachine({
+        initial: 'a',
+        states: {
+          a: {
+            on: {
+              EVENT: { target: 'b' }
+            }
+          },
+          b: {
+            on: {
+              EVENT: { description: description, target: 'c' }
+            }
+          },
+          c: {}
+        }
+      });
 
-    const model = createTestModel(machine);
+      const model = createTestModel(machine);
 
-    const paths = model.getPaths();
+      const paths = model.getPaths();
 
-    expect(paths.map((path) => path.description)).toEqual([
-      'Reaches state "c" "go to c": EVENT → EVENT'
-    ]);
-  });
+      expect(paths.map((path) => path.description)).toEqual([result]);
+    }
+  );
 });
 
 describe('transition coverage', () => {


### PR DESCRIPTION
closes #3369 

Figured I'd take a look at this over lunch. This seems like a reasonable starting point. It works for jest. I'm not sure what the output would be for something like Cypress. I know you support other testing frameworks and it's possible there's more to be thought about here. This is perhaps a fine naive solution.

https://github.com/statelyai/xstate/issues/3369

![image](https://user-images.githubusercontent.com/3719502/171254603-b9dca738-b291-44c8-8baa-0fb76ddb4bd4.png)
