### PR TITLE
Fixed an issue with reentrancy during external transition when targeting a history state

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -97,6 +97,7 @@ import {
   getConfiguration,
   has,
   getChildren,
+  getAllChildren,
   getAllStateNodes,
   isInFinalState,
   isLeafNode,
@@ -379,7 +380,7 @@ class StateNode<
     ): void {
       stateNode.order = order++;
 
-      for (const child of getChildren(stateNode)) {
+      for (const child of getAllChildren(stateNode)) {
         dfs(child);
       }
     }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -15,12 +15,16 @@ export const isLeafNode = (
   stateNode: StateNode<any, any, any, any, any, any>
 ) => stateNode.type === 'atomic' || stateNode.type === 'final';
 
+export function getAllChildren<TC, TE extends EventObject>(
+  stateNode: StateNode<TC, any, TE>
+): Array<StateNode<TC, any, TE>> {
+  return Object.keys(stateNode.states).map((key) => stateNode.states[key]);
+}
+
 export function getChildren<TC, TE extends EventObject>(
   stateNode: StateNode<TC, any, TE>
 ): Array<StateNode<TC, any, TE>> {
-  return Object.keys(stateNode.states)
-    .map((key) => stateNode.states[key])
-    .filter((sn) => sn.type !== 'history');
+  return getAllChildren(stateNode).filter((sn) => sn.type !== 'history');
 }
 
 export function getAllStateNodes<TC, TE extends EventObject>(

--- a/packages/core/test/history.test.ts
+++ b/packages/core/test/history.test.ts
@@ -120,6 +120,46 @@ describe('history states', () => {
 
     expect(service.state.value).toEqual({ idle: 'absent' });
   });
+
+  it('should reenter persisted state during external transition targeting a history state', () => {
+    const actual: string[] = [];
+
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            REENTER: '#b_hist'
+          },
+          initial: 'a1',
+          states: {
+            a1: {
+              on: {
+                NEXT: 'a2'
+              }
+            },
+            a2: {
+              entry: () => actual.push('a2 entered'),
+              exit: () => actual.push('a2 exited')
+            },
+            a3: {
+              type: 'history',
+              id: 'b_hist'
+            }
+          }
+        }
+      }
+    });
+
+    const service = interpret(machine).start();
+
+    service.send({ type: 'NEXT' });
+
+    actual.length = 0;
+    service.send({ type: 'REENTER' });
+
+    expect(actual).toEqual(['a2 exited', 'a2 entered']);
+  });
 });
 
 describe('deep history states', () => {


### PR DESCRIPTION
Fixes a regression from https://github.com/statelyai/xstate/pull/3424/files#diff-7f553f4d4c285f1c05cced2e979c5b957d8884e39e74cc6797b32c63a0be7e7aR981 where I've started using `.order` to compare source and target positions in the tree. This has not yet been published so we don't need to add a changeset.

I've removed `.order` from history nodes here: https://github.com/statelyai/xstate/pull/3171/files#r834036363 but back then it was OK because `.order` wasn't actually used in a meaningful way that would impact history states.