### PR TITLE
Make all transitions internal by default

### DIFF
--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -363,17 +363,7 @@ export function formatTransition<
   }
 ): AnyTransitionDefinition {
   const normalizedTarget = normalizeTarget(transitionConfig.target);
-  const internal =
-    stateNode === stateNode.machine.root
-      ? true // always internal for root
-      : 'internal' in transitionConfig
-      ? transitionConfig.internal
-      : normalizedTarget
-      ? normalizedTarget.some(
-          (_target) =>
-            isString(_target) && _target[0] === stateNode.machine.delimiter
-        )
-      : true;
+  const external = transitionConfig.external ?? false;
   const { guards } = stateNode.machine.options;
   const target = resolveTarget(stateNode, normalizedTarget);
 
@@ -394,7 +384,7 @@ export function formatTransition<
       : undefined,
     target,
     source: stateNode,
-    internal,
+    external,
     eventType: transitionConfig.event,
     toJSON: () => ({
       ...transition,
@@ -539,6 +529,7 @@ export function formatInitialTransition<
       source: stateNode,
       actions: [],
       eventType: null as any,
+      external: false,
       target: resolvedTarget!,
       toJSON: () => ({
         ...transition,
@@ -998,7 +989,7 @@ function getTransitionDomain(
   }
 
   if (
-    transition.internal &&
+    !transition.external &&
     transition.source.type === 'compound' &&
     targetStates.every((targetStateNode) =>
       isDescendant(targetStateNode, transition.source)
@@ -1077,6 +1068,7 @@ export function microstep<
           {
             target: [...currentState.configuration].filter(isAtomicStateNode),
             source: machine.root,
+            external: true,
             actions: [],
             eventType: null as any,
             toJSON: null as any // TODO: fix

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -297,7 +297,7 @@ export interface TransitionConfig<
 > {
   guard?: GuardConfig<TContext, TEvent>;
   actions?: BaseActions<TContext, TEvent, TAction>;
-  internal?: boolean;
+  external?: boolean;
   target?: TransitionTarget<TContext, TEvent> | undefined;
   meta?: Record<string, any>;
   description?: string;
@@ -1393,6 +1393,7 @@ export interface TransitionDefinition<
   target: Array<StateNode<TContext, TEvent>> | undefined;
   source: StateNode<TContext, TEvent>;
   actions: BaseActionObject[];
+  external: boolean;
   guard?: GuardDefinition<TContext, TEvent>;
   eventType: TEvent['type'] | '*';
   toJSON: () => {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -495,7 +495,7 @@ describe('entry/exit actions', () => {
       expect(called).toBe(true);
     });
 
-    it('root entry/exit actions should not be called on root external transitions', () => {
+    it('root entry/exit actions should be called on root external transitions', () => {
       let entrySpy = jest.fn();
       let exitSpy = jest.fn();
 
@@ -506,7 +506,7 @@ describe('entry/exit actions', () => {
         on: {
           EVENT: {
             target: '#two',
-            internal: false
+            external: true
           }
         },
         initial: 'one',
@@ -525,8 +525,8 @@ describe('entry/exit actions', () => {
 
       service.send({ type: 'EVENT' });
 
-      expect(entrySpy).not.toHaveBeenCalled();
-      expect(exitSpy).not.toHaveBeenCalled();
+      expect(entrySpy).toHaveBeenCalled();
+      expect(exitSpy).toHaveBeenCalled();
     });
 
     describe('should ignore same-parent state actions (sparse)', () => {

--- a/packages/core/test/internalTransitions.test.ts
+++ b/packages/core/test/internalTransitions.test.ts
@@ -19,14 +19,14 @@ const wordMachine = createMachine({
         RIGHT_CLICK: '.right',
         RIGHT_CLICK_EXTERNAL: {
           target: '.right',
-          internal: false
+          external: true
         },
         CENTER_CLICK: '.center',
         JUSTIFY_CLICK: '.justify',
         RESET: 'direction', // explicit self-transition
         RESET_TO_CENTER: {
           target: 'direction.center',
-          internal: false
+          external: true
         }
       }
     }

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -788,7 +788,6 @@ describe('invoke', () => {
         entry: () => entryActionsCount++,
         on: {
           UPDATE: {
-            internal: true,
             actions: () => {
               actionsCount++;
             }
@@ -3226,8 +3225,8 @@ describe('invoke', () => {
     service.send({ type: 'FINISH' });
     expect(disposed).toBe(true);
   });
-  // https://github.com/statelyai/xstate/issues/3072
-  it('root invocations should not restart on root external transitions', () => {
+
+  it('root invocations should restart on root external transitions', () => {
     let count = 0;
 
     const machine = createMachine({
@@ -3242,7 +3241,7 @@ describe('invoke', () => {
       on: {
         EVENT: {
           target: '#two',
-          internal: false
+          external: true
         }
       },
       initial: 'one',
@@ -3258,7 +3257,7 @@ describe('invoke', () => {
 
     service.send({ type: 'EVENT' });
 
-    expect(count).toEqual(1);
+    expect(count).toEqual(2);
   });
 });
 

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -518,7 +518,7 @@ describe('predictableExec', () => {
           on: {
             REENTER: {
               target: 'active',
-              internal: false
+              external: true
             }
           }
         }

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -29,7 +29,7 @@ const exampleMachine = createMachine<any, Events>({
       on: {
         EXTERNAL: {
           target: 'one',
-          internal: false
+          external: true
         },
         INERT: {},
         INTERNAL: {


### PR DESCRIPTION
This is just a WIP to open/continue the discussion about this change. I expect that many tests might fail since we definitely rely on "inferred" transition types in many of them - it will be easy to fix those tests up, I can do it after we agree on the change itself.