### PR TITLE
allow action `type` strings in `pure` return array

### DIFF
--- a/.changeset/seven-ducks-look.md
+++ b/.changeset/seven-ducks-look.md
@@ -1,0 +1,24 @@
+---
+'xstate': patch
+---
+
+pr: #3545
+author: @with-heart
+
+Updated `pure` action types to allow action `type` strings to be returned in the array.
+
+```ts
+const machine = createMachine(
+  {
+    entry: ['doStuff']
+  },
+  {
+    actions: {
+      doStuff: pure(() => ['someAction']),
+      someAction: () => console.log('executed by doStuff')
+    }
+  }
+);
+```
+
+Returning action `type` strings were already handled by `xstate` and the types now correctly reflect that.

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -544,7 +544,9 @@ export function pure<TContext, TEvent extends EventObject>(
     context: TContext,
     event: TEvent
   ) =>
-    | SingleOrArray<ActionObject<TContext, TEvent> | TEvent['type']>
+    | SingleOrArray<
+        ActionObject<TContext, TEvent> | ActionObject<TContext, TEvent>['type']
+      >
     | undefined
 ): PureAction<TContext, TEvent> {
   return {

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -543,7 +543,9 @@ export function pure<TContext, TEvent extends EventObject>(
   getActions: (
     context: TContext,
     event: TEvent
-  ) => SingleOrArray<ActionObject<TContext, TEvent>> | undefined
+  ) =>
+    | SingleOrArray<ActionObject<TContext, TEvent> | TEvent['type']>
+    | undefined
 ): PureAction<TContext, TEvent> {
   return {
     type: ActionTypes.Pure,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1375,7 +1375,9 @@ export interface PureAction<TContext, TEvent extends EventObject>
     context: TContext,
     event: TEvent
   ) =>
-    | SingleOrArray<ActionObject<TContext, TEvent> | TEvent['type']>
+    | SingleOrArray<
+        ActionObject<TContext, TEvent> | ActionObject<TContext, TEvent>['type']
+      >
     | undefined;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1374,7 +1374,9 @@ export interface PureAction<TContext, TEvent extends EventObject>
   get: (
     context: TContext,
     event: TEvent
-  ) => SingleOrArray<ActionObject<TContext, TEvent>> | undefined;
+  ) =>
+    | SingleOrArray<ActionObject<TContext, TEvent> | TEvent['type']>
+    | undefined;
 }
 
 export interface ChooseAction<TContext, TEvent extends EventObject>

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1585,7 +1585,8 @@ describe('purely defined actions', () => {
   type Events =
     | { type: 'SINGLE'; id: number }
     | { type: 'NONE'; id: number }
-    | { type: 'EACH' };
+    | { type: 'EACH' }
+    | { type: 'AS_STRINGS' };
 
   const dynamicMachine = Machine<Ctx, Events>({
     id: 'dynamic',
@@ -1626,6 +1627,9 @@ describe('purely defined actions', () => {
                 index
               }))
             )
+          },
+          AS_STRINGS: {
+            actions: pure<any, any>(() => ['SOME_ACTION'])
           }
         }
       }
@@ -1679,6 +1683,15 @@ describe('purely defined actions', () => {
         index: 2
       }
     ]);
+  });
+
+  it('should allow for purely defined action type strings', () => {
+    const nextState = dynamicMachine.transition(
+      dynamicMachine.initialState,
+      'AS_STRINGS'
+    );
+
+    expect(nextState.actions).toEqual([{ type: 'SOME_ACTION' }]);
   });
 });
 


### PR DESCRIPTION
This PR allows action `type` strings to be returned from the `getActions` argument of `pure`. `xstate` already handles action strings correctly but the types don't match that functionality.

This PR pairs well with statelyai/xstate-tools#207