### PR TITLE
[xstate/solid] Change prepublish to prepare

### DIFF
--- a/.changeset/sharp-weeks-end.md
+++ b/.changeset/sharp-weeks-end.md
@@ -2,4 +2,4 @@
 '@xstate/solid': patch
 ---
 
-Change prepublish to prepare in package.json to fix build not running on npm publish for @xstate/solid
+Fixed an issue with npm lifecycle scripts that caused only a single set of files to be published.

--- a/.changeset/sharp-weeks-end.md
+++ b/.changeset/sharp-weeks-end.md
@@ -1,0 +1,5 @@
+---
+'@xstate/solid': patch
+---
+
+Change prepublish to prepare in package.json to fix build not running on npm publish for @xstate/solid

--- a/packages/xstate-solid/package.json
+++ b/packages/xstate-solid/package.json
@@ -34,7 +34,7 @@
     "clean": "rm -rf dist lib es tsconfig.tsbuildinfo",
     "build": "tsc && tsc --outDir es --module es2015 && rollup -c",
     "test": "jest",
-    "prepublish": "npm run build"
+    "prepare": "npm run build"
   },
   "bugs": {
     "url": "https://github.com/statelyai/xstate/issues"


### PR DESCRIPTION
Change `prepublish` to `prepare` in package.json to fix build not running on npm publish.
