### PR TITLE
Add a test for exiting exiting a deep descendant during a self-transition

### DIFF
--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -485,6 +485,37 @@ describe('entry/exit actions', () => {
         newLightMachine.transition('red', 'NOTHING').actions.map((a) => a.type)
       ).toEqual(['exit_walk', 'exit_red', 'enter_red', 'enter_walk']);
     });
+
+    it('should exit deep descendant during a self-transition', () => {
+      const actual: string[] = [];
+      const m = createMachine({
+        initial: 'a',
+        states: {
+          a: {
+            on: {
+              EV: 'a'
+            },
+            initial: 'a1',
+            states: {
+              a1: {
+                initial: 'a11',
+                states: {
+                  a11: {
+                    exit: () => actual.push('a11.exit')
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+
+      const service = interpret(m).start();
+
+      service.send('EV');
+
+      expect(actual).toEqual(['a11.exit']);
+    });
   });
 
   describe('parallel states', () => {


### PR DESCRIPTION
I was testing some scenarios to see if I can break the existing algorithm - I couldn't make it happen so that's good. Since I've already written this test I've concluded that it might be worthwhile to add it either way.