### PR TITLE
Fixed issues around reentrancy during external transitions

### DIFF
--- a/.changeset/large-snails-decide.md
+++ b/.changeset/large-snails-decide.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with targeted ancestors not being correctly exited when reented during external transitions.

--- a/.changeset/rich-monkeys-relate.md
+++ b/.changeset/rich-monkeys-relate.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with the _active_ descendants of the targeted ancestor not being correctly reentered during external transitions.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -956,14 +956,11 @@ class StateNode<
       transitions: [selectedTransition],
       exitSet: isInternal
         ? []
-        : [
-            this,
-            ...flatten(
-              nextStateNodes.map((targetNode) =>
-                this.getExternalReentryNodes(targetNode)
-              )
+        : flatten(
+            nextStateNodes.map((targetNode) =>
+              this.getExternalReentryNodes(targetNode)
             )
-          ],
+          ),
       configuration: allNextStateNodes,
       source: state,
       actions
@@ -977,7 +974,7 @@ class StateNode<
     targetNode: StateNode<TContext, any, TEvent, any, any, any>
   ): Array<StateNode<TContext, any, TEvent, any, any, any>> {
     if (this.order < targetNode.order) {
-      return [];
+      return [this];
     }
 
     const nodes: Array<StateNode<TContext, any, TEvent, any, any, any>> = [];

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -958,7 +958,7 @@ class StateNode<
         ? []
         : flatten(
             nextStateNodes.map((targetNode) =>
-              this.getExternalReentryNodes(targetNode)
+              this.getPotentiallyReenteringNodes(targetNode)
             )
           ),
       configuration: allNextStateNodes,
@@ -970,7 +970,7 @@ class StateNode<
   // even though the name of this function mentions reentry nodes
   // we are pushing its result into `exitSet`
   // that's because what we exit might be reentered (it's an invariant of reentrancy)
-  private getExternalReentryNodes(
+  private getPotentiallyReenteringNodes(
     targetNode: StateNode<TContext, any, TEvent, any, any, any>
   ): Array<StateNode<TContext, any, TEvent, any, any, any>> {
     if (this.order < targetNode.order) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1134,7 +1134,6 @@ export interface ActivityMap {
 export interface StateTransition<TContext, TEvent extends EventObject> {
   transitions: Array<TransitionDefinition<TContext, TEvent>>;
   configuration: Array<StateNode<TContext, any, TEvent, any, any, any>>;
-  entrySet: Array<StateNode<TContext, any, TEvent, any, any, any>>;
   exitSet: Array<StateNode<TContext, any, TEvent, any, any, any>>;
   /**
    * The source state that preceded the transition.

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -873,8 +873,6 @@ describe('entry/exit actions', () => {
     });
 
     it('should reenter parallel region when a parallel state gets reentered while targeting another region', () => {
-      const actions: string[] = [];
-
       const machine = createMachine({
         initial: 'ready',
         states: {
@@ -884,13 +882,8 @@ describe('entry/exit actions', () => {
               FOO: '#cameraOff'
             },
             states: {
-              devicesInfo: {
-                entry: () => actions.push('entry devicesInfo'),
-                exit: () => actions.push('exit devicesInfo')
-              },
+              devicesInfo: {},
               camera: {
-                entry: () => actions.push('entry camera'),
-                exit: () => actions.push('exit camera'),
                 initial: 'on',
                 states: {
                   on: {},
@@ -904,16 +897,22 @@ describe('entry/exit actions', () => {
         }
       });
 
+      const flushTracked = trackEntries(machine);
+
       const service = interpret(machine).start();
 
-      actions.length = 0;
+      flushTracked();
       service.send('FOO');
 
-      expect(actions).toEqual([
-        'exit camera',
-        'exit devicesInfo',
-        'entry devicesInfo',
-        'entry camera'
+      expect(flushTracked()).toEqual([
+        'exit: ready.camera.on',
+        'exit: ready.camera',
+        'exit: ready.devicesInfo',
+        'exit: ready',
+        'enter: ready',
+        'enter: ready.devicesInfo',
+        'enter: ready.camera',
+        'enter: ready.camera.off'
       ]);
     });
   });

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -463,6 +463,7 @@ describe('entry/exit actions', () => {
 
       expect(flushTracked()).toEqual([
         'exit: loaded.idle',
+        'exit: loaded',
         'enter: loaded',
         'enter: loaded.idle'
       ]);
@@ -647,6 +648,7 @@ describe('entry/exit actions', () => {
       expect(flushTracked()).toEqual([
         'exit: A.A2.A2_child',
         'exit: A.A2',
+        'exit: A',
         'enter: A',
         'enter: A.A1'
       ]);
@@ -725,7 +727,8 @@ describe('entry/exit actions', () => {
         'exit: a.a1',
         'exit: a',
         'enter: a',
-        'enter: a.a1'
+        'enter: a.a1',
+        'enter: a.a1.a11'
       ]);
     });
   });


### PR DESCRIPTION
We didn't have an explicit issue open about those fixed issues. Those are things that I've spotted when investigating some issue reports and when reviewing some other PR.

The issue with the targeted ancestor not being **exited** correctly when it was already being **entered** during reentering transition has been mentioned in the second point here:
https://github.com/statelyai/xstate/issues/3613#issuecomment-1256307617