### PR TITLE
[v5] Rename reducer -> transition function

### DIFF
--- a/packages/core/src/actors/index.ts
+++ b/packages/core/src/actors/index.ts
@@ -1,7 +1,7 @@
 import type { EventObject, ActorRef, BaseActorRef } from '../types.js';
 import { symbolObservable } from '../symbolObservable.js';
 import { ActorStatus } from '../interpreter.js';
-export { fromReducer } from './reducer.js';
+export { fromTransition } from './transition.js';
 export { fromPromise } from './promise.js';
 export { fromObservable, fromEventObservable } from './observable.js';
 export { fromCallback } from './callback.js';

--- a/packages/core/src/actors/transition.ts
+++ b/packages/core/src/actors/transition.ts
@@ -2,14 +2,16 @@ import { ActorBehavior, ActorContext, EventObject } from '../types';
 import { isSCXMLEvent } from '../utils';
 
 /**
- * Returns an actor behavior from a reducer and its initial state.
+ * Returns an actor behavior from a transition function and its initial state.
  *
- * @param transition The pure reducer that returns the next state given the current state and event.
- * @param initialState The initial state of the reducer.
+ * A transition function is a function that takes the current state and an event and returns the next state.
+ *
+ * @param transition The pure transition function that returns the next state given the current state and event.
+ * @param initialState The initial state of the transition function.
  * @returns An actor behavior
  */
 
