### PR TITLE
Remove `predictableActionArguments` warning

### DIFF
--- a/.changeset/silver-mayflies-speak.md
+++ b/.changeset/silver-mayflies-speak.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The warning for setting `predictableActionArguments` has been removed. It is recommended that you set it to `true` only if you need this behavior.

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -17,9 +17,6 @@ import {
   TypegenDisabled,
   ResolveTypegenMeta
 } from './typegenTypes';
-import { IS_PRODUCTION } from './environment';
-
-let warned = false;
 
 /**
  * @deprecated Use `createMachine(...)` instead.
@@ -142,11 +139,5 @@ export function createMachine<
   TServiceMap,
   TTypesMeta
 > {
-  if (!IS_PRODUCTION && !config.predictableActionArguments && !warned) {
-    warned = true;
-    console.warn(
-      'It is highly recommended to set `predictableActionArguments` to `true` when using `createMachine`. https://xstate.js.org/docs/guides/actions.html'
-    );
-  }
   return new StateNode(config, options as any) as any;
 }


### PR DESCRIPTION
This PR removes this warning:

> It is highly recommended to set `predictableActionArguments` to `true` when using `createMachine`. https://xstate.js.org/docs/guides/actions.html 

Setting this to `true` is really intended to _fix_ behaviors related to action argument predictability. IMO it is best if this is only set this to `true` if it fixes an existing problem.