### PR TITLE
Remove `Interpreter#onError`

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -262,19 +262,6 @@ export class Interpreter<
   }
 
   /**
-   * Adds an error listener that is notified with an `Error` whenever an
-   * error occurs during execution.
-   *
-   * @param listener The error listener
-   */
-  public onError(listener: ErrorListener): this {
-    this.observers.add({
-      error: listener
-    });
-    return this;
-  }
-
-  /**
    * Adds a state listener that is notified when the statechart has reached its final state.
    * @param listener The state listener
    */

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -1033,14 +1033,17 @@ describe('invoke', () => {
           }
         });
 
-        const actor = interpret(promiseMachine)
-          .onDone(doneSpy)
-          .onError((err) => {
+        const actor = interpret(promiseMachine);
+
+        actor.onDone(doneSpy);
+        actor.subscribe({
+          error: (err) => {
             // TODO: determine if err should be the full SCXML error event
             expect(err).toBeInstanceOf(Error);
             expect(err.message).toBe('test');
-          })
-          .start();
+          }
+        });
+        actor.start();
 
         actor.subscribe({
           complete() {


### PR DESCRIPTION
Implements what has been documented as a change here: [.changeset/perfect-ants-count.md](https://github.com/statelyai/xstate/pull/3455/files#diff-7a71c2790bd3a7c7eb671dd7c85372a49cad80b94a99e023d738274308984732)