### PR TITLE
Call subscription.complete on interpreter stop

### DIFF
--- a/.changeset/pretty-dots-push.md
+++ b/.changeset/pretty-dots-push.md
@@ -1,0 +1,5 @@
+---
+"xstate": patch
+---
+
+Call the `complete` callback of the subscribed `observer` when an interpreter gets stopped.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -699,20 +699,20 @@ export function toInvokeSource(
 }
 
 export function toObserver<T>(
-  nextHandler: Observer<T> | ((value: T) => void),
+  nextHandler?: Partial<Observer<T>> | ((value: T) => void),
   errorHandler?: (error: any) => void,
   completionHandler?: () => void
 ): Observer<T> {
-  if (typeof nextHandler === 'object') {
-    return nextHandler;
-  }
-
-  const noop = () => void 0;
+  const noop = () => {};
+  const isObserver = typeof nextHandler === 'object';
+  const self = isObserver ? nextHandler : null;
 
   return {
-    next: nextHandler,
-    error: errorHandler || noop,
-    complete: completionHandler || noop
+    next: ((isObserver ? nextHandler.next : nextHandler) || noop).bind(self),
+    error: ((isObserver ? nextHandler.error : errorHandler) || noop).bind(self),
+    complete: (
+      (isObserver ? nextHandler.complete : completionHandler) || noop
+    ).bind(self)
   };
 }
 

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1750,6 +1750,44 @@ Event: {\\"type\\":\\"SOME_EVENT\\"}"
       service.send('INC');
       service.send('INC');
     });
+
+    it('should call complete() once a final state is reached', (done) => {
+      const mockNextCb = jest.fn();
+      const mockCompleteCb = jest.fn();
+
+      const intervalService = interpret(intervalMachine).start();
+
+      intervalService.subscribe(mockNextCb, undefined, mockCompleteCb);
+
+      intervalService.onStop(() => {
+        expect(mockNextCb.mock.calls.length).toBe(6);
+        expect(mockCompleteCb.mock.calls.length).toBe(1);
+        done();
+      });
+    });
+
+    it('should call complete() once the interpreter is stopped', (done) => {
+      let count = 0;
+      const mockNextCb = jest.fn();
+      const mockCompleteCb = jest.fn();
+
+      const intervalService = interpret(intervalMachine).start();
+
+      intervalService.subscribe(mockNextCb, undefined, mockCompleteCb);
+
+      intervalService.onTransition(() => {
+        count += 1;
+        if (count === 2) {
+          intervalService.stop();
+        }
+      });
+
+      intervalService.onStop(() => {
+        expect(mockNextCb.mock.calls.length).toBe(2);
+        expect(mockCompleteCb.mock.calls.length).toBe(1);
+        done();
+      });
+    });
   });
 
   describe('services', () => {


### PR DESCRIPTION
When an interpreter is stoped, [all listeners get removed](https://github.com/statelyai/xstate/blob/6badd2ba3642391bee640aa4914003ad57f2e703/packages/core/src/interpreter.ts#L559-L562), therefore a potential subscription should complete.

Closes: #3452