### PR TITLE
Export `raise` and `sendTo`

### DIFF
--- a/.changeset/sharp-masks-talk.md
+++ b/.changeset/sharp-masks-talk.md
@@ -1,0 +1,11 @@
+---
+'xstate': minor
+---
+
+The actions `raise` and `sendTo` can now be imported directly from `xstate`:
+
+```js
+import { raise, sendTo } from 'xstate';
+
+// ...
+```

--- a/docs/fr/guides/actions.md
+++ b/docs/fr/guides/actions.md
@@ -340,8 +340,7 @@ The `raise()` action creator queues an event to the statechart, in the internal 
 | `event`  | string or event object | The event to raise. |
 
 ```js
-import { createMachine, actions } from 'xstate';
-const { raise } = actions;
+import { createMachine, raise } from 'xstate';
 
 const raiseActionDemo = createMachine({
   id: 'raisedmo',

--- a/docs/guides/actions.md
+++ b/docs/guides/actions.md
@@ -361,8 +361,7 @@ The `raise()` action creator queues an event to the statechart, in the internal 
 | `event`  | string or event object | The event to raise. |
 
 ```js
-import { createMachine, actions } from 'xstate';
-const { raise } = actions;
+import { createMachine, raise } from 'xstate';
 
 const raiseActionDemo = createMachine({
   id: 'raisedmo',

--- a/docs/zh/guides/actions.md
+++ b/docs/zh/guides/actions.md
@@ -339,8 +339,7 @@ console.log(send({ type: 'SOME_EVENT' }, { to: 'child' }));
 | `event` | string or event object | 要提升的事件 |
 
 ```js
-import { createMachine, actions } from 'xstate';
-const { raise } = actions;
+import { createMachine, raise } from 'xstate';
 
 const raiseActionDemo = createMachine({
   id: 'raisedmo',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -27,8 +27,10 @@ export {
   actions,
   assign,
   send,
+  sendTo,
   sendParent,
   sendUpdate,
+  raise,
   forwardTo,
   interpret,
   Interpreter,
@@ -41,7 +43,16 @@ export {
   t
 };
 
-const { assign, send, sendParent, sendUpdate, forwardTo, doneInvoke } = actions;
+const {
+  assign,
+  send,
+  sendTo,
+  sendParent,
+  sendUpdate,
+  forwardTo,
+  doneInvoke,
+  raise
+} = actions;
 
 declare global {
   interface SymbolConstructor {


### PR DESCRIPTION
This PR exports `raise` and `sendTo` directly from `xstate`.