### PR TITLE
[core] Add self to action meta

### DIFF
--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -12,7 +12,8 @@ import {
   Typestate,
   ActorRef,
   StateMachine,
-  SimpleEventsOf
+  SimpleEventsOf,
+  AnyInterpreter
 } from './types';
 import { EMPTY_ACTIVITY_MAP } from './constants';
 import { matchesState, isString, warn } from './utils';
@@ -65,7 +66,8 @@ export const isState = isStateConfig;
 
 export function bindActionToState<TC, TE extends EventObject>(
   action: ActionObject<TC, TE>,
-  state: State<TC, TE, any, any, any>
+  state: State<TC, TE, any, any, any>,
+  interpreter: AnyInterpreter
 ): ActionObject<TC, TE> {
   const { exec } = action;
   const boundAction: ActionObject<TC, TE> = {
@@ -76,7 +78,8 @@ export function bindActionToState<TC, TE extends EventObject>(
             exec(state.context, state.event as TE, {
               action: action as any,
               state,
-              _event: state._event
+              _event: state._event,
+              self: interpreter
             })
         : undefined
   } as any;

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -806,8 +806,8 @@ export class Interpreter<
         batchedActions.push(
           ...(this.machine.config.predictableActionArguments
             ? nextState.actions
-            : (nextState.actions.map((a) =>
-                bindActionToState(a, nextState)
+            : (nextState.actions.map((action) =>
+                bindActionToState(action, nextState, this)
               ) as Array<ActionObject<TContext, TEvent>>))
         );
 
@@ -980,14 +980,15 @@ export class Interpreter<
 
     if (exec) {
       try {
-        return (exec as any)(
+        return exec(
           context,
           _event.data,
           !this.machine.config.predictableActionArguments
             ? {
                 action,
                 state: this.state,
-                _event
+                _event,
+                self: this
               }
             : {
                 action,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -103,6 +103,7 @@ export interface ActionMeta<
 > extends StateMeta<TContext, TEvent> {
   action: TAction;
   _event: SCXML.Event<TEvent>;
+  self: AnyActorRef | undefined;
 }
 
 export interface AssignMeta<TContext, TEvent extends EventObject> {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1792,7 +1792,8 @@ describe('actions config', () => {
           {
             action: action as any,
             state: initialState,
-            _event: initialState._event
+            _event: initialState._event,
+            self: undefined
           }
         );
       }
@@ -1812,7 +1813,8 @@ describe('actions config', () => {
           {
             action: action as any,
             state: initialState,
-            _event: initialState._event
+            _event: initialState._event,
+            self: undefined
           }
         );
       }
@@ -2763,4 +2765,20 @@ describe('assign action order', () => {
       expect(captured).toEqual([2, 2, 2]);
     }
   );
+
+  it('should include reference to self (interpreter)', (done) => {
+    const machine = createMachine({
+      initial: 'active',
+      states: {
+        active: {
+          entry: (_ctx, _e, { self }) => {
+            expect(self).toBeDefined();
+            done();
+          }
+        }
+      }
+    });
+
+    interpret(machine).start();
+  });
 });


### PR DESCRIPTION
This PR adds the `self` interpreter reference to action meta arguments:

```js
const machine = createMachine({
  entry: (ctx, ev, { self }) => {
    // can pass self around
  }
});
```

