### PR TITLE
add support for action groups

### DIFF
--- a/.changeset/wicked-pandas-add.md
+++ b/.changeset/wicked-pandas-add.md
@@ -2,25 +2,33 @@
 'xstate': minor
 ---
 
-An action can now be defined as an "action group", which is an array of action `type` strings pointing to other actions that will be executed when the group is executed. This allows you to define named groups of actions that are executed together.
+An action can now be defined as an "action group" which is an array of actions that will be executed when the group action is executed. This allows you to define named groups of actions that are executed together.
 
 ```js
 const machine = createMachine(
   {
+    context: { value: '' },
     on: {
-      event: { actions: 'group' }
+      valueUpdated: { actions: 'updateValue' }
     }
   },
   {
     actions: {
-      group: ['action1', 'action2'],
-      action1: () => console.log('action 1'),
-      action2: () => console.log('action 2')
+      updateValue: [
+        assign({
+          value: (_context, event) => event.value
+        }),
+        'capitalizeValue',
+        (context) => console.log(`Value: ${context.value}`)
+      ],
+      capitalizeValue: assign({
+        value: (context) => context.value.toUpperCase()
+      })
     }
   }
 );
 
 const service = interpret(machine).start();
 
-service.send(service, 'event'); // "action 1", "action 2"
+service.send({ type: 'valueUpdated', value: 'hello' }); // logs "Value: HELLO"
 ```

--- a/.changeset/wicked-pandas-add.md
+++ b/.changeset/wicked-pandas-add.md
@@ -1,0 +1,26 @@
+---
+'xstate': minor
+---
+
+An action can now be defined as an "action group", which is an array of action `type` strings pointing to other actions that will be executed when the group is executed. This allows you to define named groups of actions that are executed together.
+
+```js
+const machine = createMachine(
+  {
+    on: {
+      event: { actions: 'group' }
+    }
+  },
+  {
+    actions: {
+      group: ['action1', 'action2'],
+      action1: () => console.log('action 1'),
+      action2: () => console.log('action 2')
+    }
+  }
+);
+
+const service = interpret(machine).start();
+
+service.send(service, 'event'); // "action 1", "action 2"
+```

--- a/docs/guides/actions.md
+++ b/docs/guides/actions.md
@@ -214,27 +214,35 @@ entry: send({ type: 'SOME_EVENT' });
 
 ## Action groups
 
-An action can be defined as an "action group", which is an array of action `type` strings pointing to other actions that will be executed when the group is executed. This allows you to define named groups of actions that are executed together.
+An action can be defined as an "action group" which is an array of actions that will be executed when the group action is executed. This allows you to define named groups of actions that are executed together.
 
 ```js
 const machine = createMachine(
   {
+    context: { value: '' },
     on: {
-      event: { actions: 'group' }
+      valueUpdated: { actions: 'updateValue' }
     }
   },
   {
     actions: {
-      group: ['action1', 'action2'],
-      action1: () => console.log('action 1'),
-      action2: () => console.log('action 2')
+      updateValue: [
+        assign({
+          value: (_context, event) => event.value
+        }),
+        'capitalizeValue',
+        (context) => console.log(`Value: ${context.value}`)
+      ],
+      capitalizeValue: assign({
+        value: (context) => context.value.toUpperCase()
+      })
     }
   }
 );
 
 const service = interpret(machine).start();
 
-service.send(service, 'event'); // "action 1", "action 2"
+service.send({ type: 'valueUpdated', value: 'hello' }); // logs "Value: HELLO"
 ```
 
 ::: tip

--- a/packages/core/src/actionTypes.ts
+++ b/packages/core/src/actionTypes.ts
@@ -19,3 +19,4 @@ export const error = ActionTypes.ErrorCustom;
 export const update = ActionTypes.Update;
 export const choose = ActionTypes.Choose;
 export const pure = ActionTypes.Pure;
+export const actionGroup = ActionTypes.ActionGroup;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -754,7 +754,15 @@ export type ActionFunctionMap<
         TEvent,
         TAction extends { type: K } ? TAction : never
       >
-    | Array<K>;
+    | Array<
+        | ActionObject<TContext, TEvent>
+        | ActionFunction<
+            TContext,
+            TEvent,
+            TAction extends { type: K } ? TAction : never
+          >
+        | K
+      >;
 };
 
 export type DelayFunctionMap<TContext, TEvent extends EventObject> = Record<
