### PR TITLE
Fixed memory leak by separating sessionId from actor registration in the system

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -145,7 +145,7 @@ export class Interpreter<
       this.system.set(key, this);
     }
 
-    this.sessionId = this.system._register(this);
+    this.sessionId = this.system._bookId();
     this.id = id ?? this.sessionId;
     this.logger = logger;
     this.clock = clock;
@@ -286,6 +286,7 @@ export class Interpreter<
       return this;
     }
 
+    this.system._register(this.sessionId, this);
     this.status = ActorStatus.Running;
 
     if (this.behavior.start) {

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -1,14 +1,14 @@
 import { ActorSystem, ActorSystemInfo, AnyActorRef } from './types.js';
 
 export function createSystem<T extends ActorSystemInfo>(): ActorSystem<T> {
-  let sessionIdIndex = 0;
+  let sessionIdCounter = 0;
   const children = new Map<string, AnyActorRef>();
   const keyedActors = new Map<keyof T['actors'], AnyActorRef | undefined>();
   const reverseKeyedActors = new WeakMap<AnyActorRef, keyof T['actors']>();
 
   const system: ActorSystem<T> = {
-    _register: (actorRef) => {
-      const id = `x:${sessionIdIndex++}`;
+    _bookId: () => `x:${sessionIdCounter++}`,
+    _register: (id, actorRef) => {
       children.set(id, actorRef);
       return id;
     },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2005,7 +2005,8 @@ export interface ActorSystemInfo {
 }
 
 export interface ActorSystem<T extends ActorSystemInfo> {
-  _register: (actorRef: AnyActorRef) => string;
+  _bookId: () => string;
+  _register: (sessionId: string, actorRef: AnyActorRef) => string;
   _unregister: (actorRef: AnyActorRef) => void;
   get: <K extends keyof T['actors']>(key: K) => T['actors'][K] | undefined;
   set: <K extends keyof T['actors']>(key: K, actorRef: T['actors'][K]) => void;


### PR DESCRIPTION
Not doing this would reintroduce https://github.com/statelyai/xstate/issues/956 which was fixed by https://github.com/statelyai/xstate/pull/957