### PR TITLE
Revert "Run `pull_request` workflow on its latest commit (#3490)"

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,5 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request && github.event.pull_request.head.sha || env.GITHUB_SHA }}
       - uses: ./.github/actions/ci-setup
       - uses: ./.github/actions/ci-checks


### PR DESCRIPTION
I came to the conclusion that this change wasn't needed/desirable. 

The default behavior on GitHub can lead to some weird effects/logs but it's just something to keep in mind and not something that we should prevent. The default behavior gives us stronger guarantees that if the CI is OK in the PR then it will also be OK after merging that PR. It doesn't give us 100% guarantees though as the CI run happens at a different time than the actual merge - but it's still better than not having this at all. To get that 100% guarantee we'd have to enforce "branch is up to date with main" before merging but that sounds like a lot of hassle to me and my opinion is that it's not worth it.