### PR TITLE
Fixed `AnyBehavior` to actually allow any `Behavior`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1882,7 +1882,7 @@ export interface Behavior<
   start?: (actorCtx: ActorContext<TEvent, TSnapshot>) => TInternalState;
 }
 
-export type AnyBehavior = Behavior<AnyEventObject, any, any>;
+export type AnyBehavior = Behavior<any, any, any>;
 
 export type SnapshotFrom<T> = ReturnTypeOrValue<T> extends infer R
   ? R extends Interpreter<infer _, infer __>

--- a/packages/core/test/typeHelpers.test.ts
+++ b/packages/core/test/typeHelpers.test.ts
@@ -6,7 +6,9 @@ import {
   EventFrom,
   interpret,
   MachineImplementationsFrom,
-  StateValueFrom
+  StateValueFrom,
+  Behavior,
+  ActorRefFrom
 } from '../src';
 import { TypegenMeta } from '../src/typegenTypes';
 
@@ -316,5 +318,20 @@ describe('SnapshotFrom', () => {
     acceptState(service.initialState);
     // @ts-expect-error
     acceptState("isn't any");
+  });
+});
+
+describe('ActorRefFrom', () => {
+  it('should return `ActorRef` based on a `Behavior`', () => {
+    const behavior: Behavior<{ type: 'TEST' }> = {
+      transition: () => {},
+      initialState: undefined
+    };
+
+    function acceptActorRef(actorRef: ActorRefFrom<typeof behavior>) {
+      actorRef.send({ type: 'TEST' });
+    }
+
+    acceptActorRef(interpret(behavior).start());
   });
 });


### PR DESCRIPTION
`TEvent` is contravariant and thus `AnyEventObject` can't be used at this position to allow all behaviors:
[TS playground](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgKIDcLgPICMBWECYyA3gFDLJgCeADhAFzIDOYUoA5gNzkC+5cqEixEKAIIgaGLGDyFiyCAA9IIACYs0mHASIkKVANoBrCDWZsOITgF1mcKbwHlaDZJJoAhCAAs46MAA9lDIALzIPv6BIQA8njK6CmAANMiONAB8vELg0PBIkX4BwVCxACqJJCpqmmTU9Eys7FzIfGnlAMogcHQsvkFgmWSU1FCOLMBgwSDMABQAthAsLHCcTZU6YACU4cNdPX0DYM6CwvliHsQhAEoQMBVVSqpYdaQNDJYtNm0d3b39QbDQysV7zJYrNYbKq7MLDdBBYDqXhUdZgf5HQbzWH7DGAk78QRuCTXKB3GAAMSgQQWURKcXKwwi5WetS0dJiZVAMGgyE2sjS3N5BwBx0yowA-FcwLd7o8tn9DvjxVRmCAIJgoLxidLZZTqQsKky+azXlpPBzSsgpeJSeSqTTLQzhmqNdAcuoiAAbOBQFAIIIgNjIXAARmYTrK72JzAARJVOuVY796gGAK7gZihtrZVyNDzZiK2mVk+4Ow3EoIwEOh3MAejrVGQAD0JYIA0GSICAO6oKDUqDMC3FTnhGtAA)

For contravariant positions `never` can be used to "catch all", like here:
[TS playground](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgKIDcLgPICMBWECYyA3gFDLJgCeADhAFzIDOYUoA5gNzkC+5cqEixEKAIIgaGLGDyFiyCAA9IIACYs0mHASIkKVANoBrCDWZsOITgF1mcKbwHlaDZJJoAhCAAs46MAA9lDIALzIPv6BIQA8IBCYUAA0yI40AHy8QuDQ8EiRfgHBULEAKjLgSqpYmmTU9Eys7FzIfKllAMogcHQsvkFgGWSU1FCOLMBgwSDMABQAthAsLHCcTRU6YACU4cNdPX0DYM6CwnliHsQhAEoQMOWVJCpqdaQNDJYtNm0d3b39QbDQysWrzJYrNYbJ67MLDdBBYDqXhUdZgf5HQbzWH7DGAk78QRuCTXKB3GAAMSgQQWUWKcTKwwiZWqry0dJipVAMGgyE2slS3N5BwBxwyowA-FcwLd7o8tn9DvjxVRmAkkrxidLZZTqQtyky+azalpPBySsgpeJSeSqTTzQzhmrEtBsuoiAAbOBQFAIIIgNjIXAARmYDtK72JzAARBVOmVo796n6AK7gZjBtpZVyNDyZiLWmVk+52-XEoIwIPB7MAehrVGQAD0JYI-QGSFMWNgTMwzUVOeEq0A).

OTOH, `never` is sometimes hard to work with and I'm a little bit hesitant to use it like this.