### PR TITLE
Bring back (& rewrite) accidentally removed tests

### DIFF
--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -3,8 +3,8 @@ import { interpret, createMachine, assign } from '../src/index';
 
 // TODO: remove this file but before doing that ensure that things tested here are covered by other tests
 
-describe('activities', () => {
-  it('identifies initial root activities', () => {
+describe('invocations (activities)', () => {
+  it('identifies initial root invocations', () => {
     let active = false;
     const machine = createMachine({
       invoke: {
@@ -18,7 +18,7 @@ describe('activities', () => {
     expect(active).toBe(true);
   });
 
-  it('identifies initial activities', () => {
+  it('identifies initial invocations', () => {
     let active = false;
     const machine = createMachine({
       initial: 'a',
@@ -37,7 +37,7 @@ describe('activities', () => {
     expect(active).toBe(true);
   });
 
-  it('identifies initial deep activities', () => {
+  it('identifies initial deep invocations', () => {
     let active = false;
     const machine = createMachine({
       initial: 'a',
@@ -61,7 +61,7 @@ describe('activities', () => {
     expect(active).toBe(true);
   });
 
-  it('identifies start activities', () => {
+  it('identifies start invocations', () => {
     let active = false;
     const machine = createMachine({
       initial: 'a',
@@ -88,7 +88,7 @@ describe('activities', () => {
     expect(active).toBe(true);
   });
 
-  it('identifies start activities for child states and active activities', () => {
+  it('identifies start invocations for child states and active invocations', () => {
     let active = false;
     const machine = createMachine({
       initial: 'a',
@@ -126,7 +126,7 @@ describe('activities', () => {
     expect(active).toBe(true);
   });
 
-  it('identifies stop activities for child states', () => {
+  it('identifies stop invocations for child states', () => {
     let active = false;
     const machine = createMachine({
       initial: 'a',
@@ -169,7 +169,7 @@ describe('activities', () => {
     expect(active).toBe(false);
   });
 
-  it('identifies multiple stop activities for child and parent states', () => {
+  it('identifies multiple stop invocations for child and parent states', () => {
     let active1 = false;
     let active2 = false;
 
@@ -244,7 +244,7 @@ describe('activities', () => {
     expect(active).toBe(true);
   });
 
-  it('should remember the activities even after an ignored event', () => {
+  it('should remember the invocations even after an ignored event', () => {
     let cleanupSpy = jest.fn();
     let active = false;
     const machine = createMachine({
@@ -277,7 +277,7 @@ describe('activities', () => {
     expect(cleanupSpy).not.toBeCalled();
   });
 
-  it('should remember the activities when transitioning within the invoking state', () => {
+  it('should remember the invocations when transitioning within the invoking state', () => {
     let cleanupSpy = jest.fn();
     let active = false;
     const machine = createMachine({

--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -1,372 +1,440 @@
 import { fromCallback } from '../src/actors';
-import { stateIn } from '../src/guards';
-import { interpret, createMachine } from '../src/index';
+import { interpret, createMachine, assign } from '../src/index';
 
 // TODO: remove this file but before doing that ensure that things tested here are covered by other tests
 
-const lightMachine = createMachine({
-  initial: 'green',
-  states: {
-    green: {
-      invoke: ['fadeInGreen'],
-      on: {
-        TIMER: 'yellow'
+describe('activities', () => {
+  it('identifies initial root activities', () => {
+    let active = false;
+    const machine = createMachine({
+      invoke: {
+        src: fromCallback(() => {
+          active = true;
+        })
       }
-    },
-    yellow: {
-      on: {
-        TIMER: 'red'
-      }
-    },
-    red: {
-      initial: 'walk',
-      invoke: ['activateCrosswalkLight'],
-      on: {
-        TIMER: 'green'
-      },
-      states: {
-        walk: { on: { PED_WAIT: 'wait' } },
-        wait: {
-          invoke: ['blinkCrosswalkLight'],
-          on: { PED_STOP: 'stop' }
-        },
-        stop: {}
-      }
-    }
-  }
-});
+    });
+    interpret(machine).start();
 
-describe('activities with guarded transitions', () => {
-  it('should activate even if there are subsequent automatic, but blocked transitions', (done) => {
-    const machine = createMachine(
-      {
-        initial: 'A',
-        states: {
-          A: {
-            on: {
-              E: 'B'
-            }
-          },
-          B: {
-            invoke: ['B_ACTIVITY'],
-            always: [{ guard: () => false, target: 'A' }]
+    expect(active).toBe(true);
+  });
+
+  it('identifies initial activities', () => {
+    let active = false;
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: fromCallback(() => {
+              active = true;
+            })
           }
         }
-      },
-      {
-        actors: {
-          B_ACTIVITY: () =>
-            fromCallback(() => {
-              done();
-            })
+      }
+    });
+    interpret(machine).start();
+
+    expect(active).toBe(true);
+  });
+
+  it('identifies initial deep activities', () => {
+    let active = false;
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          initial: 'a1',
+          states: {
+            a1: {
+              invoke: {
+                src: fromCallback(() => {
+                  active = true;
+                })
+              }
+            }
+          }
         }
       }
-    );
+    });
+    interpret(machine).start();
+
+    expect(active).toBe(true);
+  });
+
+  it('identifies start activities', () => {
+    let active = false;
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            TIMER: 'b'
+          }
+        },
+        b: {
+          invoke: {
+            src: fromCallback(() => {
+              active = true;
+            })
+          }
+        }
+      }
+    });
+
+    const service = interpret(machine).start();
+
+    service.send({ type: 'TIMER' });
+
+    expect(active).toBe(true);
+  });
+
+  it('identifies start activities for child states and active activities', () => {
+    let active = false;
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            TIMER: 'b'
+          }
+        },
+        b: {
+          initial: 'b1',
+          states: {
+            b1: {
+              on: {
+                TIMER: 'b2'
+              }
+            },
+            b2: {
+              invoke: {
+                src: fromCallback(() => {
+                  active = true;
+                })
+              }
+            }
+          }
+        }
+      }
+    });
+    const service = interpret(machine);
+
+    service.start();
+    service.send({ type: 'TIMER' });
+    service.send({ type: 'TIMER' });
+
+    expect(active).toBe(true);
+  });
+
+  it('identifies stop activities for child states', () => {
+    let active = false;
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            TIMER: 'b'
+          }
+        },
+        b: {
+          initial: 'b1',
+          states: {
+            b1: {
+              on: {
+                TIMER: 'b2'
+              }
+            },
+            b2: {
+              invoke: {
+                src: fromCallback(() => {
+                  active = true;
+                  return () => (active = false);
+                })
+              },
+              on: {
+                TIMER: 'b3'
+              }
+            },
+            b3: {}
+          }
+        }
+      }
+    });
+    const service = interpret(machine).start();
+
+    service.send({ type: 'TIMER' });
+    service.send({ type: 'TIMER' });
+    service.send({ type: 'TIMER' });
+
+    expect(active).toBe(false);
+  });
+
+  it('identifies multiple stop activities for child and parent states', () => {
+    let active1 = false;
+    let active2 = false;
+
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            TIMER: 'b'
+          }
+        },
+        b: {
+          initial: 'b1',
+          invoke: {
+            src: fromCallback(() => {
+              active1 = true;
+              return () => (active1 = false);
+            })
+          },
+          states: {
+            b1: {
+              invoke: {
+                src: fromCallback(() => {
+                  active2 = true;
+                  return () => (active2 = false);
+                })
+              }
+            }
+          },
+          on: {
+            TIMER: 'a'
+          }
+        }
+      }
+    });
+    const service = interpret(machine);
+
+    service.start();
+    service.send({ type: 'TIMER' });
+    service.send({ type: 'TIMER' });
+
+    expect(active1).toBe(false);
+    expect(active2).toBe(false);
+  });
+
+  it('should activate even if there are subsequent always but blocked transition', () => {
+    let active = false;
+    const machine = createMachine({
+      initial: 'A',
+      states: {
+        A: {
+          on: {
+            E: 'B'
+          }
+        },
+        B: {
+          invoke: {
+            src: fromCallback(() => {
+              active = true;
+              return () => (active = false);
+            })
+          },
+          always: [{ guard: () => false, target: 'A' }]
+        }
+      }
+    });
 
     const service = interpret(machine).start();
 
     service.send({ type: 'E' });
-  });
-});
 
-describe('remembering activities', () => {
-  const machine = createMachine({
-    initial: 'A',
-    states: {
-      A: {
-        on: {
-          E: 'B'
-        }
-      },
-      B: {
-        invoke: 'B_ACTIVITY',
-        on: {
-          E: 'A'
+    expect(active).toBe(true);
+  });
+
+  it('should remember the activities even after an ignored event', () => {
+    let cleanupSpy = jest.fn();
+    let active = false;
+    const machine = createMachine({
+      initial: 'A',
+      states: {
+        A: {
+          on: {
+            E: 'B'
+          }
+        },
+        B: {
+          invoke: {
+            src: fromCallback(() => {
+              active = true;
+              return () => {
+                active = false;
+                cleanupSpy();
+              };
+            })
+          }
         }
       }
-    }
-  });
-
-  it('should remember the activities even after an event', (done) => {
-    const service = interpret(
-      machine.provide({
-        actors: {
-          B_ACTIVITY: () =>
-            fromCallback(() => {
-              done();
-            })
-        }
-      })
-    ).start();
+    });
+    const service = interpret(machine).start();
 
     service.send({ type: 'E' });
     service.send({ type: 'IGNORE' });
-  });
-});
 
-describe('activities', () => {
-  it('identifies initial activities', (done) => {
-    const service = interpret(
-      lightMachine.provide({
-        actors: {
-          fadeInGreen: () =>
-            fromCallback(() => {
-              done();
-            })
-        }
-      })
-    );
-
-    service.start();
-  });
-  it('identifies start activities', (done) => {
-    const service = interpret(
-      lightMachine.provide({
-        actors: {
-          activateCrosswalkLight: () =>
-            fromCallback(() => {
-              done();
-            })
-        }
-      })
-    );
-
-    service.start();
-    service.send({ type: 'TIMER' }); // yellow
-    service.send({ type: 'TIMER' }); // red
+    expect(active).toBe(true);
+    expect(cleanupSpy).not.toBeCalled();
   });
 
-  it('identifies start activities for child states and active activities', (done) => {
-    const service = interpret(
-      lightMachine.provide({
-        actors: {
-          blinkCrosswalkLight: () =>
-            fromCallback(() => {
-              done();
-            })
-        }
-      })
-    );
-
-    service.start();
-    service.send({ type: 'TIMER' }); // yellow
-    service.send({ type: 'TIMER' }); // red.walk
-    service.send({ type: 'PED_WAIT' }); // red.wait
-  });
-
-  it('identifies stop activities for child states', (done) => {
-    const service = interpret(
-      lightMachine.provide({
-        actors: {
-          blinkCrosswalkLight: () =>
-            fromCallback(() => {
+  it('should remember the activities when transitioning within the invoking state', () => {
+    let cleanupSpy = jest.fn();
+    let active = false;
+    const machine = createMachine({
+      initial: 'A',
+      states: {
+        A: {
+          invoke: {
+            src: fromCallback(() => {
+              active = true;
               return () => {
-                done();
+                active = false;
+                cleanupSpy();
               };
             })
-        }
-      })
-    );
-
-    service.start();
-    service.send({ type: 'TIMER' }); // yellow
-    service.send({ type: 'TIMER' }); // red.walk
-    service.send({ type: 'PED_WAIT' }); // red.wait
-    service.send({ type: 'PED_STOP' });
-  });
-
-  it('identifies multiple stop activities for child and parent states', (done) => {
-    let stopActivateCrosswalkLightcalled = false;
-
-    const service = interpret(
-      lightMachine.provide({
-        actors: {
-          fadeInGreen: () =>
-            fromCallback(() => {
-              if (stopActivateCrosswalkLightcalled) {
-                done();
+          },
+          initial: 'A1',
+          states: {
+            A1: {
+              on: {
+                E: 'A2'
               }
-            }),
-          activateCrosswalkLight: () =>
-            fromCallback(() => {
-              return () => {
-                stopActivateCrosswalkLightcalled = true;
-              };
-            })
-        }
-      })
-    );
-
-    service.start();
-    service.send({ type: 'TIMER' }); // yellow
-    service.send({ type: 'TIMER' }); // red.walk
-    service.send({ type: 'PED_WAIT' }); // red.wait
-    service.send({ type: 'PED_STOP' }); // red.stop
-    service.send({ type: 'TIMER' }); // green
-  });
-});
-
-describe('transient activities', () => {
-  const machine = createMachine({
-    type: 'parallel',
-    states: {
-      A: {
-        invoke: ['A'],
-        initial: 'A1',
-        states: {
-          A1: {
-            invoke: ['A1'],
-            on: {
-              A: 'AWAIT'
-            }
-          },
-          AWAIT: {
-            id: 'AWAIT',
-            invoke: ['AWAIT'],
-            always: 'A2'
-          },
-          A2: {
-            invoke: ['A2'],
-            on: {
-              A: 'A1'
-            }
-          }
-        },
-        on: {
-          A1: '.A1',
-          A2: '.A2'
-        }
-      },
-      B: {
-        initial: 'B1',
-        invoke: ['B'],
-        states: {
-          B1: {
-            invoke: ['B1'],
-            always: {
-              target: 'B2',
-              guard: stateIn('#AWAIT')
             },
-            on: {
-              B: 'B2'
-            }
-          },
-          B2: {
-            invoke: ['B2'],
-            on: {
-              B: 'B1'
-            }
-          }
-        },
-        on: {
-          B1: '.B1',
-          B2: '.B2'
-        }
-      },
-      C: {
-        initial: 'C1',
-        states: {
-          C1: {
-            invoke: ['C1'],
-            on: {
-              C: 'C1',
-              C_SIMILAR: 'C2'
-            }
-          },
-          C2: {
-            invoke: ['C1']
+            A2: {}
           }
         }
       }
-    }
+    });
+    const service = interpret(machine).start();
+
+    service.send({ type: 'E' });
+
+    expect(active).toBe(true);
+    expect(cleanupSpy).not.toBeCalled();
   });
 
-  it('should have started initial activities', (done) => {
-    const service = interpret(
-      machine.provide({
-        actors: {
-          A: () =>
-            fromCallback(() => {
-              done();
-            })
+  it('should start a new actor when leaving an invoking state and entering a new one that invokes the same actor type', () => {
+    let counter = 0;
+    const actual: string[] = [];
+    const machine = createMachine(
+      {
+        initial: 'a',
+        states: {
+          a: {
+            invoke: {
+              src: 'fooActor'
+            },
+            on: {
+              NEXT: 'b'
+            }
+          },
+          b: {
+            invoke: {
+              src: 'fooActor'
+            }
+          }
         }
-      })
+      },
+      {
+        actors: {
+          fooActor: fromCallback(() => {
+            let localId = counter;
+            counter++;
+
+            actual.push(`start ${localId}`);
+
+            return () => {
+              actual.push(`stop ${localId}`);
+            };
+          })
+        }
+      }
     );
+    const service = interpret(machine).start();
 
-    service.start();
+    service.send({ type: 'NEXT' });
+
+    expect(actual).toEqual(['start 0', 'stop 0', 'start 1']);
   });
 
-  it('should have started deep initial activities', (done) => {
-    const service = interpret(
-      machine.provide({
-        actors: {
-          A1: () =>
-            fromCallback(() => {
-              done();
-            })
+  it('should start a new actor when reentering the invoking state during an external self transition', () => {
+    let counter = 0;
+    const actual: string[] = [];
+    const machine = createMachine(
+      {
+        initial: 'a',
+        states: {
+          a: {
+            invoke: {
+              src: 'fooActor'
+            },
+            on: {
+              NEXT: {
+                target: 'a',
+                internal: false
+              }
+            }
+          }
         }
-      })
+      },
+      {
+        actors: {
+          fooActor: fromCallback(() => {
+            let localId = counter;
+            counter++;
+
+            actual.push(`start ${localId}`);
+
+            return () => {
+              actual.push(`stop ${localId}`);
+            };
+          })
+        }
+      }
     );
-    service.start();
+    const service = interpret(machine).start();
+
+    service.send({ type: 'NEXT' });
+
+    expect(actual).toEqual(['start 0', 'stop 0', 'start 1']);
   });
 
-  it('should have kept existing activities', (done) => {
-    const service = interpret(
-      machine.provide({
-        actors: {
-          A: () =>
-            fromCallback(() => {
-              done();
+  it('should have stopped after automatic transitions', () => {
+    let active = false;
+    const machine = createMachine({
+      context: {
+        counter: 0
+      },
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: fromCallback(() => {
+              active = true;
+              return () => (active = false);
             })
-        }
-      })
-    ).start();
+          },
+          always: {
+            guard: (ctx) => ctx.counter !== 0,
+            target: 'b'
+          },
+          on: {
+            INC: {
+              actions: assign((ctx) => ({
+                counter: ctx.counter + 1
+              }))
+            }
+          }
+        },
+        b: {}
+      }
+    });
+    const service = interpret(machine).start();
 
-    service.send({ type: 'A' });
-  });
+    expect(active).toBe(true);
 
-  it('should have kept same activities', (done) => {
-    const service = interpret(
-      machine.provide({
-        actors: {
-          C1: () =>
-            fromCallback(() => {
-              done();
-            })
-        }
-      })
-    ).start();
+    service.send({ type: 'INC' });
 
-    service.send({ type: 'C_SIMILAR' });
-  });
-
-  it('should have kept same activities after self transition', (done) => {
-    const service = interpret(
-      machine.provide({
-        actors: {
-          C1: () =>
-            fromCallback(() => {
-              done();
-            })
-        }
-      })
-    ).start();
-
-    service.send({ type: 'C' });
-  });
-
-  it('should have stopped after automatic transitions', (done) => {
-    const service = interpret(
-      machine.provide({
-        actors: {
-          B2: () =>
-            fromCallback(() => {
-              done();
-            })
-        }
-      })
-    ).start();
-
-    service.send({ type: 'A' });
+    expect(active).toBe(false);
   });
 });


### PR DESCRIPTION
Those tests were accidentally removed in [here](https://github.com/statelyai/xstate/commit/20e08e30de252889cc80f4aaa80d349ac33ffc88#diff-ed77fc7fa7c2ced9d56aa66d3d07015c7865cf93e17a626e25d3c48e89391d2a), leaving this test file expect-less.

I took the liberty to rewrite them in the process, to use separate machines per test.