### PR TITLE
Convenient syntax for actor subscription in `useMachine` and `useInterpret`

### DIFF
--- a/.changeset/curvy-moles-applaud.md
+++ b/.changeset/curvy-moles-applaud.md
@@ -1,0 +1,53 @@
+---
+'@xstate/react': minor
+---
+
+You can conveniently create a subscription to the interpreter inside `useInterpret` and `useMachine` hooks.
+
+```js
+const machine = createMachine({
+  initial: 'active',
+  states: {
+    inactive: {
+      on: {
+        ACTIVATE: 'active'
+      }
+    },
+    active: {
+      on: {
+        DEACTIVATE: 'inactive'
+      }
+    }
+  }
+});
+```
+
+**Before**:
+
+```jsx
+const [, , actor] = useMachine(machine);
+// Or
+const [, , actor] = useInterpret(machine);
+
+React.useEffect(() => {
+  return actor.subscribe((state) => {
+    // do something with the state object
+  }).unsubscribe;
+}, []);
+```
+
+**After**:
+
+```jsx
+const [, , actor] = useMachine(machine, {
+  subscribe: (state) => {
+    // do something with the state object
+  }
+});
+// Or
+const [, , actor] = useInterpret(machine, {
+  subscribe: (state) => {
+    // do something with the state object
+  }
+});
+```

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -82,6 +82,12 @@ export function useIdleInterpreter(
     Object.assign(service.machine.options.delays!, delays);
   }, [actions, guards, activities, services, delays]);
 
+  useIsomorphicLayoutEffect(() => {
+    if (options.subscribe) {
+      return service.subscribe(options.subscribe).unsubscribe;
+    }
+  }, []);
+
   return service as any;
 }
 

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -29,6 +29,10 @@ export interface UseMachineOptions<TContext, TEvent extends EventObject> {
    * start at this state instead of its `initialState`.
    */
   state?: StateConfig<TContext, TEvent>;
+  /**
+   * Convenient syntax to create a subscription to the interpreter at the creation time.
+   */
+  subscribe?: (state: State<TContext, TEvent>) => void;
 }
 
 type RestParams<

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
 import {
+  AnyState,
   AnyStateMachine,
   AreAllImplementationsAssumedToBeProvided,
   EventObject,
@@ -32,7 +33,7 @@ export interface UseMachineOptions<TContext, TEvent extends EventObject> {
   /**
    * Convenient syntax to create a subscription to the interpreter at the creation time.
    */
-  subscribe?: (state: State<TContext, TEvent>) => void;
+  subscribe?: (state: AnyState) => void;
 }
 
 type RestParams<

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -80,6 +80,54 @@ describeEachReactMode('useInterpret (%s)', ({ suiteKey, render }) => {
     fireEvent.click(button);
   });
 
+  it('options.subscribe should create a subscription to the interpreter', () => {
+    const machine = createMachine({
+      initial: 'off',
+      states: {
+        off: {
+          on: {
+            TOGGLE: 'on'
+          }
+        },
+        on: {
+          on: {
+            TOGGLE: 'off'
+          }
+        }
+      }
+    });
+
+    let count = 0;
+
+    const App = () => {
+      const service = useInterpret(machine, {
+        subscribe: (state) => {
+          if (state.matches('on')) {
+            count++;
+          }
+        }
+      });
+
+      return (
+        <button
+          data-testid="button"
+          onClick={() => {
+            service.send('TOGGLE');
+          }}
+        ></button>
+      );
+    };
+
+    render(<App />);
+    const button = screen.getByTestId('button');
+
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(count).toBe(2);
+  });
+
   it('actions created by a layout effect should access the latest closure values', () => {
     const actual: number[] = [];
 

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -762,4 +762,52 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
 
     expect(container.textContent).toBe('2');
   });
+
+  it('options.subscribe should create a subscription to the interpreter', () => {
+    const machine = createMachine({
+      initial: 'off',
+      states: {
+        off: {
+          on: {
+            TOGGLE: 'on'
+          }
+        },
+        on: {
+          on: {
+            TOGGLE: 'off'
+          }
+        }
+      }
+    });
+
+    let count = 0;
+
+    const App = () => {
+      const [, send] = useMachine(machine, {
+        subscribe: (state) => {
+          if (state.matches('on')) {
+            count++;
+          }
+        }
+      });
+
+      return (
+        <button
+          data-testid="button"
+          onClick={() => {
+            send('TOGGLE');
+          }}
+        ></button>
+      );
+    };
+
+    render(<App />);
+    const button = screen.getByTestId('button');
+
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(count).toBe(2);
+  });
 });


### PR DESCRIPTION
You can conveniently create a subscription to the interpreter inside `useInterpret` and `useMachine` hooks.

```js
const machine = createMachine({
  initial: 'active',
  states: {
    inactive: {
      on: {
        ACTIVATE: 'active'
      }
    },
    active: {
      on: {
        DEACTIVATE: 'inactive'
      }
    }
  }
});
```

**Before**:

```jsx
const [, , actor] = useMachine(machine);
// Or
const [, , actor] = useInterpret(machine);

React.useEffect(() => {
  return actor.subscribe((state) => {
    // do something with the state object
  }).unsubscribe;
}, []);
```

**After**:

```jsx
const [, , actor] = useMachine(machine, {
  subscribe: (state) => {
    // do something with the state object
  }
});
// Or
const [, , actor] = useInterpret(machine, {
  subscribe: (state) => {
    // do something with the state object
  }
});
```
