### PR TITLE
[core] Allow actor names in `sendTo(...)`

### DIFF
--- a/.changeset/mean-kiwis-juggle.md
+++ b/.changeset/mean-kiwis-juggle.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The `sendTo(actorName, event)` action creator now accepts a string `actorName`.

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -292,7 +292,7 @@ export function sendTo<
   TEvent extends EventObject,
   TActor extends AnyActorRef
 >(
-  actor: string | ((ctx: TContext) => TActor),
+  actor: string | TActor | ((ctx: TContext) => TActor),
   event:
     | EventFrom<TActor>
     | SendExpr<

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -292,7 +292,7 @@ export function sendTo<
   TEvent extends EventObject,
   TActor extends AnyActorRef
 >(
-  actor: (ctx: TContext) => TActor,
+  actor: string | ((ctx: TContext) => TActor),
   event:
     | EventFrom<TActor>
     | SendExpr<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1314,7 +1314,10 @@ export enum SpecialTargets {
 export interface SendActionOptions<TContext, TEvent extends EventObject> {
   id?: string | number;
   delay?: number | string | DelayExpr<TContext, TEvent>;
-  to?: string | ExprWithMeta<TContext, TEvent, string | number | ActorRef<any>>;
+  to?:
+    | string
+    | ActorRef<any>
+    | ExprWithMeta<TContext, TEvent, string | number | ActorRef<any>>;
 }
 
 export interface CancelAction extends ActionObject<any, any> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1317,7 +1317,7 @@ export interface SendActionOptions<TContext, TEvent extends EventObject> {
   to?:
     | string
     | ActorRef<any>
-    | ExprWithMeta<TContext, TEvent, string | number | ActorRef<any>>;
+    | ExprWithMeta<TContext, TEvent, string | ActorRef<any>>;
 }
 
 export interface CancelAction extends ActionObject<any, any> {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2281,6 +2281,39 @@ describe('sendTo', () => {
 
     interpret(parentMachine).start();
   });
+
+  it('should be able to send an event directly to an ActorRef', (done) => {
+    const childMachine = createMachine<any, { type: 'EVENT' }>({
+      initial: 'waiting',
+      states: {
+        waiting: {
+          on: {
+            EVENT: {
+              actions: () => done()
+            }
+          }
+        }
+      }
+    });
+
+    const parentMachine = createMachine<{
+      child: ActorRefFrom<typeof childMachine>;
+    }>({
+      context: () => ({
+        child: spawn(childMachine)
+      }),
+      entry: pure<
+        {
+          child: ActorRefFrom<typeof childMachine>;
+        },
+        any
+      >((ctx) => {
+        return [sendTo(ctx.child, { type: 'EVENT' })];
+      })
+    });
+
+    interpret(parentMachine).start();
+  });
 });
 
 it('should call transition actions in document order for same-level parallel regions', () => {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2254,6 +2254,33 @@ describe('sendTo', () => {
       })
     });
   });
+
+  it('should be able to send an event to a named actor', (done) => {
+    const childMachine = createMachine<any, { type: 'EVENT' }>({
+      initial: 'waiting',
+      states: {
+        waiting: {
+          on: {
+            EVENT: {
+              actions: () => done()
+            }
+          }
+        }
+      }
+    });
+
+    const parentMachine = createMachine<{
+      child: ActorRefFrom<typeof childMachine>;
+    }>({
+      context: () => ({
+        child: spawn(childMachine, 'child')
+      }),
+      // No type-safety for the event yet
+      entry: sendTo('child', { type: 'EVENT' })
+    });
+
+    interpret(parentMachine).start();
+  });
 });
 
 it('should call transition actions in document order for same-level parallel regions', () => {


### PR DESCRIPTION
The `sendTo(actorName, event)` action creator now accepts a string `actorName`:

```js
actions: sendTo('someNamedActor', { type: 'someEvent' })
```