### PR TITLE
Allow blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: ✨ Feature Request
     url: https://github.com/statelyai/xstate/discussions/new


### PR DESCRIPTION
I believe that not every issue has to be a a bug report or a security vulnerability - sometimes what you want to report just doesn't fit those categories.