### PR TITLE
Fixed a regression that has caused `machine.getInitialState(value)` to not follow always transitions correctly

### DIFF
--- a/.changeset/wicked-radios-brush.md
+++ b/.changeset/wicked-radios-brush.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed a regression that has caused `machine.getInitialState(value)` to not follow always transitions correctly.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1010,7 +1010,10 @@ class StateNode<
     );
 
     for (const sn of resolvedConfig) {
-      if (!has(prevConfig, sn) || has(transition.entrySet, sn.parent)) {
+      if (
+        !has(prevConfig, sn) ||
+        (has(transition.entrySet, sn.parent) && !has(transition.entrySet, sn))
+      ) {
         transition.entrySet.push(sn);
       }
     }
@@ -1661,7 +1664,7 @@ class StateNode<
     return this.resolveTransition(
       {
         configuration,
-        entrySet: [...configuration],
+        entrySet: configuration,
         exitSet: [],
         transitions: [],
         source: undefined,

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -1240,7 +1240,10 @@ export class Interpreter<
       })
       .start();
 
-    return actor as ActorRef<TChildEvent, State<TChildContext, TChildEvent>>;
+    return actor as ActorRef<
+      TChildEvent,
+      State<TChildContext, TChildEvent, any, any, any>
+    >;
   }
   private spawnBehavior<TActorEvent extends EventObject, TEmitted>(
     behavior: Behavior<TActorEvent, TEmitted>,

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -375,6 +375,22 @@ describe('machine', () => {
     });
   });
 
+  describe('machine.getInitialState', () => {
+    it('should follow always transition', () => {
+      const machine = createMachine({
+        initial: 'a',
+        states: {
+          a: {
+            always: [{ target: 'b' }]
+          },
+          b: {}
+        }
+      });
+
+      expect(machine.getInitialState('a').value).toBe('b');
+    });
+  });
+
   describe('versioning', () => {
     it('should allow a version to be specified', () => {
       const versionMachine = Machine({

--- a/packages/core/test/rehydration.test.ts
+++ b/packages/core/test/rehydration.test.ts
@@ -98,21 +98,4 @@ describe('rehydration', () => {
       expect(actual).toEqual(['active', 'root']);
     });
   });
-
-  describe('using resolved state value', () => {
-    it('should follow always transitions', () => {
-      const machine = createMachine({
-        initial: 'a',
-        states: {
-          a: {
-            always: [{ target: 'b' }]
-          },
-          b: {}
-        }
-      });
-
-      const service = interpret(machine).start(machine.getInitialState('a'));
-      expect(service.getSnapshot().value).toBe('b');
-    });
-  });
 });

--- a/packages/core/test/rehydration.test.ts
+++ b/packages/core/test/rehydration.test.ts
@@ -98,4 +98,21 @@ describe('rehydration', () => {
       expect(actual).toEqual(['active', 'root']);
     });
   });
+
+  describe('using resolved state value', () => {
+    it('should follow always transitions', () => {
+      const machine = createMachine({
+        initial: 'a',
+        states: {
+          a: {
+            always: [{ target: 'b' }]
+          },
+          b: {}
+        }
+      });
+
+      const service = interpret(machine).start(machine.getInitialState('a'));
+      expect(service.getSnapshot().value).toBe('b');
+    });
+  });
 });


### PR DESCRIPTION
fixes #3544