### PR TITLE
[core] Better type information for `state.nextEvents`

### DIFF
--- a/.changeset/spotty-trainers-march.md
+++ b/.changeset/spotty-trainers-march.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The types for `state.nextEvents` are now properly typed to the actual event types of the machine. Original PR: #1115 (Thanks @alexreardon!)

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -4,7 +4,6 @@ import {
   EventObject,
   HistoryValue,
   ActionObject,
-  EventType,
   StateValueMap,
   StateConfig,
   SCXML,
@@ -130,7 +129,7 @@ export class State<
    * The next events that will cause a transition from the current state.
    */
   // @ts-ignore - getter for this gets configured in constructor so this property can stay non-enumerable
-  public nextEvents: EventType[];
+  public nextEvents: Array<TEvent['type']>;
   /**
    * The transition definitions that resulted in this state.
    */


### PR DESCRIPTION
Originally authored by @alexreardon #1115