### PR TITLE
Docs: fixes links with badges in the tables of content

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,3 +1,11 @@
+const { slugify } = require('@vuepress/shared-utils');
+
+// TODO: remove once https://github.com/vuejs/vuepress/issues/1985 will be fixed
+function slugifyWithBadges(str) {
+  // remove badges and use original slugify function
+  return slugify(str.replace(/<Badge[^>]*\/>/, ''));
+}
+
 module.exports = {
   title: 'XState Docs',
   base: '/docs/',
@@ -20,7 +28,7 @@ module.exports = {
     }
   },
   markdown: {
-    toc: { includeLevel: [2, 3] }
+    toc: { includeLevel: [2, 3], slugify: slugifyWithBadges }
   },
   head: [
     ['script', { src: 'https://plausible.io/js/plausible.js', defer: 'defer' }]


### PR DESCRIPTION
Fixes https://github.com/statelyai/xstate/issues/3224

It's caused by long-standing issue in vuepress + markdown-it-table-of-contents: https://github.com/vuejs/vuepress/issues/1985

PR https://github.com/vuejs/vuepress/pull/2210 might fix it, but it's abandoned