### PR TITLE
[xstate/test] Narrow down the `event` type passed to `EventExecutor` based on the key

### DIFF
--- a/.changeset/flat-melons-tan.md
+++ b/.changeset/flat-melons-tan.md
@@ -1,0 +1,5 @@
+---
+"@xstate/test": patch
+---
+
+Narrow down the `event` type passed to `EventExecutor` from the corresponding key of the `events` object

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -86,7 +86,7 @@ export interface TestParam<TState, TEvent extends EventObject> {
     [key: string]: (state: TState) => void | Promise<void>;
   };
   events?: {
-    [TEventType in TEvent['type']]?: EventExecutor<TState, TEvent>;
+    [TEventType in TEvent['type']]?: EventExecutor<TState, ExtractEvent<TEvent, TEventType>>;
   };
 }
 

--- a/packages/xstate-test/test/types.test.ts
+++ b/packages/xstate-test/test/types.test.ts
@@ -1,0 +1,42 @@
+import { createMachine } from 'xstate';
+import { createTestModel } from '../src';
+
+describe('types', () => {
+  it('`EventExecutor` should be passed event with type that corresponds to its key', () => {
+    const machine = createMachine({
+      id: 'test',
+      schema: {
+        context: {} as any,
+        events: {} as
+          | { type: 'a'; valueA: boolean }
+          | { type: 'b'; valueB: number }
+      },
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            a: { target: '#test.b' }
+          }
+        },
+        b: {
+          on: {
+            b: { target: '#test.a' }
+          }
+        }
+      }
+    });
+
+    for (const path of createTestModel(machine).getPaths()) {
+      path.test({
+        events: {
+          a: ({ event }) => {
+            console.log(event.valueA);
+          },
+          b: ({ event }) => {
+            console.log(event.valueB);
+          }
+        }
+      });
+    }
+  });
+});


### PR DESCRIPTION
This narrows down the type of the `event` in the `EventExecutor` to the type that it's keyed by.

I think this is the intention of the code -- am I correct?