### PR TITLE
[v5] Rename `state._sessionid` to `state.sessionId`

### DIFF
--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -67,7 +67,7 @@ export class State<
   public event: TEvent;
   public _internalQueue: Array<SCXML.Event<TEvent>>;
   public _event: SCXML.Event<TEvent>;
-  public _sessionid: string | undefined;
+  public sessionId: string | undefined;
   public _initial: boolean = false;
   /**
    * Indicates whether the state has changed from the previous state. A state is considered "changed" if:
@@ -110,7 +110,7 @@ export class State<
             value: stateValue.value,
             context,
             _event: stateValue._event,
-            _sessionid: undefined,
+            sessionId: undefined,
             actions: [],
             meta: {},
             configuration: [], // TODO: fix,
@@ -135,7 +135,7 @@ export class State<
         value: stateValue,
         context,
         _event,
-        _sessionid: undefined,
+        sessionId: undefined,
         actions: [],
         meta: undefined,
         configuration: Array.from(configuration),
@@ -157,7 +157,7 @@ export class State<
   ) {
     this.context = config.context;
     this._event = config._event;
-    this._sessionid = config._sessionid;
+    this.sessionId = config.sessionId;
     this._internalQueue = config._internalQueue ?? [];
     this.event = this._event.data;
     this.historyValue = config.historyValue || {};

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -322,7 +322,7 @@ export class StateMachine<
         value: {}, // TODO: this is computed in state constructor
         context,
         _event: initEvent as SCXML.Event<TEvent>,
-        _sessionid: actorCtx?.sessionId ?? undefined,
+        sessionId: actorCtx?.sessionId ?? undefined,
         actions: [],
         meta: undefined,
         configuration: config,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1586,7 +1586,7 @@ export interface StateConfig<
   value: StateValue;
   context: TContext;
   _event: SCXML.Event<TEvent>;
-  _sessionid: string | undefined;
+  sessionId: string | undefined;
   historyValue?: HistoryValue<TContext, TEvent>;
   actions?: BaseActionObject[];
   meta?: any;

--- a/packages/core/test/actionCreators.test.ts
+++ b/packages/core/test/actionCreators.test.ts
@@ -75,7 +75,7 @@ describe('action creators', () => {
             context: { delay: 100 },
             value: {},
             _event: {} as any,
-            _sessionid: '',
+            sessionId: '',
             transitions: [],
             children: {}
           }),

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -466,7 +466,7 @@ describe('State', () => {
           }
         });
 
-        expect(testMachine.initialState._sessionid).toBeUndefined();
+        expect(testMachine.initialState.sessionId).toBeUndefined();
       });
 
       it('_sessionid should be the service sessionId for invoked machines', (done) => {
@@ -488,7 +488,7 @@ describe('State', () => {
 
         service
           .onTransition((state) => {
-            expect(state._sessionid).toEqual(service.sessionId);
+            expect(state.sessionId).toEqual(service.sessionId);
           })
           .onDone(() => {
             done();
@@ -515,13 +515,13 @@ describe('State', () => {
 
         const { initialState } = testMachine;
 
-        initialState._sessionid = 'somesessionid';
+        initialState.sessionId = 'somesessionid';
 
         const nextState = testMachine.transition(initialState, {
           type: 'TOGGLE'
         });
 
-        expect(nextState._sessionid).toEqual('somesessionid');
+        expect(nextState.sessionId).toEqual('somesessionid');
       });
     });
   });

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -294,7 +294,7 @@ describe('@xstate/inspect', () => {
         },
         {
           "sessionId": "x:7",
-          "state": "{"value":{},"done":false,"context":{"value":{"unsafe":"[unsafe]"}},"historyValue":{},"actions":[{"type":"xstate.assign","params":{"context":{"value":{"unsafe":"[unsafe]"}},"actions":[]}}],"event":{"type":"EV","value":{"unsafe":"[unsafe]"}},"_event":{"name":"EV","data":{"type":"EV","value":{"unsafe":"[unsafe]"}},"$$type":"scxml","type":"external"},"_sessionid":"x:7","_initial":false,"changed":true,"transitions":[{"actions":[{"type":"xstate.assign","params":{"assignment":{}}}],"event":"EV","source":"#(machine)","internal":true,"eventType":"EV"}],"children":{},"tags":[]}",
+          "state": "{"value":{},"done":false,"context":{"value":{"unsafe":"[unsafe]"}},"historyValue":{},"actions":[{"type":"xstate.assign","params":{"context":{"value":{"unsafe":"[unsafe]"}},"actions":[]}}],"event":{"type":"EV","value":{"unsafe":"[unsafe]"}},"_event":{"name":"EV","data":{"type":"EV","value":{"unsafe":"[unsafe]"}},"$$type":"scxml","type":"external"},"sessionId":"x:7","_initial":false,"changed":true,"transitions":[{"actions":[{"type":"xstate.assign","params":{"assignment":{}}}],"event":"EV","source":"#(machine)","internal":true,"eventType":"EV"}],"children":{},"tags":[]}",
           "type": "service.state",
         },
       ]
@@ -313,7 +313,7 @@ describe('@xstate/inspect', () => {
         },
         {
           "sessionId": "x:7",
-          "state": "{"value":{},"done":false,"context":{"value":{"unsafe":"[unsafe]"}},"historyValue":{},"actions":[],"event":{"type":"UNKNOWN"},"_event":{"name":"UNKNOWN","data":{"type":"UNKNOWN"},"$$type":"scxml","type":"external"},"_sessionid":"x:7","_initial":false,"changed":false,"transitions":[],"children":{},"tags":[]}",
+          "state": "{"value":{},"done":false,"context":{"value":{"unsafe":"[unsafe]"}},"historyValue":{},"actions":[],"event":{"type":"UNKNOWN"},"_event":{"name":"UNKNOWN","data":{"type":"UNKNOWN"},"$$type":"scxml","type":"external"},"sessionId":"x:7","_initial":false,"changed":false,"transitions":[],"children":{},"tags":[]}",
           "type": "service.state",
         },
       ]


### PR DESCRIPTION
This Pr renames `state._sessionid` to `state.sessionId` for consistency.