### PR TITLE
Fix 'Done Data' example code in communications.md

### DIFF
--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -446,9 +446,9 @@ const secretMachine = createMachine({
     },
     reveal: {
       type: 'final',
-      data: {
-        secret: (context, event) => context.secret
-      }
+      data: (context, event) => ({
+        secret: context.secret
+      })
     }
   }
 });


### PR DESCRIPTION
The provided example is not working while using it with TypeScript (And I suppose it would not work with JavaScript as well). 

The type on `data` is 

```typescript
Mapper<TContext, TEvent, any> | PropertyMapper<TContext, TEvent, any>
```

Where `PropertyMapper` is not working correctly. TS can'd properly infer the `context` and `event` types if the code was written as in example.

 I suppose for that bug could be created, but for now I would like docs to be correct.