### PR TITLE
Fix warning about unmet peer dependencies

### DIFF
--- a/.changeset/stupid-buttons-brake.md
+++ b/.changeset/stupid-buttons-brake.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': minor
+---
+
+Fix warning about unmet peer dependencies

--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -65,7 +65,7 @@
     }
   },
   "dependencies": {
-    "use-isomorphic-layout-effect": "^1.0.0",
+    "use-isomorphic-layout-effect": "^1.1.2",
     "use-sync-external-store": "^1.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9585,10 +9585,10 @@ url-parse-lax@^3.0.0:
   dependencies:
     prepend-http "^2.0.0"
 
-use-isomorphic-layout-effect@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz#7bb6589170cd2987a152042f9084f9effb75c225"
-  integrity sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==
+use-isomorphic-layout-effect@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
 
 use-sync-external-store@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
When installing `@xstate/react` on a React 18 project, we get a warning that `use-isomorphic-layout-effect@1.0.0` doesn't support this version of React. As such, this pull request bumps the required minimum version of the dependency to fix the warning. There were no breaking changes in the dependency between 1.0.0 and 1.1.2 so from what I can see, this can be released as a minor version bump.