### PR TITLE
`state.can` docs update

### DIFF
--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -269,6 +269,10 @@ A state is considered “changed” if [`state.changed`](#state-changed) is `tru
 - there are new `state.actions` to be executed
 - its `state.context` changes.
 
+::: warning
+`state.can` will execute transition guards too.
+:::
+
 ## Persisting state
 
 As mentioned, a `State` object can be persisted by serializing it to a string JSON format:

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -248,8 +248,8 @@ const machine = createMachine({
 
 const inactiveState = machine.initialState;
 
-inactiveState.can({type: 'TOGGLE'}); // true
-inactiveState.can({type: 'DO_SOMETHING'}); // false
+inactiveState.can({ type: 'TOGGLE' }); // true
+inactiveState.can({ type: 'DO_SOMETHING' }); // false
 
 // Also takes in full event objects:
 inactiveState.can({
@@ -257,10 +257,10 @@ inactiveState.can({
   data: 42
 }); // false
 
-const activeState = machine.transition(inactiveState, {type: 'TOGGLE'});
+const activeState = machine.transition(inactiveState, { type: 'TOGGLE' });
 
-activeState.can({type: 'TOGGLE'}); // false
-activeState.can({type: 'DO_SOMETHING'}); // true, since an action will be executed
+activeState.can({ type: 'TOGGLE' }); // false
+activeState.can({ type: 'DO_SOMETHING' }); // true, since an action will be executed
 ```
 
 A state is considered “changed” if [`state.changed`](#state-changed) is `true` and if any of the following are true:

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -270,7 +270,7 @@ A state is considered “changed” if [`state.changed`](#state-changed) is `tru
 - its `state.context` changes.
 
 ::: warning
-`state.can` will execute transition guards too.
+The `state.can(...)` function will also check transition guards by executing them. Transition guards should be pure functions.
 :::
 
 ## Persisting state

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -248,8 +248,8 @@ const machine = createMachine({
 
 const inactiveState = machine.initialState;
 
-inactiveState.can('TOGGLE'); // true
-inactiveState.can('DO_SOMETHING'); // false
+inactiveState.can({type: 'TOGGLE'}); // true
+inactiveState.can({type: 'DO_SOMETHING'}); // false
 
 // Also takes in full event objects:
 inactiveState.can({
@@ -257,10 +257,10 @@ inactiveState.can({
   data: 42
 }); // false
 
-const activeState = machine.transition(inactiveState, 'TOGGLE');
+const activeState = machine.transition(inactiveState, {type: 'TOGGLE'});
 
-activeState.can('TOGGLE'); // false
-activeState.can('DO_SOMETHING'); // true, since an action will be executed
+activeState.can({type: 'TOGGLE'}); // false
+activeState.can({type: 'DO_SOMETHING'}); // true, since an action will be executed
 ```
 
 A state is considered “changed” if [`state.changed`](#state-changed) is `true` and if any of the following are true:


### PR DESCRIPTION
- Add warning that `state.can` will execute transition guards
- Updates `state.can` examples to use the full event object due to valid confusion in the discord discussion below and the fact that TypeScript demands the full event object.

Based on the discussion at https://discord.com/channels/795785288994652170/1022469795582591057/1022481693929635880