@@ -791,7 +799,18 @@ type MachineOptionsActions<
         Cast<Prop<TIndexedEvents, TEventsCausingActions[K]>, EventObject>,
         Cast<Prop<TIndexedActions, K>, BaseActionObject>
       >
-    | Array<Cast<Prop<TIndexedActions, K>, BaseActionObject>['type']>;
+    | Array<
+        | ActionObject<
+            TContext,
+            Cast<Prop<TIndexedEvents, TEventsCausingActions[K]>, EventObject>
+          >
+        | ActionFunction<
+            TContext,
+            Cast<Prop<TIndexedEvents, TEventsCausingActions[K]>, EventObject>,
+            Cast<Prop<TIndexedActions, K>, BaseActionObject>
+          >
+        | keyof TEventsCausingActions
+      >;
 };
 
 type MachineOptionsDelays<
@@ -1387,7 +1406,11 @@ export interface ActionGroupAction<
   TAction extends BaseActionObject
 > extends ActionObject<TContext, TEvent> {
   type: ActionTypes.ActionGroup;
-  actions: Array<TAction['type']>;
+  actions: Array<
+    | TAction['type']
+    | ActionObject<TContext, TEvent>
+    | ActionFunction<TContext, TEvent>
+  >;
 }
 
 export interface ChooseAction<TContext, TEvent extends EventObject>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -152,6 +152,7 @@ export type BaseAction<
   | CancelAction
   | StopAction<TContext, TEvent>
   | ChooseAction<TContext, TEvent>
+  | ActionGroupAction<TContext, TEvent, TAction>
   | ActionFunction<TContext, TEvent>;
 
 export type BaseActions<
@@ -752,7 +753,8 @@ export type ActionFunctionMap<
         TContext,
         TEvent,
         TAction extends { type: K } ? TAction : never
-      >;
+      >
+    | Array<K>;
 };
 
 export type DelayFunctionMap<TContext, TEvent extends EventObject> = Record<
@@ -788,7 +790,8 @@ type MachineOptionsActions<
         TContext,
         Cast<Prop<TIndexedEvents, TEventsCausingActions[K]>, EventObject>,
         Cast<Prop<TIndexedActions, K>, BaseActionObject>
-      >;
+      >
+    | Array<Cast<Prop<TIndexedActions, K>, BaseActionObject>['type']>;
 };
 
 type MachineOptionsDelays<
@@ -1169,7 +1172,8 @@ export enum ActionTypes {
   ErrorCustom = 'xstate.error',
   Update = 'xstate.update',
   Pure = 'xstate.pure',
-  Choose = 'xstate.choose'
+  Choose = 'xstate.choose',
+  ActionGroup = 'xstate.actionGroup'
 }
 
 export interface RaiseAction<TEvent extends EventObject> {
@@ -1375,6 +1379,15 @@ export interface PureAction<TContext, TEvent extends EventObject>
     context: TContext,
     event: TEvent
   ) => SingleOrArray<ActionObject<TContext, TEvent>> | undefined;
+}
+
+export interface ActionGroupAction<
+  TContext,
+  TEvent extends EventObject,
+  TAction extends BaseActionObject
+> extends ActionObject<TContext, TEvent> {
+  type: ActionTypes.ActionGroup;
+  actions: Array<TAction['type']>;
 }
 
 export interface ChooseAction<TContext, TEvent extends EventObject>

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1682,6 +1682,32 @@ describe('purely defined actions', () => {
   });
 });
 
+describe('action groups', () => {
+  it('should execute actions provided as type strings in a group', () => {
+    const action1 = jest.fn();
+    const action2 = jest.fn();
+
+    const machine = Machine(
+      {
+        entry: ['group1']
+      },
+      {
+        actions: {
+          group1: ['action1', 'action2', 'group2'],
+          group2: ['action1', 'action2'],
+          action1,
+          action2
+        }
+      }
+    );
+
+    interpret(machine).start();
+
+    expect(action1).toHaveBeenCalledTimes(2);
+    expect(action2).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('forwardTo()', () => {
   it('should forward an event to a service', (done) => {
     const child = Machine<void, { type: 'EVENT'; value: number }>({


### PR DESCRIPTION
Per discussion in #3554, this PR adds support for action groups.

This allows us to execute named (and possibly nested) groups of actions together:

```ts
const machine = createMachine(
  {
    entry: 'group',
  },
  {
    actions: {
      group: ['action1', 'group2'],
      group2: ['action2']
      action1: () => console.log('action1'),
      action2: () => console.log('action2'),
    },
  },
)

interpret(machine).start()

// "action1", "action2"
```
