### PR TITLE
During external events, only enter target and descendent nodes

### DIFF
--- a/.changeset/mighty-phones-press.md
+++ b/.changeset/mighty-phones-press.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+During external events, only enter target plus descendent nodes.

--- a/.changeset/mighty-phones-press.md
+++ b/.changeset/mighty-phones-press.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-During external events, only enter target plus descendent nodes.
+Fixed an issue with external transitions targeting ancestor states. In such a case, `entry` actions were incorrectly called on the states between the source state and the target state for states that were not reentered within this transition.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -976,11 +976,22 @@ class StateNode<
   private getExternalReentryNodes(
     targetNode: StateNode<TContext, any, TEvent, any, any, any>
   ): Array<StateNode<TContext, any, TEvent, any, any, any>> {
+    if (this.order > targetNode.order) {
+      return [targetNode];
+    }
+
     const nodes: Array<StateNode<TContext, any, TEvent, any, any, any>> = [];
-    let [marker, possibleAncestor]: [
-      StateNode<TContext, any, TEvent, any, any, any> | undefined,
-      StateNode<TContext, any, TEvent, any, any, any>
-    ] = targetNode.order > this.order ? [targetNode, this] : [this, targetNode];
+    let marker:
+      | StateNode<TContext, any, TEvent, any, any, any>
+      | undefined = targetNode;
+    let possibleAncestor: StateNode<
+      TContext,
+      any,
+      TEvent,
+      any,
+      any,
+      any
+    > = this;
 
     while (marker && marker !== possibleAncestor) {
       nodes.push(marker);

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -223,6 +223,46 @@ describe('entry/exit actions', () => {
     }
   });
 
+  const deepMachine2 = createMachine({
+    initial: 'A',
+    id: 'root',
+    predictableActionArguments: true,
+    states: {
+      A: {
+        initial: 'default',
+        entry: 'enter_A',
+        on: {
+          CHANGE_TO_A2: 'A.A2'
+        },
+        states: {
+          default: {
+            entry: 'enter_default'
+          },
+          A1: {
+            entry: 'enter_A1',
+            exit: 'exit_A1',
+            on: {
+              CHANGE_TO_A2A: 'A2.A2a'
+            }
+          },
+          A2: {
+            initial: 'A2a',
+            entry: 'enter_A2',
+            states: {
+              A2a: {
+                entry: 'enter_A2a',
+                exit: 'exit_A2a',
+                on: {
+                  CHANGE_TO_A: '#root.A'
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  });
+
   const parallelMachine2 = Machine({
     initial: 'A',
     states: {
@@ -520,6 +560,28 @@ describe('entry/exit actions', () => {
       expect(
         newLightMachine.transition('red', 'NOTHING').actions.map((a) => a.type)
       ).toEqual(['exit_walk', 'exit_red', 'enter_red', 'enter_walk']);
+    });
+
+    it('should exit current node and enter target node when target is not a descendent or ancestor of current', () => {
+      expect(
+        deepMachine2
+          .transition('A.A1', 'CHANGE_TO_A2A')
+          .actions.map((a) => a.type)
+      ).toEqual(['exit_A1', 'enter_A2', 'enter_A2a']);
+    });
+
+    it('should exit current node and enter target node when target is ancestor of current', () => {
+      expect(
+        deepMachine2
+          .transition('A.A2.A2a', 'CHANGE_TO_A')
+          .actions.map((a) => a.type)
+      ).toEqual(['exit_A2a', 'enter_A', 'enter_default']);
+    });
+
+    it('should enter all descendents when target is a descendent of current', () => {
+      expect(
+        deepMachine2.transition('A', 'CHANGE_TO_A2').actions.map((a) => a.type)
+      ).toEqual(['enter_A', 'enter_A2', 'enter_A2a']);
     });
 
     it('should exit deep descendant during a self-transition', () => {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -624,12 +624,14 @@ describe('entry/exit actions', () => {
           A: {
             initial: 'default',
             entry: () => actual.push('enter_A'),
+            exit: () => actual.push('exit_A'),
             on: {
               CHANGE_TO_A2: 'A.A2'
             },
             states: {
               default: {
-                entry: () => actual.push('enter_default')
+                entry: () => actual.push('enter_default'),
+                exit: () => actual.push('exit_default')
               },
               A1: {
                 entry: () => actual.push('enter_A1'),
@@ -659,7 +661,13 @@ describe('entry/exit actions', () => {
       const service = interpret(machine).start('A');
       service.send('CHANGE_TO_A2');
 
-      expect(actual).toEqual(['enter_A', 'enter_A2', 'enter_A2a']);
+      expect(actual).toEqual([
+        'exit_default',
+        'exit_A',
+        'enter_A',
+        'enter_A2',
+        'enter_A2a'
+      ]);
     });
 
     it('should exit deep descendant during a self-transition', () => {


### PR DESCRIPTION
Found that when the current node was a descendent of the target node, it was re-entering every node as it climbed to the target.

fixes https://github.com/statelyai/xstate/issues/3618
fixes https://github.com/statelyai/xstate/issues/3613