### PR TITLE
Add UMD builds backs in the core

### DIFF
--- a/.changeset/twenty-fishes-fix.md
+++ b/.changeset/twenty-fishes-fix.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Added back UMD builds. Please note that XState now comes with multiple entrypoints and you might need to load all of them (`XState`, `XStateActions`, `XStateGuards`, etc.). It's also worth mentioning that those bundles don't reference each other so they don't actually share any code and some code might be duplicated between them.

--- a/packages/core/actions/package.json
+++ b/packages/core/actions/package.json
@@ -1,4 +1,8 @@
 {
   "main": "dist/xstate-actions.cjs.js",
-  "module": "dist/xstate-actions.esm.js"
+  "module": "dist/xstate-actions.esm.js",
+  "umd:main": "dist/xstate-actions.umd.min.js",
+  "preconstruct": {
+    "umdName": "XStateActions"
+  }
 }

--- a/packages/core/actors/package.json
+++ b/packages/core/actors/package.json
@@ -1,4 +1,8 @@
 {
   "main": "dist/xstate-actors.cjs.js",
-  "module": "dist/xstate-actors.esm.js"
+  "module": "dist/xstate-actors.esm.js",
+  "umd:main": "dist/xstate-actors.umd.min.js",
+  "preconstruct": {
+    "umdName": "XStateActors"
+  }
 }

--- a/packages/core/dev/package.json
+++ b/packages/core/dev/package.json
@@ -1,4 +1,8 @@
 {
   "main": "dist/xstate-dev.cjs.js",
-  "module": "dist/xstate-dev.esm.js"
+  "module": "dist/xstate-dev.esm.js",
+  "umd:main": "dist/xstate-dev.umd.min.js",
+  "preconstruct": {
+    "umdName": "XStateDev"
+  }
 }

--- a/packages/core/guards/package.json
+++ b/packages/core/guards/package.json
@@ -1,4 +1,8 @@
 {
   "main": "dist/xstate-guards.cjs.js",
-  "module": "dist/xstate-guards.esm.js"
+  "module": "dist/xstate-guards.esm.js",
+  "umd:main": "dist/xstate-guards.umd.min.js",
+  "preconstruct": {
+    "umdName": "XStateGuards"
+  }
 }

--- a/packages/core/model/package.json
+++ b/packages/core/model/package.json
@@ -1,8 +1,0 @@
-{
-  "main": "dist/xstate-model.cjs.js",
-  "module": "dist/xstate-model.esm.js",
-  "umd:main": "dist/xstate-model.umd.min.js",
-  "preconstruct": {
-    "umdName": "XStateModel"
-  }
-}

