### PR TITLE
[v5] Remove `.onTransition()`

### DIFF
--- a/.changeset/lemon-dancers-repeat.md
+++ b/.changeset/lemon-dancers-repeat.md
@@ -1,0 +1,13 @@
+---
+'xstate': major
+---
+
+The `actor.onTransition(...)` method has been removed in favor of `.subscribe(...)`
+
+```diff
+ const actor = interpret(machine)
+-  .onTransition(...)
+-  .start();
++actor.subscribe(...);
++actor.start();
+```

--- a/examples/todo-mvc-svelte/src/Todos.svelte
+++ b/examples/todo-mvc-svelte/src/Todos.svelte
@@ -7,7 +7,6 @@
   import { useMachine } from '@xstate/svelte';
 
   const { state, send, service } = useMachine(todosMachine, { devTools: true });
-  // service.onTransition((state) => console.log(state));
 
   $: ({ todo, todos, filter } = $state.context);
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -219,19 +219,6 @@ export class Interpreter<
     }
   }
 
-  /*
-   * Adds a listener that is notified whenever a state transition happens. The listener is called with
-   * the next state and the event object that caused the state transition.
-   *
-   * @param listener The state listener
-   * @deprecated Use .subscribe(listener) instead
-   */
-  public onTransition(listener: SnapshotListener<TBehavior>): this {
-    const observer = toObserver(listener);
-    this.observers.add(observer);
-    return this;
-  }
-
   public subscribe(observer: Observer<SnapshotFrom<TBehavior>>): Subscription;
   public subscribe(
     nextListener?: (state: SnapshotFrom<TBehavior>) => void,

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -734,11 +734,11 @@ describe('actors', () => {
       }
     });
 
-    interpret(startMachine)
-      .onTransition(() => {
-        expect(count).toEqual(1);
-      })
-      .start();
+    const actor = interpret(startMachine);
+    actor.subscribe(() => {
+      expect(count).toEqual(1);
+    });
+    actor.start();
   });
 
   it('should only spawn an actor in an initial state of a child that gets invoked in the initial state of a parent when the parent gets started', () => {
@@ -868,13 +868,13 @@ describe('actors', () => {
         }
       });
 
-      const countService = interpret(countMachine)
-        .onTransition((state) => {
-          if (state.context.count?.getSnapshot() === 2) {
-            done();
-          }
-        })
-        .start();
+      const countService = interpret(countMachine);
+      countService.subscribe((state) => {
+        if (state.context.count?.getSnapshot() === 2) {
+          done();
+        }
+      });
+      countService.start();
 
       countService.send({ type: 'INC' });
       countService.send({ type: 'INC' });

--- a/packages/core/test/assign.test.ts
+++ b/packages/core/test/assign.test.ts
@@ -398,18 +398,12 @@ describe('assign meta', () => {
       }
     });
 
-    let state: any;
-
-    const service = interpret(parentMachine)
-      .onTransition((s) => {
-        state = s;
-      })
-      .start();
+    const service = interpret(parentMachine).start();
 
     service.send({ type: 'PING_CHILD' });
     service.send({ type: 'PING_CHILD' });
 
