### PR TITLE
xstate-svelte: Avoid using svelte store get in useSelector.

### DIFF
--- a/.changeset/afraid-kids-happen.md
+++ b/.changeset/afraid-kids-happen.md
@@ -2,4 +2,4 @@
 '@xstate/svelte': patch
 ---
 
-Avoid using svelte store get in useSelector
+Improve performance of the `useSelector` by avoiding `get`

--- a/.changeset/afraid-kids-happen.md
+++ b/.changeset/afraid-kids-happen.md
@@ -1,0 +1,5 @@
+---
+'@xstate/svelte': patch
+---
+
+Avoid using svelte store get in useSelector

--- a/packages/xstate-svelte/src/useSelector.ts
+++ b/packages/xstate-svelte/src/useSelector.ts
@@ -20,8 +20,8 @@ export const useSelector = <
     sub = actor.subscribe((state) => {
       const nextSelected = selector(state);
       if (!compare(prevSelected, nextSelected)) {
-        set(nextSelected);
         prevSelected = nextSelected;
+        set(nextSelected);
       }
     });
 

--- a/packages/xstate-svelte/src/useSelector.ts
+++ b/packages/xstate-svelte/src/useSelector.ts
@@ -1,4 +1,4 @@
-import { get, readable } from 'svelte/store';
+import { readable } from 'svelte/store';
 import type { ActorRef, Subscribable, Subscription } from 'xstate';
 
 const defaultCompare = (a, b) => a === b;
@@ -13,11 +13,15 @@ export const useSelector = <
   compare: (a: T, b: T) => boolean = defaultCompare
 ) => {
   let sub: Subscription;
-  const selected = readable(selector(actor.getSnapshot()), (set) => {
+
+  let prevSelected = selector(actor.getSnapshot());
+
+  const selected = readable(prevSelected, (set) => {
     sub = actor.subscribe((state) => {
       const nextSelected = selector(state);
-      if (!compare(get(selected), nextSelected)) {
+      if (!compare(prevSelected, nextSelected)) {
         set(nextSelected);
+        prevSelected = nextSelected;
       }
     });
 


### PR DESCRIPTION
The Svelte docs say `get`  should [not be used in hot paths](https://svelte.dev/docs#run-time-svelte-store-get). It is used in `useSelector` to compare the updated value with the previous value.  This PR changes the function to store the previous value in a local variable instead.