### PR TITLE
Fixed Markdown formatting in CHANGELOGs

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#3571](https://github.com/statelyai/xstate/pull/3571) [`6fdaae710`](https://github.com/statelyai/xstate/commit/6fdaae710e0c29e3d8ec4d694ba525d7bdb27484) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Reading state directly from ~~`someService.state`~~ is deprecated. Use `someService.getSnapshot()` instead.
 
-* [#3555](https://github.com/statelyai/xstate/pull/3555) [`4c13b3faf`](https://github.com/statelyai/xstate/commit/4c13b3fafbdabeac6a773d0b73a63b705b3eb775) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `sendTo(actorName, event)` action creator now accepts a string `actorName`.
+- [#3555](https://github.com/statelyai/xstate/pull/3555) [`4c13b3faf`](https://github.com/statelyai/xstate/commit/4c13b3fafbdabeac6a773d0b73a63b705b3eb775) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `sendTo(actorName, event)` action creator now accepts a string `actorName`.
 
 ## 4.33.5
 
@@ -14,7 +14,7 @@
 
 - [#3559](https://github.com/statelyai/xstate/pull/3559) [`ddbc9bc5c`](https://github.com/statelyai/xstate/commit/ddbc9bc5c5f0e1cc597468c5f8ae32c8931b368d) Thanks [@Andarist](https://github.com/Andarist)! - Fixed minor compatibility issues with TypeScript 4.8 in the codebase. This fixes the typechecking with TypeScript 4.8 in projects that don't use `skipLibCheck: true`.
 
-* [#3563](https://github.com/statelyai/xstate/pull/3563) [`e3c7a9caf`](https://github.com/statelyai/xstate/commit/e3c7a9caf025e37d2e2106abff05628abbc8dd4a) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with not executing actions in response to received **batched** events when using `predictableActionArguments`.
+- [#3563](https://github.com/statelyai/xstate/pull/3563) [`e3c7a9caf`](https://github.com/statelyai/xstate/commit/e3c7a9caf025e37d2e2106abff05628abbc8dd4a) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with not executing actions in response to received **batched** events when using `predictableActionArguments`.
 
 - [#3520](https://github.com/statelyai/xstate/pull/3520) [`95a6a06d0`](https://github.com/statelyai/xstate/commit/95a6a06d0041d0201cf66ab8962fb8769187584b) Thanks [@Andarist](https://github.com/Andarist)! - Fixed a runtime crash when sending multiple events as an array to a service. It is not recommended to use this feature though as it will be removed in the next major version.
 
@@ -30,7 +30,7 @@
 
 - [#3540](https://github.com/statelyai/xstate/pull/3540) [`121fad172`](https://github.com/statelyai/xstate/commit/121fad172560f26c9374582c65a48bbe540f5c6e) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue that caused `invoke`d actors to be created before resolving `assign` actions from `entry` of the same state when using `predictableActionArguments` flag.
 
-* [#3541](https://github.com/statelyai/xstate/pull/3541) [`6c081ab87`](https://github.com/statelyai/xstate/commit/6c081ab87c4d344012ff72bae295de8f3ccdcca1) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with not being able to read the updated snapshot of a child when receiving and processing events from it and when using `predictableActionArguments` flag.
+- [#3541](https://github.com/statelyai/xstate/pull/3541) [`6c081ab87`](https://github.com/statelyai/xstate/commit/6c081ab87c4d344012ff72bae295de8f3ccdcca1) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with not being able to read the updated snapshot of a child when receiving and processing events from it and when using `predictableActionArguments` flag.
 
 ## 4.33.2
 
@@ -55,7 +55,7 @@
 
   Please be aware that you might not able to use `state` from the `meta` argument when using this flag.
 
-* [#3126](https://github.com/statelyai/xstate/pull/3126) [`37b751cb3`](https://github.com/statelyai/xstate/commit/37b751cb3c80073d6f559f0eba2ae3619a643e63) Thanks [@Andarist](https://github.com/Andarist)! - All `exit` actions in the machine will now be correctly resolved and executed when a machine gets stopped or reaches its top-level final state. Previously, the actions were not correctly resolved and that was leading to runtime errors.
+- [#3126](https://github.com/statelyai/xstate/pull/3126) [`37b751cb3`](https://github.com/statelyai/xstate/commit/37b751cb3c80073d6f559f0eba2ae3619a643e63) Thanks [@Andarist](https://github.com/Andarist)! - All `exit` actions in the machine will now be correctly resolved and executed when a machine gets stopped or reaches its top-level final state. Previously, the actions were not correctly resolved and that was leading to runtime errors.
 
   To implement this fix in a reliable way, a new internal event has been introduced: `{ type: 'xstate.stop' }` and when the machine stops its execution, all exit handlers of the current state (i.e. the active state nodes) will be called with that event. You should always assume that an exit handler might be called with that event.
 
@@ -63,11 +63,11 @@
 
 - [#3178](https://github.com/statelyai/xstate/pull/3178) [`6badd2ba3`](https://github.com/statelyai/xstate/commit/6badd2ba3642391bee640aa4914003ad57f2e703) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Added a dev-only error when `forwardTo` accidentally ends up trying to forward an event to an undefined actor. Such a situation indicates a logical error and risks an infinite loop.
 
-* [#3453](https://github.com/statelyai/xstate/pull/3453) [`368ed9b1c`](https://github.com/statelyai/xstate/commit/368ed9b1cd0ea2df8cbf6662b352455afae7abfa) Thanks [@pixtron](https://github.com/pixtron)! - Call the `complete` callback of the subscribed `observer` when an interpreter gets stopped.
+- [#3453](https://github.com/statelyai/xstate/pull/3453) [`368ed9b1c`](https://github.com/statelyai/xstate/commit/368ed9b1cd0ea2df8cbf6662b352455afae7abfa) Thanks [@pixtron](https://github.com/pixtron)! - Call the `complete` callback of the subscribed `observer` when an interpreter gets stopped.
 
 - [#3422](https://github.com/statelyai/xstate/pull/3422) [`e35493f59`](https://github.com/statelyai/xstate/commit/e35493f59d277ca57f0982417d5ba3bca0a352ed) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with parallel regions not always being correctly reentered on external transitions of the containing parallel state targeting another region within that parallel state.
 
-* [#3447](https://github.com/statelyai/xstate/pull/3447) [`e93754d7a`](https://github.com/statelyai/xstate/commit/e93754d7a65d8c143bcb0070e8412ca4ebc9e523) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The types for `state.nextEvents` are now properly typed to the actual event types of the machine. Original PR: #1115 (Thanks @alexreardon!)
+- [#3447](https://github.com/statelyai/xstate/pull/3447) [`e93754d7a`](https://github.com/statelyai/xstate/commit/e93754d7a65d8c143bcb0070e8412ca4ebc9e523) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The types for `state.nextEvents` are now properly typed to the actual event types of the machine. Original PR: #1115 (Thanks @alexreardon!)
 
 - [#3424](https://github.com/statelyai/xstate/pull/3424) [`88d540eb8`](https://github.com/statelyai/xstate/commit/88d540eb8e0b659c9621cc5c365bd626a000c1d7) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with targeted ancestors not being correctly reentered during external transitions.
 
@@ -95,22 +95,22 @@
   // This will
   const loggedInState = await waitFor(
     loginService,
-    state => state.hasTag('loggedIn'),
+    (state) => state.hasTag('loggedIn'),
     { timeout: Infinity }
   );
   ```
 
   This fixes a bug that causes `waitFor` to reject with an error immediately due to the behaviour of `setTimeout`.
 
-* [#3230](https://github.com/statelyai/xstate/pull/3230) [`780458c92`](https://github.com/statelyai/xstate/commit/780458c921d4525c7a00119c7eb43d4833978861) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with typegen types not being able to provide events that had a union of strings as their `type` (such as `{ type: 'INC' | 'DEC'; value: number; }`).
+- [#3230](https://github.com/statelyai/xstate/pull/3230) [`780458c92`](https://github.com/statelyai/xstate/commit/780458c921d4525c7a00119c7eb43d4833978861) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with typegen types not being able to provide events that had a union of strings as their `type` (such as `{ type: 'INC' | 'DEC'; value: number; }`).
 
 - [#3252](https://github.com/statelyai/xstate/pull/3252) [`a94dfd467`](https://github.com/statelyai/xstate/commit/a94dfd46772cacc59154c165f27122164f48625b) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `EventFrom` not being able to extract events that had a union of strings as their `type` (such as `{ type: 'INC' | 'DEC'; value: number; }`).
 
-* [#3090](https://github.com/statelyai/xstate/pull/3090) [`c4f73ca13`](https://github.com/statelyai/xstate/commit/c4f73ca1356d106423c8b4ee34865f7e4f2d2bb6) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with action objects not receiving correct event types when used in the second argument to the `createMachine`.
+- [#3090](https://github.com/statelyai/xstate/pull/3090) [`c4f73ca13`](https://github.com/statelyai/xstate/commit/c4f73ca1356d106423c8b4ee34865f7e4f2d2bb6) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with action objects not receiving correct event types when used in the second argument to the `createMachine`.
 
 - [#3238](https://github.com/statelyai/xstate/pull/3238) [`3df6335ef`](https://github.com/statelyai/xstate/commit/3df6335ef8db4edcf0a47d4c559716552ce4bbe8) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The typings for `sendTo(...)` have been fixed.
 
-* [#3228](https://github.com/statelyai/xstate/pull/3228) [`fe5f0e6c9`](https://github.com/statelyai/xstate/commit/fe5f0e6c9bbb6ff740673889892301c8989eacfd) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with inline functions in the config object used as transition actions not having their argument types inferred.
+- [#3228](https://github.com/statelyai/xstate/pull/3228) [`fe5f0e6c9`](https://github.com/statelyai/xstate/commit/fe5f0e6c9bbb6ff740673889892301c8989eacfd) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with inline functions in the config object used as transition actions not having their argument types inferred.
 
 - [#3252](https://github.com/statelyai/xstate/pull/3252) [`a94dfd467`](https://github.com/statelyai/xstate/commit/a94dfd46772cacc59154c165f27122164f48625b) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with default `TEvent` (`{ type: string }`) not being correctly provided to inline transition actions.
 
@@ -128,24 +128,24 @@
   // ...
   const loginService = interpret(loginMachine).start();
 
-  const loggedInState = await waitFor(loginService, state =>
+  const loggedInState = await waitFor(loginService, (state) =>
     state.hasTag('loggedIn')
   );
 
   loggedInState.hasTag('loggedIn'); // true
   ```
 
-* [#3200](https://github.com/statelyai/xstate/pull/3200) [`56c0a36`](https://github.com/statelyai/xstate/commit/56c0a36f222195d0b18edd7a72d5429a213b3808) Thanks [@Andarist](https://github.com/Andarist)! - Subscribing to a stopped interpreter will now always immediately emit its state and call a completion callback.
+- [#3200](https://github.com/statelyai/xstate/pull/3200) [`56c0a36`](https://github.com/statelyai/xstate/commit/56c0a36f222195d0b18edd7a72d5429a213b3808) Thanks [@Andarist](https://github.com/Andarist)! - Subscribing to a stopped interpreter will now always immediately emit its state and call a completion callback.
 
 ### Patch Changes
 
 - [#3166](https://github.com/statelyai/xstate/pull/3166) [`be4c5c74d`](https://github.com/statelyai/xstate/commit/be4c5c74d400a1ca58befd306029c3ce77793e3e) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `state.tags` not having correct values when resolving micro transitions (taken in response to raised events). This was creating issues when checking tags in guards.
 
-* [#3171](https://github.com/statelyai/xstate/pull/3171) [`14f8b4785`](https://github.com/statelyai/xstate/commit/14f8b4785599fb366ae2901c03c2a3202594499c) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `onDone` on parallel states not being "called" correctly when a parallel state had a history state defined directly on it.
+- [#3171](https://github.com/statelyai/xstate/pull/3171) [`14f8b4785`](https://github.com/statelyai/xstate/commit/14f8b4785599fb366ae2901c03c2a3202594499c) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `onDone` on parallel states not being "called" correctly when a parallel state had a history state defined directly on it.
 
 - [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - Fixed issues with not disposing some cached internal values when stopping interpreters, which could have led to issues when starting such an interpreter again.
 
-* [#3153](https://github.com/statelyai/xstate/pull/3153) [`b36ef9dda`](https://github.com/statelyai/xstate/commit/b36ef9dda560fca4c00428f48742fd9d2e325324) Thanks [@Andarist](https://github.com/Andarist)! - Made type displays (like in the IDE tooltips etc) more readable by using a type interface for the internal `ResolveTypegenMeta` type.
+- [#3153](https://github.com/statelyai/xstate/pull/3153) [`b36ef9dda`](https://github.com/statelyai/xstate/commit/b36ef9dda560fca4c00428f48742fd9d2e325324) Thanks [@Andarist](https://github.com/Andarist)! - Made type displays (like in the IDE tooltips etc) more readable by using a type interface for the internal `ResolveTypegenMeta` type.
 
 ## 4.30.6
 
@@ -153,15 +153,15 @@
 
 - [#3131](https://github.com/statelyai/xstate/pull/3131) [`d9a0bcfc9`](https://github.com/statelyai/xstate/commit/d9a0bcfc9be03e49726d6dc4a6bbce25239913a1) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with event type being inferred from too many places within `createMachine` call and possibly ending up as `any`/`AnyEventObject` for the entire machine.
 
-* [#3133](https://github.com/statelyai/xstate/pull/3133) [`4feef9d47`](https://github.com/statelyai/xstate/commit/4feef9d47f81d1b28f2f898431eb4bd1c42d8368) Thanks [@fw6](https://github.com/fw6)! - Fixed compatibility with esoteric [Mini Program](https://developers.weixin.qq.com/miniprogram/en/dev/framework/app-service/) environment where `global` object was available but `global.console` wasn't.
+- [#3133](https://github.com/statelyai/xstate/pull/3133) [`4feef9d47`](https://github.com/statelyai/xstate/commit/4feef9d47f81d1b28f2f898431eb4bd1c42d8368) Thanks [@fw6](https://github.com/fw6)! - Fixed compatibility with esoteric [Mini Program](https://developers.weixin.qq.com/miniprogram/en/dev/framework/app-service/) environment where `global` object was available but `global.console` wasn't.
 
 - [#3140](https://github.com/statelyai/xstate/pull/3140) [`502ffe91a`](https://github.com/statelyai/xstate/commit/502ffe91a19579f5f747b76ce29d50de81e8b15c) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with interpreters started using a persisted state not being "resolved" in full. This could cause some things, such as `after` transitions, not being executed correctly after starting an interpreter like this.
 
-* [#3147](https://github.com/statelyai/xstate/pull/3147) [`155539c85`](https://github.com/statelyai/xstate/commit/155539c8597b2f2783e8419c782922545d7e6424) Thanks [@Andarist](https://github.com/Andarist)! - Fixed a TS inference issue causing some functions to infer the constraint type for the event type even though a `StateMachine` passed to the function was parametrized with a concrete type for the event. More information can be found [here](https://github.com/statelyai/xstate/issues/3141#issuecomment-1063995705).
+- [#3147](https://github.com/statelyai/xstate/pull/3147) [`155539c85`](https://github.com/statelyai/xstate/commit/155539c8597b2f2783e8419c782922545d7e6424) Thanks [@Andarist](https://github.com/Andarist)! - Fixed a TS inference issue causing some functions to infer the constraint type for the event type even though a `StateMachine` passed to the function was parametrized with a concrete type for the event. More information can be found [here](https://github.com/statelyai/xstate/issues/3141#issuecomment-1063995705).
 
 - [#3146](https://github.com/statelyai/xstate/pull/3146) [`4cf89b5f9`](https://github.com/statelyai/xstate/commit/4cf89b5f9cf645f741164d23e3bc35dd7c5706f6) Thanks [@Andarist](https://github.com/Andarist)! - Fixed compatibility of `Interpreter` with older versions of TypeScript. This ensures that our interpreters can correctly be consumed by functions expecting `ActorRef` interface (like for example `useSelector`).
 
-* [#3139](https://github.com/statelyai/xstate/pull/3139) [`7b45fda9e`](https://github.com/statelyai/xstate/commit/7b45fda9e1bd544b505c86ddcd6cf1f949007fef) Thanks [@Andarist](https://github.com/Andarist)! - `InterpreterFrom` and `ActorRefFrom` types used on machines with typegen data should now correctly return types with final/resolved typegen data. The "final" type here means a type that already encodes the information that all required implementations have been provided. Before this change this wouldn't typecheck correctly:
+- [#3139](https://github.com/statelyai/xstate/pull/3139) [`7b45fda9e`](https://github.com/statelyai/xstate/commit/7b45fda9e1bd544b505c86ddcd6cf1f949007fef) Thanks [@Andarist](https://github.com/Andarist)! - `InterpreterFrom` and `ActorRefFrom` types used on machines with typegen data should now correctly return types with final/resolved typegen data. The "final" type here means a type that already encodes the information that all required implementations have been provided. Before this change this wouldn't typecheck correctly:
 
   ```ts
   const machine = createMachine({
@@ -189,7 +189,7 @@
 
 - [#3104](https://github.com/statelyai/xstate/pull/3104) [`3706c62f4`](https://github.com/statelyai/xstate/commit/3706c62f49daa5cf84172713a004eb26704342f5) Thanks [@Andarist](https://github.com/Andarist)! - Fixed `ContextFrom` helper type to work on typegened machines.
 
-* [#3113](https://github.com/statelyai/xstate/pull/3113) [`144131bed`](https://github.com/statelyai/xstate/commit/144131beda5c00a15fbe0f58a3309eac81d940eb) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `keys()` utility function export, which was removed in [#3089](https://github.com/statelyai/xstate/issues/3089), is now added back, as older versions of XState libraries may depend on it still. See [#3106](https://github.com/statelyai/xstate/issues/3106) for more details.
+- [#3113](https://github.com/statelyai/xstate/pull/3113) [`144131bed`](https://github.com/statelyai/xstate/commit/144131beda5c00a15fbe0f58a3309eac81d940eb) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `keys()` utility function export, which was removed in [#3089](https://github.com/statelyai/xstate/issues/3089), is now added back, as older versions of XState libraries may depend on it still. See [#3106](https://github.com/statelyai/xstate/issues/3106) for more details.
 
 - [#3104](https://github.com/statelyai/xstate/pull/3104) [`3706c62f4`](https://github.com/statelyai/xstate/commit/3706c62f49daa5cf84172713a004eb26704342f5) Thanks [@Andarist](https://github.com/Andarist)! - Fixed `EventFrom` helper type to work on machines.
 
@@ -199,15 +199,15 @@
 
 - [#3088](https://github.com/statelyai/xstate/pull/3088) [`9f02271a3`](https://github.com/statelyai/xstate/commit/9f02271a3dd0b314a270f54d4de56af8daab31d1) Thanks [@Andarist](https://github.com/Andarist)! - Added some internal `@ts-ignore` comments to fix consuming projects that do not use `skipLibCheck`.
 
-* [#3082](https://github.com/statelyai/xstate/pull/3082) [`8d3f2cfea`](https://github.com/statelyai/xstate/commit/8d3f2cfea7b57b6293fd862844400353e2a7451a) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with context type being inferred from too many places within `createMachine` call and possibly ending up as `any` for the entire machine.
+- [#3082](https://github.com/statelyai/xstate/pull/3082) [`8d3f2cfea`](https://github.com/statelyai/xstate/commit/8d3f2cfea7b57b6293fd862844400353e2a7451a) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with context type being inferred from too many places within `createMachine` call and possibly ending up as `any` for the entire machine.
 
 - [#3027](https://github.com/statelyai/xstate/pull/3027) [`97ad964bd`](https://github.com/statelyai/xstate/commit/97ad964bd064ce48c28323052557336ed4def1a9) Thanks [@hedgepigdaniel](https://github.com/hedgepigdaniel)! - Fixed an issue with not being able to call `createMachine` in a generic context when the type for the context was generic and not concrete.
 
-* [#3084](https://github.com/statelyai/xstate/pull/3084) [`50c271dc1`](https://github.com/statelyai/xstate/commit/50c271dc1a1a05b035364f8247aa4d80d613864f) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with context type defined using `schema.context` being sometimes widened based on `config.context`. If both are given the `schema.context` should always take precedence and should represent the complete type of the context.
+- [#3084](https://github.com/statelyai/xstate/pull/3084) [`50c271dc1`](https://github.com/statelyai/xstate/commit/50c271dc1a1a05b035364f8247aa4d80d613864f) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with context type defined using `schema.context` being sometimes widened based on `config.context`. If both are given the `schema.context` should always take precedence and should represent the complete type of the context.
 
 - [#3089](https://github.com/statelyai/xstate/pull/3089) [`862697e29`](https://github.com/statelyai/xstate/commit/862697e2990934d46050580d7e09c749d09d8426) Thanks [@Andarist](https://github.com/Andarist)! - Fixed compatibility with Skypack by exporting some shared utilities from root entry of XState and consuming them directly in other packages (this avoids accessing those things using deep imports and thus it avoids creating those compatibility problems).
 
-* [#3087](https://github.com/statelyai/xstate/pull/3087) [`ae9579497`](https://github.com/statelyai/xstate/commit/ae95794971f765e3f984f4080f8a92236c53cd6c) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `ActorRefFrom` not resolving the typegen metadata from machine types given to it. This could sometimes result in types assignability problems, especially when using machine factories and `spawn`.
+- [#3087](https://github.com/statelyai/xstate/pull/3087) [`ae9579497`](https://github.com/statelyai/xstate/commit/ae95794971f765e3f984f4080f8a92236c53cd6c) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `ActorRefFrom` not resolving the typegen metadata from machine types given to it. This could sometimes result in types assignability problems, especially when using machine factories and `spawn`.
 
 ## 4.30.2
 
@@ -215,7 +215,7 @@
 
 - [#3063](https://github.com/statelyai/xstate/pull/3063) [`c826559b4`](https://github.com/statelyai/xstate/commit/c826559b4c495f64c85dd79f1d1262ae9e7d15bf) Thanks [@Andarist](https://github.com/Andarist)! - Fixed a type compatibility with Svelte's readables. It should be possible again to use XState interpreters directly as readables at the type-level.
 
-* [#3051](https://github.com/statelyai/xstate/pull/3051) [`04091f29c`](https://github.com/statelyai/xstate/commit/04091f29cb80dd8e6c95e42668bd56f02f775973) Thanks [@Andarist](https://github.com/Andarist)! - Fixed type compatibility with functions accepting machines that were created before typegen was a thing in XState. This should make it possible to use the latest version of XState with `@xstate/vue`, `@xstate/react@^1` and some community packages.
+- [#3051](https://github.com/statelyai/xstate/pull/3051) [`04091f29c`](https://github.com/statelyai/xstate/commit/04091f29cb80dd8e6c95e42668bd56f02f775973) Thanks [@Andarist](https://github.com/Andarist)! - Fixed type compatibility with functions accepting machines that were created before typegen was a thing in XState. This should make it possible to use the latest version of XState with `@xstate/vue`, `@xstate/react@^1` and some community packages.
 
   Note that this change doesn't make those functions to accept machines that have typegen information on them. For that the signatures of those functions would have to be adjusted.
 
@@ -240,7 +240,7 @@
   }
   ```
 
-* [#3042](https://github.com/statelyai/xstate/pull/3042) [`e53396f08`](https://github.com/statelyai/xstate/commit/e53396f083091db26c117000ce6ec070914360e9) Thanks [@suerta-git](https://github.com/suerta-git)! - Added the `AnyStateConfig` type, which represents any `StateConfig<...>`:
+- [#3042](https://github.com/statelyai/xstate/pull/3042) [`e53396f08`](https://github.com/statelyai/xstate/commit/e53396f083091db26c117000ce6ec070914360e9) Thanks [@suerta-git](https://github.com/suerta-git)! - Added the `AnyStateConfig` type, which represents any `StateConfig<...>`:
 
   ```ts
   import type { AnyStateConfig } from 'xstate';
@@ -261,11 +261,11 @@
 
 - [#2965](https://github.com/statelyai/xstate/pull/2965) [`8b8f719c3`](https://github.com/statelyai/xstate/commit/8b8f719c36ab2c09fcd11b529cc6c9c89a06ad2e) Thanks [@satyasinha](https://github.com/satyasinha)! - All actions are now available in the `actions` variable when importing: `import { actions } from 'xstate'`
 
-* [#2892](https://github.com/statelyai/xstate/pull/2892) [`02de3d44f`](https://github.com/statelyai/xstate/commit/02de3d44f8ca87b4dcb4153d3560da7d43ee9d0b) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Persisted state can now be easily restored to a state compatible with the machine without converting it to a `State` instance first:
+- [#2892](https://github.com/statelyai/xstate/pull/2892) [`02de3d44f`](https://github.com/statelyai/xstate/commit/02de3d44f8ca87b4dcb4153d3560da7d43ee9d0b) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Persisted state can now be easily restored to a state compatible with the machine without converting it to a `State` instance first:
 
   ```js
   // Persisting a state
-  someService.subscribe(state => {
+  someService.subscribe((state) => {
     localStorage.setItem('some-state', JSON.stringify(state));
   });
 
@@ -280,11 +280,11 @@
 
 - [#3012](https://github.com/statelyai/xstate/pull/3012) [`ab431dcb8`](https://github.com/statelyai/xstate/commit/ab431dcb8bd67a3f0bcfc9b6ca31779bb15d14af) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with a reference to `@types/node` being inserted into XState's compiled output. This could cause unexpected issues in projects expecting APIs like `setTimeout` to be typed with browser compatibility in mind.
 
-* [#3023](https://github.com/statelyai/xstate/pull/3023) [`642e9f5b8`](https://github.com/statelyai/xstate/commit/642e9f5b83dae79f016be8b657d25499077bbcda) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with states created using `machine.getInitialState` not being "resolved" in full. This could cause some things, such as `after` transitions, not being executed correctly after starting an interpreter using such state.
+- [#3023](https://github.com/statelyai/xstate/pull/3023) [`642e9f5b8`](https://github.com/statelyai/xstate/commit/642e9f5b83dae79f016be8b657d25499077bbcda) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with states created using `machine.getInitialState` not being "resolved" in full. This could cause some things, such as `after` transitions, not being executed correctly after starting an interpreter using such state.
 
 - [#2982](https://github.com/statelyai/xstate/pull/2982) [`a39145580`](https://github.com/statelyai/xstate/commit/a391455803171dcf03a1a0ec589f9dd603260d63) Thanks [@Andarist](https://github.com/Andarist)! - Marked all phantom properties on the `StateMachine` type as deprecated. This deprioritized them in IDEs so they don't popup as first suggestions during property access.
 
-* [#2992](https://github.com/statelyai/xstate/pull/2992) [`22737adf2`](https://github.com/statelyai/xstate/commit/22737adf211971197f3809f406ac3bee54dc69f0) Thanks [@Andarist](https://github.com/Andarist), [@mattpocock](https://github.com/mattpocock)! - Fixed an issue with `state.context` becoming `any` after `state.matches` when typegen is used.
+- [#2992](https://github.com/statelyai/xstate/pull/2992) [`22737adf2`](https://github.com/statelyai/xstate/commit/22737adf211971197f3809f406ac3bee54dc69f0) Thanks [@Andarist](https://github.com/Andarist), [@mattpocock](https://github.com/mattpocock)! - Fixed an issue with `state.context` becoming `any` after `state.matches` when typegen is used.
 
 - [#2981](https://github.com/statelyai/xstate/pull/2981) [`edf60d67b`](https://github.com/statelyai/xstate/commit/edf60d67b3ca58eca96c7853410528c4e4abac7b) Thanks [@Andarist](https://github.com/Andarist)! - Moved an internal `@ts-ignore` to a JSDoc-style comment to fix consuming projects that do not use `skipLibCheck`. Regular inline and block comments are not preserved in the TypeScript's emit.
 
@@ -305,7 +305,7 @@
 
   This allows us to leverage the inference algorithm better and unlocks some exciting possibilities for using XState in a more type-strict manner.
 
-* [#2674](https://github.com/statelyai/xstate/pull/2674) [`1cd26811c`](https://github.com/statelyai/xstate/commit/1cd26811cea441366a082b0f77c7a6ffb135dc38) Thanks [@Andarist](https://github.com/Andarist), [@mattpocock](https://github.com/mattpocock)! - Added the ability to tighten TS declarations of machine with generated metadata. This opens several exciting doors to being able to use typegen seamlessly with XState to provide an amazing typing experience.
+- [#2674](https://github.com/statelyai/xstate/pull/2674) [`1cd26811c`](https://github.com/statelyai/xstate/commit/1cd26811cea441366a082b0f77c7a6ffb135dc38) Thanks [@Andarist](https://github.com/Andarist), [@mattpocock](https://github.com/mattpocock)! - Added the ability to tighten TS declarations of machine with generated metadata. This opens several exciting doors to being able to use typegen seamlessly with XState to provide an amazing typing experience.
 
   With the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode), you can specify a new attribute called `tsTypes: {}` in your machine definition:
 
@@ -334,7 +334,7 @@
   });
   ```
 
-* [#2957](https://github.com/statelyai/xstate/pull/2957) [`8550ddda7`](https://github.com/statelyai/xstate/commit/8550ddda73e2ad291e19173d7fa8d13e3336fbb9) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The repository links have been updated from `github.com/davidkpiano` to `github.com/statelyai`.
+- [#2957](https://github.com/statelyai/xstate/pull/2957) [`8550ddda7`](https://github.com/statelyai/xstate/commit/8550ddda73e2ad291e19173d7fa8d13e3336fbb9) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The repository links have been updated from `github.com/davidkpiano` to `github.com/statelyai`.
 
 ## 4.28.1
 
@@ -342,7 +342,7 @@
 
 - [#2943](https://github.com/statelyai/xstate/pull/2943) [`e9f3f07a1`](https://github.com/statelyai/xstate/commit/e9f3f07a1ee9fe97af7e8f532c5b3dd3c4f73cec) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an infinite loop when initially spawned actor (in an initial context) responded synchronously to its parent.
 
-* [#2953](https://github.com/statelyai/xstate/pull/2953) [`90fa97008`](https://github.com/statelyai/xstate/commit/90fa97008970283f17a3f2f6aa9b1b7071593e80) Thanks [@Andarist](https://github.com/Andarist)! - Bring back the global type declaration for the `Symbol.observable` to fix consuming projects that do not use `skipLibCheck`.
+- [#2953](https://github.com/statelyai/xstate/pull/2953) [`90fa97008`](https://github.com/statelyai/xstate/commit/90fa97008970283f17a3f2f6aa9b1b7071593e80) Thanks [@Andarist](https://github.com/Andarist)! - Bring back the global type declaration for the `Symbol.observable` to fix consuming projects that do not use `skipLibCheck`.
 
 - [#2903](https://github.com/statelyai/xstate/pull/2903) [`b6dde9075`](https://github.com/statelyai/xstate/commit/b6dde9075adb3bb3522b4b8f8eeb804d3221a527) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with exit actions being called in random order when stopping a machine. They should always be called in the reversed document order (the ones defined on children should be called before the ones defined on ancestors and the ones defined on states appearing later in the code should be called before the ones defined on their sibling states).
 
@@ -384,7 +384,7 @@
   });
   ```
 
-* [#2925](https://github.com/statelyai/xstate/pull/2925) [`239b4666a`](https://github.com/statelyai/xstate/commit/239b4666ac302d80c028fef47c6e8ab7e0ae2757) Thanks [@devanfarrell](https://github.com/devanfarrell)! - The `sendTo(actorRef, event)` action creator introduced in `4.27.0`, which was not accessible from the package exports, can now be used just like other actions:
+- [#2925](https://github.com/statelyai/xstate/pull/2925) [`239b4666a`](https://github.com/statelyai/xstate/commit/239b4666ac302d80c028fef47c6e8ab7e0ae2757) Thanks [@devanfarrell](https://github.com/devanfarrell)! - The `sendTo(actorRef, event)` action creator introduced in `4.27.0`, which was not accessible from the package exports, can now be used just like other actions:
 
   ```js
   import { actions } from 'xstate';
@@ -411,7 +411,7 @@
 
 - [#2804](https://github.com/statelyai/xstate/pull/2804) [`f3caecf5a`](https://github.com/statelyai/xstate/commit/f3caecf5ad384cfe2a843c26333aaa46a77ece68) Thanks [@davidkpiano](https://github.com/statelyai)! - The `state.can(...)` method no longer unnecessarily executes `assign()` actions and instead determines if a given event will change the state by reading transition data before evaluating actions.
 
-* [#2856](https://github.com/statelyai/xstate/pull/2856) [`49c2e9094`](https://github.com/statelyai/xstate/commit/49c2e90945d369e2dfb2e4fc376b3f46714dce09) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with stopped children sometimes starting their own child actors. This could happen when the child was stopped synchronously (for example by its parent) when transitioning to an invoking state.
+- [#2856](https://github.com/statelyai/xstate/pull/2856) [`49c2e9094`](https://github.com/statelyai/xstate/commit/49c2e90945d369e2dfb2e4fc376b3f46714dce09) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with stopped children sometimes starting their own child actors. This could happen when the child was stopped synchronously (for example by its parent) when transitioning to an invoking state.
 
 - [#2895](https://github.com/statelyai/xstate/pull/2895) [`df5ffce14`](https://github.com/statelyai/xstate/commit/df5ffce14908d0aa8056a56001039dfd260be1a4) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with some exit handlers being executed more than once when stopping a machine.
 
@@ -421,7 +421,7 @@
 
 - [#2819](https://github.com/statelyai/xstate/pull/2819) [`0d51d33cd`](https://github.com/statelyai/xstate/commit/0d51d33cd6dc6ab876a5554788300282d03fa5d1) Thanks [@simonihmig](https://github.com/simonihmig)! - Support `globalThis` in `getGlobal()` for better compatibility
 
-* [#2828](https://github.com/statelyai/xstate/pull/2828) [`c0ef3e8`](https://github.com/statelyai/xstate/commit/c0ef3e882c688e6beefb196a3293ec71b65625e3) Thanks [@davidkpiano](https://github.com/statelyai)! - XState is now compatible with TypeScript version 4.5.
+- [#2828](https://github.com/statelyai/xstate/pull/2828) [`c0ef3e8`](https://github.com/statelyai/xstate/commit/c0ef3e882c688e6beefb196a3293ec71b65625e3) Thanks [@davidkpiano](https://github.com/statelyai)! - XState is now compatible with TypeScript version 4.5.
 
 ## 4.26.0
 
@@ -449,7 +449,7 @@
 
   Future Stately tooling will use the `description` to render automatically generated documentation, type hints, and enhancements to visual tools.
 
-* [#2743](https://github.com/statelyai/xstate/pull/2743) [`e268bf34a`](https://github.com/statelyai/xstate/commit/e268bf34a0dfe442ef7b43ecf8ab5c8d81ac69fb) Thanks [@janovekj](https://github.com/janovekj)! - Add optional type parameter to narrow type returned by `EventFrom`. You can use it like this:
+- [#2743](https://github.com/statelyai/xstate/pull/2743) [`e268bf34a`](https://github.com/statelyai/xstate/commit/e268bf34a0dfe442ef7b43ecf8ab5c8d81ac69fb) Thanks [@janovekj](https://github.com/janovekj)! - Add optional type parameter to narrow type returned by `EventFrom`. You can use it like this:
 
   ```ts
   type UpdateNameEvent = EventFrom<typeof userModel>;
@@ -459,7 +459,7 @@
 
 - [#2738](https://github.com/statelyai/xstate/pull/2738) [`942fd90e0`](https://github.com/statelyai/xstate/commit/942fd90e0c7a942564dd9c2ffebb93d6c86698df) Thanks [@michelsciortino](https://github.com/michelsciortino)! - The `tags` property was missing from state's definitions. This is used when converting a state to a JSON string. Since this is how we serialize states within [`@xstate/inspect`](https://github.com/statelyai/xstate/tree/main/packages/xstate-inspect) this has caused inspected machines to miss the `tags` information.
 
-* [#2740](https://github.com/statelyai/xstate/pull/2740) [`707cb981f`](https://github.com/statelyai/xstate/commit/707cb981fdb8a5c75cacb7e9bfa5c7e5a1cc1c88) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with tags being missed on a service state after starting that service using a state value, like this:
+- [#2740](https://github.com/statelyai/xstate/pull/2740) [`707cb981f`](https://github.com/statelyai/xstate/commit/707cb981fdb8a5c75cacb7e9bfa5c7e5a1cc1c88) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with tags being missed on a service state after starting that service using a state value, like this:
 
   ```js
   const service = interpret(machine).start('active');
@@ -521,10 +521,10 @@
 
   model.createMachine({
     // `ctx` was of type `any`
-    entry: ctx => {},
+    entry: (ctx) => {},
     exit: assign({
       // `ctx` was of type `unknown`
-      foo: ctx => 42
+      foo: (ctx) => 42
     })
   });
   ```
@@ -640,7 +640,7 @@
   type Interpreter = InterpreterFrom<ReturnType<typeof machine>>;
   ```
 
-* [`413a4578`](https://github.com/statelyai/xstate/commit/413a4578cded21beffff822d1485a3725457b768) [#2491](https://github.com/statelyai/xstate/pull/2491) Thanks [@davidkpiano](https://github.com/statelyai)! - The custom `.toString()` method on action objects is now removed which improves performance in larger applications (see [#2488](https://github.com/statelyai/xstate/discussions/2488) for more context).
+- [`413a4578`](https://github.com/statelyai/xstate/commit/413a4578cded21beffff822d1485a3725457b768) [#2491](https://github.com/statelyai/xstate/pull/2491) Thanks [@davidkpiano](https://github.com/statelyai)! - The custom `.toString()` method on action objects is now removed which improves performance in larger applications (see [#2488](https://github.com/statelyai/xstate/discussions/2488) for more context).
 
 - [`5e1223cd`](https://github.com/statelyai/xstate/commit/5e1223cd58485045b192677753946df2c00eddf7) [#2422](https://github.com/statelyai/xstate/pull/2422) Thanks [@davidkpiano](https://github.com/statelyai)! - The `context` property has been removed from `StateNodeConfig`, as it has never been allowed, nor has it ever done anything. The previous typing was unsafe and allowed `context` to be specified on nested state nodes:
 
@@ -660,7 +660,7 @@
   });
   ```
 
-* [`5b70c2ff`](https://github.com/statelyai/xstate/commit/5b70c2ff21cc5d8c6cf1c13b6eb7bb12611a9835) [#2508](https://github.com/statelyai/xstate/pull/2508) Thanks [@davidkpiano](https://github.com/statelyai)! - A race condition occurred when a child service is immediately stopped and the parent service tried to remove it from its undefined state (during its own initialization). This has been fixed, and the race condition no longer occurs. See [this issue](https://github.com/statelyai/xstate/issues/2507) for details.
+- [`5b70c2ff`](https://github.com/statelyai/xstate/commit/5b70c2ff21cc5d8c6cf1c13b6eb7bb12611a9835) [#2508](https://github.com/statelyai/xstate/pull/2508) Thanks [@davidkpiano](https://github.com/statelyai)! - A race condition occurred when a child service is immediately stopped and the parent service tried to remove it from its undefined state (during its own initialization). This has been fixed, and the race condition no longer occurs. See [this issue](https://github.com/statelyai/xstate/issues/2507) for details.
 
 - [`5a9500d1`](https://github.com/statelyai/xstate/commit/5a9500d1cde9bf2300a85bc81529da83f2d08361) [#2522](https://github.com/statelyai/xstate/pull/2522) Thanks [@farskid](https://github.com/farskid), [@Andarist](https://github.com/Andarist)! - Adjusted TS type definitions of the `withContext` and `withConfig` methods so that they accept "lazy context" now.
 
@@ -672,7 +672,7 @@
   }));
   ```
 
-* [`84f9fcae`](https://github.com/statelyai/xstate/commit/84f9fcae7d2b7f99800cc3bf18097ed45c48f0f5) [#2540](https://github.com/statelyai/xstate/pull/2540) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `state.hasTag('someTag')` crashing when the `state` was rehydrated.
+- [`84f9fcae`](https://github.com/statelyai/xstate/commit/84f9fcae7d2b7f99800cc3bf18097ed45c48f0f5) [#2540](https://github.com/statelyai/xstate/pull/2540) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `state.hasTag('someTag')` crashing when the `state` was rehydrated.
 
 - [`c17dd376`](https://github.com/statelyai/xstate/commit/c17dd37621a2ba46967926d550c70a35bba7024c) [#2496](https://github.com/statelyai/xstate/pull/2496) Thanks [@VanTanev](https://github.com/VanTanev)! - Add utility type `EmittedFrom<T>` that extracts `Emitted` type from any type which can emit data
 
@@ -700,11 +700,11 @@
   const machine = createMachine({
     context: { count: 0 },
     entry: [
-      ctx => console.log(ctx.count), // 0
-      assign({ count: ctx => ctx.count + 1 }),
-      ctx => console.log(ctx.count), // 1
-      assign({ count: ctx => ctx.count + 1 }),
-      ctx => console.log(ctx.count) // 2
+      (ctx) => console.log(ctx.count), // 0
+      assign({ count: (ctx) => ctx.count + 1 }),
+      (ctx) => console.log(ctx.count), // 1
+      assign({ count: (ctx) => ctx.count + 1 }),
+      (ctx) => console.log(ctx.count) // 2
     ],
     preserveActionOrder: true
   });
@@ -713,11 +713,11 @@
   const machine = createMachine({
     context: { count: 0 },
     entry: [
-      ctx => console.log(ctx.count), // 2
-      assign({ count: ctx => ctx.count + 1 }),
-      ctx => console.log(ctx.count), // 2
-      assign({ count: ctx => ctx.count + 1 }),
-      ctx => console.log(ctx.count) // 2
+      (ctx) => console.log(ctx.count), // 2
+      assign({ count: (ctx) => ctx.count + 1 }),
+      (ctx) => console.log(ctx.count), // 2
+      assign({ count: (ctx) => ctx.count + 1 }),
+      (ctx) => console.log(ctx.count) // 2
     ]
     // preserveActionOrder: false
   });
@@ -727,7 +727,7 @@
 
 - [`4e305372`](https://github.com/statelyai/xstate/commit/4e30537266eb082ccd85f050c9372358247b4167) [#2361](https://github.com/statelyai/xstate/pull/2361) Thanks [@woutermont](https://github.com/woutermont)! - Add type for `Symbol.observable` to the `Interpreter` to improve the compatibility with RxJS.
 
-* [`1def6cf6`](https://github.com/statelyai/xstate/commit/1def6cf6109867a87b4323ee83d20a9ee0c49d7b) [#2374](https://github.com/statelyai/xstate/pull/2374) Thanks [@davidkpiano](https://github.com/statelyai)! - Existing actors can now be identified in `spawn(...)` calls by providing an `id`. This allows them to be referenced by string:
+- [`1def6cf6`](https://github.com/statelyai/xstate/commit/1def6cf6109867a87b4323ee83d20a9ee0c49d7b) [#2374](https://github.com/statelyai/xstate/pull/2374) Thanks [@davidkpiano](https://github.com/statelyai)! - Existing actors can now be identified in `spawn(...)` calls by providing an `id`. This allows them to be referenced by string:
 
   ```ts
   const machine = createMachine({
@@ -760,7 +760,7 @@
   +const machine = model.createMachine(/* ... */);
   ```
 
-* [`432b60f7`](https://github.com/statelyai/xstate/commit/432b60f7bcbcee9510e0d86311abbfd75b1a674e) [#2280](https://github.com/statelyai/xstate/pull/2280) Thanks [@davidkpiano](https://github.com/statelyai)! - Actors can now be invoked/spawned from reducers using the `fromReducer(...)` behavior creator:
+- [`432b60f7`](https://github.com/statelyai/xstate/commit/432b60f7bcbcee9510e0d86311abbfd75b1a674e) [#2280](https://github.com/statelyai/xstate/pull/2280) Thanks [@davidkpiano](https://github.com/statelyai)! - Actors can now be invoked/spawned from reducers using the `fromReducer(...)` behavior creator:
 
   ```ts
   import { fromReducer } from 'xstate/lib/behaviors';
@@ -839,7 +839,7 @@
   }
   ```
 
-* [`38e6a5e9`](https://github.com/statelyai/xstate/commit/38e6a5e98a1dd54b4f2ef96942180ec0add88f2b) [#2334](https://github.com/statelyai/xstate/pull/2334) Thanks [@davidkpiano](https://github.com/statelyai)! - When using a model type in `createMachine<typeof someModel>(...)`, TypeScript will no longer compile machines that are missing the `context` property in the machine configuration:
+- [`38e6a5e9`](https://github.com/statelyai/xstate/commit/38e6a5e98a1dd54b4f2ef96942180ec0add88f2b) [#2334](https://github.com/statelyai/xstate/pull/2334) Thanks [@davidkpiano](https://github.com/statelyai)! - When using a model type in `createMachine<typeof someModel>(...)`, TypeScript will no longer compile machines that are missing the `context` property in the machine configuration:
 
   ```ts
   const machine = createMachine<typeof someModel>({
@@ -861,7 +861,7 @@
   };
   ```
 
-* [`2de3ec3e`](https://github.com/statelyai/xstate/commit/2de3ec3e994e0deb5a142aeac15e1eddeb18d1e1) [#2272](https://github.com/statelyai/xstate/pull/2272) Thanks [@davidkpiano](https://github.com/statelyai)! - The `state.meta` value is now calculated directly from `state.configuration`. This is most useful when starting a service from a persisted state:
+- [`2de3ec3e`](https://github.com/statelyai/xstate/commit/2de3ec3e994e0deb5a142aeac15e1eddeb18d1e1) [#2272](https://github.com/statelyai/xstate/pull/2272) Thanks [@davidkpiano](https://github.com/statelyai)! - The `state.meta` value is now calculated directly from `state.configuration`. This is most useful when starting a service from a persisted state:
 
   ```ts
     const machine = createMachine({
@@ -916,7 +916,7 @@
   });
 
   const service = interpret(machine)
-    .onTransition(state => {
+    .onTransition((state) => {
       // Read promise value synchronously
       const resolvedValue = state.context.promiseRef?.getSnapshot();
       // => undefined (if promise not resolved yet)
@@ -941,7 +941,7 @@
   `Subscribable<any>`s that are not `Subscribable<EventObject>`s
   should be updated accordingly.
 
-* [`38dcec1d`](https://github.com/statelyai/xstate/commit/38dcec1dad60c62cf8c47c88736651483276ff87) [#2149](https://github.com/statelyai/xstate/pull/2149) Thanks [@davidkpiano](https://github.com/statelyai)! - Invocations and entry actions for _combinatorial_ machines (machines with only a single root state) now behave predictably and will not re-execute upon targetless transitions.
+- [`38dcec1d`](https://github.com/statelyai/xstate/commit/38dcec1dad60c62cf8c47c88736651483276ff87) [#2149](https://github.com/statelyai/xstate/pull/2149) Thanks [@davidkpiano](https://github.com/statelyai)! - Invocations and entry actions for _combinatorial_ machines (machines with only a single root state) now behave predictably and will not re-execute upon targetless transitions.
 
 ## 4.19.1
 
@@ -989,14 +989,14 @@
 
 - [`d0939ec6`](https://github.com/statelyai/xstate/commit/d0939ec60161c34b053cecdaeb277606b5982375) [#2046](https://github.com/statelyai/xstate/pull/2046) Thanks [@SimeonC](https://github.com/SimeonC)! - Allow machines to communicate with the inspector even in production builds.
 
-* [`e37fffef`](https://github.com/statelyai/xstate/commit/e37fffefb742f45765945c02727edfbd5e2f9d47) [#2079](https://github.com/statelyai/xstate/pull/2079) Thanks [@davidkpiano](https://github.com/statelyai)! - There is now support for "combinatorial machines" (state machines that only have one state):
+- [`e37fffef`](https://github.com/statelyai/xstate/commit/e37fffefb742f45765945c02727edfbd5e2f9d47) [#2079](https://github.com/statelyai/xstate/pull/2079) Thanks [@davidkpiano](https://github.com/statelyai)! - There is now support for "combinatorial machines" (state machines that only have one state):
 
   ```js
   const testMachine = createMachine({
     context: { value: 42 },
     on: {
       INC: {
-        actions: assign({ value: ctx => ctx.value + 1 })
+        actions: assign({ value: (ctx) => ctx.value + 1 })
       }
     }
   });
@@ -1070,7 +1070,7 @@
   });
   ```
 
-* [`5febfe83`](https://github.com/statelyai/xstate/commit/5febfe83a7e5e866c0a4523ea4f86a966af7c50f) [#1955](https://github.com/statelyai/xstate/pull/1955) Thanks [@davidkpiano](https://github.com/statelyai)! - Event creators can now be modeled inside of the 2nd argument of `createModel()`, and types for both `context` and `events` will be inferred properly in `createMachine()` when given the `typeof model` as the first generic parameter.
+- [`5febfe83`](https://github.com/statelyai/xstate/commit/5febfe83a7e5e866c0a4523ea4f86a966af7c50f) [#1955](https://github.com/statelyai/xstate/pull/1955) Thanks [@davidkpiano](https://github.com/statelyai)! - Event creators can now be modeled inside of the 2nd argument of `createModel()`, and types for both `context` and `events` will be inferred properly in `createMachine()` when given the `typeof model` as the first generic parameter.
 
   ```ts
   import { createModel } from 'xstate/lib/model';
@@ -1256,18 +1256,18 @@
 
   ```js
   // ...
-  actions: stop(context => context.someActor);
+  actions: stop((context) => context.someActor);
   ```
 
 ### Patch Changes
 
 - [`8c78e120`](https://github.com/statelyai/xstate/commit/8c78e1205a729d933e30db01cd4260d82352a9be) [#1570](https://github.com/statelyai/xstate/pull/1570) Thanks [@davidkpiano](https://github.com/statelyai)! - The return type of `spawn(machine)` will now be `Actor<State<TContext, TEvent>, TEvent>`, which is a supertype of `Interpreter<...>`.
 
-* [`602687c2`](https://github.com/statelyai/xstate/commit/602687c235c56cca552c2d5a9d78adf224f522d8) [#1566](https://github.com/statelyai/xstate/pull/1566) Thanks [@davidkpiano](https://github.com/statelyai)! - Exit actions will now be properly called when an invoked machine reaches its final state. See [#1109](https://github.com/statelyai/xstate/issues/1109) for more details.
+- [`602687c2`](https://github.com/statelyai/xstate/commit/602687c235c56cca552c2d5a9d78adf224f522d8) [#1566](https://github.com/statelyai/xstate/pull/1566) Thanks [@davidkpiano](https://github.com/statelyai)! - Exit actions will now be properly called when an invoked machine reaches its final state. See [#1109](https://github.com/statelyai/xstate/issues/1109) for more details.
 
 - [`6e44d02a`](https://github.com/statelyai/xstate/commit/6e44d02ad03af4041046120dd6c975e3b5b3772a) [#1553](https://github.com/statelyai/xstate/pull/1553) Thanks [@davidkpiano](https://github.com/statelyai)! - The `state.children` property now properly shows all spawned and invoked actors. See [#795](https://github.com/statelyai/xstate/issues/795) for more details.
 
-* [`72b0880e`](https://github.com/statelyai/xstate/commit/72b0880e6444ae009adca72088872bb5c0760ce3) [#1504](https://github.com/statelyai/xstate/pull/1504) Thanks [@Andarist](https://github.com/Andarist)! - Added `status` property on the `Interpreter` - this can be used to differentiate not started, running and stopped interpreters. This property is best compared to values on the new `InterpreterStatus` export.
+- [`72b0880e`](https://github.com/statelyai/xstate/commit/72b0880e6444ae009adca72088872bb5c0760ce3) [#1504](https://github.com/statelyai/xstate/pull/1504) Thanks [@Andarist](https://github.com/Andarist)! - Added `status` property on the `Interpreter` - this can be used to differentiate not started, running and stopped interpreters. This property is best compared to values on the new `InterpreterStatus` export.
 
 ## 4.13.0
 
@@ -1279,7 +1279,7 @@
 
 - [`b1684ead`](https://github.com/statelyai/xstate/commit/b1684eadb1f859db5c733b8d403afc825c294948) [#1402](https://github.com/statelyai/xstate/pull/1402) Thanks [@Andarist](https://github.com/Andarist)! - Improved TypeScript type-checking performance a little bit by using distributive conditional type within `TransitionsConfigArray` declarations instead of a mapped type. Kudos to [@amcasey](https://github.com/amcasey), some discussion around this can be found [here](https://github.com/microsoft/TypeScript/issues/39826#issuecomment-675790689)
 
-* [`ad3026d4`](https://github.com/statelyai/xstate/commit/ad3026d4309e9a1c719e09fd8c15cdfefce22055) [#1407](https://github.com/statelyai/xstate/pull/1407) Thanks [@tomenden](https://github.com/tomenden)! - Fixed an issue with not being able to run XState in Web Workers due to assuming that `window` or `global` object is available in the executing environment, but none of those are actually available in the Web Workers context.
+- [`ad3026d4`](https://github.com/statelyai/xstate/commit/ad3026d4309e9a1c719e09fd8c15cdfefce22055) [#1407](https://github.com/statelyai/xstate/pull/1407) Thanks [@tomenden](https://github.com/tomenden)! - Fixed an issue with not being able to run XState in Web Workers due to assuming that `window` or `global` object is available in the executing environment, but none of those are actually available in the Web Workers context.
 
 - [`4e949ec8`](https://github.com/statelyai/xstate/commit/4e949ec856349062352562c825beb0654e528f81) [#1401](https://github.com/statelyai/xstate/pull/1401) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with spawned actors being spawned multiple times when they got spawned in an initial state of a child machine that is invoked in the initial state of a parent machine.
 
@@ -1327,7 +1327,7 @@
 
 - [`b72e29dd`](https://github.com/statelyai/xstate/commit/b72e29dd728b4c1be4bdeaec93909b4e307db5cf) [#1354](https://github.com/statelyai/xstate/pull/1354) Thanks [@davidkpiano](https://github.com/statelyai)! - The `Action` type was simplified, and as a result, you should see better TypeScript performance.
 
-* [`4dbabfe7`](https://github.com/statelyai/xstate/commit/4dbabfe7d5ba154e852b4d460a2434c6fc955726) [#1320](https://github.com/statelyai/xstate/pull/1320) Thanks [@davidkpiano](https://github.com/statelyai)! - The `invoke.src` property now accepts an object that describes the invoke source with its `type` and other related metadata. This can be read from the `services` option in the `meta.src` argument:
+- [`4dbabfe7`](https://github.com/statelyai/xstate/commit/4dbabfe7d5ba154e852b4d460a2434c6fc955726) [#1320](https://github.com/statelyai/xstate/pull/1320) Thanks [@davidkpiano](https://github.com/statelyai)! - The `invoke.src` property now accepts an object that describes the invoke source with its `type` and other related metadata. This can be read from the `services` option in the `meta.src` argument:
 
   ```js
   const machine = createMachine(
@@ -1365,7 +1365,7 @@
 
 - [`3ab3f25e`](https://github.com/statelyai/xstate/commit/3ab3f25ea297e4d770eef512e9583475c943845d) [#1285](https://github.com/statelyai/xstate/pull/1285) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with initial state of invoked machines being read without custom data passed to them which could lead to a crash when evaluating transient transitions for the initial state.
 
-* [`a7da1451`](https://github.com/statelyai/xstate/commit/a7da14510fd1645ad041836b567771edb5b90827) [#1290](https://github.com/statelyai/xstate/pull/1290) Thanks [@davidkpiano](https://github.com/statelyai)! - The "Attempted to spawn an Actor [...] outside of a service. This will have no effect." warnings are now silenced for "lazily spawned" actors, which are actors that aren't immediately active until the function that creates them are called:
+- [`a7da1451`](https://github.com/statelyai/xstate/commit/a7da14510fd1645ad041836b567771edb5b90827) [#1290](https://github.com/statelyai/xstate/pull/1290) Thanks [@davidkpiano](https://github.com/statelyai)! - The "Attempted to spawn an Actor [...] outside of a service. This will have no effect." warnings are now silenced for "lazily spawned" actors, which are actors that aren't immediately active until the function that creates them are called:
 
   ```js
   // ⚠️ "active" actor - will warn
@@ -1382,7 +1382,7 @@
 
 - [`c1f3d260`](https://github.com/statelyai/xstate/commit/c1f3d26069ee70343f8045a48411e02a68f98cbd) [#1317](https://github.com/statelyai/xstate/pull/1317) Thanks [@Andarist](https://github.com/Andarist)! - Fixed a type returned by a `raise` action - it's now `RaiseAction<TEvent> | SendAction<TContext, AnyEventObject, TEvent>` instead of `RaiseAction<TEvent> | SendAction<TContext, TEvent, TEvent>`. This makes it comaptible in a broader range of scenarios.
 
-* [`8270d5a7`](https://github.com/statelyai/xstate/commit/8270d5a76c71add3a5109e069bd85716b230b5d4) [#1372](https://github.com/statelyai/xstate/pull/1372) Thanks [@christianchown](https://github.com/christianchown)! - Narrowed the `ServiceConfig` type definition to use a specific event type to prevent compilation errors on strictly-typed `MachineOptions`.
+- [`8270d5a7`](https://github.com/statelyai/xstate/commit/8270d5a76c71add3a5109e069bd85716b230b5d4) [#1372](https://github.com/statelyai/xstate/pull/1372) Thanks [@christianchown](https://github.com/christianchown)! - Narrowed the `ServiceConfig` type definition to use a specific event type to prevent compilation errors on strictly-typed `MachineOptions`.
 
 - [`01e3e2dc`](https://github.com/statelyai/xstate/commit/01e3e2dcead63dce3eef5ab745395584efbf05fa) [#1320](https://github.com/statelyai/xstate/pull/1320) Thanks [@davidkpiano](https://github.com/statelyai)! - The JSON definition for `stateNode.invoke` objects will no longer include the `onDone` and `onError` transitions, since those transitions are already merged into the `transitions` array. This solves the issue of reviving a serialized machine from JSON, where before, the `onDone` and `onError` transitions for invocations were wrongly duplicated.
 
@@ -1392,7 +1392,7 @@
 
 - [`36ed8d0a`](https://github.com/statelyai/xstate/commit/36ed8d0a3adf5b7fd187b0abe198220398e8b056) [#1262](https://github.com/statelyai/xstate/pull/1262) Thanks [@Andarist](https://github.com/Andarist)! - Improved type inference for `InvokeConfig['data']`. This has required renaming `data` property on `StateNode` instances to `doneData`. This property was never meant to be a part of the public API, so we don't consider this to be a breaking change.
 
-* [`2c75ab82`](https://github.com/statelyai/xstate/commit/2c75ab822e49cb1a23c1e14eb7bd04548ab143eb) [#1219](https://github.com/statelyai/xstate/pull/1219) Thanks [@davidkpiano](https://github.com/statelyai)! - The resolved value of the `invoke.data` property is now available in the "invoke meta" object, which is passed as the 3rd argument to the service creator in `options.services`. This will work for all types of invoked services now, including promises, observables, and callbacks.
+- [`2c75ab82`](https://github.com/statelyai/xstate/commit/2c75ab822e49cb1a23c1e14eb7bd04548ab143eb) [#1219](https://github.com/statelyai/xstate/pull/1219) Thanks [@davidkpiano](https://github.com/statelyai)! - The resolved value of the `invoke.data` property is now available in the "invoke meta" object, which is passed as the 3rd argument to the service creator in `options.services`. This will work for all types of invoked services now, including promises, observables, and callbacks.
 
   ```js
   const machine = createMachine({
@@ -1459,7 +1459,7 @@
 
 - [`0133954`](https://github.com/statelyai/xstate/commit/013395463b955e950ab24cb4be51faf524b0de6e) [#1178](https://github.com/statelyai/xstate/pull/1178) Thanks [@davidkpiano](https://github.com/statelyai)! - The types for the `send()` and `sendParent()` action creators have been changed to fix the issue of only being able to send events that the machine can receive. In reality, a machine can and should send events to other actors that it might not be able to receive itself. See [#711](https://github.com/statelyai/xstate/issues/711) for more information.
 
-* [`a1f1239`](https://github.com/statelyai/xstate/commit/a1f1239e20e05e338ed994d031e7ef6f2f09ad68) [#1189](https://github.com/statelyai/xstate/pull/1189) Thanks [@davidkpiano](https://github.com/statelyai)! - Previously, `state.matches(...)` was problematic because it was casting `state` to `never` if it didn't match the state value. This is now fixed by making the `Typestate` resolution more granular.
+- [`a1f1239`](https://github.com/statelyai/xstate/commit/a1f1239e20e05e338ed994d031e7ef6f2f09ad68) [#1189](https://github.com/statelyai/xstate/pull/1189) Thanks [@davidkpiano](https://github.com/statelyai)! - Previously, `state.matches(...)` was problematic because it was casting `state` to `never` if it didn't match the state value. This is now fixed by making the `Typestate` resolution more granular.
 
 - [`dbc6a16`](https://github.com/statelyai/xstate/commit/dbc6a161c068a3e12dd12452b68a66fe3f4fb8eb) [#1183](https://github.com/statelyai/xstate/pull/1183) Thanks [@davidkpiano](https://github.com/statelyai)! - Actions from a restored state provided as a custom initial state to `interpret(machine).start(initialState)` are now executed properly. See #1174 for more information.
 
@@ -1467,11 +1467,11 @@
 
 - [`a10d604`](https://github.com/statelyai/xstate/commit/a10d604a6afcf39048b02be5436acdd197f16c2b) [#1176](https://github.com/statelyai/xstate/pull/1176) Thanks [@itfarrier](https://github.com/itfarrier)! - Fix passing state schema into State generic
 
-* [`326db72`](https://github.com/statelyai/xstate/commit/326db725e50f7678af162626c6c7491e4364ec07) [#1185](https://github.com/statelyai/xstate/pull/1185) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with invoked service not being correctly started if other service got stopped in a subsequent microstep (in response to raised or null event).
+- [`326db72`](https://github.com/statelyai/xstate/commit/326db725e50f7678af162626c6c7491e4364ec07) [#1185](https://github.com/statelyai/xstate/pull/1185) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with invoked service not being correctly started if other service got stopped in a subsequent microstep (in response to raised or null event).
 
 - [`c3a496e`](https://github.com/statelyai/xstate/commit/c3a496e1f92ec27db0643fd1ddc32d683db4e751) [#1160](https://github.com/statelyai/xstate/pull/1160) Thanks [@davidkpiano](https://github.com/statelyai)! - Delayed transitions defined using `after` were previously causing a circular dependency when the machine was converted using `.toJSON()`. This has now been fixed.
 
-* [`e16e48e`](https://github.com/statelyai/xstate/commit/e16e48e05e6243a3eacca58a13d3e663cd641f55) [#1153](https://github.com/statelyai/xstate/pull/1153) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `choose` and `pure` not being able to use actions defined in options.
+- [`e16e48e`](https://github.com/statelyai/xstate/commit/e16e48e05e6243a3eacca58a13d3e663cd641f55) [#1153](https://github.com/statelyai/xstate/pull/1153) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `choose` and `pure` not being able to use actions defined in options.
 
 - [`d496ecb`](https://github.com/statelyai/xstate/commit/d496ecb11b26011f2382d1ce6c4433284a7b3e9b) [#1165](https://github.com/statelyai/xstate/pull/1165) Thanks [@davidkpiano](https://github.com/statelyai)! - XState will now warn if you define an `.onDone` transition on the root node. Root nodes which are "done" represent the machine being in its final state, and can no longer accept any events. This has been reported as confusing in [#1111](https://github.com/statelyai/xstate/issues/1111).
 
@@ -1481,7 +1481,7 @@
 
 - [`8a97785`](https://github.com/statelyai/xstate/commit/8a97785055faaeb1b36040dd4dc04e3b90fa9ec2) [#1137](https://github.com/statelyai/xstate/pull/1137) Thanks [@davidkpiano](https://github.com/statelyai)! - Added docs for the `choose()` and `pure()` action creators, as well as exporting the `pure()` action creator in the `actions` object.
 
-* [`e65dee9`](https://github.com/statelyai/xstate/commit/e65dee928fea60df1e9f83c82fed8102dfed0000) [#1131](https://github.com/statelyai/xstate/pull/1131) Thanks [@wKovacs64](https://github.com/wKovacs64)! - Include the new `choose` action in the `actions` export from the `xstate` core package. This was missed in v4.9.0.
+- [`e65dee9`](https://github.com/statelyai/xstate/commit/e65dee928fea60df1e9f83c82fed8102dfed0000) [#1131](https://github.com/statelyai/xstate/pull/1131) Thanks [@wKovacs64](https://github.com/wKovacs64)! - Include the new `choose` action in the `actions` export from the `xstate` core package. This was missed in v4.9.0.
 
 ## 4.9.0
 
@@ -1489,15 +1489,15 @@
 
 - [`f3ff150`](https://github.com/statelyai/xstate/commit/f3ff150f7c50f402704d25cdc053b76836e447e3) [#1103](https://github.com/statelyai/xstate/pull/1103) Thanks [@davidkpiano](https://github.com/statelyai)! - Simplify the `TransitionConfigArray` and `TransitionConfigMap` types in order to fix excessively deep type instantiation TypeScript reports. This addresses [#1015](https://github.com/statelyai/xstate/issues/1015).
 
-* [`6c47b66`](https://github.com/statelyai/xstate/commit/6c47b66c3289ff161dc96d9b246873f55c9e18f2) [#1076](https://github.com/statelyai/xstate/pull/1076) Thanks [@Andarist](https://github.com/Andarist)! - Added support for conditional actions. It's possible now to have actions executed based on conditions using following:
+- [`6c47b66`](https://github.com/statelyai/xstate/commit/6c47b66c3289ff161dc96d9b246873f55c9e18f2) [#1076](https://github.com/statelyai/xstate/pull/1076) Thanks [@Andarist](https://github.com/Andarist)! - Added support for conditional actions. It's possible now to have actions executed based on conditions using following:
 
   ```js
   entry: [
     choose([
-      { cond: ctx => ctx > 100, actions: raise('TOGGLE') },
+      { cond: (ctx) => ctx > 100, actions: raise('TOGGLE') },
       {
         cond: 'hasMagicBottle',
-        actions: [assign(ctx => ({ counter: ctx.counter + 1 }))]
+        actions: [assign((ctx) => ({ counter: ctx.counter + 1 }))]
       },
       { actions: ['fallbackAction'] }
     ])
@@ -1510,7 +1510,7 @@
 
 - [`1a129f0`](https://github.com/statelyai/xstate/commit/1a129f0f35995981c160d756a570df76396bfdbd) [#1073](https://github.com/statelyai/xstate/pull/1073) Thanks [@Andarist](https://github.com/Andarist)! - Cleanup internal structures upon receiving termination events from spawned actors.
 
-* [`e88aa18`](https://github.com/statelyai/xstate/commit/e88aa18431629e1061b74dfd4a961b910e274e0b) [#1085](https://github.com/statelyai/xstate/pull/1085) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with data expressions of root's final nodes being called twice.
+- [`e88aa18`](https://github.com/statelyai/xstate/commit/e88aa18431629e1061b74dfd4a961b910e274e0b) [#1085](https://github.com/statelyai/xstate/pull/1085) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with data expressions of root's final nodes being called twice.
 
 - [`88b17b2`](https://github.com/statelyai/xstate/commit/88b17b2476ff9a0fbe810df9d00db32c2241cd6e) [#1090](https://github.com/statelyai/xstate/pull/1090) Thanks [@rjdestigter](https://github.com/rjdestigter)! - This change carries forward the typestate type information encoded in the arguments of the following functions and assures that the return type also has the same typestate type information:
 
@@ -1518,7 +1518,7 @@
   - `.state` getter defined for services.
   - `start` method of services.
 
-* [`d5f622f`](https://github.com/statelyai/xstate/commit/d5f622f68f4065a2615b5a4a1caae6b508b4840e) [#1069](https://github.com/statelyai/xstate/pull/1069) Thanks [@davidkpiano](https://github.com/statelyai)! - Loosened event type for `SendAction<TContext, AnyEventObject>`
+- [`d5f622f`](https://github.com/statelyai/xstate/commit/d5f622f68f4065a2615b5a4a1caae6b508b4840e) [#1069](https://github.com/statelyai/xstate/pull/1069) Thanks [@davidkpiano](https://github.com/statelyai)! - Loosened event type for `SendAction<TContext, AnyEventObject>`
 
 ## 4.8.0
 
@@ -1544,7 +1544,7 @@
 
 - [`c8db035`](https://github.com/statelyai/xstate/commit/c8db035b90a7ab4a557359d493d3dd7973dacbdd) [#936](https://github.com/statelyai/xstate/pull/936) Thanks [@davidkpiano](https://github.com/statelyai)! - The `escalate()` action can now take in an expression, which will be evaluated against the `context`, `event`, and `meta` to return the error data.
 
-* [`2a3fea1`](https://github.com/statelyai/xstate/commit/2a3fea18dcd5be18880ad64007d44947cc327d0d) [#952](https://github.com/statelyai/xstate/pull/952) Thanks [@davidkpiano](https://github.com/statelyai)! - The typings for the raise() action have been fixed to allow any event to be raised. This typed behavior will be refined in version 5, to limit raised events to those that the machine accepts.
+- [`2a3fea1`](https://github.com/statelyai/xstate/commit/2a3fea18dcd5be18880ad64007d44947cc327d0d) [#952](https://github.com/statelyai/xstate/pull/952) Thanks [@davidkpiano](https://github.com/statelyai)! - The typings for the raise() action have been fixed to allow any event to be raised. This typed behavior will be refined in version 5, to limit raised events to those that the machine accepts.
 
 - [`f86d419`](https://github.com/statelyai/xstate/commit/f86d41979ed108e2ac4df63299fc16f798da69f7) [#957](https://github.com/statelyai/xstate/pull/957) Thanks [@Andarist](https://github.com/Andarist)! - Fixed memory leak - each created service has been registered in internal map but it was never removed from it. Registration has been moved to a point where Interpreter is being started and it's deregistered when it is being stopped.
 

--- a/packages/xstate-fsm/CHANGELOG.md
+++ b/packages/xstate-fsm/CHANGELOG.md
@@ -132,7 +132,7 @@
 
   </details>
 
-* [`3c10215`](https://github.com/statelyai/xstate/commit/3c102158d24d3f12aa671bc39dea0a2e98e3c34f) [#811](https://github.com/statelyai/xstate/pull/811) Thanks [@ghengeveld](https://github.com/ghengeveld)! - A `config` property got exposed on created machines. It's the same object which got passed in as argument.
+- [`3c10215`](https://github.com/statelyai/xstate/commit/3c102158d24d3f12aa671bc39dea0a2e98e3c34f) [#811](https://github.com/statelyai/xstate/pull/811) Thanks [@ghengeveld](https://github.com/ghengeveld)! - A `config` property got exposed on created machines. It's the same object which got passed in as argument.
 
 ### Patch Changes
 

--- a/packages/xstate-graph/CHANGELOG.md
+++ b/packages/xstate-graph/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Renamed `getAdjacencyMap` to `getValueAdjacencyMap`.
 
-* [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Changed `getSimplePaths` to `getSimplePlans`, and `getShortestPaths` to `getShortestPlans`. Both of these functions can be passed a machine, and return `StatePlan[]`.
+- [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Changed `getSimplePaths` to `getSimplePlans`, and `getShortestPaths` to `getShortestPlans`. Both of these functions can be passed a machine, and return `StatePlan[]`.
 
   Added functions `traverseSimplePlans`, `traverseShortestPlans`,`traverseShortestPlansFromTo`, `traverseSimplePlansTo` and `traverseSimplePlansFromTo`, which can be passed a `Behavior` and return `StatePlan[]`.
 

--- a/packages/xstate-inspect/CHANGELOG.md
+++ b/packages/xstate-inspect/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - [#3198](https://github.com/statelyai/xstate/pull/3198) [`09e2130df`](https://github.com/statelyai/xstate/commit/09e2130dff80815c10df38496a761fe8ae0d9f6e) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue that prevented some states from being sent correctly to the inspector when serializable values hold references to objects throwing on `toJSON` property access (like `obj.toJSON`). This property is accessed by the native algorithm before the value gets passed to the custom `serializer`. Because of a bug we couldn't correctly serialize such values even when a custom `serializer` was implemented that was meant to replace it in a custom way from within its parent's level.
 
-* [#3199](https://github.com/statelyai/xstate/pull/3199) [`f3d63147d`](https://github.com/statelyai/xstate/commit/f3d63147d36791344d55fa9c945af32daeefa2fa) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue that caused sending the same event multiple times to the inspector for restarted services.
+- [#3199](https://github.com/statelyai/xstate/pull/3199) [`f3d63147d`](https://github.com/statelyai/xstate/commit/f3d63147d36791344d55fa9c945af32daeefa2fa) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue that caused sending the same event multiple times to the inspector for restarted services.
 
 - [#3076](https://github.com/statelyai/xstate/pull/3076) [`34f3d9be7`](https://github.com/statelyai/xstate/commit/34f3d9be74d2bd9db51b2db06c5a65d980aec9c4) Thanks [@SimeonC](https://github.com/SimeonC)! - Fixed an issue with "maximum call stack size exceeded" errors being thrown when registering a machine with a very deep object in its context despite using a serializer capable of replacing such an object.
 
@@ -28,7 +28,7 @@
 
 - [#3144](https://github.com/statelyai/xstate/pull/3144) [`e08030faf`](https://github.com/statelyai/xstate/commit/e08030faf00e2bcb192040b6ba04178ecf057509) Thanks [@lecepin](https://github.com/lecepin)! - Added UMD build for this package that is available in the `dist` directory in the published package.
 
-* [#3144](https://github.com/statelyai/xstate/pull/3144) [`e08030faf`](https://github.com/statelyai/xstate/commit/e08030faf00e2bcb192040b6ba04178ecf057509) Thanks [@lecepin](https://github.com/lecepin)! - Added proper `peerDependency` on XState. It was incorrectly omitted from the `package.json` of this package.
+- [#3144](https://github.com/statelyai/xstate/pull/3144) [`e08030faf`](https://github.com/statelyai/xstate/commit/e08030faf00e2bcb192040b6ba04178ecf057509) Thanks [@lecepin](https://github.com/lecepin)! - Added proper `peerDependency` on XState. It was incorrectly omitted from the `package.json` of this package.
 
 ## 0.6.3
 
@@ -81,7 +81,7 @@
   });
   ```
 
-* [#2894](https://github.com/statelyai/xstate/pull/2894) [`8435c5b84`](https://github.com/statelyai/xstate/commit/8435c5b841e318c5d35dfea65242246dfb4b34f8) Thanks [@Andarist](https://github.com/Andarist)! - The package has been upgraded to be compatible with `ws@8.x`. The WS server created server-side has to be of a compatible version now.
+- [#2894](https://github.com/statelyai/xstate/pull/2894) [`8435c5b84`](https://github.com/statelyai/xstate/commit/8435c5b841e318c5d35dfea65242246dfb4b34f8) Thanks [@Andarist](https://github.com/Andarist)! - The package has been upgraded to be compatible with `ws@8.x`. The WS server created server-side has to be of a compatible version now.
 
 ## 0.5.2
 
@@ -143,7 +143,7 @@
 
   const windowReceiver = createWindowReceiver(/* options? */);
 
-  windowReceiver.subscribe(event => {
+  windowReceiver.subscribe((event) => {
     // here, you will receive events like:
     // { type: "service.register", machine: ..., state: ..., sessionId: ... }
     console.log(event);

--- a/packages/xstate-react/CHANGELOG.md
+++ b/packages/xstate-react/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [#3456](https://github.com/statelyai/xstate/pull/3456) [`131d429ab`](https://github.com/statelyai/xstate/commit/131d429ab350aaca371c4c7974829c621a50c024) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `shallowEqual` helper comparator function.
 
-* [#3500](https://github.com/statelyai/xstate/pull/3500) [`0dfc6d92f`](https://github.com/statelyai/xstate/commit/0dfc6d92f6950b3eb78e0693ae3b0abe5751bf42) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `useSelector` always computing fresh snapshots internally for uninitialized services. This avoids the internal `useSyncExternalStore` from warning about the snapshot value not being cached properly.
+- [#3500](https://github.com/statelyai/xstate/pull/3500) [`0dfc6d92f`](https://github.com/statelyai/xstate/commit/0dfc6d92f6950b3eb78e0693ae3b0abe5751bf42) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `useSelector` always computing fresh snapshots internally for uninitialized services. This avoids the internal `useSyncExternalStore` from warning about the snapshot value not being cached properly.
 
 ## 3.0.0
 
@@ -14,7 +14,7 @@
 
 - [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - This package now accepts React 18 as a peer dep and the implementation has been rewritten to use [`use-sync-external-store`](https://www.npmjs.com/package/use-sync-external-store) package. This doesn't break compatibility with older versions of React since we are using the shim to keep compatibility with those older versions.
 
-* [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - `asEffect` and `asLayoutEffect` action creators were removed. They were not fitting the React model that well and could lead to issues as their existence suggested that they are easy to use.
+- [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - `asEffect` and `asLayoutEffect` action creators were removed. They were not fitting the React model that well and could lead to issues as their existence suggested that they are easy to use.
 
   To execute actions at those exact times you can always either just call your stuff directly from those effects or send events to the machine from those effects and execute explicit actions in response to said events.
 
@@ -24,11 +24,11 @@
 
 - [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - In v2 we have changed signatures of `useMachine` and `useInterpret`. Instead of accepting a list of generics they now only support a single generic: `TMachine`. This change, erroneously, was only introduced to types targeting TS@4.x but the types targeting previous TS releases were still using the older signatures. This has now been fixed and users of older TS versions should now be able to leverage typegen with `@xstate/react`.
 
-* [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - `useMachine` for `xstate` now correctly rerenders with the initial state when the internal service is being restarted. This might happen during Fast Refresh and now you shouldn't be able to observe this stale state that didn't match the actual state of the service.
+- [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - `useMachine` for `xstate` now correctly rerenders with the initial state when the internal service is being restarted. This might happen during Fast Refresh and now you shouldn't be able to observe this stale state that didn't match the actual state of the service.
 
 - [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - `useMachine` for `@xstate/fsm` now starts the service in an effect. This avoids side-effects in render and improves the compatibility with `StrictMode`.
 
-* [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - Implementations given to `useMachine` targeting `@xstate/fsm` are now updated in a layout effect. This avoid some stale closure problems for actions that are executed in response to events sent from layout effects.
+- [#2939](https://github.com/statelyai/xstate/pull/2939) [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf) Thanks [@Andarist](https://github.com/Andarist)! - Implementations given to `useMachine` targeting `@xstate/fsm` are now updated in a layout effect. This avoid some stale closure problems for actions that are executed in response to events sent from layout effects.
 
 * Updated dependencies [[`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf), [`360e85462`](https://github.com/statelyai/xstate/commit/360e8546298c4a06b6d51d8f12c0563672dd7acf)]:
   - @xstate/fsm@2.0.0
@@ -47,7 +47,7 @@
 
   When using hooks from `@xstate/react` it's recommended to skip providing explicit generics to them. Note that that generics list has changed since v1 and we now only accept a single generic, `TMachine`.
 
-* [#2674](https://github.com/statelyai/xstate/pull/2674) [`ab919d300`](https://github.com/statelyai/xstate/commit/ab919d300f6d2b78871d3399ec58a697c4268d9b) Thanks [@Andarist](https://github.com/Andarist)! - Removed already deprecated `useService` from `@xstate/react`. You can replace its usage with `useActor`.
+- [#2674](https://github.com/statelyai/xstate/pull/2674) [`ab919d300`](https://github.com/statelyai/xstate/commit/ab919d300f6d2b78871d3399ec58a697c4268d9b) Thanks [@Andarist](https://github.com/Andarist)! - Removed already deprecated `useService` from `@xstate/react`. You can replace its usage with `useActor`.
 
 ### Patch Changes
 
@@ -65,7 +65,7 @@
 
 - [#2736](https://github.com/statelyai/xstate/pull/2736) [`2246ae051`](https://github.com/statelyai/xstate/commit/2246ae051663f261b4750d7adba57f008ec28f1d) Thanks [@Andarist](https://github.com/Andarist), [@davidkpiano](https://github.com/statelyai), [@VanTanev](https://github.com/VanTanev)! - The `useSelector(...)` hook now works as expected when the `actor` passed in changes. The hook will properly subscribe to the new `actor` and select the desired value. See [#2702](https://github.com/statelyai/xstate/issues/2702)
 
-* [#2685](https://github.com/statelyai/xstate/pull/2685) [`469268d39`](https://github.com/statelyai/xstate/commit/469268d39fbc23996599773adfc4ca824b48585f) Thanks [@farskid](https://github.com/farskid), [@Andarist](https://github.com/Andarist)! - Fixed a regression with a development-only warning not being shown when a machine reference is updated during the hook lifecycle. This usually happens when machine options are dependent on external values and they're passed via `withConfig`.
+- [#2685](https://github.com/statelyai/xstate/pull/2685) [`469268d39`](https://github.com/statelyai/xstate/commit/469268d39fbc23996599773adfc4ca824b48585f) Thanks [@farskid](https://github.com/farskid), [@Andarist](https://github.com/Andarist)! - Fixed a regression with a development-only warning not being shown when a machine reference is updated during the hook lifecycle. This usually happens when machine options are dependent on external values and they're passed via `withConfig`.
 
   ```js
   const machine = createMachine({
@@ -113,7 +113,7 @@
   Previously, guards could not reference external props, because they would not be updated when the props changed. For instance:
 
   ```tsx
-  const Modal = props => {
+  const Modal = (props) => {
     useMachine(modalMachine, {
       guards: {
         isModalOpen: () => props.isOpen
@@ -127,7 +127,7 @@
   This is not true of actions/services. This will work as expected:
 
   ```tsx
-  const Modal = props => {
+  const Modal = (props) => {
     useMachine(modalMachine, {
       actions: {
         consoleLogModalOpen: () => {
@@ -259,7 +259,7 @@
 
 - [`b076b253`](https://github.com/statelyai/xstate/commit/b076b25364224874f62e8065892be40dfbb28030) [#1947](https://github.com/statelyai/xstate/pull/1947) Thanks [@lukekarrys](https://github.com/lukekarrys)! - Fix typing of the service returned from the fsm useMachine hook by passing it Typestate
 
-* [`9b5dc784`](https://github.com/statelyai/xstate/commit/9b5dc7843c44f50bcca0ffccb843b3d50cef6ddc) [#1950](https://github.com/statelyai/xstate/pull/1950) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `toObserver` being internally imported from `xstate/lib/utils` which has broken UMD build and the declared peer dep contract.
+- [`9b5dc784`](https://github.com/statelyai/xstate/commit/9b5dc7843c44f50bcca0ffccb843b3d50cef6ddc) [#1950](https://github.com/statelyai/xstate/pull/1950) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with `toObserver` being internally imported from `xstate/lib/utils` which has broken UMD build and the declared peer dep contract.
 
 ## 1.3.0
 
@@ -278,13 +278,13 @@
   };
   ```
 
-* [`577ae023`](https://github.com/statelyai/xstate/commit/577ae02384926b49e876011c4393f212b49066f8) [#1915](https://github.com/statelyai/xstate/pull/1915) Thanks [@davidkpiano](https://github.com/statelyai)! - New hook: `useSelector(actor, selector)`, which subscribes to `actor` and returns the selected state derived from `selector(snapshot)`:
+- [`577ae023`](https://github.com/statelyai/xstate/commit/577ae02384926b49e876011c4393f212b49066f8) [#1915](https://github.com/statelyai/xstate/pull/1915) Thanks [@davidkpiano](https://github.com/statelyai)! - New hook: `useSelector(actor, selector)`, which subscribes to `actor` and returns the selected state derived from `selector(snapshot)`:
 
   ```js
   import { useSelector } from '@xstate/react';
 
   const App = ({ someActor }) => {
-    const count = useSelector(someActor, state => state.context.count);
+    const count = useSelector(someActor, (state) => state.context.count);
 
     // ...
   };
@@ -362,7 +362,7 @@
 
 - [`c7927083`](https://github.com/statelyai/xstate/commit/c7927083a651e3c51952ade2ffda793df0391bf6) [#1516](https://github.com/statelyai/xstate/pull/1516) Thanks [@davidkpiano](https://github.com/statelyai)! - The `send` function returned from the `useService()` now can take two arguments (an event type and payload), to match the behavior of `@xstate/react` version 0.x.
 
-* [`db77623a`](https://github.com/statelyai/xstate/commit/db77623a48955d762cffa9b624f438220add5eed) [#1516](https://github.com/statelyai/xstate/pull/1516) Thanks [@davidkpiano](https://github.com/statelyai)! - The `send` value returned from the `useService()` hook will now accept a payload, which matches the signature of the `send` value returned from the `useMachine()` hook:
+- [`db77623a`](https://github.com/statelyai/xstate/commit/db77623a48955d762cffa9b624f438220add5eed) [#1516](https://github.com/statelyai/xstate/pull/1516) Thanks [@davidkpiano](https://github.com/statelyai)! - The `send` value returned from the `useService()` hook will now accept a payload, which matches the signature of the `send` value returned from the `useMachine()` hook:
 
   ```js
   const [state, send] = useService(someService);
@@ -378,7 +378,7 @@
 
 - [`93f6db02`](https://github.com/statelyai/xstate/commit/93f6db02a2d56ec997198ddef0af3d7730bb79bb) [#1594](https://github.com/statelyai/xstate/pull/1594) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with internal `setState` in `useService` being called with 2 arguments instead of 1.
 
-* [`72b0880e`](https://github.com/statelyai/xstate/commit/72b0880e6444ae009adca72088872bb5c0760ce3) [#1504](https://github.com/statelyai/xstate/pull/1504) Thanks [@Andarist](https://github.com/Andarist)! - Fixed issue with `useService` returning an initial state for services in their final states.
+- [`72b0880e`](https://github.com/statelyai/xstate/commit/72b0880e6444ae009adca72088872bb5c0760ce3) [#1504](https://github.com/statelyai/xstate/pull/1504) Thanks [@Andarist](https://github.com/Andarist)! - Fixed issue with `useService` returning an initial state for services in their final states.
 
 ## 1.0.1
 
@@ -405,7 +405,7 @@ All notable changes to this project will be documented in this file.
 - The `useActor` hook now takes a second argument: `getSnapshot` which is a function that should return the last emitted value:
 
   ```js
-  const [state, send] = useActor(someActor, actor => actor.current);
+  const [state, send] = useActor(someActor, (actor) => actor.current);
   ```
 
 ## [1.0.0-rc.6]

--- a/packages/xstate-svelte/CHANGELOG.md
+++ b/packages/xstate-svelte/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - [#3172](https://github.com/statelyai/xstate/pull/3172) [`390a115cd`](https://github.com/statelyai/xstate/commit/390a115cd1912c017654ecd367ef9a869f7e8fe8) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with the internal interpreter created by `useMachine` being unsubscribed when its subscribers' count went to zero. The lifetime of this interpreter should be bound to the lifetime of the component that has created it.
 
-* [#3209](https://github.com/statelyai/xstate/pull/3209) [`8520e203b`](https://github.com/statelyai/xstate/commit/8520e203b60124fb66da2cedad27d0c9771dc62c) Thanks [@schibrikov](https://github.com/schibrikov)! - Added ESM build to fix some bundling issues, more information can be found [here](https://github.com/statelyai/xstate/issues/2642)
+- [#3209](https://github.com/statelyai/xstate/pull/3209) [`8520e203b`](https://github.com/statelyai/xstate/commit/8520e203b60124fb66da2cedad27d0c9771dc62c) Thanks [@schibrikov](https://github.com/schibrikov)! - Added ESM build to fix some bundling issues, more information can be found [here](https://github.com/statelyai/xstate/issues/2642)
 
 ## 1.0.0
 

--- a/packages/xstate-test/CHANGELOG.md
+++ b/packages/xstate-test/CHANGELOG.md
@@ -8,7 +8,7 @@
 
   Also added `getPaths`, which defaults to `getShortestPaths`. This can be passed a `pathGenerator` to customize how paths are generated.
 
-* [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@mattpocock](https://github.com/mattpocock)! - Moved event cases out of `events`, and into their own attribute called `eventCases`:
+- [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@mattpocock](https://github.com/mattpocock)! - Moved event cases out of `events`, and into their own attribute called `eventCases`:
 
   ```ts
   const model = createTestModel(machine, {
@@ -41,7 +41,7 @@
 
 - [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Removed `.testCoverage()`, and instead made `getPlans`, `getShortestPlans` and `getSimplePlans` cover all states and transitions enabled by event cases by default.
 
-* [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Added validation on `createTestModel` to ensure that you don't include invalid machine configuration in your test machine. Invalid machine configs include `invoke`, `after`, and any actions with a `delay`.
+- [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Added validation on `createTestModel` to ensure that you don't include invalid machine configuration in your test machine. Invalid machine configs include `invoke`, `after`, and any actions with a `delay`.
 
   Added `createTestMachine`, which provides a slimmed-down API for creating machines which removes these types from the config type signature.
 
@@ -86,7 +86,7 @@
   toggledOn -> TOGGLE -> toggledOff -> TOGGLE -> toggledOn
   ```
 
-* [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@mattpocock](https://github.com/mattpocock), [@davidkpiano](https://github.com/davidkpiano)! - Moved `events` from `createTestModel` to `path.test`.
+- [#3036](https://github.com/statelyai/xstate/pull/3036) Thanks [@mattpocock](https://github.com/mattpocock), [@davidkpiano](https://github.com/davidkpiano)! - Moved `events` from `createTestModel` to `path.test`.
 
   Old:
 

--- a/packages/xstate-vue/CHANGELOG.md
+++ b/packages/xstate-vue/CHANGELOG.md
@@ -15,7 +15,7 @@
 
   When using hooks from `@xstate/vue` it's recommended to skip providing explicit generics to them. Note that that generics list has changed since v1 and we now only accept a single generic, `TMachine`.
 
-* [#3083](https://github.com/statelyai/xstate/pull/3083) [`bc592582a`](https://github.com/statelyai/xstate/commit/bc592582a8b486ca3a6277ca9a9c922590572346) Thanks [@Andarist](https://github.com/Andarist)! - Removed already deprecated `useService` from `@xstate/vue`. You can replace its usage with `useActor`.
+- [#3083](https://github.com/statelyai/xstate/pull/3083) [`bc592582a`](https://github.com/statelyai/xstate/commit/bc592582a8b486ca3a6277ca9a9c922590572346) Thanks [@Andarist](https://github.com/Andarist)! - Removed already deprecated `useService` from `@xstate/vue`. You can replace its usage with `useActor`.
 
 ### Patch Changes
 
@@ -122,7 +122,10 @@
   export default {
     props: ['someActor'],
     setup(props) {
-      const count = useSelector(props.someActor, state => state.context.count);
+      const count = useSelector(
+        props.someActor,
+        (state) => state.context.count
+      );
       // ...
       return { count };
     }
@@ -147,7 +150,7 @@
   });
   ```
 
-* [`bfe42972`](https://github.com/statelyai/xstate/commit/bfe42972cf624b990a280244e12e5976e5bd3048) [#1991](https://github.com/statelyai/xstate/pull/1991) Thanks [@santicros](https://github.com/santicros)! - Fixed the UMD build by externalizing XState & Vue correctly.
+- [`bfe42972`](https://github.com/statelyai/xstate/commit/bfe42972cf624b990a280244e12e5976e5bd3048) [#1991](https://github.com/statelyai/xstate/pull/1991) Thanks [@santicros](https://github.com/santicros)! - Fixed the UMD build by externalizing XState & Vue correctly.
 
 - [`4346cabc`](https://github.com/statelyai/xstate/commit/4346cabc42963211b471f214056db4d4f7e85539) [#1991](https://github.com/statelyai/xstate/pull/1991) Thanks [@santicros](https://github.com/santicros)! - Added new `useInterpret`, which is a low-level composable that interprets the `machine` and returns the `service`:
 
@@ -157,7 +160,7 @@
   export default defineComponent({
     setup() {
       const state = ref();
-      const service = useInterpret(machine, {}, nextState => {
+      const service = useInterpret(machine, {}, (nextState) => {
         state.value = nextState.value;
       });
       return { service, state };
@@ -165,7 +168,7 @@
   });
   ```
 
-* [`012ef363`](https://github.com/statelyai/xstate/commit/012ef3635cc06d8e5199cb85326b4b372714ca89) [#1991](https://github.com/statelyai/xstate/pull/1991) Thanks [@santicros](https://github.com/santicros)! - Added a proper ESM file using the`"module"` field in the `package.json`. It helps bundlers to automatically pick this over a file authored using CommonJS and allows them to apply some optimizations easier.
+- [`012ef363`](https://github.com/statelyai/xstate/commit/012ef3635cc06d8e5199cb85326b4b372714ca89) [#1991](https://github.com/statelyai/xstate/pull/1991) Thanks [@santicros](https://github.com/santicros)! - Added a proper ESM file using the`"module"` field in the `package.json`. It helps bundlers to automatically pick this over a file authored using CommonJS and allows them to apply some optimizations easier.
 
 ## 0.4.0
 


### PR DESCRIPTION
This combined with https://github.com/statelyai/xstate/pull/3586 should eliminate all of those unrelated changes showing up in PRs in `**/CHANGELOG.md` files.

The problem was that the older version of Changesets was using its local version of Prettier (1.x) but we were using 2.x - so depending on what script was formatting those files we got different results.
