### PR TITLE
[Documentation] - Service Schema Typescript

### DIFF
--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -165,6 +165,9 @@ createMachine(
 );
 ```
 
+Note: The service returns an object with ONE key, i.e data. 
+You just have to mention ```data: yourType``` in service schema. But when writing the service function, make sure to return just the ```yourType```
+
 ### How to get the most out of the VS Code extension
 
 #### Use named actions/guards/services


### PR DESCRIPTION
Added a note about how service schema accepts only type with data key. But while writing the service function, we have to return the type assigned to data key. This misinterpretation took me hours to realize.

having this specifically mentioned in the documentation would help