-    expect(state.context).toMatchInlineSnapshot(`
+    expect(service.getSnapshot().context).toMatchInlineSnapshot(`
       {
         "eventLog": [
           {

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -69,14 +69,14 @@ describe('SCXML events', () => {
       }
     });
 
-    interpret(machine)
-      .onTransition((state) => {
-        if (state.done) {
-          expect(state.context.childOrigin).toEqual('callback_child');
-          done();
-        }
-      })
-      .start();
+    const actor = interpret(machine);
+    actor.subscribe((state) => {
+      if (state.done) {
+        expect(state.context.childOrigin).toEqual('callback_child');
+        done();
+      }
+    });
+    actor.start();
   });
 
   it('respond() should be able to respond to sender', (done) => {

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -187,12 +187,11 @@ describe('final states', () => {
       }
     });
 
-    let _context: any;
-
     const service = interpret(machine)
-      .onTransition((state) => (_context = state.context))
       .onDone(() => {
-        expect(_context).toEqual({ revealedSecret: 'the secret' });
+        expect(service.getSnapshot().context).toEqual({
+          revealedSecret: 'the secret'
+        });
         done();
       })
       .start();

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -54,18 +54,6 @@ const lightMachine = createMachine({
 
 describe('interpreter', () => {
   describe('initial state', () => {
-    it('immediately notifies the listener with the initial state and event', (done) => {
-      const service = interpret(idMachine);
-      service.subscribe((initialState) => {
-        expect(initialState).toBeInstanceOf(State);
-        expect(initialState.value).toEqual(idMachine.initialState.value);
-        expect(initialState.event.type).toEqual('xstate.init');
-        done();
-      });
-
-      service.start();
-    });
-
     it('.getSnapshot returns the initial state', () => {
       const service = interpret(idMachine);
 

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -55,7 +55,8 @@ const lightMachine = createMachine({
 describe('interpreter', () => {
   describe('initial state', () => {
     it('immediately notifies the listener with the initial state and event', (done) => {
-      const service = interpret(idMachine).onTransition((initialState) => {
+      const service = interpret(idMachine);
+      service.subscribe((initialState) => {
         expect(initialState).toBeInstanceOf(State);
         expect(initialState.value).toEqual(idMachine.initialState.value);
         expect(initialState.event.type).toEqual('xstate.init');
@@ -210,15 +211,6 @@ describe('interpreter', () => {
 
       expect(spy).not.toHaveBeenCalled();
     });
-
-    it('should not notify subscribers of the current state upon subscription (onTransition)', () => {
-      const spy = jest.fn();
-      const service = interpret(machine).start();
-
-      service.onTransition(spy);
-
-      expect(spy).not.toHaveBeenCalled();
-    });
   });
 
   describe('send with delay', () => {
@@ -227,7 +219,8 @@ describe('interpreter', () => {
 
       const service = interpret(lightMachine, {
         clock: new SimulatedClock()
-      }).onTransition((state) => {
+      });
+      service.subscribe((state) => {
         currentStates.push(state);
 
         if (currentStates.length === 4) {
@@ -486,26 +479,21 @@ describe('interpreter', () => {
         }
       );
 
-      let state: any;
-
-      interpret(letterMachine, { clock })
-        .onTransition((s) => {
-          state = s;
-        })
+      const actor = interpret(letterMachine, { clock })
         .onDone(() => {
           done();
         })
         .start();
 
-      expect(state.value).toEqual('a');
+      expect(actor.getSnapshot().value).toEqual('a');
       clock.increment(100);
-      expect(state.value).toEqual('b');
+      expect(actor.getSnapshot().value).toEqual('b');
       clock.increment(100 + 50);
-      expect(state.value).toEqual('c');
+      expect(actor.getSnapshot().value).toEqual('c');
       clock.increment(20);
-      expect(state.value).toEqual('d');
+      expect(actor.getSnapshot().value).toEqual('d');
       clock.increment(100 + 200);
-      expect(state.value).toEqual('e');
+      expect(actor.getSnapshot().value).toEqual('e');
       clock.increment(100 + 50);
     });
   });
@@ -643,20 +631,18 @@ describe('interpreter', () => {
   });
 
   it('can cancel a delayed event', () => {
-    let currentState: AnyState;
-
     const service = interpret(lightMachine, {
       clock: new SimulatedClock()
-    }).onTransition((state) => (currentState = state));
+    });
     const clock = service.clock as SimulatedClock;
     service.start();
 
     clock.increment(5);
     service.send({ type: 'KEEP_GOING' });
 
-    expect(currentState!.value).toEqual('green');
+    expect(service.getSnapshot().value).toEqual('green');
     clock.increment(10);
-    expect(currentState!.value).toEqual('green');
+    expect(service.getSnapshot().value).toEqual('green');
   });
 
   it('can cancel a delayed event using expression to resolve send id', (done) => {
@@ -760,11 +746,11 @@ describe('interpreter', () => {
     });
 
     let state: any;
-    const deferService = interpret(deferMachine)
-      .onTransition((s) => {
-        state = s;
-      })
-      .onDone(() => done());
+    const deferService = interpret(deferMachine).onDone(() => done());
+
+    deferService.subscribe((nextState) => {
+      state = nextState;
+    });
 
     // uninitialized
     deferService.send({ type: 'NEXT_A' });
@@ -803,20 +789,19 @@ describe('interpreter', () => {
   });
 
   it('should not update when stopped', () => {
-    let state = lightMachine.initialState;
     const service = interpret(lightMachine, {
       clock: new SimulatedClock()
-    }).onTransition((s) => (state = s));
+    });
 
     service.start();
     service.send({ type: 'TIMER' }); // yellow
-    expect(state.value).toEqual('yellow');
+    expect(service.getSnapshot().value).toEqual('yellow');
 
     service.stop();
     try {
       service.send({ type: 'TIMER' }); // red if interpreter is not stopped
     } catch (e) {
-      expect(state.value).toEqual('yellow');
+      expect(service.getSnapshot().value).toEqual('yellow');
     }
   });
 
@@ -1016,16 +1001,10 @@ describe('interpreter', () => {
         }
       });
 
-      let state: AnyState;
-
-      interpret(raiseMachine)
-        .onTransition((s) => {
-          state = s;
-        })
-        .onDone(() => {
-          expect(state.value).toBe('pass');
-        })
-        .start();
+      const service = interpret(raiseMachine).start();
+      service.onDone(() => {
+        expect(service.getSnapshot().value).toBe('pass');
+      });
     });
   });
 
@@ -1072,16 +1051,15 @@ describe('interpreter', () => {
         }
       });
 
-      interpret(parentMachine)
-        .onTransition((state) => {
-          if (state.matches('start')) {
-            const childActor = state.children.child;
+      const actor = interpret(parentMachine);
+      actor.subscribe((state) => {
+        if (state.matches('start')) {
+          const childActor = state.children.child;
 
-            expect(typeof childActor!.send).toBe('function');
-          }
-        })
-        .onDone(() => done())
-        .start();
+          expect(typeof childActor!.send).toBe('function');
+        }
+      });
+      actor.onDone(() => done()).start();
     });
   });
 
@@ -1180,7 +1158,8 @@ describe('interpreter', () => {
 
     it('should initialize the service', (done) => {
       let state: any;
-      const startService = interpret(startMachine).onTransition((s) => {
+      const startService = interpret(startMachine);
+      startService.subscribe((s) => {
         state = s;
         expect(s).toBeDefined();
         expect(s.value).toEqual(startMachine.initialState.value);
@@ -1194,7 +1173,9 @@ describe('interpreter', () => {
 
     it('should not reinitialize a started service', () => {
       let stateCount = 0;
-      const startService = interpret(startMachine).onTransition(() => {
+      const startService = interpret(startMachine);
+
+      startService.subscribe(() => {
         stateCount++;
       });
 
@@ -1208,7 +1189,9 @@ describe('interpreter', () => {
     it('should be able to be initialized at a custom state', (done) => {
       const startService = interpret(startMachine, {
         state: State.from('bar', undefined, startMachine)
-      }).onTransition((state) => {
+      });
+
+      startService.subscribe((state) => {
         expect(state.matches('bar')).toBeTruthy();
         done();
       });
@@ -1220,7 +1203,9 @@ describe('interpreter', () => {
       const barState = startMachine.resolveStateValue('bar');
       const startService = interpret(startMachine, {
         state: barState
-      }).onTransition((state) => {
+      });
+
+      startService.subscribe((state) => {
         expect(state.matches('bar')).toBeTruthy();
         done();
       });
@@ -1231,7 +1216,8 @@ describe('interpreter', () => {
     it('should be able to resolve a custom initialized state', (done) => {
       const startService = interpret(startMachine, {
         state: startMachine.resolveStateValue('foo')
-      }).onTransition((state) => {
+      });
+      startService.subscribe((state) => {
         expect(state.matches({ foo: 'one' })).toBeTruthy();
         done();
       });
@@ -1370,9 +1356,9 @@ describe('interpreter', () => {
       });
 
       const stateValues: StateValue[] = [];
-      const service = interpret(stateMachine)
-        .onTransition((current) => stateValues.push(current.value))
-        .start();
+      const service = interpret(stateMachine);
+      service.subscribe((current) => stateValues.push(current.value));
+      service.start();
       service.send({ type: 'START' });
 
       const expectedStateValues = ['idle', 'next'];
@@ -1407,9 +1393,9 @@ describe('interpreter', () => {
       );
 
       const stateValues: StateValue[] = [];
-      const service = interpret(stateMachine)
-        .onTransition((current) => stateValues.push(current.value))
-        .start();
+      const service = interpret(stateMachine);
+      service.subscribe((current) => stateValues.push(current.value));
+      service.start();
       service.send({ type: 'START' });
 
       const expectedStateValues = ['idle', 'next'];
@@ -1627,20 +1613,18 @@ describe('interpreter', () => {
         }
       });
 
-      const service = interpret(parentMachine)
-        .onTransition((state) => {
-          const childActor = state.children.childActor;
+      const service = interpret(parentMachine).onDone(() => {
+        expect(service.getSnapshot().children).not.toHaveProperty('childActor');
+        done();
+      });
 
-          if (state.matches('active') && childActor) {
-            childActor.send({ type: 'FIRE' });
-          }
-        })
-        .onDone(() => {
-          expect(service.getSnapshot().children).not.toHaveProperty(
-            'childActor'
-          );
-          done();
-        });
+      service.subscribe((state) => {
+        const childActor = state.children.childActor;
+
+        if (state.matches('active') && childActor) {
+          childActor.send({ type: 'FIRE' });
+        }
+      });
 
       service.start();
     });
@@ -1680,21 +1664,19 @@ describe('interpreter', () => {
         }
       });
 
-      const service = interpret(parentMachine)
-        .onTransition((state) => {
-          if (state.matches('active')) {
-            const childActor = state.children.childActor;
+      const service = interpret(parentMachine).onDone(() => {
+        expect(service.getSnapshot().matches('success')).toBeTruthy();
+        expect(service.getSnapshot().children).not.toHaveProperty('childActor');
+        done();
+      });
 
-            expect(childActor).toHaveProperty('send');
-          }
-        })
-        .onDone(() => {
-          expect(service.getSnapshot().matches('success')).toBeTruthy();
-          expect(service.getSnapshot().children).not.toHaveProperty(
-            'childActor'
-          );
-          done();
-        });
+      service.subscribe((state) => {
+        if (state.matches('active')) {
+          const childActor = state.children.childActor;
+
+          expect(childActor).toHaveProperty('send');
+        }
+      });
 
       service.start();
     });
@@ -1723,18 +1705,16 @@ describe('interpreter', () => {
         }
       });
 
-      const service = interpret(parentMachine)
-        .onTransition((state) => {
-          if (state.matches('active')) {
-            expect(state.children['childActor']).not.toBeUndefined();
-          }
-        })
-        .onDone(() => {
-          expect(service.getSnapshot().children).not.toHaveProperty(
-            'childActor'
-          );
-          done();
-        });
+      const service = interpret(parentMachine).onDone(() => {
+        expect(service.getSnapshot().children).not.toHaveProperty('childActor');
+        done();
+      });
+
+      service.subscribe((state) => {
+        if (state.matches('active')) {
+          expect(state.children['childActor']).not.toBeUndefined();
+        }
+      });
 
       service.start();
     });
@@ -1760,12 +1740,12 @@ describe('interpreter', () => {
         }
       });
 
-      interpret(formMachine)
-        .onTransition((state) => {
-          expect(state.children).toHaveProperty('child');
-          done();
-        })
-        .start();
+      const actor = interpret(formMachine);
+      actor.subscribe((state) => {
+        expect(state.children).toHaveProperty('child');
+        done();
+      });
+      actor.start();
     });
 
     it('stopped spawned actors should be cleaned up in parent', (done) => {
@@ -1884,12 +1864,11 @@ describe('interpreter', () => {
 
     const initialState = actor.getSnapshot();
 
-    actor
-      .onTransition((state) => {
-        expect(state).toBe(initialState);
-        done();
-      })
-      .start();
+    actor.subscribe((state) => {
+      expect(state).toBe(initialState);
+      done();
+    });
+    actor.start();
   });
 
   it('should call an onDone callback immediately if the service is already done', (done) => {

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -145,21 +145,20 @@ describe('invoke', () => {
 
     let count: number;
 
-    interpret(someParentMachine)
-      .onTransition((state) => {
-        count = state.context.count;
-      })
-      .onDone(() => {
-        // 1. The 'parent' machine will enter 'start' state
-        // 2. The 'child' service will be run with ID 'someService'
-        // 3. The 'child' machine will enter 'init' state
-        // 4. The 'entry' action will be executed, which sends 'INC' to 'parent' machine twice
-        // 5. The context will be updated to increment count to 2
+    const actor = interpret(someParentMachine).onDone(() => {
+      // 1. The 'parent' machine will enter 'start' state
+      // 2. The 'child' service will be run with ID 'someService'
+      // 3. The 'child' machine will enter 'init' state
+      // 4. The 'entry' action will be executed, which sends 'INC' to 'parent' machine twice
+      // 5. The context will be updated to increment count to 2
+      expect(actor.getSnapshot().context.count).toEqual(2);
+      done();
+    });
 
-        expect(count).toEqual(2);
-        done();
-      })
-      .start();
+    actor.subscribe((state) => {
+      count = state.context.count;
+    });
+    actor.start();
   });
 
   it('should forward events to services if autoForward: true', () => {
@@ -215,10 +214,11 @@ describe('invoke', () => {
     );
 
     let state: any;
-    const service = interpret(someParentMachine)
-      .onTransition((s) => {
-        state = s;
-      })
+    const service = interpret(someParentMachine);
+    service.subscribe((s) => {
+      state = s;
+    });
+    service
       .onDone(() => {
         // 1. The 'parent' machine will not do anything (inert transition)
         // 2. The 'FORWARD_DEC' event will be forwarded to the 'child' machine (autoForward: true)
@@ -307,13 +307,9 @@ describe('invoke', () => {
       }
     });
 
-    let state: any;
     const service = interpret(parentMachine)
-      .onTransition((s) => {
-        state = s;
-      })
       .onDone(() => {
-        expect(state.context).toEqual({ countedTo: 3 });
+        expect(service.getSnapshot().context).toEqual({ countedTo: 3 });
         expect(actual).toEqual([
           'child got INCREMENT',
           'parent got INCREMENT',
@@ -1111,13 +1107,9 @@ describe('invoke', () => {
           }
         });
 
-        let state: any;
-        interpret(promiseMachine)
-          .onTransition((s) => {
-            state = s;
-          })
+        const actor = interpret(promiseMachine)
           .onDone(() => {
-            expect(state.context.count).toEqual(1);
+            expect(actor.getSnapshot().context.count).toEqual(1);
             done();
           })
           .start();
@@ -1153,13 +1145,9 @@ describe('invoke', () => {
           }
         );
 
-        let state: any;
-        interpret(promiseMachine)
-          .onTransition((s) => {
-            state = s;
-          })
+        const actor = interpret(promiseMachine)
           .onDone(() => {
-            expect(state.context.count).toEqual(1);
+            expect(actor.getSnapshot().context.count).toEqual(1);
             done();
           })
           .start();
@@ -1494,10 +1482,9 @@ describe('invoke', () => {
 
       const expectedStateValues = ['pending', 'first', 'intermediate'];
       const stateValues: StateValue[] = [];
-      interpret(callbackMachine)
-        .onTransition((current) => stateValues.push(current.value))
-        .start()
-        .send({ type: 'BEGIN' });
+      const actor = interpret(callbackMachine);
+      actor.subscribe((current) => stateValues.push(current.value));
+      actor.start().send({ type: 'BEGIN' });
       for (let i = 0; i < expectedStateValues.length; i++) {
         expect(stateValues[i]).toEqual(expectedStateValues[i]);
       }
@@ -1535,10 +1522,9 @@ describe('invoke', () => {
 
       const expectedStateValues = ['idle', 'intermediate'];
       const stateValues: StateValue[] = [];
-      interpret(callbackMachine)
-        .onTransition((current) => stateValues.push(current.value))
-        .start()
-        .send({ type: 'BEGIN' });
+      const actor = interpret(callbackMachine);
+      actor.subscribe((current) => stateValues.push(current.value));
+      actor.start().send({ type: 'BEGIN' });
       for (let i = 0; i < expectedStateValues.length; i++) {
         expect(stateValues[i]).toEqual(expectedStateValues[i]);
       }
@@ -1583,12 +1569,11 @@ describe('invoke', () => {
 
       const expectedStateValues = ['pending', 'second', 'third'];
       const stateValues: StateValue[] = [];
-      interpret(callbackMachine)
-        .onTransition((current) => {
-          stateValues.push(current.value);
-        })
-        .start()
-        .send({ type: 'BEGIN' });
+      const actor = interpret(callbackMachine);
+      actor.subscribe((current) => {
+        stateValues.push(current.value);
+      });
+      actor.start().send({ type: 'BEGIN' });
 
       for (let i = 0; i < expectedStateValues.length; i++) {
         expect(stateValues[i]).toEqual(expectedStateValues[i]);
@@ -1800,12 +1785,9 @@ describe('invoke', () => {
         }
       });
 
-      interpret(asyncWithDoneMachine)
-        .onTransition((s) => {
-          state = s;
-        })
+      const actor = interpret(asyncWithDoneMachine)
         .onDone(() => {
-          expect(state.context.result).toEqual(42);
+          expect(actor.getSnapshot().context.result).toEqual(42);
           done();
         })
         .start();
@@ -1940,11 +1922,12 @@ describe('invoke', () => {
       it('ends on the completed state', (done) => {
         const events: EventObject[] = [];
         let state: any;
-        const service = interpret(anotherParentMachine)
-          .onTransition((s) => {
-            state = s;
-            events.push(s.event);
-          })
+        const service = interpret(anotherParentMachine);
+        service.subscribe((s) => {
+          state = s;
+          events.push(s.event);
+        });
+        service
           .onDone(() => {
             expect(events.map((e) => e.type)).toEqual([
               actionTypes.init,
@@ -2265,13 +2248,13 @@ describe('invoke', () => {
         }
       });
 
-      const countService = interpret(countMachine)
-        .onTransition((state) => {
-          if (state.children['count']?.getSnapshot() === 2) {
-            done();
-          }
-        })
-        .start();
+      const countService = interpret(countMachine);
+      countService.subscribe((state) => {
+        if (state.children['count']?.getSnapshot() === 2) {
+          done();
+        }
+      });
+      countService.start();
 
       countService.send({ type: 'INC' });
       countService.send({ type: 'INC' });
@@ -2343,13 +2326,13 @@ describe('invoke', () => {
         }
       });
 
-      const countService = interpret(countMachine)
-        .onTransition((state) => {
-          if (state.children['count']?.getSnapshot() === 2) {
-            done();
-          }
-        })
-        .start();
+      const countService = interpret(countMachine);
+      countService.subscribe((state) => {
+        if (state.children['count']?.getSnapshot() === 2) {
+          done();
+        }
+      });
+      countService.start();
 
       countService.send({ type: 'INC' });
       countService.send({ type: 'INC' });
@@ -2386,13 +2369,13 @@ describe('invoke', () => {
         }
       });
 
-      const countService = interpret(countMachine)
-        .onTransition((state) => {
-          if (state.children['count']?.getSnapshot() === 2) {
-            done();
-          }
-        })
-        .start();
+      const countService = interpret(countMachine);
+      countService.subscribe((state) => {
+        if (state.children['count']?.getSnapshot() === 2) {
+          done();
+        }
+      });
+      countService.start();
 
       countService.send({ type: 'INC' });
     });
@@ -2497,15 +2480,13 @@ describe('invoke', () => {
     });
 
     it('should start all services at once', (done) => {
-      let state: any;
-      const service = interpret(multiple)
-        .onTransition((s) => {
-          state = s;
-        })
-        .onDone(() => {
-          expect(state.context).toEqual({ one: 'one', two: 'two' });
-          done();
+      const service = interpret(multiple).onDone(() => {
+        expect(service.getSnapshot().context).toEqual({
+          one: 'one',
+          two: 'two'
         });
+        done();
+      });
 
       service.start();
     });
@@ -2566,15 +2547,13 @@ describe('invoke', () => {
     });
 
     it('should run services in parallel', (done) => {
-      let state: any;
-      const service = interpret(parallel)
-        .onTransition((s) => {
-          state = s;
-        })
-        .onDone(() => {
-          expect(state.context).toEqual({ one: 'one', two: 'two' });
-          done();
+      const service = interpret(parallel).onDone(() => {
+        expect(service.getSnapshot().context).toEqual({
+          one: 'one',
+          two: 'two'
         });
+        done();
+      });
 
       service.start();
     });

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -143,8 +143,6 @@ describe('invoke', () => {
       }
     );
 
-    let count: number;
-
     const actor = interpret(someParentMachine).onDone(() => {
       // 1. The 'parent' machine will enter 'start' state
       // 2. The 'child' service will be run with ID 'someService'
@@ -155,9 +153,6 @@ describe('invoke', () => {
       done();
     });
 
-    actor.subscribe((state) => {
-      count = state.context.count;
-    });
     actor.start();
   });
 
@@ -1760,8 +1755,6 @@ describe('invoke', () => {
     });
 
     it('should call onDone when resolved (async)', (done) => {
-      let state: any;
-
       const asyncWithDoneMachine = createMachine<{ result?: any }>({
         id: 'async',
         initial: 'fetch',

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -120,16 +120,15 @@ describe('state meta data', () => {
 
     const secondState = machine.resolveStateValue('second');
 
-    const service = interpret(machine, { state: secondState }).onTransition(
-      (state) => {
-        expect(state.meta).toEqual({
-          'test.second': {
-            name: 'second state'
-          }
-        });
-        done();
-      }
-    );
+    const service = interpret(machine, { state: secondState });
+    service.subscribe((state) => {
+      expect(state.meta).toEqual({
+        'test.second': {
+          name: 'second state'
+        }
+      });
+      done();
+    });
     service.start();
   });
 });

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -350,13 +350,14 @@ async function runW3TestToCompletion(machine: AnyStateMachine): Promise<void> {
     let nextState: AnyState;
     let prevState: AnyState;
 
-    interpret(machine, {
+    const actor = interpret(machine, {
       logger: () => void 0
-    })
-      .onTransition((state) => {
-        prevState = nextState;
-        nextState = state;
-      })
+    });
+    actor.subscribe((state) => {
+      prevState = nextState;
+      nextState = state;
+    });
+    actor
       .onDone(() => {
         // Add 'final' for test230.txml which does not have a 'pass' state
         if (['final', 'pass'].includes(nextState.value as string)) {
@@ -390,11 +391,12 @@ async function runTestToCompletion(
 
   const service = interpret(machine, {
     clock: new SimulatedClock()
-  })
-    .onTransition((state) => {
-      prevState = nextState;
-      nextState = state;
-    })
+  });
+  service.subscribe((state) => {
+    prevState = nextState;
+    nextState = state;
+  });
+  service
     .onDone(() => {
       if (nextState.value === 'fail') {
         throw new Error(

--- a/packages/xstate-inspect/examples/server.ts
+++ b/packages/xstate-inspect/examples/server.ts
@@ -41,6 +41,6 @@ const machine = createMachine({
   }
 });
 
-interpret(machine, { devTools: true })
-  .onTransition((s) => console.log(s.value))
-  .start();
+const actor = interpret(machine, { devTools: true });
+actor.subscribe((s) => console.log(s.value));
+actor.start();

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -109,11 +109,13 @@ describe('@xstate/inspect', () => {
     const devTools = createDevTools();
 
     devTools.onRegister((inspectedService) => {
-      inspectedService.onTransition((state) => {
+      function checkState(state) {
         if (state.event.type === 'CIRCULAR') {
           done();
         }
-      });
+      }
+      inspectedService.subscribe(checkState);
+      checkState(inspectedService.getSnapshot());
     });
 
     inspect({

--- a/packages/xstate-scxml/test/scxml.test.ts
+++ b/packages/xstate-scxml/test/scxml.test.ts
@@ -30,10 +30,11 @@ async function runTestToCompletion(
   const service = interpret(machine, {
     state: nextState,
     clock: new SimulatedClock()
-  })
-    .onTransition((state) => {
-      nextState = state;
-    })
+  });
+  service.subscribe((state) => {
+    nextState = state;
+  });
+  service
     .onDone(() => {
       done = true;
     })


### PR DESCRIPTION
This PR removes `.onTransition(...)` in favor of `.subscribe(...)`

```diff
 const actor = interpret(machine)
-  .onTransition(...)
-  .start();
+actor.subscribe(...);
+actor.start();
``` 