### PR TITLE
Deprecate `cond` → `guard`

### DIFF
--- a/.changeset/rude-geckos-admire.md
+++ b/.changeset/rude-geckos-admire.md
@@ -1,0 +1,17 @@
+---
+'xstate': minor
+---
+
+The `cond` property has been deprecated in favor of the `guards` property. The `cond` property will be renamed in the next major version.
+
+```diff
+const machine = createMachine({
+  // ...
+  on: {
+    EVENT: {
+-     cond: (context, event) => { ... },
++     guard: (context, event) => { ... },
+    }
+  }
+})
+```

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -1990,10 +1990,16 @@ class StateNode<
 
     const target = this.resolveTarget(normalizedTarget);
 
+    const guard = toGuard(
+      transitionConfig.guard ?? transitionConfig.cond,
+      guards as any
+    );
+
     const transition = {
       ...transitionConfig,
       actions: toActionObjects(toArray(transitionConfig.actions)),
-      cond: toGuard(transitionConfig.cond, guards as any),
+      cond: guard,
+      guard,
       target,
       source: this as any,
       internal,

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -798,7 +798,10 @@ export function resolveActions<TContext, TEvent extends EventObject>(
       case actionTypes.choose: {
         const chooseAction = actionObject as ChooseAction<TContext, TEvent>;
         const matchedActions = chooseAction.conds.find((condition) => {
-          const guard = toGuard(condition.cond, machine.options.guards as any);
+          const guard = toGuard(
+            condition.guard ?? condition.cond,
+            machine.options.guards as any
+          );
           return (
             !guard ||
             evaluateGuard(

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -218,7 +218,7 @@ function mapAction<
       const conds: ChooseCondition<TContext, TEvent>[] = [];
 
       let current: ChooseCondition<TContext, TEvent> = {
-        cond: createCond(element.attributes!.cond as string),
+        guard: createCond(element.attributes!.cond as string),
         actions: []
       };
 
@@ -231,7 +231,7 @@ function mapAction<
           case 'elseif':
             conds.push(current);
             current = {
-              cond: createCond(el.attributes!.cond as string),
+              guard: createCond(el.attributes!.cond as string),
               actions: []
             };
             break;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -132,7 +132,11 @@ export interface ChooseCondition<
   TExpressionEvent extends EventObject,
   TEvent extends EventObject = TExpressionEvent
 > {
+  /**
+   * @deprecated Use `guard` instead
+   */
   cond?: Condition<TContext, TExpressionEvent>;
+  guard?: Condition<TContext, TExpressionEvent>;
   actions: Actions<TContext, TExpressionEvent, TEvent>;
 }
 
@@ -234,7 +238,11 @@ export type Guard<TContext, TEvent extends EventObject> =
 
 export interface GuardMeta<TContext, TEvent extends EventObject>
   extends StateMeta<TContext, TEvent> {
+  /**
+   * @deprecated Use `guard` instead
+   */
   cond: Guard<TContext, TEvent>;
+  guard: Guard<TContext, TEvent>;
 }
 
 export type Condition<TContext, TEvent extends EventObject> =
@@ -256,7 +264,11 @@ export interface TransitionConfig<
   TExpressionEvent extends EventObject,
   TEvent extends EventObject = TExpressionEvent
 > {
+  /**
+   * @deprecated Use `guard` instead
+   */
   cond?: Condition<TContext, TExpressionEvent>;
+  guard?: Condition<TContext, TExpressionEvent>;
   actions?: BaseActions<TContext, TExpressionEvent, TEvent, BaseActionObject>;
   in?: StateValue;
   internal?: boolean;
@@ -1472,7 +1484,11 @@ export interface TransitionDefinition<TContext, TEvent extends EventObject>
   target: Array<StateNode<TContext, any, TEvent>> | undefined;
   source: StateNode<TContext, any, TEvent>;
   actions: Array<ActionObject<TContext, TEvent>>;
+  /**
+   * @deprecated Use `guard` instead
+   */
   cond?: Guard<TContext, TEvent>;
+  guard?: Guard<TContext, TEvent>;
   eventType: TEvent['type'] | NullEvent['type'] | '*';
   toJSON: () => {
     target: string[] | undefined;
@@ -1498,24 +1514,6 @@ export interface DelayedTransitionDefinition<
   TEvent extends EventObject
 > extends TransitionDefinition<TContext, TEvent> {
   delay: number | string | DelayExpr<TContext, TEvent>;
-}
-
-export interface Edge<
-  TContext,
-  TEvent extends EventObject,
-  TEventType extends TEvent['type'] = string
-> {
-  event: TEventType;
-  source: StateNode<TContext, any, TEvent>;
-  target: StateNode<TContext, any, TEvent>;
-  cond?: Condition<TContext, TEvent & { type: TEventType }>;
-  actions: Array<Action<TContext, TEvent>>;
-  meta?: MetaObject;
-  transition: TransitionDefinition<TContext, TEvent>;
-}
-export interface NodesAndEdges<TContext, TEvent extends EventObject> {
-  nodes: StateNode[];
-  edges: Array<Edge<TContext, TEvent, TEvent['type']>>;
 }
 
 export interface Segment<TContext, TEvent extends EventObject> {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -669,6 +669,7 @@ export function evaluateGuard<TContext, TEvent extends EventObject>(
   const guardMeta: GuardMeta<TContext, TEvent> = {
     state,
     cond: guard,
+    guard,
     _event
   };
 

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2437,6 +2437,34 @@ describe('choose', () => {
 
     expect(service.state.context).toEqual({ answer: 42 });
   });
+
+  it('can use "guard" instead of "cond"', () => {
+    interface Ctx {
+      isValid: boolean;
+      answer?: number;
+    }
+
+    const machine = createMachine<Ctx>({
+      context: {
+        isValid: true
+      },
+      initial: 'foo',
+      states: {
+        foo: {
+          entry: choose([
+            {
+              guard: (ctx) => ctx.isValid,
+              actions: assign<Ctx>({ answer: 42 })
+            }
+          ])
+        }
+      }
+    });
+
+    const service = interpret(machine).start();
+
+    expect(service.getSnapshot().context.answer).toEqual(42);
+  });
 });
 
 describe('sendParent', () => {

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -412,4 +412,49 @@ describe('guards - other', () => {
 
     expect(service.state.value).toBe('c');
   });
+
+  it('can be renamed to guard instead of cond (named)', () => {
+    const machine = createMachine(
+      {
+        initial: 'a',
+        states: {
+          a: {
+            on: {
+              NEXT: {
+                guard: 'isValid',
+                target: 'b'
+              }
+            }
+          },
+          b: {}
+        }
+      },
+      {
+        guards: {
+          isValid: () => true
+        }
+      }
+    );
+
+    expect(machine.transition('a', 'NEXT').value).toBe('b');
+  });
+
+  it('can be renamed to guard instead of cond (inline)', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            NEXT: {
+              guard: () => true,
+              target: 'b'
+            }
+          }
+        },
+        b: {}
+      }
+    });
+
+    expect(machine.transition('a', 'NEXT').value).toBe('b');
+  });
 });

--- a/packages/core/test/json.test.ts
+++ b/packages/core/test/json.test.ts
@@ -140,6 +140,7 @@ describe('json', () => {
           "cond": undefined,
           "event": "done.invoke.(machine).active:invocation[0]",
           "eventType": "done.invoke.(machine).active:invocation[0]",
+          "guard": undefined,
           "internal": false,
           "source": "#(machine).active",
           "target": Array [
@@ -152,6 +153,7 @@ describe('json', () => {
           "cond": undefined,
           "event": "error.platform.(machine).active:invocation[0]",
           "eventType": "error.platform.(machine).active:invocation[0]",
+          "guard": undefined,
           "internal": false,
           "source": "#(machine).active",
           "target": Array [
@@ -164,6 +166,7 @@ describe('json', () => {
           "cond": undefined,
           "event": "EVENT",
           "eventType": "EVENT",
+          "guard": undefined,
           "internal": false,
           "source": "#(machine).active",
           "target": Array [


### PR DESCRIPTION
This PR deprecates the `cond` property in favor of the `guards` property. The `cond` property will be renamed in the next major version.

```diff
const machine = createMachine({
  // ...
  on: {
    EVENT: {
-     cond: (context, event) => { ... },
+     guard: (context, event) => { ... },
    }
  }
})
```

Note: `cond` will continue to work (no breaking changes); however, you will see a deprecation warning:

<img width="323" alt="CleanShot 2023-03-04 at 14 41 10@2x" src="https://user-images.githubusercontent.com/1093738/222931979-6a9e8567-88df-4b4e-a0d4-495688624fdd.png">
<img width="323" alt="CleanShot 2023-03-04 at 14 41 23@2x" src="https://user-images.githubusercontent.com/1093738/222931982-24eaaaff-5abf-46d5-9ec9-23575048f3ec.png">
