### PR TITLE
Fixed an issue with `useSelector` always computing fresh snapshots internally for uninitialized services

### DIFF
--- a/.changeset/weak-singers-jog.md
+++ b/.changeset/weak-singers-jog.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+Fixed an issue with `useSelector` always computing fresh snapshots internally for uninitialized services. This avoids the internal `useSyncExternalStore` from warning about the snapshot value not being cached properly.

--- a/packages/xstate-react/src/useSelector.ts
+++ b/packages/xstate-react/src/useSelector.ts
@@ -11,6 +11,7 @@ function isService(actor: any): actor is Interpreter<any, any, any, any> {
 const defaultCompare = (a, b) => a === b;
 const defaultGetSnapshot = (a, initialStateCacheRef) => {
   if (isService(a)) {
+    // A status of 0 = interpreter not started
     if (a.status === 0 && initialStateCacheRef.current) {
       return initialStateCacheRef.current;
     }

--- a/packages/xstate-react/src/useSelector.ts
+++ b/packages/xstate-react/src/useSelector.ts
@@ -1,6 +1,6 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
-import { ActorRef, Interpreter, Subscribable } from 'xstate';
+import { ActorRef, AnyState, Interpreter, Subscribable } from 'xstate';
 import { isActorWithState } from './useActor';
 import { getServiceSnapshot } from './utils';
 
@@ -9,12 +9,17 @@ function isService(actor: any): actor is Interpreter<any, any, any, any> {
 }
 
 const defaultCompare = (a, b) => a === b;
-const defaultGetSnapshot = (a) =>
-  isService(a)
-    ? getServiceSnapshot(a)
-    : isActorWithState(a)
-    ? a.state
-    : undefined;
+const defaultGetSnapshot = (a, initialStateCacheRef) => {
+  if (isService(a)) {
+    if (a.status === 0 && initialStateCacheRef.current) {
+      return initialStateCacheRef.current;
+    }
+    const snapshot = getServiceSnapshot(a);
+    initialStateCacheRef.current = a.status === 0 ? snapshot : null;
+    return snapshot;
+  }
+  return isActorWithState(a) ? a.state : undefined;
+};
 
 export function useSelector<
   TActor extends ActorRef<any, any>,
@@ -24,8 +29,10 @@ export function useSelector<
   actor: TActor,
   selector: (emitted: TEmitted) => T,
   compare: (a: T, b: T) => boolean = defaultCompare,
-  getSnapshot: (a: TActor) => TEmitted = defaultGetSnapshot
+  getSnapshot?: (a: TActor) => TEmitted
 ): T {
+  const initialStateCacheRef = useRef<AnyState | null>(null);
+
   const subscribe = useCallback(
     (handleStoreChange) => {
       const { unsubscribe } = actor.subscribe(handleStoreChange);
@@ -34,10 +41,12 @@ export function useSelector<
     [actor]
   );
 
-  const boundGetSnapshot = useCallback(() => getSnapshot(actor), [
-    actor,
-    getSnapshot
-  ]);
+  const boundGetSnapshot = useCallback(() => {
+    if (getSnapshot) {
+      return getSnapshot(actor);
+    }
+    return defaultGetSnapshot(actor, initialStateCacheRef);
+  }, [actor, getSnapshot]);
 
   const selectedSnapshot = useSyncExternalStoreWithSelector(
     subscribe,


### PR DESCRIPTION
closes #3497