### PR TITLE
Introduce `TExpressionEvent` generic

### DIFF
--- a/.changeset/shy-donkeys-glow.md
+++ b/.changeset/shy-donkeys-glow.md
@@ -1,0 +1,7 @@
+---
+'xstate': minor
+---
+
+All actions received a new generic: `TExpressionEvent`. To type things more correctly and allow TS to infer things better we need to distinguish between all events accepted by a machine (`TEvent`) and the event type that actions are "called" with (`TExpressionEvent`).
+
+It's best to rely on type inference so you shouldn't have to specify this generic manually all over the place.

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1093,7 +1093,7 @@ class StateNode<
       })
       .concat({
         type: 'state_done',
-        actions: doneEvents.map((event) => raise(event)) as Array<
+        actions: doneEvents.map((event) => raise(event as any)) as Array<
           ActionObject<TContext, TEvent>
         >
       });

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1317,7 +1317,7 @@ class StateNode<
     );
 
     const [raisedEvents, nonRaisedActions] = partition(
-      resolvedActions,
+      resolvedActions as any,
       isRaisableAction
     );
 
@@ -1435,7 +1435,7 @@ class StateNode<
         const raisedEvent = raisedEvents.shift()!;
         maybeNextState = this.resolveRaisedTransition(
           maybeNextState,
-          raisedEvent._event,
+          raisedEvent._event as any,
           _event,
           predictableExec
         );

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -185,7 +185,7 @@ export function resolveRaise<
   ctx: TContext,
   _event: SCXML.Event<TExpressionEvent>,
   delaysMap?: DelayFunctionMap<TContext, TEvent>
