### PR TITLE
Fixed an issue with not being able to read the updated snapshot of a child when receiving and processing events from it and when using `predictableActionArguments` flag

### DIFF
--- a/.changeset/tiny-carrots-tease.md
+++ b/.changeset/tiny-carrots-tease.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with not being able to read the updated snapshot of a child when receiving and processing events from it and when using `predictableActionArguments` flag.


### PR DESCRIPTION
fixes #3533