### PR TITLE
Handle events sent to `self` closer to events send to other targets

### DIFF
--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -121,7 +121,7 @@ export function send<
           );
         }
       } else {
-        targetActorRef = resolvedTarget;
+        targetActorRef = resolvedTarget || actorContext?.self;
       }
 
       return {
@@ -132,7 +132,8 @@ export function send<
           to: targetActorRef,
           _event: resolvedEvent,
           event: resolvedEvent.data,
-          delay: resolvedDelay
+          delay: resolvedDelay,
+          internal: resolvedTarget === SpecialTargets.Internal
         }
       };
     }

--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -87,12 +87,8 @@ function getActionFunction<TState extends AnyState>(
         interpreter.defer(sendAction);
         return;
       } else {
-        if (sendAction.params.to) {
-          const target = sendAction.params.to;
-          execSendTo(sendAction.params._event, target, actorCtx);
-        } else {
-          interpreter.send(sendAction.params._event as SCXML.Event<any>);
-        }
+        const target = sendAction.params.to!;
+        execSendTo(sendAction.params._event, target, actorCtx);
       }
     },
     [actionTypes.cancel]: (_ctx, _e, { action }) => {

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1493,9 +1493,7 @@ export function resolveActionsAndContext<
         if (
           resolvedActionObject.type === actionTypes.raise ||
           (resolvedActionObject.type === actionTypes.send &&
-            actorCtx &&
-            (resolvedActionObject as SendActionObject).params.to ===
-              actorCtx.self)
+            (resolvedActionObject as SendActionObject).params.internal)
         ) {
           raiseActions.push(resolvedActionObject);
         } else {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1254,6 +1254,7 @@ export interface SendActionObject<
     event: TSentEvent;
     delay?: number;
     id: string | number;
+    internal: boolean;
   };
 }
 

--- a/packages/core/test/after.test.ts
+++ b/packages/core/test/after.test.ts
@@ -55,6 +55,7 @@ describe('delayed transitions', () => {
               "type": "xstate.after(1000)#light.yellow",
             },
             "id": "xstate.after(1000)#light.yellow",
+            "internal": false,
             "to": undefined,
           },
           "type": "xstate.send",


### PR DESCRIPTION
Implementing the suggestion from https://github.com/statelyai/xstate/pull/3455/files#r966943424