### PR TITLE
Deprecate `createModel(...)`

### DIFF
--- a/.changeset/shiny-kangaroos-battle.md
+++ b/.changeset/shiny-kangaroos-battle.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+The `createModel(...)` function is now marked as deprecated, as it will be removed in XState version 5. It is recommended to use [Typegen](https://stately.ai/blog/introducing-typescript-typegen-for-xstate) instead.

--- a/docs/fr/guides/models.md
+++ b/docs/fr/guides/models.md
@@ -1,5 +1,11 @@
 # Models
 
+::: warning
+
+The `createModel(...)` function is deprecated and will be removed in XState version 5. It is recommended to use [Typegen](https://stately.ai/blog/introducing-typescript-typegen-for-xstate) instead.
+
+:::
+
 In XState, you can model a machine's `context` and `events` externally by using `createModel(...)`. This provides a convenient way to strongly type `context` and `events`, as well as helpers for event creation, assignment and other implementation details in the future.
 
 Using `createModel(...)` is _completely optional_, and is meant to improve the developer experience. The main reasons for using it are:

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -1,5 +1,11 @@
 # Models
 
+::: warning
+
+The `createModel(...)` function is deprecated and will be removed in XState version 5. It is recommended to use [Typegen](https://stately.ai/blog/introducing-typescript-typegen-for-xstate) instead.
+
+:::
+
 In XState, you can model a machine's `context` and `events` externally by using `createModel(...)`. This provides a convenient way to strongly type `context` and `events`, as well as helpers for event creation, assignment and other implementation details in the future.
 
 Using `createModel(...)` is _completely optional_, and is meant to improve the developer experience. The main reasons for using it are:

--- a/docs/zh/guides/models.md
+++ b/docs/zh/guides/models.md
@@ -1,5 +1,11 @@
 # 模型 Models
 
+::: warning
+
+The `createModel(...)` function is deprecated and will be removed in XState version 5. It is recommended to use [Typegen](https://stately.ai/blog/introducing-typescript-typegen-for-xstate) instead.
+
+:::
+
 在 XState 中，你可以使用 `createModel(...)` 在外部对状态机的 `context` 和 `events` 进行建模。 这提供了一种强类型`context` 和`events` 的便捷方式，以及未来事件创建、分配和其他实现细节的帮助。
 
 使用 `createModel(...)` 是 _完全可选的_，旨在改善开发人员体验。 使用它的主要原因是：

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -15,6 +15,9 @@ import {
   ModelCreators
 } from './model.types';
 
+/**
+ * @deprecated Use [Typegen](https://stately.ai/blog/introducing-typescript-typegen-for-xstate) instead.
+ */
 export function createModel<
   TContext,
   TEvent extends EventObject,


### PR DESCRIPTION

The `createModel(...)` function is now marked as deprecated, as it will be removed in XState version 5. It is recommended to use [Typegen](https://stately.ai/blog/introducing-typescript-typegen-for-xstate) instead.