### PR TITLE
Fixed compatibility of the generated TS types for `createActorContext` with pre-4.7

### DIFF
--- a/.changeset/healthy-fireants-beg.md
+++ b/.changeset/healthy-fireants-beg.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': patch
+---
+
+Fixed compatibility of the generated TS types for `createActorContext` with pre-4.7.

--- a/packages/xstate-react/src/createActorContext.tsx
+++ b/packages/xstate-react/src/createActorContext.tsx
@@ -21,7 +21,7 @@ export function createActorContext<TMachine extends AnyStateMachine>(
     | Observer<StateFrom<TMachine>>
     | ((value: StateFrom<TMachine>) => void)
 ): {
-  useActor: () => ReturnType<typeof useActorUnbound<ActorRefFrom<TMachine>>>;
+  useActor: () => [StateFrom<TMachine>, ActorRefFrom<TMachine>['send']];
   useSelector: <T>(
     selector: (snapshot: EmittedFrom<TMachine>) => T,
     compare?: (a: T, b: T) => boolean


### PR DESCRIPTION
fixes what was reported [here](https://github.com/statelyai/xstate/discussions/3828#discussioncomment-4957618), cc @equal-matt

#tooclosetothesun