### PR TITLE
Fixed an issue with not being able to send events to initially started child actors when using `predictableActionArguments`

### DIFF
--- a/.changeset/lovely-terms-yell.md
+++ b/.changeset/lovely-terms-yell.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with not being able to send events to initially started child actors when using `predictableActionArguments`.


### PR DESCRIPTION
fixes https://github.com/statelyai/xstate/issues/3548