-export function fromReducer<TState, TEvent extends EventObject>(
+export function fromTransition<TState, TEvent extends EventObject>(
   transition: (
     state: TState,
     event: TEvent,

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -20,7 +20,7 @@ import { raise } from '../src/actions/raise';
 import { assign } from '../src/actions/assign';
 import { sendTo } from '../src/actions/send';
 import { EMPTY, interval, of } from 'rxjs';
-import { fromReducer } from '../src/actors/reducer';
+import { fromTransition } from '../src/actors/transition.js';
 import { fromObservable, fromEventObservable } from '../src/actors/observable';
 import { fromPromise } from '../src/actors/promise';
 import { fromCallback } from '../src/actors/callback';
@@ -842,8 +842,8 @@ describe('actors', () => {
   });
 
   describe('with behaviors', () => {
-    it('should work with a reducer behavior', (done) => {
-      const countBehavior = fromReducer((count: number, event: any) => {
+    it('should work with a transition function behavior', (done) => {
+      const countBehavior = fromTransition((count: number, event: any) => {
         if (event.type === 'INC') {
           return count + 1;
         } else if (event.type === 'DEC') {

--- a/packages/core/test/behaviors.test.ts
+++ b/packages/core/test/behaviors.test.ts
@@ -4,7 +4,7 @@ import { createMachine, interpret } from '../src/index.js';
 import {
   fromObservable,
   fromPromise,
-  fromReducer
+  fromTransition
 } from '../src/actors/index.js';
 import { waitFor } from '../src/waitFor.js';
 import { raise, sendTo } from '../src/actions.js';
@@ -169,9 +169,9 @@ describe('promise behavior (fromPromise)', () => {
   });
 });
 
-describe('reducer behavior (fromReducer)', () => {
-  it('should interpret a reducer', () => {
-    const reducerBehavior = fromReducer(
+describe('transition function behavior (fromTransition)', () => {
+  it('should interpret a transition function', () => {
+    const transitionBehavior = fromTransition(
       (state, event) => {
         if (event.type === 'toggle') {
           return {
@@ -188,7 +188,7 @@ describe('reducer behavior (fromReducer)', () => {
       { status: 'active' as 'inactive' | 'active' }
     );
 
-    const actor = interpret(reducerBehavior).start();
+    const actor = interpret(transitionBehavior).start();
 
     expect(actor.getSnapshot().status).toBe('active');
 
@@ -197,8 +197,8 @@ describe('reducer behavior (fromReducer)', () => {
     expect(actor.getSnapshot().status).toBe('inactive');
   });
 
-  it('should persist a reducer', () => {
-    const behavior = fromReducer(
+  it('should persist a transition function', () => {
+    const behavior = fromTransition(
       (state, event) => {
         if (event.type === 'activate') {
           return { status: 'active' as const };
@@ -310,7 +310,7 @@ describe('machine behavior', () => {
         start: {
           invoke: {
             id: 'reducer',
-            src: fromReducer((s) => s, { status: 'active' })
+            src: fromTransition((s) => s, { status: 'active' })
           }
         }
       }

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -5,7 +5,7 @@ import {
   fromCallback,
   fromObservable,
   fromPromise,
-  fromReducer
+  fromTransition
 } from '../src/actors';
 
 describe('input', () => {
@@ -123,17 +123,17 @@ describe('input', () => {
     expect(promiseActor.getSnapshot()).toEqual({ count: 42 });
   });
 
-  it('should create a reducer actor with input', () => {
-    const reducerBehavior = fromReducer(
+  it('should create a transition function actor with input', () => {
+    const transitionBehavior = fromTransition(
       (state) => state,
       ({ input }) => input
     );
 
-    const reducerActor = interpret(reducerBehavior, {
+    const transitionActor = interpret(transitionBehavior, {
       input: { count: 42 }
     }).start();
 
-    expect(reducerActor.getSnapshot()).toEqual({ count: 42 });
+    expect(transitionActor.getSnapshot()).toEqual({ count: 42 });
   });
 
   it('should create an observable actor with input', (done) => {

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -11,7 +11,7 @@ import {
   SpecialTargets,
   toSCXMLEvent
 } from '../src/index.js';
-import { fromReducer } from '../src/actors/index.js';
+import { fromTransition } from '../src/actors/index.js';
 import { fromObservable, fromEventObservable } from '../src/actors/index.js';
 import { fromPromise } from '../src/actors/index.js';
 import { fromCallback } from '../src/actors/index.js';
@@ -2139,8 +2139,8 @@ describe('invoke', () => {
     });
   });
 
-  describe('with reducers', () => {
-    it('should work with a reducer', (done) => {
+  describe('with transition functions', () => {
+    it('should work with a transition function', (done) => {
       const countReducer = (
         count: number,
         event: { type: 'INC' } | { type: 'DEC' }
@@ -2156,7 +2156,7 @@ describe('invoke', () => {
       const countMachine = createMachine({
         invoke: {
           id: 'count',
-          src: fromReducer(countReducer, 0)
+          src: fromTransition(countReducer, 0)
         },
         on: {
           INC: {
@@ -2199,7 +2199,7 @@ describe('invoke', () => {
       const countMachine = createMachine({
         invoke: {
           id: 'count',
-          src: fromReducer(countReducer, 0)
+          src: fromTransition(countReducer, 0)
         },
         on: {
           INC: {

--- a/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
+++ b/packages/xstate-graph/test/__snapshots__/graph.test.ts.snap
@@ -899,7 +899,373 @@ exports[`shortest paths for reducers 1`] = `
 ]
 `;
 
+exports[`shortest paths for transition functions 1`] = `
+[
+  {
+    "state": 0,
+    "steps": [],
+  },
+  {
+    "state": 1,
+    "steps": [
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 1,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 1,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 1,
+    "steps": [
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 1,
+    "steps": [
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+      {
+        "eventType": "reset",
+        "state": 2,
+      },
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "reset",
+        "state": 1,
+      },
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+      {
+        "eventType": "reset",
+        "state": 2,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "reset",
+        "state": 1,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+      {
+        "eventType": "reset",
+        "state": 2,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "reset",
+        "state": 1,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 2,
+    "steps": [
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+    ],
+  },
+  {
+    "state": 2,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+    ],
+  },
+  {
+    "state": 2,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+    ],
+  },
+  {
+    "state": 2,
+    "steps": [
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+    ],
+  },
+  {
+    "state": 2,
+    "steps": [
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+    ],
+  },
+]
+`;
+
 exports[`simple paths for reducers 1`] = `
+[
+  {
+    "state": 0,
+    "steps": [],
+  },
+  {
+    "state": 1,
+    "steps": [
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "b",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 0,
+    "steps": [
+      {
+        "eventType": "reset",
+        "state": 0,
+      },
+    ],
+  },
+  {
+    "state": 2,
+    "steps": [
+      {
+        "eventType": "a",
+        "state": 0,
+      },
+      {
+        "eventType": "b",
+        "state": 1,
+      },
+    ],
+  },
+]
+`;
+
+exports[`simple paths for transition functions 1`] = `
 [
   {
     "state": 0,

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -25,9 +25,7 @@ function getPathsSnapshot(
   return paths.map((path) => getPathSnapshot(path));
 }
 
-function getPathSnapshot(
-  path: StatePath<any, any>
-): {
+function getPathSnapshot(path: StatePath<any, any>): {
   state: StateValue;
   steps: Array<{ state: StateValue; eventType: string }>;
 } {
@@ -499,7 +497,7 @@ describe('@xstate/graph', () => {
   });
 });
 
-it('simple paths for reducers', () => {
+it('simple paths for transition functions', () => {
   const a = getShortestPaths(
     {
       transition: (s, e) => {
@@ -525,7 +523,7 @@ it('simple paths for reducers', () => {
   expect(getPathsSnapshot(a)).toMatchSnapshot();
 });
 
-it('shortest paths for reducers', () => {
+it('shortest paths for transition functions', () => {
   const a = getSimplePaths(
     {
       transition: (s, e) => {

--- a/packages/xstate-react/test/useSpawn.test.tsx
+++ b/packages/xstate-react/test/useSpawn.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, screen } from '@testing-library/react';
-import { fromReducer } from 'xstate/actors';
+import { fromTransition } from 'xstate/actors';
 import { useActor, useSpawn } from '../src/index.js';
 import { describeEachReactMode } from './utils';
 
@@ -13,7 +13,7 @@ describeEachReactMode('useSpawn (%s)', ({ render }) => {
       return state;
     };
 
-    const behavior = fromReducer(reducer, 0);
+    const behavior = fromTransition(reducer, 0);
 
     const Test = () => {
       const actorRef = useSpawn(behavior);

--- a/packages/xstate-solid/test/createSpawn.test.tsx
+++ b/packages/xstate-solid/test/createSpawn.test.tsx
@@ -1,7 +1,7 @@
 /* @jsxImportSource solid-js */
 import { useActor, createSpawn } from '../src';
 import { render, fireEvent, screen } from 'solid-testing-library';
-import { fromReducer } from 'xstate/actors';
+import { fromTransition } from 'xstate/actors';
 
 describe("usage with core's spawnBehavior", () => {
   it('should be able to spawn an actor from a behavior', () => {
@@ -14,7 +14,7 @@ describe("usage with core's spawnBehavior", () => {
     };
 
     const Test = () => {
-      const actorRef = createSpawn(fromReducer(reducer, 0));
+      const actorRef = createSpawn(fromTransition(reducer, 0));
       const [count, send] = useActor(() => actorRef);
 
       return (

--- a/packages/xstate-vue/test/UseSpawn.vue
+++ b/packages/xstate-vue/test/UseSpawn.vue
@@ -6,7 +6,7 @@
 
 <script lang="ts">
 import { useActor, useSpawn } from '../src/index.js';
-import { fromReducer } from 'xstate/actors';
+import { fromTransition } from 'xstate/actors';
 import { defineComponent } from 'vue';
 
 const reducer = (state: number, event: { type: 'INC' }): number => {
@@ -16,7 +16,7 @@ const reducer = (state: number, event: { type: 'INC' }): number => {
   return state;
 };
 
-const behavior = fromReducer(reducer, 0);
+const behavior = fromTransition(reducer, 0);
 
 export default defineComponent({
   setup() {


### PR DESCRIPTION
This PR renames `fromReducer` to `fromTransition`.