### PR TITLE
Fixed the declared signature of one of the `StateMachine`'s methods to avoid using a private name `this`

### DIFF
--- a/.changeset/slow-carrots-confess.md
+++ b/.changeset/slow-carrots-confess.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed the declared signature of one of the `StateMachine`'s methods to avoid using a private name `this`. This makes it possible to emit correct `.d.ts` for the associated file.

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@changesets/cli": "^2.19.0",
     "@manypkg/cli": "^0.16.1",
     "@manypkg/get-packages": "^1.1.3",
-    "@preconstruct/cli": "^2.1.0",
+    "@preconstruct/cli": "^2.1.5",
     "@testing-library/jest-dom": "^5.11.9",
     "@testing-library/vue": "^6.4.0",
     "@types/jest": "^24.0.23",

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -322,7 +322,7 @@ export class StateMachine<
   /**
    * Returns the initial `State` instance, with reference to `self` as an `ActorRef`.
    */
-  public getInitialState(): StateFrom<typeof this> {
+  public getInitialState(): State<TContext, TEvent, TResolvedTypesMeta> {
     const { preInitialState } = this;
     const nextState = resolveMicroTransition(
       this,

--- a/packages/core/src/actors.ts
+++ b/packages/core/src/actors.ts
@@ -434,7 +434,7 @@ export function fromMachine<TMachine extends AnyStateMachine>(
       if (initialState) {
         return initialState;
       }
-      initialState = castedMachine.getInitialState();
+      initialState = castedMachine.getInitialState() as StateFrom<TMachine>;
       return initialState;
     }
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2039,10 +2039,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@preconstruct/cli@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.1.0.tgz#76b30a8952f534f9f4a99862d7267815b6e3b57d"
-  integrity sha512-FfyWlZbinuv3be7yss8p9Yq87V88XKa6XUskeRSFDKgcgH1FwtTg9xYrEJm7j5QV4KThiQfPqoUN4m7hLxWlHg==
+"@preconstruct/cli@^2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@preconstruct/cli/-/cli-2.1.5.tgz#f7f6d06809f382521589af15f67b87009b240c58"
+  integrity sha512-bMnGTkaotxq+xoOkXoUOfTFvxBX/ZUxukcacf3mx3G7Iz5m/T4ZGzSOU12pxl64e+rVWGTKlUsgaDSgyFkup0A==
   dependencies:
     "@babel/code-frame" "^7.5.5"
     "@babel/core" "^7.7.7"


### PR DESCRIPTION
Unfortunately `typeof this` cannot be used like this in public methods 😭 See a super simple [TS playground](https://www.typescriptlang.org/play?#code/MYGwhgzhAECC0G8BQ1XQLYFMAuALA9gCYAUAlIgL4poDmOAspmQFzTYCeADpvgGZu4AljGRox0AE44ArhIB2laJCVz21VBQDcSCkA) demonstrating the problem.

We've missed this because Preconstruct was accidentally swallowing those errors but that has been fixed in [`@preconstruct/cli@2.1.2`](https://github.com/preconstruct/preconstruct/releases/tag/%40preconstruct%2Fcli%402.1.2)