### PR TITLE
Add optional options argument to FSM useMachine docs heading

### DIFF
--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -248,7 +248,7 @@ const App = () => {
 };
 ```
 
-### `useMachine(machine)` with `@xstate/fsm`
+### `useMachine(machine, options?)` with `@xstate/fsm`
 
 A [React hook](https://reactjs.org/hooks) that interprets the given finite state `machine` from [`@xstate/fsm`] and starts a service that runs for the lifetime of the component.
 


### PR DESCRIPTION
How I read and interpreted the docs, there is little difference between `useMachine` from the core package and the FSM package, which is why the missing optional `options` argument in the header of this paragraph caught me a bit off guard, and I think it's clearer to readers to add it.