### PR TITLE
Remove test action execution

### DIFF
--- a/packages/xstate-test/src/TestModel.ts
+++ b/packages/xstate-test/src/TestModel.ts
@@ -48,7 +48,6 @@ export class TestModel<TState, TEvent extends EventObject> {
       getEvents: () => [],
       stateMatcher: (_, stateKey) => stateKey === '*',
       eventCases: {},
-      execute: () => void 0,
       logger: {
         log: console.log.bind(console),
         error: console.error.bind(console)
@@ -319,8 +318,6 @@ export class TestModel<TState, TEvent extends EventObject> {
     for (const stateTestKey of stateTestKeys) {
       await params.states?.[stateTestKey](state);
     }
-
-    this.afterTestState(state, resolvedOptions);
   }
 
   private getStateTestKeys(
@@ -341,13 +338,6 @@ export class TestModel<TState, TEvent extends EventObject> {
     return stateTestKeys;
   }
 
-  private afterTestState(
-    state: TState,
-    resolvedOptions: TestModelOptions<TState, TEvent>
-  ) {
-    resolvedOptions.execute(state);
-  }
-
   public testStateSync(
     params: TestParam<TState, TEvent>,
     state: TState,
@@ -363,8 +353,6 @@ export class TestModel<TState, TEvent extends EventObject> {
         `The test for '${stateTestKey}' returned a promise - did you mean to use the sync method?`
       );
     }
-
-    this.afterTestState(state, resolvedOptions);
   }
 
   private getEventExec(

--- a/packages/xstate-test/src/machine.ts
+++ b/packages/xstate-test/src/machine.ts
@@ -1,6 +1,5 @@
 import { SerializedState, serializeState, SimpleBehavior } from '@xstate/graph';
 import {
-  ActionObject,
   AnyEventObject,
   AnyState,
   AnyStateMachine,
@@ -38,19 +37,6 @@ export function createTestMachine<
   options?: TestMachineOptions<TContext, TEvent, TTypesMeta>
 ) {
   return createMachine(config, options as any);
-}
-
-export function executeAction(
-  actionObject: ActionObject<any, any>,
-  state: AnyState
-): void {
-  if (typeof actionObject.exec === 'function') {
-    actionObject.exec(state.context, state.event, {
-      _event: state._event,
-      action: actionObject,
-      state
-    });
-  }
 }
 
 function serializeMachineTransition(
@@ -124,11 +110,6 @@ export function createTestModel<TMachine extends AnyStateMachine>(
         return key.startsWith('#')
           ? state.configuration.includes(machine.getStateNodeById(key))
           : state.matches(key);
-      },
-      execute: (state) => {
-        state.actions.forEach((action) => {
-          executeAction(action, state);
-        });
       },
       getEvents: (state, eventCases) =>
         flatten(

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -86,7 +86,10 @@ export interface TestParam<TState, TEvent extends EventObject> {
     [key: string]: (state: TState) => void | Promise<void>;
   };
   events?: {
-    [TEventType in TEvent['type']]?: EventExecutor<TState, ExtractEvent<TEvent, TEventType>>;
+    [TEventType in TEvent['type']]?: EventExecutor<
+      TState,
+      ExtractEvent<TEvent, TEventType>
+    >;
   };
 }
 
@@ -116,10 +119,6 @@ export type EventExecutor<TState, TEvent extends EventObject> = (
 
 export interface TestModelOptions<TState, TEvent extends EventObject>
   extends TraversalOptions<TState, TEvent> {
-  /**
-   * Executes actions based on the `state` after the state is tested.
-   */
-  execute: (state: TState) => void;
   stateMatcher: (state: TState, stateKey: string) => boolean;
   logger: {
     log: (msg: string) => void;

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -201,40 +201,6 @@ it('prevents infinite recursion based on a provided limit', () => {
   }).toThrowErrorMatchingInlineSnapshot(`"Traversal limit exceeded"`);
 });
 
-// TODO: have this as an opt-in
-it('executes actions', async () => {
-  let executedActive = false;
-  let executedDone = false;
-  const machine = createTestMachine({
-    initial: 'idle',
-    states: {
-      idle: {
-        on: {
-          TOGGLE: { target: 'active', actions: 'boom' }
-        }
-      },
-      active: {
-        entry: () => {
-          executedActive = true;
-        },
-        on: { TOGGLE: 'done' }
-      },
-      done: {
-        entry: () => {
-          executedDone = true;
-        }
-      }
-    }
-  });
-
-  const model = createTestModel(machine);
-
-  await testUtils.testModel(model, {});
-
-  expect(executedActive).toBe(true);
-  expect(executedDone).toBe(true);
-});
-
 describe('test model options', () => {
   it('options.testState(...) should test state', async () => {
     const testedStates: any[] = [];


### PR DESCRIPTION
This PR removes the ability to execute actions in the upcoming `@xstate/test`. Executing side-effects should only be done either within the event execution or asserting the state (if needed).

@Andarist Not sure how to handle the alpha changeset for this one