### PR TITLE
add `TagsFrom` helper type

### DIFF
--- a/.changeset/mean-oranges-dress.md
+++ b/.changeset/mean-oranges-dress.md
@@ -6,12 +6,12 @@ The new `TagsFrom` helper type extracts the type of `tags` from a state machine 
 
 ```ts
 const machine = createMachine({
+  // `tags` attached to machine via typegen
+  tsTypes: {} as import('./machine.typegen').Typegen0,
   tags: ['a', 'b'],
   states: {
-    c: { tags: 'c' }
+    idle: { tags: 'c' }
   },
-  // `tags` attached to machine via typegen
-  tsTypes: {} as import('./machine.typegen').Typegen0
 });
 
 type Tags = TagsFrom<typeof machine>; // 'a' | 'b' | 'c'
@@ -23,7 +23,7 @@ If typegen is not enabled, `TagsFrom` returns `string`:
 const machine = createMachine({
   tags: ['a', 'b'],
   states: {
-    c: { tags: 'c' }
+    idle: { tags: 'c' }
   }
 });
 

--- a/.changeset/mean-oranges-dress.md
+++ b/.changeset/mean-oranges-dress.md
@@ -2,7 +2,7 @@
 'xstate': minor
 ---
 
-The new `TagsFrom` helper type extracts the type of `tags` from any type which uses tags (when typegen is enabled):
+The new `TagsFrom` helper type extracts the type of `tags` from a state machine when typegen is enabled:
 
 ```ts
 const machine = createMachine({

--- a/.changeset/mean-oranges-dress.md
+++ b/.changeset/mean-oranges-dress.md
@@ -1,0 +1,31 @@
+---
+'xstate': minor
+---
+
+The new `TagsFrom` helper type extracts the type of `tags` from any type which uses tags (when typegen is enabled):
+
+```ts
+const machine = createMachine({
+  tags: ['a', 'b'],
+  states: {
+    c: { tags: 'c' }
+  },
+  // `tags` attached to machine via typegen
+  tsTypes: {} as import('./machine.typegen').Typegen0
+});
+
+type Tags = TagsFrom<typeof machine>; // 'a' | 'b' | 'c'
+```
+
+If typegen is not enabled, `TagsFrom` returns `string`:
+
+```ts
+const machine = createMachine({
+  tags: ['a', 'b'],
+  states: {
+    c: { tags: 'c' }
+  }
+});
+
+type Tags = TagsFrom<typeof machine>; // string
+```

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,4 @@
 import { Clock, Interpreter } from './interpreter';
-import { createMachine } from './Machine';
 import { Model } from './model.types';
 import { State } from './State';
 import { StateNode } from './StateNode';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -155,8 +155,9 @@ type SimpleActionsOf<T extends BaseActionObject> = ActionObject<
 /**
  * Events that do not require payload
  */
-export type SimpleEventsOf<TEvent extends EventObject> =
-  ExtractWithSimpleSupport<TEvent>;
+export type SimpleEventsOf<
+  TEvent extends EventObject
+> = ExtractWithSimpleSupport<TEvent>;
 
 export type BaseAction<
   TContext,
@@ -1984,18 +1985,53 @@ type Matches<TypegenEnabledArg, TypegenDisabledArg> = {
   (stateValue: TypegenDisabledArg): any;
 };
 
-export type StateValueFrom<TMachine extends AnyStateMachine> =
-  StateFrom<TMachine>['matches'] extends Matches<
-    infer TypegenEnabledArg,
-    infer TypegenDisabledArg
-  >
-    ? TMachine['__TResolvedTypesMeta'] extends TypegenEnabled
-      ? TypegenEnabledArg
-      : TypegenDisabledArg
-    : never;
+export type StateValueFrom<
+  TMachine extends AnyStateMachine
+> = StateFrom<TMachine>['matches'] extends Matches<
+  infer TypegenEnabledArg,
+  infer TypegenDisabledArg
+>
+  ? TMachine['__TResolvedTypesMeta'] extends TypegenEnabled
+    ? TypegenEnabledArg
+    : TypegenDisabledArg
+  : never;
 
 export type PredictableActionArgumentsExec = (
   action: ActionObject<unknown, EventObject>,
   context: unknown,
   _event: SCXML.Event<EventObject>
 ) => void;
+
+type _TagsFrom<TResolvedTypesMeta> = TResolvedTypesMeta extends TypegenEnabled
+  ? Prop<Prop<TResolvedTypesMeta, 'resolved'>, 'tags'>
+  : string;
+
+export type TagsFrom<T> = ReturnTypeOrValue<T> extends infer R
+  ? R extends StateMachine<
+      infer _,
+      infer __,
+      infer ___,
+      infer ____,
+      infer _____,
+      infer ______,
+      infer TResolvedTypesMeta
+    >
+    ? _TagsFrom<TResolvedTypesMeta>
+    : R extends State<
+        infer _,
+        infer __,
+        infer ___,
+        infer ____,
+        infer TResolvedTypesMeta
+      >
+    ? _TagsFrom<TResolvedTypesMeta>
+    : R extends Interpreter<
+        infer _,
+        infer __,
+        infer ___,
+        infer ____,
+        infer TResolvedTypesMeta
+      >
+    ? _TagsFrom<TResolvedTypesMeta>
+    : never
+  : never;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,5 @@
 import { Clock, Interpreter } from './interpreter';
+import { createMachine } from './Machine';
 import { Model } from './model.types';
 import { State } from './State';
 import { StateNode } from './StateNode';
@@ -2002,36 +2003,6 @@ export type PredictableActionArgumentsExec = (
   _event: SCXML.Event<EventObject>
 ) => void;
 
-type _TagsFrom<TResolvedTypesMeta> = TResolvedTypesMeta extends TypegenEnabled
-  ? Prop<Prop<TResolvedTypesMeta, 'resolved'>, 'tags'>
-  : string;
-
-export type TagsFrom<T> = ReturnTypeOrValue<T> extends infer R
-  ? R extends StateMachine<
-      infer _,
-      infer __,
-      infer ___,
-      infer ____,
-      infer _____,
-      infer ______,
-      infer TResolvedTypesMeta
-    >
-    ? _TagsFrom<TResolvedTypesMeta>
-    : R extends State<
-        infer _,
-        infer __,
-        infer ___,
-        infer ____,
-        infer TResolvedTypesMeta
-      >
-    ? _TagsFrom<TResolvedTypesMeta>
-    : R extends Interpreter<
-        infer _,
-        infer __,
-        infer ___,
-        infer ____,
-        infer TResolvedTypesMeta
-      >
-    ? _TagsFrom<TResolvedTypesMeta>
-    : never
-  : never;
+export type TagsFrom<TMachine extends AnyStateMachine> = Parameters<
+  StateFrom<TMachine>['hasTag']
+>[0];

--- a/packages/core/test/typeHelpers.test.ts
+++ b/packages/core/test/typeHelpers.test.ts
@@ -432,11 +432,11 @@ describe('EmittedFrom', () => {
 
 describe('tags', () => {
   it('derives tags from StateMachine when typegen is enabled', () => {
+    interface TypesMeta extends TypegenMeta {
+      tags: 'a' | 'b' | 'c';
+    }
     const machine = createMachine({
-      tsTypes: ({} as unknown) as {
-        '@@xstate/typegen': true;
-        tags: 'a' | 'b' | 'c';
-      }
+      tsTypes: {} as TypesMeta
     });
 
     type Tags = TagsFrom<typeof machine>;
@@ -451,12 +451,7 @@ describe('tags', () => {
   });
 
   it('derives string from StateMachine without typegen', () => {
-    const machine = createMachine({
-      tsTypes: ({} as unknown) as {
-        '@@xstate/typegen': false;
-        tags: 'a' | 'b' | 'c';
-      }
-    });
+    const machine = createMachine({});
 
     type Tags = TagsFrom<typeof machine>;
 

--- a/packages/core/test/typeHelpers.test.ts
+++ b/packages/core/test/typeHelpers.test.ts
@@ -6,7 +6,8 @@ import {
   EventFrom,
   interpret,
   MachineOptionsFrom,
-  StateValueFrom
+  StateValueFrom,
+  TagsFrom
 } from '../src';
 import { createModel } from '../src/model';
 import { TypegenMeta } from '../src/typegenTypes';
@@ -426,5 +427,45 @@ describe('EmittedFrom', () => {
     acceptState(machine.initialState);
     // @ts-expect-error
     acceptState("isn't any");
+  });
+});
+
+describe('tags', () => {
+  it('derives tags from StateMachine when typegen is enabled', () => {
+    const machine = createMachine({
+      tsTypes: ({} as unknown) as {
+        '@@xstate/typegen': true;
+        tags: 'a' | 'b' | 'c';
+      }
+    });
+
+    type Tags = TagsFrom<typeof machine>;
+
+    const acceptTag = (_tag: Tags) => {};
+
+    acceptTag('a');
+    acceptTag('b');
+    acceptTag('c');
+    // @ts-expect-error d is not a valid tag
+    acceptTag('d');
+  });
+
+  it('derives string from StateMachine without typegen', () => {
+    const machine = createMachine({
+      tsTypes: ({} as unknown) as {
+        '@@xstate/typegen': false;
+        tags: 'a' | 'b' | 'c';
+      }
+    });
+
+    type Tags = TagsFrom<typeof machine>;
+
+    const acceptTag = (_tag: Tags) => {};
+
+    acceptTag('a');
+    acceptTag('b');
+    acceptTag('c');
+    // d is a valid tag, as is any string
+    acceptTag('d');
   });
 });

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -957,38 +957,3 @@ describe('actions', () => {
     });
   });
 });
-
-describe('tags', () => {
-  it('derives tags from StateMachine when typegen is enabled', () => {
-    const machine = createMachine({
-      tsTypes: ({} as unknown) as {
-        '@@xstate/typegen': true;
-        tags: 'a' | 'b' | 'c';
-      }
-    });
-
-    type Tags = TagsFrom<typeof machine>;
-
-    const a: Tags = 'a';
-    const b: Tags = 'b';
-    const c: Tags = 'c';
-    // @ts-expect-error 'd' is not a valid tag
-    const d: Tags = 'd';
-  });
-
-  it('derives string from StateMachine without typegen', () => {
-    const machine = createMachine({
-      tsTypes: ({} as unknown) as {
-        '@@xstate/typegen': false;
-        tags: 'a' | 'b' | 'c';
-      }
-    });
-
-    type Tags = TagsFrom<typeof machine>;
-
-    const a: Tags = 'a';
-    const b: Tags = 'b';
-    const c: Tags = 'c';
-    const d: Tags = 'd';
-  });
-});

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -959,7 +959,7 @@ describe('actions', () => {
 });
 
 describe('tags', () => {
-  describe('with typegen', () => {
+  it('derives tags from StateMachine when typegen is enabled', () => {
     const machine = createMachine({
       tsTypes: ({} as unknown) as {
         '@@xstate/typegen': true;
@@ -967,40 +967,16 @@ describe('tags', () => {
       }
     });
 
-    it('derives tags from StateMachine', () => {
-      type Tags = TagsFrom<typeof machine>;
+    type Tags = TagsFrom<typeof machine>;
 
-      const a: Tags = 'a';
-      const b: Tags = 'b';
-      const c: Tags = 'c';
-      // @ts-expect-error 'd' is not a valid tag
-      const d: Tags = 'd';
-    });
-
-    it('derives tags from State', () => {
-      type Tags = TagsFrom<StateFrom<typeof machine>>;
-
-      const a: Tags = 'a';
-      const b: Tags = 'b';
-      const c: Tags = 'c';
-      // @ts-expect-error 'd' is not a valid tag
-      const d: Tags = 'd';
-    });
-
-    it('derives tags from Interpreter', () => {
-      const service = interpret(machine);
-
-      type Tags = TagsFrom<typeof service>;
-
-      const a: Tags = 'a';
-      const b: Tags = 'b';
-      const c: Tags = 'c';
-      // @ts-expect-error 'd' is not a valid tag
-      const d: Tags = 'd';
-    });
+    const a: Tags = 'a';
+    const b: Tags = 'b';
+    const c: Tags = 'c';
+    // @ts-expect-error 'd' is not a valid tag
+    const d: Tags = 'd';
   });
 
-  describe('without typegen', () => {
+  it('derives string from StateMachine without typegen', () => {
     const machine = createMachine({
       tsTypes: ({} as unknown) as {
         '@@xstate/typegen': false;
@@ -1008,33 +984,11 @@ describe('tags', () => {
       }
     });
 
-    it('derives string from Machine', () => {
-      type Tags = TagsFrom<typeof machine>;
+    type Tags = TagsFrom<typeof machine>;
 
-      const a: Tags = 'a';
-      const b: Tags = 'b';
-      const c: Tags = 'c';
-      const d: Tags = 'd';
-    });
-
-    it('derives string from State', () => {
-      type Tags = TagsFrom<StateFrom<typeof machine>>;
-
-      const a: Tags = 'a';
-      const b: Tags = 'b';
-      const c: Tags = 'c';
-      const d: Tags = 'd';
-    });
-
-    it('derives string from Interpreter', () => {
-      const service = interpret(machine);
-
-      type Tags = TagsFrom<typeof service>;
-
-      const a: Tags = 'a';
-      const b: Tags = 'b';
-      const c: Tags = 'c';
-      const d: Tags = 'd';
-    });
+    const a: Tags = 'a';
+    const b: Tags = 'b';
+    const c: Tags = 'c';
+    const d: Tags = 'd';
   });
 });

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -6,9 +6,7 @@ import {
   interpret,
   StateMachine,
   spawn,
-  ActorRefFrom,
-  TagsFrom,
-  StateFrom
+  ActorRefFrom
 } from '../src/index';
 import { raise, stop } from '../src/actions';
 import { createModel } from '../src/model';

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -6,7 +6,9 @@ import {
   interpret,
   StateMachine,
   spawn,
-  ActorRefFrom
+  ActorRefFrom,
+  TagsFrom,
+  StateFrom
 } from '../src/index';
 import { raise, stop } from '../src/actions';
 import { createModel } from '../src/model';
@@ -952,6 +954,87 @@ describe('actions', () => {
         count: (context) => context.count + 1,
         skip: true
       })
+    });
+  });
+});
+
+describe('tags', () => {
+  describe('with typegen', () => {
+    const machine = createMachine({
+      tsTypes: ({} as unknown) as {
+        '@@xstate/typegen': true;
+        tags: 'a' | 'b' | 'c';
+      }
+    });
+
+    it('derives tags from StateMachine', () => {
+      type Tags = TagsFrom<typeof machine>;
+
+      const a: Tags = 'a';
+      const b: Tags = 'b';
+      const c: Tags = 'c';
+      // @ts-expect-error 'd' is not a valid tag
+      const d: Tags = 'd';
+    });
+
+    it('derives tags from State', () => {
+      type Tags = TagsFrom<StateFrom<typeof machine>>;
+
+      const a: Tags = 'a';
+      const b: Tags = 'b';
+      const c: Tags = 'c';
+      // @ts-expect-error 'd' is not a valid tag
+      const d: Tags = 'd';
+    });
+
+    it('derives tags from Interpreter', () => {
+      const service = interpret(machine);
+
+      type Tags = TagsFrom<typeof service>;
+
+      const a: Tags = 'a';
+      const b: Tags = 'b';
+      const c: Tags = 'c';
+      // @ts-expect-error 'd' is not a valid tag
+      const d: Tags = 'd';
+    });
+  });
+
+  describe('without typegen', () => {
+    const machine = createMachine({
+      tsTypes: ({} as unknown) as {
+        '@@xstate/typegen': false;
+        tags: 'a' | 'b' | 'c';
+      }
+    });
+
+    it('derives string from Machine', () => {
+      type Tags = TagsFrom<typeof machine>;
+
+      const a: Tags = 'a';
+      const b: Tags = 'b';
+      const c: Tags = 'c';
+      const d: Tags = 'd';
+    });
+
+    it('derives string from State', () => {
+      type Tags = TagsFrom<StateFrom<typeof machine>>;
+
+      const a: Tags = 'a';
+      const b: Tags = 'b';
+      const c: Tags = 'c';
+      const d: Tags = 'd';
+    });
+
+    it('derives string from Interpreter', () => {
+      const service = interpret(machine);
+
+      type Tags = TagsFrom<typeof service>;
+
+      const a: Tags = 'a';
+      const b: Tags = 'b';
+      const c: Tags = 'c';
+      const d: Tags = 'd';
     });
   });
 });


### PR DESCRIPTION
Hi yall! I saw a helper type request on Discord today that seemed easy enough to implement: `TagsFrom`

`TagsFrom` allows us to access the typegen `tags` type of a `Machine` ~~`State`, or `Interpreter`~~:

```ts
import { TagsFrom } from "xstate";

const machine = createMachine({
  tsTypes: {} as {
    "@@xstate/typegen": true;
    tags: "a" | "b" | "c";
  }
});

type Tags = TagsFrom<typeof machine>; // 'a' | 'b' | 'c'
```

If typegen isn't enabled, `TagsFrom` returns `string` (which matches `hasTag`):

```ts
import { TagsFrom } from "xstate";

const machine = createMachine({});

type Tags = TagsFrom<typeof machine>; // string
```
