### PR TITLE
[core] Deprecate `service.state`

### DIFF
--- a/.changeset/gold-kiwis-mate.md
+++ b/.changeset/gold-kiwis-mate.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Reading state directly from ~~`someService.state`~~ is deprecated. Use `someService.getSnapshot()` instead.

--- a/docs/fr/guides/actors.md
+++ b/docs/fr/guides/actors.md
@@ -73,7 +73,7 @@ Alternatively `spawn` accepts an options object as the second argument which may
 
 - `name` (optional) - a string uniquely identifying the actor. This should be unique for all spawned actors and invoked services.
 - `autoForward` - (optional) `true` if all events sent to this machine should also be sent (or _forwarded_) to the invoked child (`false` by default)
-- `sync` - (optional) `true` if this machine should be automatically subscribed to the spawned child machine's state, the state will be stored as `.state` on the child machine ref
+- `sync` - (optional) `true` if this machine should be automatically subscribed to the spawned child machine's state, the state can be retrieved from `.getSnapshot()` on the child machine ref
 
 ```js {13-14}
 import { createMachine, spawn } from 'xstate';
@@ -371,7 +371,7 @@ To do this, set `{ sync: true }` as an option to `spawn(...)`:
 // ...
 ```
 
-This will automatically subscribe the machine to the spawned child machine's state, which is kept updated and can be accessed via `getSnapshot()`:
+This will automatically subscribe the machine to the spawned child machine's state, which is kept updated and can be accessed via `.getSnapshot()`:
 
 ```js
 someService.onTransition((state) => {
@@ -385,20 +385,8 @@ someService.onTransition((state) => {
 });
 ```
 
-```js
-someService.onTransition((state) => {
-  const { someRef } = state.context;
-
-  console.log(someRef.state);
-  // => State {
-  //   value: ...,
-  //   context: ...
-  // }
-});
-```
-
 ::: warning
-By default, `sync` is set to `false`. Never read an actor's `.state` when `sync` is disabled; otherwise, you will end up referencing stale state.
+By default, `sync` is set to `false`. Never read an actor's state from `.getSnapshot()` when `sync` is disabled; otherwise, you will end up referencing stale state.
 :::
 
 ## Sending Updates <Badge text="4.7+" />

--- a/docs/fr/packages/xstate-react/index.md
+++ b/docs/fr/packages/xstate-react/index.md
@@ -102,7 +102,7 @@ A [React hook](https://reactjs.org/hooks) that subscribes to emitted changes fro
 
 - `actor` - an actor-like object that contains `.send(...)` and `.subscribe(...)` methods.
 - `getSnapshot` - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist.
 
 ```js
 const [state, send] = useActor(someSpawnedActor);

--- a/docs/fr/packages/xstate-vue/index.md
+++ b/docs/fr/packages/xstate-vue/index.md
@@ -101,7 +101,7 @@ _Since 0.5.0_
 
 - `actor` - an actor-like object that contains `.send(...)` and `.subscribe(...)` methods.
 - `getSnapshot` - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist.
 
 ```js
 import { useActor } from '@xstate/vue';

--- a/docs/guides/actors.md
+++ b/docs/guides/actors.md
@@ -73,7 +73,7 @@ Alternatively `spawn` accepts an options object as the second argument which may
 
 - `name` (optional) - a string uniquely identifying the actor. This should be unique for all spawned actors and invoked services.
 - `autoForward` - (optional) `true` if all events sent to this machine should also be sent (or _forwarded_) to the invoked child (`false` by default)
-- `sync` - (optional) `true` if this machine should be automatically subscribed to the spawned child machine's state, the state will be stored as `.state` on the child machine ref
+- `sync` - (optional) `true` if this machine should be automatically subscribed to the spawned child machine's state, the state can be retrieved from `.getSnapshot()` on the child machine ref
 
 ```js {13-14}
 import { createMachine, spawn } from 'xstate';
@@ -385,20 +385,8 @@ someService.onTransition((state) => {
 });
 ```
 
-```js
-someService.onTransition((state) => {
-  const { someRef } = state.context;
-
-  console.log(someRef.state);
-  // => State {
-  //   value: ...,
-  //   context: ...
-  // }
-});
-```
-
 ::: warning
-By default, `sync` is set to `false`. Never read an actor's `.state` when `sync` is disabled; otherwise, you will end up referencing stale state.
+By default, `sync` is set to `false`. Never read an actor's state from `.getSnapshot()` when `sync` is disabled; otherwise, you will end up referencing stale state.
 :::
 
 ## Sending Updates <Badge text="4.7+" />

--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -102,7 +102,7 @@ A [React hook](https://reactjs.org/hooks) that subscribes to emitted changes fro
 
 - `actor` - an actor-like object that contains `.send(...)` and `.subscribe(...)` methods.
 - `getSnapshot` - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist.
 
 ```js
 const [state, send] = useActor(someSpawnedActor);
@@ -178,7 +178,7 @@ _Since 1.3.0_
 - `selector` - a function that takes in an actor's "current state" (snapshot) as an argument and returns the desired selected value.
 - `compare` (optional) - a function that determines if the current selected value is the same as the previous selected value.
 - `getSnapshot` (optional) - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist. Will automatically pull the state from services.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist. Will automatically pull the state from services.
 
 ```js
 import { useSelector } from '@xstate/react';

--- a/docs/packages/xstate-vue/index.md
+++ b/docs/packages/xstate-vue/index.md
@@ -101,7 +101,7 @@ _Since 0.5.0_
 
 - `actor` - an actor-like object that contains `.send(...)` and `.subscribe(...)` methods.
 - `getSnapshot` - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist.
 
 ```js
 import { useActor } from '@xstate/vue';

--- a/docs/zh/guides/actors.md
+++ b/docs/zh/guides/actors.md
@@ -385,18 +385,6 @@ someService.onTransition((state) => {
 });
 ```
 
-```js
-someService.onTransition((state) => {
-  const { someRef } = state.context;
-
-  console.log(someRef.state);
-  // => State {
-  //   value: ...,
-  //   context: ...
-  // }
-});
-```
-
 ::: warning
 默认情况下，`sync` 设置为 `false`。 当禁用`sync`时，永远不要读取演员的`.state`； 否则，你最终将引用陈旧的状态。
 :::

--- a/docs/zh/packages/xstate-react/index.md
+++ b/docs/zh/packages/xstate-react/index.md
@@ -102,7 +102,7 @@ A [React hook](https://reactjs.org/hooks) that subscribes to emitted changes fro
 
 - `actor` - an actor-like object that contains `.send(...)` and `.subscribe(...)` methods.
 - `getSnapshot` - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist.
 
 ```js
 const [state, send] = useActor(someSpawnedActor);
@@ -178,7 +178,7 @@ _Since 1.3.0_
 - `selector` - a function that takes in an actor's "current state" (snapshot) as an argument and returns the desired selected value.
 - `compare` (optional) - a function that determines if the current selected value is the same as the previous selected value.
 - `getSnapshot` (optional) - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist. Will automatically pull the state from services.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist. Will automatically pull the state from services.
 
 ```js
 import { useSelector } from '@xstate/react';

--- a/docs/zh/packages/xstate-vue/index.md
+++ b/docs/zh/packages/xstate-vue/index.md
@@ -101,7 +101,7 @@ _Since 0.5.0_
 
 - `actor` - an actor-like object that contains `.send(...)` and `.subscribe(...)` methods.
 - `getSnapshot` - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist.
 
 ```js
 import { useActor } from '@xstate/vue';
@@ -176,7 +176,7 @@ _Since 0.6.0_
 - `selector` - a function that takes in an actor's "current state" (snapshot) as an argument and returns the desired selected value.
 - `compare` (optional) - a function that determines if the current selected value is the same as the previous selected value.
 - `getSnapshot` (optional) - a function that should return the latest emitted value from the `actor`.
-  - Defaults to attempting to get the `actor.state`, or returning `undefined` if that does not exist. Will automatically pull the state from services.
+  - Defaults to attempting to get the snapshot from `actor.getSnapshot()`, or returning `undefined` if that does not exist. Will automatically pull the state from services.
 
 ```js
 import { useSelector } from '@xstate/vue';

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -271,6 +271,9 @@ export class Interpreter<
       return this._initialState;
     });
   }
