### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/codesee-arch-diagram.yml
+++ b/.github/workflows/codesee-arch-diagram.yml
@@ -7,6 +7,9 @@ on:
 
 name: CodeSee Map
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   test_map_action:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,8 +5,12 @@ on:
     branches:
       - main
 
+permissions: {}
 jobs:
   build:
+    permissions:
+      contents: write  #  to push changes in repo (jamesives/github-pages-deploy-action)
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - '**'
 
+permissions:
+  contents: read  #  to fetch code (actions/checkout)
+
 jobs:
   build:
     timeout-minutes: 20

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     permissions:
       contents: write  #  to create release (changesets/action)
+      issues: write # to post issue comments (changesets/action)
       pull-requests: write  #  to create pull request (changesets/action)
 
     if: github.repository == 'statelyai/xstate'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,13 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write  #  to create release (changesets/action)
+      pull-requests: write  #  to create pull request (changesets/action)
+
     if: github.repository == 'statelyai/xstate'
 
     timeout-minutes: 20


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.