### PR TITLE
Build docs using node 16

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   build:
     permissions:
-      contents: write  #  to push changes in repo (jamesives/github-pages-deploy-action)
+      contents: write #  to push changes in repo (jamesives/github-pages-deploy-action)
 
     runs-on: ubuntu-latest
 
@@ -19,6 +19,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
 
       - name: Build docs
         working-directory: docs


### PR DESCRIPTION
This PR uses setup-node script to set node 16 for the docs build.