### PR TITLE
Use `ParameterizedObject` as constraint in many types

### DIFF
--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -5,7 +5,7 @@ import {
   MachineContext,
   ActorMap,
   InternalMachineImplementations,
-  BaseActionObject
+  ParameterizedObject
 } from './types.js';
 import {
   TypegenConstraint,
@@ -23,21 +23,21 @@ export function createMachine<
   config: MachineConfig<
     TContext,
     TEvent,
-    BaseActionObject,
+    ParameterizedObject,
     TActorMap,
     TTypesMeta
   >,
   implementations?: InternalMachineImplementations<
     TContext,
     TEvent,
-    ResolveTypegenMeta<TTypesMeta, TEvent, BaseActionObject, TActorMap>
+    ResolveTypegenMeta<TTypesMeta, TEvent, ParameterizedObject, TActorMap>
   >
 ): StateMachine<
   TContext,
   TEvent,
-  BaseActionObject,
+  ParameterizedObject,
   TActorMap,
-  ResolveTypegenMeta<TTypesMeta, TEvent, BaseActionObject, TActorMap>
+  ResolveTypegenMeta<TTypesMeta, TEvent, ParameterizedObject, TActorMap>
 > {
   return new StateMachine<any, any, any, any, any>(
     config,

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -25,7 +25,6 @@ import type {
 import type {
   ActorContext,
   ActorMap,
-  BaseActionObject,
   ActorBehavior,
   EventObject,
   InternalMachineImplementations,
@@ -41,7 +40,8 @@ import type {
   StateValue,
   TransitionDefinition,
   AnyActorContext,
-  PersistedMachineState
+  PersistedMachineState,
+  ParameterizedObject
 } from './types.js';
 import {
   isSCXMLErrorEvent,
@@ -66,7 +66,7 @@ function createDefaultOptions() {
 export class StateMachine<
   TContext extends MachineContext,
   TEvent extends EventObject = EventObject,
-  TAction extends BaseActionObject = BaseActionObject,
+  TAction extends ParameterizedObject = ParameterizedObject,
   TActorMap extends ActorMap = ActorMap,
   TResolvedTypesMeta = ResolveTypegenMeta<
     TypegenDisabled,

--- a/packages/core/src/typegenTypes.ts
+++ b/packages/core/src/typegenTypes.ts
@@ -1,5 +1,4 @@
 import {
-  BaseActionObject,
   EventObject,
   IndexByType,
   IsNever,
@@ -7,7 +6,8 @@ import {
   Values,
   IsAny,
   ActorMap,
-  Cast
+  Cast,
+  ParameterizedObject
 } from './types.js';
 
 export interface TypegenDisabled {
@@ -90,7 +90,7 @@ export interface TypegenMeta extends TypegenEnabled {
 
 export interface ResolvedTypegenMeta extends TypegenMeta {
   resolved: TypegenMeta & {
-    indexedActions: Record<string, BaseActionObject>;
+    indexedActions: Record<string, ParameterizedObject>;
     indexedEvents: Record<string, EventObject>;
   };
 }
@@ -108,11 +108,9 @@ export type AreAllImplementationsAssumedToBeProvided<
   ? true
   : TResolvedTypesMeta extends TypegenEnabled
   ? IsNever<
-      Values<
-        {
-          [K in keyof TMissingImplementations]: TMissingImplementations[K];
-        }
-      >
+      Values<{
+        [K in keyof TMissingImplementations]: TMissingImplementations[K];
+      }>
     > extends true
     ? true
     : false
@@ -175,7 +173,7 @@ type AllowAllEvents = {
 export interface ResolveTypegenMeta<
   TTypesMeta extends TypegenConstraint,
   TEvent extends EventObject,
-  TAction extends BaseActionObject,
+  TAction extends ParameterizedObject,
   TActorMap extends ActorMap
 > {
   '@@xstate/typegen': TTypesMeta['@@xstate/typegen'];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -89,7 +89,7 @@ export interface BaseDynamicActionObject<
       /**
        * The original action object
        */
-      action: BaseActionObject;
+      action: ParameterizedObject;
       actorContext: AnyActorContext | undefined;
     }
   ) => [AnyState, TResolvedAction];
@@ -98,7 +98,7 @@ export interface BaseDynamicActionObject<
   (
     arg: TContext,
     ev: TExpressionEvent,
-    meta: ActionMeta<TContext, TEvent, BaseActionObject>
+    meta: ActionMeta<TContext, TEvent, ParameterizedObject>
   ): void;
 }
 
@@ -107,7 +107,7 @@ export type MachineContext = Record<string, any>;
 export interface ActionMeta<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TAction extends BaseActionObject = BaseActionObject
+  TAction extends ParameterizedObject = ParameterizedObject
 > extends StateMeta<TContext, TEvent> {
   action: TAction;
   _event: SCXML.Event<TEvent>;
@@ -139,7 +139,7 @@ export interface AssignMeta<
 export type ActionFunction<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
-  TAction extends BaseActionObject = BaseActionObject,
+  TAction extends ParameterizedObject = ParameterizedObject,
   TEvent extends EventObject = TExpressionEvent
 > = {
   bivarianceHack(
@@ -164,21 +164,22 @@ export type Action<
   TEvent extends EventObject = TExpressionEvent
 > =
   | ActionType
-  | BaseActionObject
-  | ActionFunction<TContext, TExpressionEvent, BaseActionObject, TEvent>
+  | ParameterizedObject
+  | ActionFunction<TContext, TExpressionEvent, ParameterizedObject, TEvent>
   | BaseDynamicActionObject<TContext, TExpressionEvent, TEvent, any, any>; // TODO: fix last param
 
 /**
  * Extracts action objects that have no extra properties.
  */
-type SimpleActionsFrom<T extends BaseActionObject> = BaseActionObject extends T
-  ? T // If actions are unspecified, all action types are allowed (unsafe)
-  : ExtractWithSimpleSupport<T>;
+type SimpleActionsFrom<T extends ParameterizedObject> =
+  ParameterizedObject extends T
+    ? T // If actions are unspecified, all action types are allowed (unsafe)
+    : ExtractWithSimpleSupport<T>;
 
 export type BaseAction<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
-  TAction extends BaseActionObject,
+  TAction extends ParameterizedObject,
   TEvent extends EventObject
 > =
   | BaseDynamicActionObject<
@@ -196,7 +197,7 @@ export type BaseActions<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
   TEvent extends EventObject,
-  TAction extends BaseActionObject
+  TAction extends ParameterizedObject
 > = SingleOrArray<BaseAction<TContext, TExpressionEvent, TAction, TEvent>>;
 
 export type Actions<
@@ -307,7 +308,7 @@ export interface TransitionConfig<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
   TEvent extends EventObject = TExpressionEvent,
-  TAction extends BaseActionObject = BaseActionObject
+  TAction extends ParameterizedObject = ParameterizedObject
 > {
   guard?: GuardConfig<TContext, TExpressionEvent>;
   actions?: BaseActions<TContext, TExpressionEvent, TEvent, TAction>;
@@ -465,7 +466,7 @@ export type StateNodesConfig<
 export type StatesConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TAction extends BaseActionObject = BaseActionObject
+  TAction extends ParameterizedObject = ParameterizedObject
 > = {
   [K in string]: StateNodeConfig<TContext, TEvent, TAction>;
 };
@@ -562,7 +563,7 @@ export interface InvokeConfig<
 export interface StateNodeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TAction extends BaseActionObject = BaseActionObject
+  TAction extends ParameterizedObject = ParameterizedObject
 > {
   /**
    * The initial state transition.
@@ -749,7 +750,7 @@ export type SimpleOrStateNodeConfig<
 export type ActionFunctionMap<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TAction extends BaseActionObject = BaseActionObject
+  TAction extends ParameterizedObject = ParameterizedObject
 > = {
   [K in TAction['type']]?:
     | BaseDynamicActionObject<TContext, TEvent, TEvent, TAction, any>
@@ -774,7 +775,7 @@ export type DelayConfig<
 export interface MachineImplementationsSimplified<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TAction extends BaseActionObject = BaseActionObject
+  TAction extends ParameterizedObject = ParameterizedObject
 > {
   guards: Record<string, GuardPredicate<TContext, TEvent>>;
   actions: ActionFunctionMap<TContext, TEvent, TAction>;
@@ -800,13 +801,13 @@ type MachineImplementationsActions<
         TContext,
         Cast<Prop<TIndexedEvents, TEventsCausingActions[K]>, EventObject>,
         Cast<Prop<TIndexedEvents, keyof TIndexedEvents>, EventObject>,
-        any, // TODO: this should receive something like `Cast<Prop<TIndexedActions, K>, BaseActionObject>`, but at the moment builtin actions expect Resolved*Action here and this should be simplified somehow
+        any, // TODO: this should receive something like `Cast<Prop<TIndexedActions, K>, ParameterizedObject>`, but at the moment builtin actions expect Resolved*Action here and this should be simplified somehow
         any
       >
     | ActionFunction<
         TContext,
         Cast<Prop<TIndexedEvents, TEventsCausingActions[K]>, EventObject>,
-        BaseActionObject, // TODO: when bringing back parametrized actions this should accept something like `Cast<Prop<TIndexedActions, K>, BaseActionObject>`. At the moment we need to keep this type argument consistent with what is provided to the fake callable signature within `BaseDynamicActionObject`
+        ParameterizedObject, // TODO: when bringing back parametrized actions this should accept something like `Cast<Prop<TIndexedActions, K>, ParameterizedObject>`. At the moment we need to keep this type argument consistent with what is provided to the fake callable signature within `BaseDynamicActionObject`
         Cast<Prop<TIndexedEvents, keyof TIndexedEvents>, EventObject>
       >;
 };
@@ -974,7 +975,7 @@ export type InternalMachineImplementations<
 export type MachineImplementations<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TAction extends BaseActionObject = BaseActionObject,
+  TAction extends ParameterizedObject = ParameterizedObject,
   TActorMap extends ActorMap = ActorMap,
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 > = InternalMachineImplementations<
@@ -998,7 +999,7 @@ export type ContextFactory<TContext extends MachineContext> = ({
 export interface MachineConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TAction extends BaseActionObject = BaseActionObject,
+  TAction extends ParameterizedObject = ParameterizedObject,
   TActorMap extends ActorMap = ActorMap,
   TTypesMeta = TypegenDisabled
 > extends StateNodeConfig<NoInfer<TContext>, NoInfer<TEvent>, TAction> {


### PR DESCRIPTION
It doesn't yet use this type in every place that it should but it's using it at least in the ones that are the closest to the user.