--- a/packages/core/model/package.json
+++ b/packages/core/model/package.json
@@ -1,4 +1,8 @@
 {
   "main": "dist/xstate-model.cjs.js",
-  "module": "dist/xstate-model.esm.js"
+  "module": "dist/xstate-model.esm.js",
+  "umd:main": "dist/xstate-model.umd.min.js",
+  "preconstruct": {
+    "umdName": "XStateModel"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "Finite State Machines and Statecharts for the Modern Web.",
   "main": "dist/xstate.cjs.js",
   "module": "dist/xstate.esm.js",
+  "umd:main": "dist/xstate.umd.min.js",
   "sideEffects": false,
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
I'm not a fan of shipping those in 2022 but this has been asked on Discord. I don't want to work too much on those bundles because I think that if somebody needs those then they need to figure out creating those on their end (it's not that hard and we won't have a lot of consumers for those bundles nowadays). 

The main problem with them for us is that Rollup doesn't support code-splitting for such targets:
> Error: Invalid value "umd" for option "output.format" - UMD and IIFE output formats are not supported for code-splitting builds. 

This can easily be checked on their [playground](https://rollupjs.org/repl/?version=2.75.6&shareable=JTdCJTIybW9kdWxlcyUyMiUzQSU1QiU3QiUyMm5hbWUlMjIlM0ElMjJtYWluLmpzJTIyJTJDJTIyY29kZSUyMiUzQSUyMiUyRiolMjBNVUxUSVBMRSUyMEVOVFJZJTIwTU9EVUxFUyUyMColMkYlNUNuaW1wb3J0JTIwaHlwZXJDdWJlJTIwZnJvbSUyMCcuJTJGaHlwZXJDdWJlLmpzJyUzQiU1Q24lNUNuY29uc29sZS5sb2coJTIwaHlwZXJDdWJlKCUyMDUlMjApJTIwKSUzQiUyMiUyQyUyMmlzRW50cnklMjIlM0F0cnVlJTdEJTJDJTdCJTIybmFtZSUyMiUzQSUyMm90aGVyRW50cnkuanMlMjIlMkMlMjJjb2RlJTIyJTNBJTIyJTJGJTJGJTIwQWRkaXRpb25hbCUyMGVudHJ5JTIwbW9kdWxlcyUyMGNyZWF0ZSUyMG5ldyUyMGNodW5rcyU1Q25pbXBvcnQlMjBjdWJlJTIwZnJvbSUyMCcuJTJGY3ViZS5qcyclM0IlNUNuJTVDbmNvbnNvbGUubG9nKCUyMGN1YmUoJTIwNSUyMCklMjApJTNCJTIyJTJDJTIyaXNFbnRyeSUyMiUzQXRydWUlN0QlMkMlN0IlMjJuYW1lJTIyJTNBJTIyY3ViZS5qcyUyMiUyQyUyMmNvZGUlMjIlM0ElMjJpbXBvcnQlMjBzcXVhcmUlMjBmcm9tJTIwJy4lMkZzcXVhcmUuanMnJTNCJTVDbiU1Q24lMkYlMkYlMjBFdmVyeXRoaW5nJTIwdXNlZCUyMGJ5JTIwYm90aCUyMGVudHJ5JTIwbW9kdWxlcyUyMHdpbGwlMjBiZWNvbWUlNUNuJTJGJTJGJTIwYSUyMHNlcGFyYXRlJTIwY2h1bmslMjB0aGF0JTIwaXMlMjBpbXBvcnRlZCUyMGJ5JTIwYm90aCUyMGVudHJ5JTVDbiUyRiUyRiUyMGNodW5rcyUyMHRvJTIwYXZvaWQlMjBjb2RlJTIwZHVwbGljYXRpb24lNUNuZXhwb3J0JTIwZGVmYXVsdCUyMGZ1bmN0aW9uJTIwY3ViZSUyMCglMjB4JTIwKSUyMCU3QiU1Q24lNUN0cmV0dXJuJTIwc3F1YXJlKHgpJTIwKiUyMHglM0IlNUNuJTdEJTIyJTJDJTIyaXNFbnRyeSUyMiUzQWZhbHNlJTdEJTJDJTdCJTIybmFtZSUyMiUzQSUyMmh5cGVyQ3ViZS5qcyUyMiUyQyUyMmNvZGUlMjIlM0ElMjJpbXBvcnQlMjBjdWJlJTIwZnJvbSUyMCcuJTJGY3ViZS5qcyclM0IlNUNuJTVDbiUyRiUyRiUyMFRoaXMlMjBpcyUyMG9ubHklMjBpbXBvcnRlZCUyMGJ5JTIwb25lJTIwZW50cnklMjBtb2R1bGUlMjBhbmQlNUNuJTJGJTJGJTIwc2hhcmVzJTIwYSUyMGNodW5rJTIwd2l0aCUyMHRoYXQlMjBtb2R1bGUlNUNuZXhwb3J0JTIwZGVmYXVsdCUyMGZ1bmN0aW9uJTIwaHlwZXJDdWJlJTIwKCUyMHglMjApJTIwJTdCJTVDbiU1Q3RyZXR1cm4lMjBjdWJlKHgpJTIwKiUyMHglM0IlNUNuJTdEJTIyJTJDJTIyaXNFbnRyeSUyMiUzQWZhbHNlJTdEJTJDJTdCJTIybmFtZSUyMiUzQSUyMnNxdWFyZS5qcyUyMiUyQyUyMmNvZGUlMjIlM0ElMjIlMkYlMkYlMjBUaGlzJTIwaXMlMjBhbHNvJTIwc2hhcmVkJTIwYmV0d2VlbiUyMHRoZSUyMGVudHJ5JTIwY2h1bmtzJTVDbmV4cG9ydCUyMGRlZmF1bHQlMjBmdW5jdGlvbiUyMHNxdWFyZSUyMCglMjB4JTIwKSUyMCU3QiU1Q24lNUN0cmV0dXJuJTIweCUyMColMjB4JTNCJTVDbiU3RCUyMiUyQyUyMmlzRW50cnklMjIlM0FmYWxzZSU3RCU1RCUyQyUyMm9wdGlvbnMlMjIlM0ElN0IlMjJmb3JtYXQlMjIlM0ElMjJ1bWQlMjIlMkMlMjJuYW1lJTIyJTNBJTIybXlCdW5kbGUlMjIlMkMlMjJhbWQlMjIlM0ElN0IlMjJpZCUyMiUzQSUyMiUyMiU3RCUyQyUyMmdsb2JhbHMlMjIlM0ElN0IlN0QlN0QlMkMlMjJleGFtcGxlJTIyJTNBbnVsbCU3RA==)

So since code-splitting isnt' supported we have to bundle all of the entrypoints separately and that might cause issues with shared state, `instanceof` and similar.

Alternatively we could prepare special "all at once" UMD bundles but... that would complicate our setup and would have rather poor RoI given how niche those bundles are nowadays.

I'm kinda providing those here with a disclaimer that YMMV. I didn't test them in full and stuff might not work properly. 