+  /**
+   * @deprecated Use `.getSnapshot()` instead.
+   */
   public get state(): State<
     TContext,
     TEvent,

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -76,7 +76,7 @@ export function useMachine<TMachine extends AnyStateMachine>(
         : service.machine.initialState) as State<any, any, any, any, any>;
     }
 
-    return service.state;
+    return service.getSnapshot();
   }, [service]);
 
   const isEqual = useCallback(

--- a/packages/xstate-react/src/utils.ts
+++ b/packages/xstate-react/src/utils.ts
@@ -20,7 +20,7 @@ export function partition<T, A extends T, B extends T>(
 export function getServiceSnapshot<
   TService extends Interpreter<any, any, any, any>
 >(service: TService): TService['state'] {
-  return service.status !== 0 ? service.state : service.machine.initialState;
+  return service.getSnapshot();
 }
 
 // From https://github.com/reduxjs/react-redux/blob/master/src/utils/shallowEqual.ts

--- a/packages/xstate-react/src/utils.ts
+++ b/packages/xstate-react/src/utils.ts
@@ -20,7 +20,9 @@ export function partition<T, A extends T, B extends T>(
 export function getServiceSnapshot<
   TService extends Interpreter<any, any, any, any>
 >(service: TService): TService['state'] {
-  return service.getSnapshot();
+  return service.status !== 0
+    ? service.getSnapshot()
+    : service.machine.initialState;
 }
 
 // From https://github.com/reduxjs/react-redux/blob/master/src/utils/shallowEqual.ts

--- a/packages/xstate-react/test/useSelector.test.tsx
+++ b/packages/xstate-react/test/useSelector.test.tsx
@@ -599,4 +599,27 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
     expect(snapshots.every((s) => s === snapshot1));
     expect(console.error).toHaveBeenCalledTimes(0);
   });
+
+  it(`shouldn't interfere with spawning actors that are part of the initial state of an actor`, () => {
+    let called = false;
+    const child = createMachine({
+      entry: () => (called = true)
+    });
+    const machine = createMachine({
+      context: () => ({
+        childRef: spawn(child)
+      })
+    });
+
+    function App() {
+      const service = useInterpret(machine);
+      useSelector(service, () => {});
+      expect(called).toBe(false);
+      return null;
+    }
+
+    render(<App />);
+
+    expect(called).toBe(true);
+  });
 });


### PR DESCRIPTION
This PR deprecates `someService.state` in favor of `someService.getSnapshot()`.