### PR TITLE
add every for periodic transitions

### DIFF
--- a/.changeset/friendly-experts-roll.md
+++ b/.changeset/friendly-experts-roll.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+add every for periodic transitions

--- a/docs/guides/periods.md
+++ b/docs/guides/periods.md
@@ -56,7 +56,7 @@ states: {
 // ...
 ```
 
-Periodic events can also be conditional with regard to a single period value:
+Periodic events can also be conditional with regard to a single interval value:
 
 ```js
 // ...
@@ -75,7 +75,7 @@ states: {
 
 ### Periodic expressions on transitions <Badge text="4.4+" />
 
-Periodic events specified on the `every: { ... }` property can have dynamic priods, specified either by a string period reference:
+Periodic events specified on the `every: { ... }` property can have dynamic priods, specified either by a string interval reference:
 
 ```js
 const lightDelayMachine = createMachine(
@@ -102,7 +102,7 @@ const lightDelayMachine = createMachine(
   },
   {
     // String delays configured here
-    periods: {
+    intervals: {
       LIGHT_DELAY: (context, event) => {
         return context.trafficLevel === 'low' ? 1000 : 3000;
       },
@@ -129,14 +129,14 @@ green: {
 // ...
 ```
 
-However, prefer using string period references, just like the first example, or in the `period` property:
+However, prefer using string interval references, just like the first example, or in the `interval` property:
 
 ```js
 // ...
 green: {
   after: [
     {
-      period: 'LIGHT_DELAY',
+      interval: 'LIGHT_DELAY',
       actions: doSomeAction
     }
   ]
@@ -146,14 +146,14 @@ green: {
 
 ## Periodic events
 
-If you just want to send an event every period of time, you can specify the `period` as an option in the second argument of the `send(...)` action creator:
+If you just want to send an event every period of time, you can specify the `interval` as an option in the second argument of the `send(...)` action creator:
 
 ```js
 import { actions } from 'xstate';
 const { send } = actions;
 
 // action to send the 'TIMER' event every 1 second
-const sendTimerEvery1Second = send({ type: 'TIMER' }, { period: 1000 });
+const sendTimerEvery1Second = send({ type: 'TIMER' }, { interval: 1000 });
 ```
 
 You can also prevent those delayed events from being sent by canceling them. This is done with the `cancel(...)` action creator:
@@ -166,7 +166,7 @@ const { send, cancel } = actions;
 const sendTimerAfter1Second = send(
   { type: 'TIMER' },
   {
-    period: 1000,
+    interval: 1000,
     id: 'oneSecondInterval' // give the event a unique ID
   }
 );
@@ -204,8 +204,8 @@ The `every: ...` property does not introduce anything new to statechart semantic
 states: {
   green: {
     entry: [
-      send(every(1000, 'light.green'), { period: 1000 }),
-      send(every(2000, 'light.green'), { period: 2000 })
+      send(every(1000, 'light.green'), { interval: 1000 }),
+      send(every(2000, 'light.green'), { interval: 2000 })
     ],
     onExit: [
       cancel(every(1000, 'light.green')),
@@ -225,4 +225,4 @@ states: {
 // ...
 ```
 
-The interpreted statechart will `send(...)` the `every(...)` events recurrently every `period`, unless the state node is exited, which will `cancel(...)` those periodic `send(...)` events.
+The interpreted statechart will `send(...)` the `every(...)` events recurrently every `interval`, unless the state node is exited, which will `cancel(...)` those periodic `send(...)` events.

--- a/docs/guides/periods.md
+++ b/docs/guides/periods.md
@@ -1,0 +1,228 @@
+# Periodic events and transitions
+
+Intervals can be handled declaratively with statecharts. To learn more, see the section in our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#delayed-transitions).
+
+## Periodic transitions
+
+Events or transitions can be taken automatically every period of time. This is represented in a state definition in the `every` property, which maps millisecond periods to their transitions:
+
+```js
+const lightPeriodsMachine = createMachine({
+  id: 'lightPeriod',
+  initial: 'green',
+  context: {
+    timeSpentInGreen: 0,
+    timeSpentInYellow: 0
+  },
+  states: {
+    green: {
+      every: {
+        // every 1 second, timeSpentInGreen will be increased by 1 second
+        1000: {
+          actions: assign({
+            timeSpentInGreen: (context) => context.timeSpentInGreen + 1
+          })
+        }
+      },
+      on: {
+        GO_TO_YELLOW: 'yellow'
+      }
+    },
+    yellow: {
+      every: {
+        // every 0.5 seconds, timeSpentInYellow will be increased by 0.5 seconds
+        500: {
+          actions: assign({
+            timeSpentInYellow: (context) => context.timeSpentInYellow + 0.5
+          })
+        }
+      }
+    }
+  }
+});
+```
+
+Periodic events and transitions can be specified in the same way that you specify them on the `on: ...` property. They can be explicit:
+
+```js
+// ...
+states: {
+  green: {
+    every: {
+      1000: { actions: doSomeAction }
+    }
+  }
+}
+// ...
+```
+
+Periodic events can also be conditional with regard to a single period value:
+
+```js
+// ...
+states: {
+  green: {
+    every: {
+      1000: [
+        { actions: doSomething, cond: 'trafficIsLight' },
+        { actions: doAnotherThing },
+      ]
+    }
+  }
+}
+// ...
+```
+
+### Periodic expressions on transitions <Badge text="4.4+" />
+
+Periodic events specified on the `every: { ... }` property can have dynamic priods, specified either by a string period reference:
+
+```js
+const lightDelayMachine = createMachine(
+  {
+    id: 'lightDelay',
+    initial: 'green',
+    context: {
+      trafficLevel: 'low'
+    },
+    states: {
+      green: {
+        every: {
+          // after 1 second, transition to yellow
+          LIGHT_DELAY: { actions: doSomething }
+        }
+      },
+      yellow: {
+        after: {
+          YELLOW_LIGHT_DELAY: { actions: doTheYellowThing }
+        }
+      }
+      // ...
+    }
+  },
+  {
+    // String delays configured here
+    periods: {
+      LIGHT_DELAY: (context, event) => {
+        return context.trafficLevel === 'low' ? 1000 : 3000;
+      },
+      YELLOW_LIGHT_DELAY: 500 // static value
+    }
+  }
+);
+```
+
+Or directly by a function, just like conditional periodic events:
+
+```js
+// ...
+green: {
+  every: [
+    {
+      priod: (context, event) => {
+        return context.trafficLevel === 'low' ? 1000 : 3000;
+      },
+      target: 'yellow'
+    }
+  ]
+},
+// ...
+```
+
+However, prefer using string period references, just like the first example, or in the `period` property:
+
+```js
+// ...
+green: {
+  after: [
+    {
+      period: 'LIGHT_DELAY',
+      actions: doSomeAction
+    }
+  ]
+},
+// ...
+```
+
+## Periodic events
+
+If you just want to send an event every period of time, you can specify the `period` as an option in the second argument of the `send(...)` action creator:
+
+```js
+import { actions } from 'xstate';
+const { send } = actions;
+
+// action to send the 'TIMER' event every 1 second
+const sendTimerEvery1Second = send({ type: 'TIMER' }, { period: 1000 });
+```
+
+You can also prevent those delayed events from being sent by canceling them. This is done with the `cancel(...)` action creator:
+
+```js
+import { actions } from 'xstate';
+const { send, cancel } = actions;
+
+// action to send the 'TIMER' event every 1 second
+const sendTimerAfter1Second = send(
+  { type: 'TIMER' },
+  {
+    period: 1000,
+    id: 'oneSecondInterval' // give the event a unique ID
+  }
+);
+
+const cancelTimer = cancel('oneSecondInterval'); // pass the ID of event to cancel
+
+const toggleMachine = createMachine({
+  id: 'toggle',
+  initial: 'inactive',
+  states: {
+    inactive: {
+      entry: sendTimerAfter1Second,
+      on: {
+        TIMER: { target: 'active' },
+        CANCEL: { actions: cancelTimer }
+      }
+    },
+    active: {}
+  }
+});
+
+// when the CANCEL event is sent, the TIMER event will be canceled.
+```
+
+## Interpretation
+
+With the XState [interpreter](./interpretation.md), periodic actions will use the native`setInterval` and `clearInterval` functions.
+
+## Behind the scenes
+
+The `every: ...` property does not introduce anything new to statechart semantics. Instead, it creates normal transitions that look like this:
+
+```js
+// ...
+states: {
+  green: {
+    entry: [
+      send(every(1000, 'light.green'), { period: 1000 }),
+      send(every(2000, 'light.green'), { period: 2000 })
+    ],
+    onExit: [
+      cancel(every(1000, 'light.green')),
+      cancel(every(2000, 'light.green'))
+    ],
+    on: {
+      [every(1000, 'light.green')]: {
+        target: 'yellow',
+        cond: 'trafficIsLight'
+      },
+      [every(2000, 'light.green')]: {
+        target: 'yellow'
+      }
+    }
+  }
+}
+// ...
+```
+
+The interpreted statechart will `send(...)` the `every(...)` events recurrently every `period`, unless the state node is exited, which will `cancel(...)` those periodic `send(...)` events.

--- a/packages/core/src/SimulatedClock.ts
+++ b/packages/core/src/SimulatedClock.ts
@@ -11,8 +11,15 @@ interface SimulatedTimeout {
   timeout: number;
   fn: (...args: any[]) => void;
 }
+
+interface SimulatedInterval {
+  start: number;
+  interval: number;
+  fn: (...args: any[]) => void;
+}
 export class SimulatedClock implements SimulatedClock {
   private timeouts: Map<number, SimulatedTimeout> = new Map();
+  private intervals: Map<number, SimulatedInterval> = new Map();
   private _now: number = 0;
   private _id: number = 0;
   public now() {
@@ -26,6 +33,18 @@ export class SimulatedClock implements SimulatedClock {
     this.timeouts.set(id, {
       start: this.now(),
       timeout,
+      fn
+    });
+    return id;
+  }
+  public clearInterval(id: number) {
+    this.intervals.delete(id);
+  }
+  public setInterval(fn: (...args: any[]) => void, interval: number) {
+    const id = this.getId();
+    this.intervals.set(id, {
+      start: this.now(),
+      interval,
       fn
     });
     return id;

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -122,7 +122,7 @@ const createDefaultOptions = <TContext>(): MachineOptions<TContext, any> => ({
   services: {},
   activities: {},
   delays: {},
-  periods: {}
+  intervals: {}
 });
 
 const validateArrayifiedTransitions = <TContext>(
@@ -505,7 +505,7 @@ class StateNode<
       guards,
       services,
       delays,
-      periods
+      intervals
     } = this.options;
 
     return new StateNode(
@@ -516,7 +516,7 @@ class StateNode<
         guards: { ...guards, ...options.guards },
         services: { ...services, ...options.services },
         delays: { ...delays, ...options.delays },
-        periods: { ...periods, ...options.periods }
+        intervals: { ...intervals, ...options.intervals }
       },
       context ?? this.context
     );
@@ -634,7 +634,7 @@ class StateNode<
   }
 
   private mutateEntryExitWithTimedEvent(
-    timerType: 'delay' | 'period',
+    timerType: 'delay' | 'interval',
     time:
       | string
       | number
@@ -724,25 +724,25 @@ class StateNode<
     const periodicEvents = isArray(everyConfig)
       ? everyConfig.map((transition, i) => {
           const eventType = this.mutateEntryExitWithTimedEvent(
-            'period',
-            transition.period,
+            'interval',
+            transition.interval,
             every,
             i
           );
           return { ...transition, event: eventType };
         })
       : flatten(
-          Object.keys(everyConfig).map((period, i) => {
-            const configTransition = everyConfig[period];
+          Object.keys(everyConfig).map((interval, i) => {
+            const configTransition = everyConfig[interval];
             const resolvedTransition = isString(configTransition)
               ? { target: configTransition }
               : configTransition;
 
-            const resolvedPeriod = !isNaN(+period) ? +period : period;
+            const resolvedInterval = !isNaN(+interval) ? +interval : interval;
 
             const eventType = this.mutateEntryExitWithTimedEvent(
-              'period',
-              resolvedPeriod,
+              'interval',
+              resolvedInterval,
               every,
               i
             );
@@ -750,14 +750,14 @@ class StateNode<
             return toArray(resolvedTransition).map((transition) => ({
               ...transition,
               event: eventType,
-              period: resolvedPeriod
+              interval: resolvedInterval
             }));
           })
         );
 
     return periodicEvents.map((periodicEvent) => ({
       ...this.formatTransition(periodicEvent),
-      period: periodicEvent.period
+      interval: periodicEvent.interval
     }));
   }
 

--- a/packages/core/src/actionTypes.ts
+++ b/packages/core/src/actionTypes.ts
@@ -9,6 +9,7 @@ export const cancel = ActionTypes.Cancel;
 export const nullEvent = ActionTypes.NullEvent;
 export const assign = ActionTypes.Assign;
 export const after = ActionTypes.After;
+export const every = ActionTypes.Every;
 export const doneState = ActionTypes.DoneState;
 export const log = ActionTypes.Log;
 export const init = ActionTypes.Init;

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -201,7 +201,7 @@ export function send<
     type: actionTypes.send,
     event: isFunction(event) ? event : toEventObject<TSentEvent>(event),
     delay: options ? options.delay : undefined,
-    period: options ? options.period : undefined,
+    interval: options ? options.interval : undefined,
     id:
       options && options.id !== undefined
         ? options.id
@@ -220,7 +220,7 @@ export function resolveSend<
   ctx: TContext,
   _event: SCXML.Event<TEvent>,
   delaysMap?: DelayFunctionMap<TContext, TEvent>,
-  periodsMap?: PeriodFunctionMap<TContext, TEvent>
+  intervalsMap?: PeriodFunctionMap<TContext, TEvent>
 ): SendActionObject<TContext, TEvent, TSentEvent> {
   const meta = {
     _event
@@ -253,7 +253,7 @@ export function resolveSend<
     _event: resolvedEvent,
     event: resolvedEvent.data,
     delay: getResolvedTime(delaysMap, action.delay) || undefined,
-    period: getResolvedTime(periodsMap, action.period) || undefined
+    interval: getResolvedTime(intervalsMap, action.interval) || undefined
   };
 }
 
@@ -494,14 +494,14 @@ export function after(delayRef: number | string, id?: string) {
 
 /**
  * Returns an event type that represents an implicit event that
- * is sent every specified periodic time `period`.
+ * is sent every specified periodic time `interval`.
  *
- * @param period The period to retrigger the event in milliseconds
+ * @param interval The period to retrigger the event in milliseconds
  * @param id The state node ID where this event is handled
  */
-export function every(period: number | string, id?: string) {
+export function every(interval: number | string, id?: string) {
   const idSuffix = id ? `#${id}` : '';
-  return `${ActionTypes.Every}(${period})${idSuffix}`;
+  return `${ActionTypes.Every}(${interval})${idSuffix}`;
 }
 
 /**
@@ -657,7 +657,7 @@ export function resolveActions<TContext, TEvent extends EventObject>(
               updatedContext,
               _event,
               machine.options.delays as any,
-              machine.options.periods as any
+              machine.options.intervals as any
             ) as ActionObject<TContext, TEvent>; // TODO: fix ActionTypes.Init
 
             if (!IS_PRODUCTION) {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -853,7 +853,7 @@ export class Interpreter<
           (sendAction as SendActionObject<TContext, TEvent, TEvent>)._event
         );
       }
-    }, sendAction.period as number);
+    }, sendAction.interval as number);
   }
 
   private cancel(sendId: string | number): void {
@@ -909,7 +909,7 @@ export class Interpreter<
         if (typeof sendAction.delay === 'number') {
           this.defer(sendAction);
           return;
-        } else if (typeof sendAction.period === 'number') {
+        } else if (typeof sendAction.interval === 'number') {
           this.repeatEvery(sendAction);
           return;
         } else {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -857,13 +857,10 @@ export class Interpreter<
   }
 
   private cancel(sendId: string | number): void {
-    if (this.delayedEventsMap[sendId]) {
-      this.clock.clearTimeout(this.delayedEventsMap[sendId]);
-      delete this.delayedEventsMap[sendId];
-    } else if (this.periodicEventsMap[sendId]) {
-      this.clock.clearInterval(this.periodicEventsMap[sendId]);
-      delete this.periodicEventsMap[sendId];
-    }
+    this.clock.clearTimeout(this.delayedEventsMap[sendId]);
+    delete this.delayedEventsMap[sendId];
+    this.clock.clearInterval(this.periodicEventsMap[sendId]);
+    delete this.periodicEventsMap[sendId];
   }
 
   private exec(

--- a/packages/core/src/typegenTypes.ts
+++ b/packages/core/src/typegenTypes.ts
@@ -72,6 +72,14 @@ export interface TypegenMeta extends TypegenEnabled {
   eventsCausingDelays: Record<string, string>;
   /**
    * Keeps track of which events lead to which
+   * intervals.
+   *
+   * Key: 'EVENT_NAME'
+   * Value: 'intervalName' | 'otherIntervalName'
+   */
+  eventsCausingIntervals: Record<string, string>;
+  /**
+   * Keeps track of which events lead to which
    * guards.
    *
    * Key: 'EVENT_NAME'
@@ -168,6 +176,7 @@ type MergeWithInternalEvents<TIndexedEvents, TInternalEvents> = TIndexedEvents &
 type AllowAllEvents = {
   eventsCausingActions: Record<string, string>;
   eventsCausingDelays: Record<string, string>;
+  eventsCausingIntervals: Record<string, string>;
   eventsCausingGuards: Record<string, string>;
   eventsCausingServices: Record<string, string>;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -399,7 +399,7 @@ export type PeriodicEvents<TContext, TEvent extends EventObject> =
     >
   | Array<
       TransitionConfig<TContext, TEvent> & {
-        period: number | string | Expr<TContext, TEvent, number>;
+        interval: number | string | Expr<TContext, TEvent, number>;
       }
     >;
 
@@ -928,11 +928,11 @@ type GeneratePeriodsConfigPart<
   TRequireMissingImplementations,
   TMissingImplementations
 > = MaybeMakeMissingImplementationsRequired<
-  'periods',
-  Prop<TMissingImplementations, 'periods'>,
+  'intervals',
+  Prop<TMissingImplementations, 'intervals'>,
   TRequireMissingImplementations
 > & {
-  periods?: MachineOptionsPeriods<TContext, TResolvedTypesMeta>;
+  intervals?: MachineOptionsPeriods<TContext, TResolvedTypesMeta>;
 };
 
 type GenerateGuardsConfigPart<
@@ -1375,7 +1375,7 @@ export enum SpecialTargets {
 export interface SendActionOptions<TContext, TEvent extends EventObject> {
   id?: string | number;
   delay?: number | string | DelayExpr<TContext, TEvent>;
-  period?: number | string | PeriodExpr<TContext, TEvent>;
+  interval?: number | string | PeriodExpr<TContext, TEvent>;
   to?: string | ExprWithMeta<TContext, TEvent, string | number | ActorRef<any>>;
 }
 
@@ -1480,7 +1480,7 @@ export interface DelayedTransitionDefinition<
 
 export interface PeriodicEventDefinition<TContext, TEvent extends EventObject>
   extends TransitionDefinition<TContext, TEvent> {
-  period: number | string | PeriodExpr<TContext, TEvent>;
+  interval: number | string | PeriodExpr<TContext, TEvent>;
 }
 
 export interface Edge<

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -667,6 +667,42 @@ describe('entry/exit actions', () => {
         done();
       }, 50);
     });
+    it("shouldn't exit (and reenter) state on targetless periodic transition", (done) => {
+      const actual: string[] = [];
+
+      const machine = Machine({
+        initial: 'one',
+        states: {
+          one: {
+            entry: () => {
+              actual.push('entered one');
+            },
+            exit: () => {
+              actual.push('exited one');
+            },
+            every: {
+              10: {
+                actions: () => {
+                  actual.push('got FOO');
+                }
+              }
+            }
+          }
+        }
+      });
+
+      interpret(machine).start();
+
+      setTimeout(() => {
+        expect(actual).toEqual([
+          'entered one',
+          'got FOO',
+          'got FOO',
+          'got FOO'
+        ]);
+        done();
+      }, 38);
+    });
   });
 
   describe('when reaching a final state', () => {

--- a/packages/core/test/every.test.ts
+++ b/packages/core/test/every.test.ts
@@ -1,0 +1,227 @@
+import { createMachine, interpret, State } from '../src';
+import { actionTypes, every } from '../src/actions';
+
+const lightMachine = createMachine({
+  id: 'light',
+  initial: 'green',
+  context: {
+    canTurnGreen: true
+  },
+  states: {
+    green: {
+      every: {
+        1000: 'yellow'
+      }
+    },
+    yellow: {
+      every: {
+        1000: [{ target: 'red' }]
+      }
+    },
+    red: {
+      every: [{ period: 1000, target: 'green' }]
+    }
+  }
+});
+
+describe('periodic events', () => {
+  it('should format transitions properly', () => {
+    const greenNode = lightMachine.states.green;
+
+    const transitions = greenNode.transitions;
+
+    expect(transitions.map((t) => t.eventType)).toEqual([
+      every(1000, greenNode.id)
+    ]);
+  });
+
+  it('should be able to transition after a period from nested initial state', (done) => {
+    const machine = createMachine({
+      initial: 'nested',
+      states: {
+        nested: {
+          initial: 'wait',
+          states: {
+            wait: {
+              every: {
+                10: '#end'
+              }
+            }
+          }
+        },
+        end: {
+          id: 'end',
+          type: 'final'
+        }
+      }
+    });
+
+    interpret(machine)
+      .onDone(() => {
+        done();
+      })
+      .start();
+  });
+
+  it('parent state should enter child state without re-entering self (relative target)', (done) => {
+    const actual: string[] = [];
+    const machine = createMachine({
+      initial: 'one',
+      states: {
+        one: {
+          initial: 'two',
+          entry: () => actual.push('entered one'),
+          states: {
+            two: {
+              entry: () => actual.push('entered two')
+            },
+            three: {
+              entry: () => actual.push('entered three'),
+              always: '#end'
+            }
+          },
+          every: {
+            10: '.three'
+          }
+        },
+        end: {
+          id: 'end',
+          type: 'final'
+        }
+      }
+    });
+
+    interpret(machine)
+      .onDone(() => {
+        expect(actual).toEqual(['entered one', 'entered two', 'entered three']);
+        done();
+      })
+      .start();
+  });
+
+  it('should defer a single send event for a periodic transition with multiple conditions (#886)', () => {
+    type Events = { type: 'FOO' };
+
+    const machine = createMachine<{}, Events>({
+      initial: 'X',
+      states: {
+        X: {
+          on: {
+            FOO: 'X'
+          },
+          every: {
+            1500: [
+              {
+                target: 'Y',
+                cond: () => true
+              },
+              {
+                target: 'Z'
+              }
+            ]
+          }
+        },
+        Y: {},
+        Z: {}
+      }
+    });
+
+    expect(machine.initialState.actions.length).toBe(1);
+  });
+
+  it('should execute a periodic event after starting from a persisted state', (done) => {
+    const createMyMachine = () =>
+      createMachine({
+        initial: 'A',
+        states: {
+          A: {
+            on: {
+              NEXT: 'B'
+            }
+          },
+          B: {
+            every: {
+              1: 'C'
+            }
+          },
+          C: {
+            type: 'final'
+          }
+        }
+      });
+
+    let service = interpret(createMyMachine()).start();
+
+    const persistedState = State.create(
+      JSON.parse(JSON.stringify(service.state))
+    );
+
+    service = interpret(createMyMachine()).start(persistedState);
+
+    service.send({ type: 'NEXT' });
+
+    service.onDone(() => done());
+  });
+
+  describe('period expressions', () => {
+    type Events =
+      | { type: 'ACTIVATE'; delay: number }
+      | { type: 'NOEXPR'; delay: number };
+    const delayExprMachine = createMachine<{ period: number }, Events>(
+      {
+        id: 'delayExpr',
+        initial: 'inactive',
+        context: {
+          period: 1000
+        },
+        states: {
+          inactive: {
+            every: [
+              {
+                period: (ctx) => ctx.period,
+                target: 'active'
+              }
+            ],
+            on: {
+              ACTIVATE: 'active',
+              NOEXPR: 'activeNoExpr'
+            }
+          },
+          active: {
+            every: [
+              {
+                period: 'somePeriod',
+                target: 'inactive'
+              }
+            ]
+          },
+          activeNoExpr: {
+            every: [
+              {
+                period: 'nonExistantPeriod',
+                target: 'inactive'
+              }
+            ]
+          }
+        }
+      },
+      {
+        periods: {
+          somePeriod: (ctx, event) => ctx.period + (event as any).period
+        }
+      }
+    );
+
+    it('should evaluate the expression (function) to determine the period', () => {
+      const { initialState } = delayExprMachine;
+
+      const sendActions = initialState.actions.filter(
+        (a) => a.type === actionTypes.send
+      );
+
+      expect(sendActions.length).toBe(1);
+
+      expect(sendActions[0].period).toEqual(1000);
+    });
+  });
+});

--- a/packages/core/test/every.test.ts
+++ b/packages/core/test/every.test.ts
@@ -19,7 +19,7 @@ const lightMachine = createMachine({
       }
     },
     red: {
-      every: [{ period: 1000, target: 'green' }]
+      every: [{ interval: 1000, target: 'green' }]
     }
   }
 });
@@ -167,18 +167,18 @@ describe('periodic events', () => {
     type Events =
       | { type: 'ACTIVATE'; delay: number }
       | { type: 'NOEXPR'; delay: number };
-    const delayExprMachine = createMachine<{ period: number }, Events>(
+    const delayExprMachine = createMachine<{ interval: number }, Events>(
       {
         id: 'delayExpr',
         initial: 'inactive',
         context: {
-          period: 1000
+          interval: 1000
         },
         states: {
           inactive: {
             every: [
               {
-                period: (ctx) => ctx.period,
+                interval: (ctx) => ctx.interval,
                 target: 'active'
               }
             ],
@@ -190,7 +190,7 @@ describe('periodic events', () => {
           active: {
             every: [
               {
-                period: 'somePeriod',
+                interval: 'somePeriod',
                 target: 'inactive'
               }
             ]
@@ -198,7 +198,7 @@ describe('periodic events', () => {
           activeNoExpr: {
             every: [
               {
-                period: 'nonExistantPeriod',
+                interval: 'nonExistantPeriod',
                 target: 'inactive'
               }
             ]
@@ -206,8 +206,8 @@ describe('periodic events', () => {
         }
       },
       {
-        periods: {
-          somePeriod: (ctx, event) => ctx.period + (event as any).period
+        intervals: {
+          somePeriod: (ctx, event) => ctx.interval + (event as any).interval
         }
       }
     );
@@ -221,7 +221,7 @@ describe('periodic events', () => {
 
       expect(sendActions.length).toBe(1);
 
-      expect(sendActions[0].period).toEqual(1000);
+      expect(sendActions[0].interval).toEqual(1000);
     });
   });
 });


### PR DESCRIPTION
Hello 👋

This PR makes possible to add an `every` event that will trigger an event/transition recurrently after each period.

```
const lightPeriodsMachine = createMachine({
  id: 'lightPeriod',
  initial: 'green',
  context: {
    timeSpentInGreen: 0,
    timeSpentInYellow: 0
  },
  states: {
    green: {
      every: {
        // every 1 second, timeSpentInGreen will be increased by 1 second
        1000: {
          actions: assign({
            timeSpentInGreen: (context) => context.timeSpentInGreen + 1
          })
        }
      },
      on: {
        GO_TO_YELLOW: 'yellow'
      }
    },
    yellow: {
      every: {
        // every 0.5 seconds, timeSpentInYellow will be increased by 0.5 seconds
        500: {
          actions: assign({
            timeSpentInYellow: (context) => context.timeSpentInYellow + 0.5
          })
        }
      }
    }
  }
});
```

https://www.itemis.com/en/yakindu/state-machine/documentation/user-guide/sclang_reactions#sclang_reaction_trigger_every

