### PR TITLE
Initial value as function

### DIFF
--- a/.changeset/light-planes-sparkle.md
+++ b/.changeset/light-planes-sparkle.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+A machines initial state can now be set using a function

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -352,7 +352,9 @@ class StateNode<
       );
     }
 
-    this.initial = this.config.initial;
+    this.initial = isFunction(this.config.initial)
+      ? this.config.initial()
+      : this.config.initial;
 
     this.states = (this.config.states
       ? mapValues(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -541,7 +541,10 @@ export interface StateNodeConfig<
   /**
    * The initial state node key.
    */
-  initial?: keyof TStateSchema['states'] | undefined;
+  initial?:
+    | keyof TStateSchema['states']
+    | (() => keyof TStateSchema['states'])
+    | undefined;
   /**
    * @deprecated
    */

--- a/packages/core/test/initial.test.ts
+++ b/packages/core/test/initial.test.ts
@@ -1,6 +1,6 @@
-import { Machine } from '../src';
+import { Machine, MachineConfig } from '../src';
 
-const config = {
+const configWithStringInitial = {
   initial: 'a',
   states: {
     a: {
@@ -18,42 +18,78 @@ const config = {
   }
 };
 
-const deepMachine = Machine(config);
-
-const parallelDeepMachine = Machine({
-  type: 'parallel',
+const configWithFunctionInitial = {
+  initial: () => 'a',
   states: {
-    foo: config,
-    bar: config
+    a: {
+      initial: () => 'b',
+      states: {
+        b: {
+          initial: () => 'c',
+          states: {
+            c: {}
+          }
+        }
+      }
+    },
+    leaf: {}
   }
-});
+};
 
-const deepParallelMachine = Machine({
-  initial: 'one',
-  states: {
-    one: parallelDeepMachine.config,
-    two: parallelDeepMachine.config
-  }
-});
+const createDeepMachine = (config: MachineConfig<any, any, any>) =>
+  Machine(config);
+
+const createParallelDeepMachine = (config: MachineConfig<any, any, any>) =>
+  Machine({
+    type: 'parallel',
+    states: {
+      foo: config,
+      bar: config
+    }
+  });
+
+const createDeepParallelMachine = (config: MachineConfig<any, any, any>) =>
+  Machine({
+    initial: 'one',
+    states: {
+      one: createParallelDeepMachine(config).config,
+      two: createParallelDeepMachine(config).config
+    }
+  });
 
 describe('Initial states', () => {
-  it('should return the correct initial state', () => {
+  it.each([
+    ['string', createDeepMachine(configWithStringInitial)],
+    ['function', createDeepMachine(configWithFunctionInitial)]
+  ])('should return the correct initial state as %s', (_, deepMachine) => {
     expect(deepMachine.initialState.value).toEqual({ a: { b: 'c' } });
   });
 
-  it('should return the correct initial state (parallel)', () => {
-    expect(parallelDeepMachine.initialState.value).toEqual({
-      foo: { a: { b: 'c' } },
-      bar: { a: { b: 'c' } }
-    });
-  });
-
-  it('should return the correct initial state (deep parallel)', () => {
-    expect(deepParallelMachine.initialState.value).toEqual({
-      one: {
+  it.each([
+    ['string', createParallelDeepMachine(configWithStringInitial)],
+    ['function', createParallelDeepMachine(configWithFunctionInitial)]
+  ])(
+    'should return the correct initial state (parallel) as %s',
+    (_, parallelDeepMachine) => {
+      expect(parallelDeepMachine.initialState.value).toEqual({
         foo: { a: { b: 'c' } },
         bar: { a: { b: 'c' } }
-      }
-    });
-  });
+      });
+    }
+  );
+
+  it.each([
+    ['string', createDeepParallelMachine(configWithStringInitial)],
+    ['function', createDeepParallelMachine(configWithFunctionInitial)]
+  ])(
+    'should return the correct initial state (deep parallel) as %s',
+    (_, deepParallelMachine) => {
+      expect(deepParallelMachine.initialState.value).toEqual({
+        one: {
+          foo: { a: { b: 'c' } },
+          bar: { a: { b: 'c' } }
+        }
+      });
+    }
+  );
 });


### PR DESCRIPTION
This PR makes it possible to set the initial state from a function. My use case for this is that I have a parallel machine where I want parts of it to be saved in localStorage, and then initiated with that value. There might be some better way to do this, but currently I am doing this

```js
{
  Volume: {
  initial: 'Initial',
    states: {
      Initial: {
        invoke: {
          src: () =>
            Promise.resolve(
              localStorage.getItem('volume-state') ?? 'Unmuted'
            ),
          onDone: [
            {
              cond: (c, e) => e.data === 'Muted',
              target: 'Muted',
            },
            { target: 'Unmuted' },
          ],
        },
      },
      Muted: {
        entry: () => localStorage.setItem('volume-state', 'Muted'),
        on: {
          Toggle: {
            target: 'Unmuted',
          },
        },
      },
      Unmuted: {
        entry: () => localStorage.setItem('volume-state', 'Unmuted'),
        on: {
          Toggle: {
            target: 'Muted',
          },
        },
      },
    },
  },
}
```

With this change I would instead be able to do this
```js
Volume: {
    initial: () => localStorage.getItem("volume-state") ?? "Unmuted",
    states: {
      Muted: {
        entry: () => localStorage.setItem("volume-state", "Muted"),
        on: {
          Toggle: {
            target: "Unmuted",
          },
        },
      },
      Unmuted: {
        entry: () => localStorage.setItem("volume-state", "Unmuted"),
        on: {
          Toggle: {
            target: "Muted",
          },
        },
      },
    },
  },
```

It makes it easier and cleaner to be able to restore parts of a parallel state, but also for saving the state without having to save the complete state tree and restore it.