### PR TITLE
Fixed an issue with not executing actions in response to received **batched** events when using `predictableActionArguments`

### DIFF
--- a/.changeset/silver-jokes-juggle.md
+++ b/.changeset/silver-jokes-juggle.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with not executing actions in response to received **batched** events when using `predictableActionArguments`.


### PR DESCRIPTION
reported by @richtera