### PR TITLE
Run `pull_request` workflow on its latest commit

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -17,5 +17,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request && github.event.pull_request.head.sha || env.GITHUB_SHA }}
       - uses: ./.github/actions/ci-setup
       - uses: ./.github/actions/ci-checks


### PR DESCRIPTION
I can't say that I've tested this thoroughly but I checked the GitHub docs and more and I think that it should work.

This is also mentioned here in the `actions/checkout` docs [here](https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit). But since we are using the same workflow for both push and pull_request triggers we need to conditionally create the desired SHA.