### PR TITLE
Defer stopping actors

### DIFF
--- a/packages/core/src/exec.ts
+++ b/packages/core/src/exec.ts
@@ -157,8 +157,9 @@ function getActionFunction<TState extends AnyState>(
       const { actor } = (action as StopActionObject).params;
 
       if (actor) {
-        actor.stop?.();
-        delete state.children[actor.id];
+        actorCtx.defer?.(() => {
+          actor.stop?.();
+        });
       }
     },
     [actionTypes.log]: (_ctx, _e, { action }) => {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1153,10 +1153,7 @@ describe('entry/exit actions', () => {
       expect(eventReceived).toBe(true);
     });
 
-    // TODO: Determine what is the correct behavior here
-    // We're incorrectly assuming that sending from child -> grandchild is synchronous
-    // A race condition can occur where the grandchild is stopped before an event is received
-    it.skip('sent events from exit handlers of a stopped child should be received by its children', () => {
+    it('sent events from exit handlers of a stopped child should be received by its children', () => {
       let eventReceived = false;
 
       const grandchild = createMachine({
@@ -1201,10 +1198,7 @@ describe('entry/exit actions', () => {
       expect(eventReceived).toBe(true);
     });
 
-    // TODO: Determine what is the correct behavior here
-    // We're incorrectly assuming that sending from child -> grandchild is synchronous
-    // A race condition can occur where the grandchild is stopped before an event is received
-    it.skip('sent events from exit handlers of a done child should be received by its children ', () => {
+    it('sent events from exit handlers of a done child should be received by its children ', () => {
       let eventReceived = false;
 
       const grandchild = createMachine({

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1287,7 +1287,7 @@ describe('actors', () => {
             fromPromise(
               () =>
                 new Promise<number>((_, rej) => {
-                  setTimeout(() => rej(errorMessage), 1000);
+                  setTimeout(() => rej(errorMessage), 1);
                 })
             ),
             'test'

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -259,11 +259,11 @@ describe('predictableExec', () => {
       initial: 'active',
       context: ({ spawn }) => {
         const localId = ++invokeCounter;
-        actual.push(`start ${localId}`);
 
         return {
           actorRef: spawn(
             fromCallback(() => {
+              actual.push(`start ${localId}`);
               return () => {
                 actual.push(`stop ${localId}`);
               };
@@ -283,10 +283,10 @@ describe('predictableExec', () => {
                 assign({
                   actorRef: (_ctx, _ev, { spawn }) => {
                     const localId = ++invokeCounter;
-                    actual.push(`start ${localId}`);
 
                     return spawn(
                       fromCallback(() => {
+                        actual.push(`start ${localId}`);
                         return () => {
                           actual.push(`stop ${localId}`);
                         };
@@ -321,11 +321,11 @@ describe('predictableExec', () => {
       initial: 'active',
       context: ({ spawn }) => {
         const localId = ++invokeCounter;
-        actual.push(`start ${localId}`);
 
         return {
           actorRef: spawn(
             fromCallback(() => {
+              actual.push(`start ${localId}`);
               return () => {
                 actual.push(`stop ${localId}`);
               };
@@ -343,10 +343,10 @@ describe('predictableExec', () => {
                 assign({
                   actorRef: (_ctx, _ev, { spawn }) => {
                     const localId = ++invokeCounter;
-                    actual.push(`start ${localId}`);
 
                     return spawn(
                       fromCallback(() => {
+                        actual.push(`start ${localId}`);
                         return () => {
                           actual.push(`stop ${localId}`);
                         };
@@ -381,11 +381,11 @@ describe('predictableExec', () => {
       initial: 'active',
       context: ({ spawn }) => {
         const localId = ++invokeCounter;
-        actual.push(`start ${localId}`);
 
         return {
           actorRef: spawn(
             fromCallback(() => {
+              actual.push(`start ${localId}`);
               return () => {
                 actual.push(`stop ${localId}`);
               };
@@ -403,10 +403,10 @@ describe('predictableExec', () => {
                 assign({
                   actorRef: (_ctx, _ev, { spawn }) => {
                     const localId = ++invokeCounter;
-                    actual.push(`start ${localId}`);
 
                     return spawn(
                       fromCallback(() => {
+                        actual.push(`start ${localId}`);
                         return () => {
                           actual.push(`stop ${localId}`);
                         };
@@ -463,10 +463,10 @@ describe('predictableExec', () => {
                 assign({
                   actorRef: (_ctx, _ev, { spawn }) => {
                     const localId = ++invokeCounter;
-                    actual.push(`start ${localId}`);
 
                     return spawn(
                       fromCallback(() => {
+                        actual.push(`start ${localId}`);
                         return () => {
                           actual.push(`stop ${localId}`);
                         };


### PR DESCRIPTION
As per comment [here](https://github.com/statelyai/xstate/pull/3455/files#r968358269):
> This tests a very specific situation - with no other machines in the picture etc so a grandchild can't be just stopped for any other reason than because its parent here (child) gets stopped.

> No race condition is possible here even if we assume that sending events is asynchronous because this test tests that events sent from child to grandchild are sent "in order". It also tests that a sent event is sent before an implicit event that informs the grandchild to stop. In other words, it tests that we can send events from a machine to its children before notifying them about them being stopped and it tests that they can process that event (because the stop notification has not been delivered to them yet, or because it stays queued after that other event).

---

The issue here was that even though actions were resolved and executed correctly as per the algorithm quoted recently by @davidkpiano [here](https://github.com/statelyai/xstate/pull/3712#issue-1502992414) - we were first executing the executable content (exit actions) and then stopping children.

The problem is that sending events is currently "deferred" to enable `.getSnapshot()` reads in the receiver (the receiver can read the updated state of the origin in its transitions for the received event). However, stop actions were not deferred like this - and thus the sent events could never reach their destination (as by the time they were **actually** executed the destination/target actor was already stopped).