### PR TITLE
Resolve action objects as lazily as possible to avoid stale closure problem in React

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -31,7 +31,7 @@ import type {
 } from './types';
 import type { State } from './State';
 import * as actionTypes from './actionTypes';
-import { toActionObject } from './actions';
+import { toActionObjects } from './actions';
 import { formatInitialTransition, formatTransition } from './stateUtils';
 import {
   getDelayedTransitions,
@@ -182,13 +182,9 @@ export class StateNode<
     this.history =
       this.config.history === true ? 'shallow' : this.config.history || false;
 
-    this.entry = toArray(this.config.entry).map((action) =>
-      toActionObject(action, this.machine.options.actions)
-    );
+    this.entry = toActionObjects(this.config.entry);
+    this.exit = toActionObjects(this.config.exit);
 
-    this.exit = toArray(this.config.exit).map((action) =>
-      toActionObject(action, this.machine.options.actions)
-    );
     this.meta = this.config.meta;
     this.doneData =
       this.type === 'final'

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1710,10 +1710,9 @@ export function resolveActionsAndContext<
         ).params.actions;
 
         if (matchedActions) {
-          toActionObjects(
-            toArray(matchedActions),
-            machine.options.actions
-          ).forEach(resolveAction);
+          toActionObjects(matchedActions, machine.options.actions).forEach(
+            resolveAction
+          );
         }
       } else if (executableActionObject.type === actionTypes.assign) {
         const resolvedActionObject = executableActionObject.resolve(


### PR DESCRIPTION
This might have not been a bug introduced in the `v5/interpret-all-behaviors` branch but I've noticed it when reviewing it so I'm just creating a branch targeting that.