-): RaiseActionObject<TContext, TEvent> {
+): RaiseActionObject<TContext, TExpressionEvent, TEvent> {
   const meta = {
     _event
   };
@@ -231,13 +231,13 @@ export function send<
   TEvent extends EventObject,
   TSentEvent extends EventObject = AnyEventObject
 >(
-  event: Event<TSentEvent> | SendExpr<TContext, TEvent, TSentEvent>,
+  event: Event<AnyEventObject> | SendExpr<TContext, TEvent, AnyEventObject>,
   options?: SendActionOptions<TContext, TEvent>
 ): SendAction<TContext, TEvent, TSentEvent> {
   return {
     to: options ? options.to : undefined,
     type: actionTypes.send,
-    event: isFunction(event) ? event : toEventObject<TSentEvent>(event),
+    event: isFunction(event) ? event : toEventObject(event),
     delay: options ? options.delay : undefined,
     // TODO: don't auto-generate IDs here like that
     // there is too big chance of the ID collision
@@ -246,7 +246,7 @@ export function send<
         ? options.id
         : isFunction(event)
         ? event.name
-        : (getEventType<TSentEvent>(event) as string)
+        : (getEventType(event) as string)
   } as any;
 }
 
@@ -307,7 +307,7 @@ export function sendParent<
   TEvent extends EventObject,
   TSentEvent extends EventObject = AnyEventObject
 >(
-  event: Event<TSentEvent> | SendExpr<TContext, TEvent, TSentEvent>,
+  event: Event<AnyEventObject> | SendExpr<TContext, TEvent, AnyEventObject>,
   options?: SendActionOptions<TContext, TEvent>
 ): SendAction<TContext, TEvent, TSentEvent> {
   return send<TContext, TEvent, TSentEvent>(event, {
@@ -355,11 +355,9 @@ export function sendTo<
 export function sendUpdate<TContext, TEvent extends EventObject>(): SendAction<
   TContext,
   TEvent,
-  { type: ActionTypes.Update }
+  AnyEventObject
 > {
-  return sendParent<TContext, TEvent, { type: ActionTypes.Update }>(
-    actionTypes.update
-  );
+  return sendParent(actionTypes.update);
 }
 
 /**
@@ -735,7 +733,7 @@ export function resolveActions<TContext, TEvent extends EventObject>(
           machine.options.delays as any
         );
         if (predictableExec && typeof raisedAction.delay === 'number') {
-          predictableExec(raisedAction, updatedContext, _event);
+          predictableExec(raisedAction as any, updatedContext, _event);
         }
         return raisedAction;
       }

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -986,7 +986,7 @@ export class Interpreter<
     actionFunctionMap = this.machine.options.actions
   ): void => {
     const actionOrExec =
-      action.exec || getActionFunction(action.type, actionFunctionMap);
+      action.exec || getActionFunction(action.type, actionFunctionMap as any);
     const exec = isFunction(actionOrExec)
       ? actionOrExec
       : actionOrExec

--- a/packages/core/src/model.types.ts
+++ b/packages/core/src/model.types.ts
@@ -74,15 +74,17 @@ export interface Model<
   };
 }
 
-export type ModelContextFrom<TModel extends Model<any, any, any, any>> =
-  TModel extends Model<infer TContext, any, any, any> ? TContext : never;
+export type ModelContextFrom<
+  TModel extends Model<any, any, any, any>
+> = TModel extends Model<infer TContext, any, any, any> ? TContext : never;
 
 export type ModelEventsFrom<
   TModel extends Model<any, any, any, any> | undefined
 > = TModel extends Model<any, infer TEvent, any, any> ? TEvent : EventObject;
 
-export type ModelActionsFrom<TModel extends Model<any, any, any, any>> =
-  TModel extends Model<any, any, infer TAction, any> ? TAction : never;
+export type ModelActionsFrom<
+  TModel extends Model<any, any, any, any>
+> = TModel extends Model<any, any, infer TAction, any> ? TAction : never;
 
 export type EventCreator<
   Self extends AnyFunction,

--- a/packages/core/src/model.types.ts
+++ b/packages/core/src/model.types.ts
@@ -36,7 +36,11 @@ export interface Model<
       | Assigner<TContext, SimplisticExtractEvent<TEvent, TEventType>>
       | PropertyAssigner<TContext, SimplisticExtractEvent<TEvent, TEventType>>,
     eventType?: TEventType
-  ) => AssignAction<TContext, SimplisticExtractEvent<TEvent, TEventType>>;
+  ) => AssignAction<
+    TContext,
+    SimplisticExtractEvent<TEvent, TEventType>,
+    TEvent
+  >;
   events: Prop<TModelCreators, 'events'>;
   actions: Prop<TModelCreators, 'actions'>;
   reset: () => AssignAction<TContext, any>;
@@ -70,17 +74,15 @@ export interface Model<
   };
 }
 
-export type ModelContextFrom<
-  TModel extends Model<any, any, any, any>
-> = TModel extends Model<infer TContext, any, any, any> ? TContext : never;
+export type ModelContextFrom<TModel extends Model<any, any, any, any>> =
+  TModel extends Model<infer TContext, any, any, any> ? TContext : never;
 
 export type ModelEventsFrom<
   TModel extends Model<any, any, any, any> | undefined
 > = TModel extends Model<any, infer TEvent, any, any> ? TEvent : EventObject;
 
-export type ModelActionsFrom<
-  TModel extends Model<any, any, any, any>
-> = TModel extends Model<any, any, infer TAction, any> ? TAction : never;
+export type ModelActionsFrom<TModel extends Model<any, any, any, any>> =
+  TModel extends Model<any, any, infer TAction, any> ? TAction : never;
 
 export type EventCreator<
   Self extends AnyFunction,

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -137,7 +137,7 @@ function mapAction<
 >(element: XMLElement): ActionObject<TContext, TEvent> {
   switch (element.name) {
     case 'raise': {
-      return actions.raise<TContext, TEvent>(
+      return actions.raise<TContext, TEvent, TEvent>(
         element.attributes!.event! as string
       );
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -167,10 +167,8 @@ export type BaseAction<
   | SimpleActionsOf<TAction>['type']
   | TAction
   | RaiseAction<TContext, TExpressionEvent, TEvent>
-  // | SendAction<TContext, TExpressionEvent, TEvent>
+  | SendAction<TContext, TExpressionEvent, TEvent>
   | AssignAction<TContext, TExpressionEvent, TEvent>
-  // TODO: those might need to receive `TEvent` as well
-  // it might be required to type the ActionMeta in them properly
   | LogAction<TContext, TExpressionEvent, TEvent>
   | CancelAction<TContext, TExpressionEvent, TEvent>
   | StopAction<TContext, TExpressionEvent, TEvent>
@@ -1438,7 +1436,6 @@ export interface AssignAction<
   assignment:
     | Assigner<TContext, TExpressionEvent>
     | PropertyAssigner<TContext, TExpressionEvent>;
-  // (ctx: TContext, ev: TExpressionEvent): void;
 }
 
 export interface PureAction<

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -724,20 +724,24 @@ export function createInvokeId(stateNodeId: string, index: number): string {
   return `${stateNodeId}:invocation[${index}]`;
 }
 
-export function isRaisableAction<TContext, TEvent extends EventObject>(
-  action: ActionObject<TContext, TEvent>
+export function isRaisableAction<
+  TContext,
+  TExpressionEvent extends EventObject,
+  TEvent extends EventObject
+>(
+  action: ActionObject<TContext, TExpressionEvent, TEvent>
 ): action is
-  | RaiseActionObject<TContext, TEvent>
-  | SendActionObject<TContext, TEvent, TEvent> {
+  | RaiseActionObject<TContext, TExpressionEvent, TEvent>
+  | SendActionObject<TContext, TExpressionEvent, TEvent> {
   return (
     (action.type === actionTypes.raise ||
       (action.type === actionTypes.send &&
-        (action as SendActionObject<TContext, TEvent>).to ===
+        (action as SendActionObject<TContext, TExpressionEvent, TEvent>).to ===
           SpecialTargets.Internal)) &&
     typeof (
       action as
-        | RaiseActionObject<TContext, TEvent>
-        | SendActionObject<TContext, TEvent>
+        | RaiseActionObject<TContext, TExpressionEvent, TEvent>
+        | SendActionObject<TContext, TExpressionEvent, TEvent>
     ).delay !== 'number'
   );
 }

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -211,7 +211,7 @@ describe('Nested parallel stateSchema', () => {
 });
 
 describe('Raise events', () => {
-  // TODO: will be rmeoved in v5
+  // TODO: will be removed in v5
   it('should accept a valid simple event type', () => {
     interface Context {}
 
@@ -222,7 +222,7 @@ describe('Raise events', () => {
     });
   });
 
-  // TODO: will be rmeoved in v5
+  // TODO: will be removed in v5
   it('should reject an invalid simple event type', () => {
     interface Context {}
 

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -38,7 +38,7 @@ export interface ImmerUpdateEvent<
 
 export interface ImmerUpdater<TContext, TEvent extends ImmerUpdateEvent> {
   update: (input: TEvent['input']) => TEvent;
-  action: AssignAction<TContext, TEvent>;
+  action: AssignAction<TContext, TEvent, any>;
   type: TEvent['type'];
 }
 

--- a/packages/xstate-react/test/createActorContext.test.tsx
+++ b/packages/xstate-react/test/createActorContext.test.tsx
@@ -134,7 +134,7 @@ describe('createActorContext', () => {
         obj: {
           counter: 0
         },
-        arr: []
+        arr: [] as string[]
       },
       on: {
         INC: {

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -133,14 +133,12 @@ describeEachReactMode('useActor (%s)', ({ render }) => {
     });
 
     interface Ctx {
-      actorRef?: ActorRefFrom<typeof childMachine>;
+      actorRef: ActorRefFrom<typeof childMachine>;
     }
 
     const machine = createMachine<Ctx>({
       initial: 'active',
-      context: {
-        actorRef: undefined
-      },
+      context: {} as Ctx,
       states: {
         active: {
           entry: assign({
@@ -185,12 +183,12 @@ describeEachReactMode('useActor (%s)', ({ render }) => {
       }
     });
     const machine = createMachine<{
-      actorRef?: ActorRefFrom<typeof childMachine>;
+      actorRef: ActorRefFrom<typeof childMachine>;
     }>({
       initial: 'active',
       context: {
         actorRef: undefined
-      },
+      } as any,
       states: {
         active: {
           entry: assign({


### PR DESCRIPTION
With this change, the inferred types for `raise` are being improved. We can see here that both `TExpressionEvent` and `TEvent` are inferred correctly here - to `{ type: 'DECIDE'; aloha?: boolean | undefined; }` and `GreetingEvent`, respectively.
<img width="843" alt="Screenshot 2022-12-07 at 12 15 34" src="https://user-images.githubusercontent.com/9800850/206165182-5140f841-179c-470e-8e54-e5f6c972184c.png">
In here we can see that this improves autocomplete capabilities in the IDE because the contextual type is restricted to what can actually be sent to this machine:
<img width="523" alt="Screenshot 2022-12-07 at 12 15 50" src="https://user-images.githubusercontent.com/9800850/206165240-163d385e-db94-48da-b62b-b99ea869bf38.png">
And in here we can see that a type error is raised (huehue) correctly when we try to use an invalid event:
<img width="1027" alt="Screenshot 2022-12-07 at 12 16 12" src="https://user-images.githubusercontent.com/9800850/206165308-75e5f6ce-d391-4706-bea3-4324f2905974.png">

⚠️ there are some type failures here as I didn't yet adjust everything around the implementation etc. This only touches public-facing APIs etc - as only those had to be adjusted to validate the idea.

I'm not super keen on touching types in v4 as I'd really like to completely rewrite them in v5 (IMHO it's the easiest way to clean them up). OTOH, this brings some very nice improvements to the table.

Our types are so complex that it's quite hard to predict all potential problems with this but, dunno, perhaps it's worth shipping this?

fixes https://github.com/statelyai/xstate/issues/2897
fixes https://github.com/statelyai/xstate/issues/1414
fixes https://github.com/statelyai/xstate/issues/2994