### PR TITLE
Remove `@vue/vue3-jest` workaround for its `tsconfig` loading logic

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -19,10 +19,7 @@ module.exports = {
       transform: {
         '^typescript$': 'babel-jest',
         '^tsx?$': 'babel-jest'
-      },
-      // https://github.com/vuejs/vue-jest/issues/431
-      // redirect tsconfig lookup elsewhere so vue-jest doesn't attempt to load ts-jest at all
-      tsConfig: os.tmpdir()
+      }
     }
   },
   watchPlugins: [

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^12.11.1",
     "@types/use-subscription": "^1.0.0",
     "@vue/compiler-sfc": "^3.0.11",
-    "@vue/vue3-jest": "^26.0.1",
+    "@vue/vue3-jest": "^28.1.0",
     "babel-jest": "^26",
     "gh-pages": "^2.0.1",
     "husky": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2678,15 +2678,15 @@
   resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-2.0.0-rc.4.tgz#536175be968e7c5741e9c95f117024d5053ea54c"
   integrity sha512-DocrrFP28M7NO7y7iGiX9sf9n1AKEqkxXO5wedtp5FkHiAkc0xfmD4lvxgi4re5+xw7Zzb9U/vrhXKQZ0I4Q9g==
 
-"@vue/vue3-jest@^26.0.1":
-  version "26.0.1"
-  resolved "https://registry.yarnpkg.com/@vue/vue3-jest/-/vue3-jest-26.0.1.tgz#210f2214d305da33f5e4211be00e650e5f38becd"
-  integrity sha512-VO9c9exVaVkJIWjVlN7TGg/KNRsN52k2it/ovm3t2GSXc7yxbDpysCVR2nc36A84So6PnHaso57R7L+tc1fRXA==
+"@vue/vue3-jest@^28.1.0":
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/@vue/vue3-jest/-/vue3-jest-28.1.0.tgz#2f0d0c02d5862b02be0aa499e3191086e2e732fb"
+  integrity sha512-A4Ek39u0KtVlUBwzio6DZld8egggTr8JPrSUcHllX4X96LsQUJReyIgPf+sMVCfpNeZUBDqbZ4QHhudBHa9Xzw==
   dependencies:
     "@babel/plugin-transform-modules-commonjs" "^7.2.0"
     chalk "^2.1.0"
     convert-source-map "^1.6.0"
-    extract-from-css "^0.4.4"
+    css-tree "^2.0.1"
     source-map "0.5.6"
     tsconfig "^7.0.0"
 
@@ -3742,20 +3742,18 @@ cross-spawn@^7.0.0:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+css-tree@^2.0.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-2.2.1.tgz#36115d382d60afd271e377f9c5f67d02bd48c032"
+  integrity sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==
+  dependencies:
+    mdn-data "2.0.28"
+    source-map-js "^1.0.1"
+
 css.escape@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
-
-css@^2.1.0:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/css/-/css-2.2.4.tgz#c646755c73971f2bba6a601e2cf2fd71b1298929"
-  integrity sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==
-  dependencies:
-    inherits "^2.0.3"
-    source-map "^0.6.1"
-    source-map-resolve "^0.5.2"
-    urix "^0.1.0"
 
 css@^3.0.0:
   version "3.0.0"
@@ -4362,13 +4360,6 @@ extglob@^2.0.4:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
-
-extract-from-css@^0.4.4:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/extract-from-css/-/extract-from-css-0.4.4.tgz#1ea7df2e7c7c6eb9922fa08e8adaea486f6f8f92"
-  integrity sha1-HqffLnx8brmSL6COitrqSG9vj5I=
-  dependencies:
-    css "^2.1.0"
 
 extsprintf@1.3.0:
   version "1.3.0"
@@ -7071,6 +7062,11 @@ matcher@^1.0.0:
   dependencies:
     escape-string-regexp "^1.0.4"
 
+mdn-data@2.0.28:
+  version "2.0.28"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.28.tgz#5ec48e7bef120654539069e1ae4ddc81ca490eba"
+  integrity sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"
@@ -8867,7 +8863,12 @@ sort-keys@^1.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-map-resolve@^0.5.0, source-map-resolve@^0.5.2:
+source-map-js@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
+
+source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
   integrity sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==


### PR DESCRIPTION
⚠️ this currently doesn't work as it requires us to also update Jest itself. I don't want to do it right now, I'm just creating this PR as a draft and a reminder to get to this eventually.