### PR TITLE
Use predictableActionArguments flag in the createInspectMachine to avoid spurious warnings

### DIFF
--- a/.changeset/blue-jeans-think.md
+++ b/.changeset/blue-jeans-think.md
@@ -1,0 +1,5 @@
+---
+'@xstate/inspect': patch
+---
+
+Fixed an issue with a misleading dev-only warning being printed when inspecting machines because of the internal `createMachine` call.

--- a/packages/xstate-inspect/src/inspectMachine.ts
+++ b/packages/xstate-inspect/src/inspectMachine.ts
@@ -35,6 +35,7 @@ export function createInspectMachine(
     },
     InspectMachineEvent
   >({
+    predictableActionArguments: true,
     initial: 'pendingConnection',
     context: {
       client: undefined


### PR DESCRIPTION
Closes https://github.com/statelyai/xstate/issues/3771