### PR TITLE
feat(test): add tag support

### DIFF
--- a/.changeset/fast-falcons-sniff.md
+++ b/.changeset/fast-falcons-sniff.md
@@ -1,0 +1,51 @@
+---
+'@xstate/test': minor
+---
+
+Add support for tags in testing machines
+
+Tags can be re-used across multiple state nodes, which allows for abstracting out repeated bits of testing functionality.
+
+You can use tags in your tests by adding a `tags` property to testing statechart states,
+
+```js
+createTestMachine({
+  initial: 'a',
+  states: {
+    a: {
+      // The tagTest function will be run whenever a path.test() visits this state
+      tags: 'tagTest',
+
+      on: {
+        EVENT: 'b'
+      }
+    }
+
+    // ...
+  }
+});
+```
+
+and then defining the functions to run for those tags by passing them to `path.test()`
+
+```js
+path.test({
+  states: {
+    async a() {
+      /* ... */
+    }
+  },
+
+  events: {
+    async EVENT() {
+      /* ... */
+    }
+  },
+
+  tags: {
+    async tagTest() {
+      /* ... */
+    }
+  }
+});
+```

--- a/packages/xstate-test/src/TestModel.ts
+++ b/packages/xstate-test/src/TestModel.ts
@@ -324,6 +324,12 @@ export class TestModel<TState, TEvent extends EventObject> {
   ): Promise<void> {
     const resolvedOptions = this.resolveOptions(options);
 
+    // @ts-ignore I can't figure out how to make state.tags be seen as valid, even though
+    // it totally *is* valid-seeming
+    for (const tag of state.tags) {
+      await params.tags?.[tag](state);
+    }
+
     const stateTestKeys = this.getStateTestKeys(params, state, resolvedOptions);
 
     for (const stateTestKey of stateTestKeys) {

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -85,8 +85,14 @@ export interface TestParam<TState, TEvent extends EventObject> {
   states?: {
     [key: string]: (state: TState) => void | Promise<void>;
   };
+  tags?: {
+    [key: string]: (state: TState) => void | Promise<void>;
+  };
   events?: {
-    [TEventType in TEvent['type']]?: EventExecutor<TState, ExtractEvent<TEvent, TEventType>>;
+    [TEventType in TEvent['type']]?: EventExecutor<
+      TState,
+      ExtractEvent<TEvent, TEventType>
+    >;
   };
 }
 

--- a/packages/xstate-test/test/tags.test.ts
+++ b/packages/xstate-test/test/tags.test.ts
@@ -1,0 +1,85 @@
+import { StateValue } from 'xstate';
+import { createTestModel } from '../src';
+import { createTestMachine } from '../src/machine';
+import { testUtils } from './testUtils';
+
+type TagValue = [string, StateValue];
+
+describe('tags', () => {
+  it('should test tags', async () => {
+    const testedStateValues: TagValue[] = [];
+    const testModel = createTestModel(
+      createTestMachine({
+        initial: 'a',
+        states: {
+          a: {
+            tags: 'test-1',
+            on: {
+              EVENT: 'b'
+            }
+          },
+          b: {
+            tags: 'test-2',
+            initial: 'b1',
+            states: {
+              b1: {
+                tags: 'test-3',
+                on: { NEXT: 'b2' }
+              },
+              b2: {
+                tags: 'test-1'
+              }
+            }
+          }
+        }
+      })
+    );
+
+    await testUtils.testModel(testModel, {
+      tags: {
+        'test-1': (state) => {
+          testedStateValues.push(['test-1', state.value]);
+        },
+        'test-2': (state) => {
+          testedStateValues.push(['test-2', state.value]);
+        },
+        'test-3': (state) => {
+          testedStateValues.push(['test-3', state.value]);
+        }
+      }
+    });
+
+    expect(testedStateValues).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "test-1",
+          "a",
+        ],
+        Array [
+          "test-3",
+          Object {
+            "b": "b1",
+          },
+        ],
+        Array [
+          "test-2",
+          Object {
+            "b": "b1",
+          },
+        ],
+        Array [
+          "test-1",
+          Object {
+            "b": "b2",
+          },
+        ],
+        Array [
+          "test-2",
+          Object {
+            "b": "b2",
+          },
+        ],
+      ]
+    `);
+  });
+});


### PR DESCRIPTION
https://statelyai.canny.io/xstate/p/xstatetest-support-testing-against-tags

Based off of the branch for #3446 per @davidkpiano [on Discord](https://discord.com/channels/795785288994652170/801127053092716596/1026925662843457546)

Seems to be working fine, except that I can't figure out the correct typing for the `TestModel.ts` changes ಠ_ಠ

No matter what I try it refused to believe that `tags` is a property on `TState`, so I think I'm missing something around how that should be used/set-up.