### PR TITLE
Fixed how the initial state of a service is read by the `useActor` hook

### DIFF
--- a/.changeset/quiet-swans-divide.md
+++ b/.changeset/quiet-swans-divide.md
@@ -2,4 +2,4 @@
 '@xstate/react': patch
 ---
 
-Computing the initial state is now consistent with `useMachine` and `useInterpret`, avoiding stale initial state problems with nested machines
+Computing the initial state is now consistent with `useMachine` and `useActor`, avoiding stale initial state problems with nested machines

--- a/.changeset/quiet-swans-divide.md
+++ b/.changeset/quiet-swans-divide.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+Computing the initial state is now consistent with `useMachine` and `useInterpret`, avoiding stale initial state problems with nested machines

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -3,6 +3,7 @@ import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 import { ActorRef, EventObject, Sender } from 'xstate';
 import useConstant from './useConstant';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
+import { getServiceSnapshot, isService } from './utils';
 
 export function isActorWithState<T extends ActorRef<any>>(
   actorRef: T
@@ -24,7 +25,9 @@ function defaultGetSnapshot<TEmitted>(
   actorRef: ActorRef<any, TEmitted>
 ): TEmitted | undefined {
   return 'getSnapshot' in actorRef
-    ? actorRef.getSnapshot()
+    ? isService(actorRef)
+      ? getServiceSnapshot(actorRef as any)
+      : actorRef.getSnapshot()
     : isActorWithState(actorRef)
     ? actorRef.state
     : undefined;

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -136,10 +136,6 @@ export function useInterpret<TMachine extends AnyStateMachine>(
 
   useEffect(() => {
     const rehydratedState = options.state;
-    // @ts-ignore
-    // This ensures that the interpreter recomputes the initial state
-    // TODO: figure out a better way to do this
-    delete service._initialState;
     service.start(
       rehydratedState ? (State.create(rehydratedState) as any) : undefined
     );

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -136,6 +136,8 @@ export function useInterpret<TMachine extends AnyStateMachine>(
 
   useEffect(() => {
     const rehydratedState = options.state;
+    // @ts-ignore
+    delete service._initialState;
     service.start(
       rehydratedState ? (State.create(rehydratedState) as any) : undefined
     );

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -137,6 +137,8 @@ export function useInterpret<TMachine extends AnyStateMachine>(
   useEffect(() => {
     const rehydratedState = options.state;
     // @ts-ignore
+    // This ensures that the interpreter recomputes the initial state
+    // TODO: figure out a better way to do this
     delete service._initialState;
     service.start(
       rehydratedState ? (State.create(rehydratedState) as any) : undefined

--- a/packages/xstate-react/src/useSelector.ts
+++ b/packages/xstate-react/src/useSelector.ts
@@ -1,12 +1,8 @@
 import { useCallback, useRef } from 'react';
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector';
-import { ActorRef, AnyState, Interpreter, Subscribable } from 'xstate';
+import { ActorRef, AnyState, Subscribable } from 'xstate';
 import { isActorWithState } from './useActor';
-import { getServiceSnapshot } from './utils';
-
-function isService(actor: any): actor is Interpreter<any, any, any, any> {
-  return 'state' in actor && 'machine' in actor;
-}
+import { getServiceSnapshot, isService } from './utils';
 
 const defaultCompare = (a, b) => a === b;
 const defaultGetSnapshot = (a, initialStateCacheRef) => {

--- a/packages/xstate-react/src/utils.ts
+++ b/packages/xstate-react/src/utils.ts
@@ -62,3 +62,9 @@ export function shallowEqual(objA: any, objB: any) {
 
   return true;
 }
+
+export function isService(
+  actor: any
+): actor is Interpreter<any, any, any, any> {
+  return 'state' in actor && 'machine' in actor;
+}

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -180,7 +180,7 @@ describeEachReactMode('useInterpret (%s)', ({ suiteKey, render }) => {
     }
   });
 
-  it.only('should change state when started', async () => {
+  it('should change state when started', async () => {
     const childMachine = createMachine({
       initial: 'waiting',
       states: {

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
-import { createMachine } from 'xstate';
-import { fireEvent, screen } from '@testing-library/react';
-import { useInterpret, useMachine } from '../src';
+import { ActorRefFrom, createMachine, spawn } from 'xstate';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { useActor, useInterpret, useMachine } from '../src';
 import { describeEachReactMode } from './utils';
+import { sendTo } from 'xstate/lib/actions';
 
 const originalConsoleWarn = console.warn;
 
@@ -177,5 +178,63 @@ describeEachReactMode('useInterpret (%s)', ({ suiteKey, render }) => {
         Please make sure that you pass the same Machine as argument each time."
       `);
     }
+  });
+
+  it.only('should change state when started', async () => {
+    const childMachine = createMachine({
+      initial: 'waiting',
+      states: {
+        waiting: {
+          on: {
+            EVENT: 'received'
+          }
+        },
+        received: {}
+      }
+    });
+
+    const parentMachine = createMachine<{
+      childRef: ActorRefFrom<typeof childMachine>;
+    }>({
+      context: () => ({
+        childRef: spawn(childMachine)
+      }),
+      on: {
+        SEND_TO_CHILD: {
+          actions: sendTo((ctx) => ctx.childRef, { type: 'EVENT' })
+        }
+      }
+    });
+
+    const App = () => {
+      const parentActor = useInterpret(parentMachine);
+      const [parentState, parentSend] = useActor(parentActor);
+      const [childState] = useActor(parentState.context.childRef);
+
+      return (
+        <>
+          <button
+            data-testid="button"
+            onClick={() => parentSend('SEND_TO_CHILD')}
+          >
+            Send to child
+          </button>
+          <div data-testid="child-state">{childState.value}</div>
+        </>
+      );
+    };
+
+    render(<App />);
+
+    const button = screen.getByTestId('button');
+    const childState = screen.getByTestId('child-state');
+
+    expect(childState.textContent).toBe('waiting');
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(childState.textContent).toBe('received');
+    });
   });
 });


### PR DESCRIPTION
This PR adds a failing test and proposes a "fix" for an issue [reported in Discord](https://discord.com/channels/795785288994652170/1061308540490367006/1061308540490367006):

> I've been putting off updating the xstate package in my company's codebase for some time now as some of our machines break when upgrading from 4.32.1 -> 4.33.0. 
>
> I finally got some time to dedicate to it and have replicated the issue in a simplified code sandbox.  The sandbox has a very basic react app, which uses a parentMachine, which in turn spawns a childMachine. There is a button that sends an event to the parentMachine. The parentMachine should then send an event to the childMachine. The UI should then update to say that the child received the event. Simple.
>
> The issue seems to be that the parentMachine does not send the event to the childMachine after the upgrade. The childMachine also does not appear in the inspector following the upgrade, possibly another symptom of whatever the underlying issue is.
> 
> Refer to the two code sandboxes below, the only difference between them is the xstate version:
> 4.32.1 https://codesandbox.io/s/xstate-issue-4-32-1-91uthm?file=/src/App.tsx
> 4.33.0 https://codesandbox.io/s/xstate-issue-4-33-0-w1c3zu?file=/src/App.tsx
> 
> Any help on this would be greatly appreciated, have been stuck on it for awhile!