### PR TITLE
chore: remove incorrect issue number from latest changeset

### DIFF
--- a/.changeset/serious-chairs-try.md
+++ b/.changeset/serious-chairs-try.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Fix types to allow for string state name in service onDone/onError config (#34)
+Fix types to allow for string state name in service onDone/onError config


### PR DESCRIPTION
I noticed that my commit from https://github.com/statelyai/xstate/pull/3745 accidentally referenced an incorrect issue #. This change drops the issue number from the changeset, as the output will already include the correct PR # when a future release is generated.