### PR TITLE
Fixed an issue with `.nextState(event)` calls accidentally executing actions in machines with `predictableActionArguments`

### DIFF
--- a/.changeset/olive-books-mate.md
+++ b/.changeset/olive-books-mate.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with `.nextState(event)` calls accidentally executing actions in machines with `predictableActionArguments`.

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -726,7 +726,7 @@ export class Interpreter<
       // Forward copy of event to child actors
       this.forward(_event);
 
-      const nextState = this.nextState(_event);
+      const nextState = this._nextState(_event);
 
       this.update(nextState, _event);
     });
@@ -851,7 +851,10 @@ export class Interpreter<
     }
   };
 
-  private _nextState(event: Event<TEvent> | SCXML.Event<TEvent>) {
+  private _nextState(
+    event: Event<TEvent> | SCXML.Event<TEvent>,
+    exec = !!this.machine.config.predictableActionArguments && this._exec
+  ) {
     const _event = toSCXMLEvent(event);
 
     if (
@@ -868,7 +871,7 @@ export class Interpreter<
         this.state,
         _event,
         undefined,
-        this.machine.config.predictableActionArguments ? this._exec : undefined
+        exec || undefined
       );
     });
 
@@ -885,7 +888,7 @@ export class Interpreter<
   public nextState(
     event: Event<TEvent> | SCXML.Event<TEvent>
   ): State<TContext, TEvent, TStateSchema, TTypestate, TResolvedTypesMeta> {
-    return this._nextState(event);
+    return this._nextState(event, false);
   }
 
   private forward(event: SCXML.Event<TEvent>): void {

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -548,4 +548,22 @@ describe('predictableExec', () => {
 
     expect(actual).toEqual([0, 1, 2]);
   });
+
+  it('`.nextState()` should not execute actions `predictableActionArguments`', () => {
+    let spy = jest.fn();
+
+    const machine = createMachine({
+      predictableActionArguments: true,
+      on: {
+        TICK: {
+          actions: spy
+        }
+      }
+    });
+
+    const service = interpret(machine).start();
+    service.nextState({ type: 'TICK' });
+
+    expect(spy).not.toBeCalled();
+  });
 });


### PR DESCRIPTION
fixes #3510
@richtera