### PR TITLE
docs: mention interpreter stopping upon reaching final state

### DIFF
--- a/docs/guides/final.md
+++ b/docs/guides/final.md
@@ -143,3 +143,4 @@ The `onDone` transition cannot be defined on the root node of the machine. This 
 - A parallel state that reaches a final substate does not stop receiving events until all its siblings are done. The final substate can still be exited with an event.
 - Final state nodes cannot have any children. They are atomic state nodes.
 - You can specify `entry` and `exit` actions on final state nodes.
+- Upon reaching final state, the interpreted machine will stop.

--- a/docs/guides/final.md
+++ b/docs/guides/final.md
@@ -143,4 +143,4 @@ The `onDone` transition cannot be defined on the root node of the machine. This 
 - A parallel state that reaches a final substate does not stop receiving events until all its siblings are done. The final substate can still be exited with an event.
 - Final state nodes cannot have any children. They are atomic state nodes.
 - You can specify `entry` and `exit` actions on final state nodes.
-- Upon reaching final state, the interpreted machine will stop.
+- Upon reaching a top-level final state, the interpreted machine will stop.


### PR DESCRIPTION
It wasn't clear what happens to the interpreter after reaching a final state.

This question was asked on Discord and is being written in docs for clarification.