### PR TITLE
Re-enter only the target when an ancestor during an external event

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -976,11 +976,22 @@ class StateNode<
   private getExternalReentryNodes(
     targetNode: StateNode<TContext, any, TEvent, any, any, any>
   ): Array<StateNode<TContext, any, TEvent, any, any, any>> {
+    if (this.order > targetNode.order) {
+      return [targetNode];
+    }
+
     const nodes: Array<StateNode<TContext, any, TEvent, any, any, any>> = [];
-    let [marker, possibleAncestor]: [
-      StateNode<TContext, any, TEvent, any, any, any> | undefined,
-      StateNode<TContext, any, TEvent, any, any, any>
-    ] = targetNode.order > this.order ? [targetNode, this] : [this, targetNode];
+    let marker:
+      | StateNode<TContext, any, TEvent, any, any, any>
+      | undefined = targetNode;
+    let possibleAncestor: StateNode<
+      TContext,
+      any,
+      TEvent,
+      any,
+      any,
+      any
+    > = this;
 
     while (marker && marker !== possibleAncestor) {
       nodes.push(marker);


### PR DESCRIPTION
Found that when the target node was an ancestor of the current node, it would add all ancestor nodes to the list of nodes to re-enter as it climbed to the target.