### PR TITLE
Mention timout in docstring of `waitFor`

### DIFF
--- a/packages/core/src/waitFor.ts
+++ b/packages/core/src/waitFor.ts
@@ -17,6 +17,8 @@ const defaultWaitForOptions: WaitForOptions = {
 /**
  * Subscribes to an actor ref and waits for its emitted value to satisfy
  * a predicate, and then resolves with that value.
+ * Will throw if the desired state is not reached after a timeout
+ * (defaults to 10 seconds).
  *
  * @example
  * ```js


### PR DESCRIPTION
I somehow missed this in the [docs](https://xstate.js.org/docs/guides/interpretation.html#waitfor) and it took me quite a while to figure out where the timeout error came from. If you look at the source, it is obvious as the options mention the timout, but I only looked at the inline docs in my editor which only showed the `waitFor` docstring that didn't mention this timeout at all 😅