### PR TITLE
[v5] Unified args

### DIFF
--- a/.changeset/hot-zoos-destroy.md
+++ b/.changeset/hot-zoos-destroy.md
@@ -1,0 +1,14 @@
+---
+'xstate': major
+---
+
+Action arguments are now consolidated into a single object argument. This is a breaking change for all actions that are called with arguments.
+
+```diff
+assign({
+- count: (context, event) => {
++ count: ({ context, event }) => {
+    return context.count + event.value;
+  }
+})
+```

--- a/.changeset/hot-zoos-destroy.md
+++ b/.changeset/hot-zoos-destroy.md
@@ -2,7 +2,7 @@
 'xstate': major
 ---
 
-Action arguments are now consolidated into a single object argument. This is a breaking change for all actions that are called with arguments.
+Action/actor/delay/guard arguments are now consolidated into a single object argument. This is a breaking change for all of those things that are called with arguments.
 
 ```diff
 assign({

--- a/.changeset/poor-badgers-explain.md
+++ b/.changeset/poor-badgers-explain.md
@@ -1,0 +1,12 @@
+---
+'xstate': major
+---
+
+Guard arguments are now consolidated into a single object argument. This is a breaking change for all guards that are called with arguments.
+
+```diff
+- guard: (context, event) => {
++ guard: ({ context, event }) => {
+  return context.count + event.value > 10;
+}
+```

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -100,7 +100,7 @@ export function toActionObject<
           function: action
         },
         execute: (actorCtx) => {
-          const arg = {
+          return action({
             context: state.context as TContext,
             event: _event.data as TEvent,
             action: actionObject,
@@ -108,8 +108,7 @@ export function toActionObject<
             state: state as AnyState,
             self: actorCtx.self,
             system: actorCtx.system
-          };
-          return action(arg);
+          });
         }
       };
 

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -58,13 +58,11 @@ export function resolveActionObject(
             return dereferencedAction({
               context: state.context,
               event: state.event,
-              meta: {
-                action: a,
-                _event: state._event,
-                state,
-                system: actorCtx.system,
-                self: actorCtx.self
-              }
+              action: a,
+              _event: state._event,
+              state,
+              system: actorCtx.system,
+              self: actorCtx.self
             });
           }
         };
@@ -105,13 +103,11 @@ export function toActionObject<
           const arg = {
             context: state.context as TContext,
             event: _event.data as TEvent,
-            meta: {
-              action: actionObject,
-              _event: _event as SCXML.Event<TEvent>,
-              state: state as AnyState,
-              self: actorCtx.self,
-              system: actorCtx.system
-            }
+            action: actionObject,
+            _event: _event as SCXML.Event<TEvent>,
+            state: state as AnyState,
+            self: actorCtx.self,
+            system: actorCtx.system
           };
           return action(arg);
         }

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -55,12 +55,16 @@ export function resolveActionObject(
           type: actionObject.type,
           params: actionObject.params,
           execute: (actorCtx) => {
-            return dereferencedAction(state.context, state.event, {
-              action: a,
-              _event: state._event,
-              state,
-              system: actorCtx.system,
-              self: actorCtx.self
+            return dereferencedAction({
+              context: state.context,
+              event: state.event,
+              meta: {
+                action: a,
+                _event: state._event,
+                state,
+                system: actorCtx.system,
+                self: actorCtx.self
+              }
             });
           }
         };
@@ -98,13 +102,18 @@ export function toActionObject<
           function: action
         },
         execute: (actorCtx) => {
-          return action(state.context as TContext, _event.data as TEvent, {
-            action: actionObject,
-            _event: _event as SCXML.Event<TEvent>,
-            state: state as AnyState,
-            self: actorCtx.self,
-            system: actorCtx.system
-          });
+          const arg = {
+            context: state.context as TContext,
+            event: _event.data as TEvent,
+            meta: {
+              action: actionObject,
+              _event: _event as SCXML.Event<TEvent>,
+              state: state as AnyState,
+              self: actorCtx.self,
+              system: actorCtx.system
+            }
+          };
+          return action(arg);
         }
       };
 

--- a/packages/core/src/actions/assign.ts
+++ b/packages/core/src/actions/assign.ts
@@ -70,12 +70,20 @@ export function assign<
 
       let partialUpdate: Partial<TContext> = {};
       if (isFunction(assignment)) {
-        partialUpdate = assignment(state.context, _event.data, meta);
+        partialUpdate = assignment({
+          context: state.context,
+          event: _event.data,
+          meta
+        });
       } else {
         for (const key of Object.keys(assignment)) {
           const propAssignment = assignment[key];
           partialUpdate[key as keyof TContext] = isFunction(propAssignment)
-            ? propAssignment(state.context, _event.data, meta)
+            ? propAssignment({
+                context: state.context,
+                event: _event.data,
+                meta
+              })
             : propAssignment;
         }
       }

--- a/packages/core/src/actions/assign.ts
+++ b/packages/core/src/actions/assign.ts
@@ -73,7 +73,7 @@ export function assign<
         partialUpdate = assignment({
           context: state.context,
           event: _event.data,
-          meta
+          ...meta
         });
       } else {
         for (const key of Object.keys(assignment)) {
@@ -82,7 +82,7 @@ export function assign<
             ? propAssignment({
                 context: state.context,
                 event: _event.data,
-                meta
+                ...meta
               })
             : propAssignment;
         }

--- a/packages/core/src/actions/assign.ts
+++ b/packages/core/src/actions/assign.ts
@@ -53,7 +53,12 @@ export function assign<
         );
       }
 
-      const meta: AssignMeta<TContext, TExpressionEvent, TEvent> = {
+      const args: AssignMeta<TContext, TExpressionEvent, TEvent> & {
+        context: TContext;
+        event: TExpressionEvent;
+      } = {
+        context: state.context,
+        event: _event.data,
         state: state as any,
         action,
         _event,
@@ -70,20 +75,12 @@ export function assign<
 
       let partialUpdate: Partial<TContext> = {};
       if (isFunction(assignment)) {
-        partialUpdate = assignment({
-          context: state.context,
-          event: _event.data,
-          ...meta
-        });
+        partialUpdate = assignment(args);
       } else {
         for (const key of Object.keys(assignment)) {
           const propAssignment = assignment[key];
           partialUpdate[key as keyof TContext] = isFunction(propAssignment)
-            ? propAssignment({
-                context: state.context,
-                event: _event.data,
-                ...meta
-              })
+            ? propAssignment(args)
             : propAssignment;
         }
       }

--- a/packages/core/src/actions/cancel.ts
+++ b/packages/core/src/actions/cancel.ts
@@ -42,12 +42,10 @@ export function cancel<
         ? sendId({
             context: state.context,
             event: _event.data,
-            meta: {
-              _event,
-              state: state as any, // TODO: fix types,
-              self: actorContext?.self ?? ({} as any),
-              system: actorContext?.system
-            }
+            _event,
+            state: state as any, // TODO: fix types,
+            self: actorContext?.self ?? ({} as any),
+            system: actorContext?.system
           })
         : sendId;
 

--- a/packages/core/src/actions/cancel.ts
+++ b/packages/core/src/actions/cancel.ts
@@ -39,11 +39,15 @@ export function cancel<
     },
     (_event, { state, actorContext }) => {
       const resolvedSendId = isFunction(sendId)
-        ? sendId(state.context, _event.data, {
-            _event,
-            state: state as any, // TODO: fix types,
-            self: actorContext?.self ?? ({} as any),
-            system: actorContext?.system
+        ? sendId({
+            context: state.context,
+            event: _event.data,
+            meta: {
+              _event,
+              state: state as any, // TODO: fix types,
+              self: actorContext?.self ?? ({} as any),
+              system: actorContext?.system
+            }
           })
         : sendId;
 

--- a/packages/core/src/actions/invoke.ts
+++ b/packages/core/src/actions/invoke.ts
@@ -62,8 +62,10 @@ export function invoke<
             systemId: invokeDef.systemId,
             input:
               typeof input === 'function'
-                ? input(state.context, _event.data as any, {
-                    self: actorContext!.self
+                ? input({
+                    context: state.context,
+                    event: _event.data as any,
+                    self: actorContext?.self
                   })
                 : input
           });

--- a/packages/core/src/actions/log.ts
+++ b/packages/core/src/actions/log.ts
@@ -50,12 +50,10 @@ export function log<
           ? expr({
               context: state.context,
               event: _event.data,
-              meta: {
-                _event,
-                state: state as any,
-                self: actorContext?.self ?? ({} as any),
-                system: actorContext?.system
-              }
+              _event,
+              state: state as any,
+              self: actorContext?.self ?? ({} as any),
+              system: actorContext?.system
             })
           : expr;
       return [

--- a/packages/core/src/actions/log.ts
+++ b/packages/core/src/actions/log.ts
@@ -8,10 +8,13 @@ import { log as logActionType } from '../actionTypes.js';
 import { createDynamicAction } from '../../actions/dynamicAction.js';
 import { BaseDynamicActionObject, DynamicLogAction } from '../index.js';
 
-const defaultLogExpr = <TContext, TEvent extends EventObject>(
-  context: TContext,
-  event: TEvent
-) => ({
+const defaultLogExpr = <TContext, TEvent extends EventObject>({
+  context,
+  event
+}: {
+  context: TContext;
+  event: TEvent;
+}) => ({
   context,
   event
 });
@@ -44,11 +47,15 @@ export function log<
     (_event, { state, actorContext }) => {
       const resolvedValue =
         typeof expr === 'function'
-          ? expr(state.context, _event.data, {
-              _event,
-              state: state as any,
-              self: actorContext?.self ?? ({} as any),
-              system: actorContext?.system
+          ? expr({
+              context: state.context,
+              event: _event.data,
+              meta: {
+                _event,
+                state: state as any,
+                self: actorContext?.self ?? ({} as any),
+                system: actorContext?.system
+              }
             })
           : expr;
       return [

--- a/packages/core/src/actions/pure.ts
+++ b/packages/core/src/actions/pure.ts
@@ -15,7 +15,10 @@ export function pure<
   TExpressionEvent extends EventObject,
   TEvent extends EventObject = TExpressionEvent
 >(
-  getActions: (arg: {
+  getActions: ({
+    context,
+    event
+  }: {
     context: TContext;
     event: TExpressionEvent;
   }) => SingleOrArray<BaseActionObject | string> | undefined

--- a/packages/core/src/actions/pure.ts
+++ b/packages/core/src/actions/pure.ts
@@ -15,10 +15,10 @@ export function pure<
   TExpressionEvent extends EventObject,
   TEvent extends EventObject = TExpressionEvent
 >(
-  getActions: (
-    context: TContext,
-    event: TExpressionEvent
-  ) => SingleOrArray<BaseActionObject | string> | undefined
+  getActions: (arg: {
+    context: TContext;
+    event: TExpressionEvent;
+  }) => SingleOrArray<BaseActionObject | string> | undefined
 ): BaseDynamicActionObject<
   TContext,
   TExpressionEvent,
@@ -41,7 +41,9 @@ export function pure<
           params: {
             actions:
               toArray(
-                toActionObjects(getActions(state.context, _event.data))
+                toActionObjects(
+                  getActions({ context: state.context, event: _event.data })
+                )
               ) ?? []
           }
         }

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -73,7 +73,7 @@ export function raise<
       // TODO: helper function for resolving Expr
       const resolvedEvent = toSCXMLEvent(
         typeof eventOrExpr === 'function'
-          ? eventOrExpr(state.context, _event.data, meta)
+          ? eventOrExpr({ context: state.context, event: _event.data, meta })
           : eventOrExpr
       );
 
@@ -82,12 +82,12 @@ export function raise<
         const configDelay = delaysMap && delaysMap[params.delay];
         resolvedDelay =
           typeof configDelay === 'function'
-            ? configDelay(state.context, _event.data, meta)
+            ? configDelay({ context: state.context, event: _event.data, meta })
             : configDelay;
       } else {
         resolvedDelay =
           typeof params.delay === 'function'
-            ? params.delay(state.context, _event.data, meta)
+            ? params.delay({ context: state.context, event: _event.data, meta })
             : params.delay;
       }
 

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -63,7 +63,7 @@ export function raise<
             ? eventOrExpr.name
             : eventOrExpr.type
       };
-      const arg: UnifiedArg<TContext, TExpressionEvent> &
+      const args: UnifiedArg<TContext, TExpressionEvent> &
         StateMeta<TContext, TExpressionEvent> = {
         context: state.context,
         event: _event.data,
@@ -76,17 +76,19 @@ export function raise<
 
       // TODO: helper function for resolving Expr
       const resolvedEvent = toSCXMLEvent(
-        typeof eventOrExpr === 'function' ? eventOrExpr(arg) : eventOrExpr
+        typeof eventOrExpr === 'function' ? eventOrExpr(args) : eventOrExpr
       );
 
       let resolvedDelay: number | undefined;
       if (typeof params.delay === 'string') {
         const configDelay = delaysMap && delaysMap[params.delay];
         resolvedDelay =
-          typeof configDelay === 'function' ? configDelay(arg) : configDelay;
+          typeof configDelay === 'function' ? configDelay(args) : configDelay;
       } else {
         resolvedDelay =
-          typeof params.delay === 'function' ? params.delay(arg) : params.delay;
+          typeof params.delay === 'function'
+            ? params.delay(args)
+            : params.delay;
       }
 
       const resolvedAction: RaiseActionObject<

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -96,7 +96,7 @@ export function send<
       // TODO: helper function for resolving Expr
       const resolvedEvent = toSCXMLEvent(
         isFunction(eventOrExpr)
-          ? eventOrExpr(state.context, _event.data, meta)
+          ? eventOrExpr({ context: state.context, event: _event.data, meta })
           : eventOrExpr
       );
 
@@ -104,16 +104,16 @@ export function send<
       if (isString(params.delay)) {
         const configDelay = delaysMap && delaysMap[params.delay];
         resolvedDelay = isFunction(configDelay)
-          ? configDelay(state.context, _event.data, meta)
+          ? configDelay({ context: state.context, event: _event.data, meta })
           : configDelay;
       } else {
         resolvedDelay = isFunction(params.delay)
-          ? params.delay(state.context, _event.data, meta)
+          ? params.delay({ context: state.context, event: _event.data, meta })
           : params.delay;
       }
 
       const resolvedTarget = isFunction(params.to)
-        ? params.to(state.context, _event.data, meta)
+        ? params.to({ context: state.context, event: _event.data, meta })
         : params.to;
       let targetActorRef: AnyActorRef | undefined;
 
@@ -214,7 +214,7 @@ export function respond<
 ) {
   return send<TContext, TEvent>(event, {
     ...options,
-    to: (_, __, { _event }) => {
+    to: ({ meta: { _event } }) => {
       return _event.origin!; // TODO: handle when _event.origin is undefined
     }
   });
@@ -251,7 +251,7 @@ export function forwardTo<
       return resolvedTarget;
     };
   }
-  return send<TContext, TEvent>((_, event) => event, {
+  return send<TContext, TEvent>(({ event }) => event, {
     ...options,
     to: target
   });
@@ -273,11 +273,11 @@ export function escalate<
   options?: SendActionParams<TContext, TEvent>
 ) {
   return sendParent<TContext, TEvent>(
-    (context, event, meta) => {
+    ({ context, event, meta }) => {
       return {
         type: actionTypes.error,
         data: isFunction(errorData)
-          ? errorData(context, event, meta)
+          ? errorData({ context, event, meta })
           : errorData
       };
     },

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -20,7 +20,8 @@ import {
   SendActionObject,
   SendActionOptions,
   State,
-  StateMeta
+  StateMeta,
+  UnifiedArg
 } from '../index.js';
 import { actionTypes, error } from '../actions.js';
 
@@ -85,7 +86,9 @@ export function send<
             ? eventOrExpr.name
             : eventOrExpr.type
       };
-      const meta: StateMeta<TContext, TEvent> = {
+      const arg: UnifiedArg<TContext, TEvent> & StateMeta<TContext, TEvent> = {
+        context: state.context,
+        event: _event.data,
         _event,
         state: state as State<TContext, TEvent>,
         self: actorContext?.self ?? (null as any),
@@ -95,26 +98,22 @@ export function send<
 
       // TODO: helper function for resolving Expr
       const resolvedEvent = toSCXMLEvent(
-        isFunction(eventOrExpr)
-          ? eventOrExpr({ context: state.context, event: _event.data, meta })
-          : eventOrExpr
+        isFunction(eventOrExpr) ? eventOrExpr(arg) : eventOrExpr
       );
 
       let resolvedDelay: number | undefined;
       if (isString(params.delay)) {
         const configDelay = delaysMap && delaysMap[params.delay];
         resolvedDelay = isFunction(configDelay)
-          ? configDelay({ context: state.context, event: _event.data, meta })
+          ? configDelay(arg)
           : configDelay;
       } else {
         resolvedDelay = isFunction(params.delay)
-          ? params.delay({ context: state.context, event: _event.data, meta })
+          ? params.delay(arg)
           : params.delay;
       }
 
-      const resolvedTarget = isFunction(params.to)
-        ? params.to({ context: state.context, event: _event.data, meta })
-        : params.to;
+      const resolvedTarget = isFunction(params.to) ? params.to(arg) : params.to;
       let targetActorRef: AnyActorRef | undefined;
 
       if (typeof resolvedTarget === 'string') {
@@ -214,7 +213,7 @@ export function respond<
 ) {
   return send<TContext, TEvent>(event, {
     ...options,
-    to: ({ meta: { _event } }) => {
+    to: ({ _event }) => {
       return _event.origin!; // TODO: handle when _event.origin is undefined
     }
   });
@@ -273,12 +272,10 @@ export function escalate<
   options?: SendActionParams<TContext, TEvent>
 ) {
   return sendParent<TContext, TEvent>(
-    ({ context, event, meta }) => {
+    (arg) => {
       return {
         type: actionTypes.error,
-        data: isFunction(errorData)
-          ? errorData({ context, event, meta })
-          : errorData
+        data: isFunction(errorData) ? errorData(arg) : errorData
       };
     },
     {

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -86,7 +86,7 @@ export function send<
             ? eventOrExpr.name
             : eventOrExpr.type
       };
-      const arg: UnifiedArg<TContext, TEvent> & StateMeta<TContext, TEvent> = {
+      const args: UnifiedArg<TContext, TEvent> & StateMeta<TContext, TEvent> = {
         context: state.context,
         event: _event.data,
         _event,
@@ -98,22 +98,24 @@ export function send<
 
       // TODO: helper function for resolving Expr
       const resolvedEvent = toSCXMLEvent(
-        isFunction(eventOrExpr) ? eventOrExpr(arg) : eventOrExpr
+        isFunction(eventOrExpr) ? eventOrExpr(args) : eventOrExpr
       );
 
       let resolvedDelay: number | undefined;
       if (isString(params.delay)) {
         const configDelay = delaysMap && delaysMap[params.delay];
         resolvedDelay = isFunction(configDelay)
-          ? configDelay(arg)
+          ? configDelay(args)
           : configDelay;
       } else {
         resolvedDelay = isFunction(params.delay)
-          ? params.delay(arg)
+          ? params.delay(args)
           : params.delay;
       }
 
-      const resolvedTarget = isFunction(params.to) ? params.to(arg) : params.to;
+      const resolvedTarget = isFunction(params.to)
+        ? params.to(args)
+        : params.to;
       let targetActorRef: AnyActorRef | undefined;
 
       if (typeof resolvedTarget === 'string') {

--- a/packages/core/src/actions/stop.ts
+++ b/packages/core/src/actions/stop.ts
@@ -46,7 +46,7 @@ export function stop<
     },
     (_event, { state }) => {
       const actorRefOrString = isFunction(actor)
-        ? actor(state.context, _event.data)
+        ? actor({ context: state.context, event: _event.data })
         : actor;
       const actorRef =
         typeof actorRefOrString === 'string'

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -20,7 +20,7 @@ export function stateIn<
   return {
     type: 'xstate.guard:in',
     params: { stateValue },
-    predicate: ({ meta: { state } }) => {
+    predicate: ({ state }) => {
       if (isString(stateValue) && isStateId(stateValue)) {
         return state.configuration.some((sn) => sn.id === stateValue.slice(1));
       }
@@ -40,7 +40,7 @@ export function not<
     type: 'xstate.boolean',
     params: { op: 'not' },
     children: [toGuardDefinition(guard)],
-    predicate: ({ context, meta }) => {
+    predicate: ({ context, ...meta }) => {
       return !meta.evaluate(
         meta.guard.children![0],
         context,
@@ -61,7 +61,7 @@ export function and<
     type: 'xstate.boolean',
     params: { op: 'and' },
     children: guards.map((guard) => toGuardDefinition(guard)),
-    predicate: ({ context, meta }) => {
+    predicate: ({ context, ...meta }) => {
       return meta.guard.children!.every((childGuard) => {
         return meta.evaluate(childGuard, context, meta._event, meta.state);
       });
@@ -76,7 +76,7 @@ export function or<TContext extends MachineContext, TEvent extends EventObject>(
     type: 'xstate.boolean',
     params: { op: 'or' },
     children: guards.map((guard) => toGuardDefinition(guard)),
-    predicate: ({ context, meta }) => {
+    predicate: ({ context, ...meta }) => {
       return meta.guard.children!.some((childGuard) => {
         return meta.evaluate(childGuard, context, meta._event, meta.state);
       });
@@ -107,7 +107,7 @@ export function evaluateGuard<
     throw new Error(`Guard '${guard.type}' is not implemented.'.`);
   }
 
-  return predicate({ context, event: _event.data, meta: guardMeta });
+  return predicate({ context, event: _event.data, ...guardMeta });
 }
 
 export function toGuardDefinition<

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -20,7 +20,7 @@ export function stateIn<
   return {
     type: 'xstate.guard:in',
     params: { stateValue },
-    predicate: (_, __, { state }) => {
+    predicate: ({ meta: { state } }) => {
       if (isString(stateValue) && isStateId(stateValue)) {
         return state.configuration.some((sn) => sn.id === stateValue.slice(1));
       }
@@ -40,10 +40,10 @@ export function not<
     type: 'xstate.boolean',
     params: { op: 'not' },
     children: [toGuardDefinition(guard)],
-    predicate: (ctx, _, meta) => {
+    predicate: ({ context, meta }) => {
       return !meta.evaluate(
         meta.guard.children![0],
-        ctx,
+        context,
         meta._event,
         meta.state
       );
@@ -61,9 +61,9 @@ export function and<
     type: 'xstate.boolean',
     params: { op: 'and' },
     children: guards.map((guard) => toGuardDefinition(guard)),
-    predicate: (ctx, _, meta) => {
+    predicate: ({ context, meta }) => {
       return meta.guard.children!.every((childGuard) => {
-        return meta.evaluate(childGuard, ctx, meta._event, meta.state);
+        return meta.evaluate(childGuard, context, meta._event, meta.state);
       });
     }
   };
@@ -76,9 +76,9 @@ export function or<TContext extends MachineContext, TEvent extends EventObject>(
     type: 'xstate.boolean',
     params: { op: 'or' },
     children: guards.map((guard) => toGuardDefinition(guard)),
-    predicate: (ctx, _, meta) => {
+    predicate: ({ context, meta }) => {
       return meta.guard.children!.some((childGuard) => {
-        return meta.evaluate(childGuard, ctx, meta._event, meta.state);
+        return meta.evaluate(childGuard, context, meta._event, meta.state);
       });
     }
   };
@@ -107,7 +107,7 @@ export function evaluateGuard<
     throw new Error(`Guard '${guard.type}' is not implemented.'.`);
   }
 
-  return predicate(context, _event.data, guardMeta);
+  return predicate({ context, event: _event.data, meta: guardMeta });
 }
 
 export function toGuardDefinition<

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -4,7 +4,6 @@ import type {
   BooleanGuardDefinition,
   GuardConfig,
   GuardDefinition,
-  GuardMeta,
   SCXML,
   GuardPredicate,
   MachineContext
@@ -40,13 +39,8 @@ export function not<
     type: 'xstate.boolean',
     params: { op: 'not' },
     children: [toGuardDefinition(guard)],
-    predicate: ({ context, ...meta }) => {
-      return !meta.evaluate(
-        meta.guard.children![0],
-        context,
-        meta._event,
-        meta.state
-      );
+    predicate: ({ evaluate, guard, context, _event, state }) => {
+      return !evaluate(guard.children![0], context, _event, state);
     }
   };
 }
@@ -61,9 +55,9 @@ export function and<
     type: 'xstate.boolean',
     params: { op: 'and' },
     children: guards.map((guard) => toGuardDefinition(guard)),
-    predicate: ({ context, ...meta }) => {
-      return meta.guard.children!.every((childGuard) => {
-        return meta.evaluate(childGuard, context, meta._event, meta.state);
+    predicate: ({ evaluate, guard, context, _event, state }) => {
+      return guard.children!.every((childGuard) => {
+        return evaluate(childGuard, context, _event, state);
       });
     }
   };
@@ -76,9 +70,9 @@ export function or<TContext extends MachineContext, TEvent extends EventObject>(
     type: 'xstate.boolean',
     params: { op: 'or' },
     children: guards.map((guard) => toGuardDefinition(guard)),
-    predicate: ({ context, ...meta }) => {
-      return meta.guard.children!.some((childGuard) => {
-        return meta.evaluate(childGuard, context, meta._event, meta.state);
+    predicate: ({ evaluate, guard, context, _event, state }) => {
+      return guard.children!.some((childGuard) => {
+        return evaluate(childGuard, context, _event, state);
       });
     }
   };
@@ -94,12 +88,6 @@ export function evaluateGuard<
   state: State<TContext, TEvent>
 ): boolean {
   const { machine } = state;
-  const guardMeta: GuardMeta<TContext, TEvent> = {
-    state,
-    guard,
-    _event,
-    evaluate: evaluateGuard
-  };
 
   const predicate = machine?.options?.guards?.[guard.type] ?? guard.predicate;
 
@@ -107,7 +95,14 @@ export function evaluateGuard<
     throw new Error(`Guard '${guard.type}' is not implemented.'.`);
   }
 
-  return predicate({ context, event: _event.data, ...guardMeta });
+  return predicate({
+    context,
+    event: _event.data,
+    state,
+    guard,
+    _event,
+    evaluate: evaluateGuard
+  });
 }
 
 export function toGuardDefinition<

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -131,13 +131,17 @@ function createGuard<
   return ({
     context,
     event,
-    meta
+    ...meta
   }: {
     context: TContext;
     event: TEvent;
-    meta;
   }) => {
-    return evaluateExecutableContent(context, event, meta, `return ${guard};`);
+    return evaluateExecutableContent(
+      context,
+      event,
+      meta as any,
+      `return ${guard};`
+    );
   };
 }
 

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -171,7 +171,7 @@ return {'${element.attributes!.location}': ${element.attributes!.expr}};
       if ('sendid' in element.attributes!) {
         return cancel(element.attributes!.sendid! as string);
       }
-      return cancel(({ context, event, meta }) => {
+      return cancel(({ context, event, ...meta }) => {
         const fnBody = `
 return ${element.attributes!.sendidexpr};
           `;
@@ -198,7 +198,7 @@ return ${element.attributes!.sendidexpr};
       if (event && !params) {
         convertedEvent = { type: event } as TEvent;
       } else {
-        convertedEvent = ({ context, event: _ev, meta }) => {
+        convertedEvent = ({ context, event: _ev, ...meta }) => {
           const fnBody = `
 return { type: ${event ? `"${event}"` : eventexpr}, ${params ? params : ''} }
             `;
@@ -210,7 +210,7 @@ return { type: ${event ? `"${event}"` : eventexpr}, ${params ? params : ''} }
       if ('delay' in element.attributes!) {
         convertedDelay = delayToMs(element.attributes!.delay);
       } else if (element.attributes!.delayexpr) {
-        convertedDelay = ({ context, event: _ev, meta }) => {
+        convertedDelay = ({ context, event: _ev, ...meta }) => {
           const fnBody = `
 return (${delayToMs})(${element.attributes!.delayexpr});
             `;
@@ -229,7 +229,7 @@ return (${delayToMs})(${element.attributes!.delayexpr});
       const label = element.attributes!.label;
 
       return log<TContext, any>(
-        ({ context, event, meta }) => {
+        ({ context, event, ...meta }) => {
           const fnBody = `
 return ${element.attributes!.expr};
             `;

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -159,12 +159,12 @@ return {'${element.attributes!.location}': ${element.attributes!.expr}};
       if ('sendid' in element.attributes!) {
         return cancel(element.attributes!.sendid! as string);
       }
-      return cancel((context, e, meta) => {
+      return cancel(({ context, event, meta }) => {
         const fnBody = `
 return ${element.attributes!.sendidexpr};
           `;
 
-        return evaluateExecutableContent(context, e, meta, fnBody);
+        return evaluateExecutableContent(context, event, meta, fnBody);
       });
     case 'send': {
       const { event, eventexpr, target, id } = element.attributes!;
@@ -186,7 +186,7 @@ return ${element.attributes!.sendidexpr};
       if (event && !params) {
         convertedEvent = { type: event } as TEvent;
       } else {
-        convertedEvent = (context, _ev, meta) => {
+        convertedEvent = ({ context, event: _ev, meta }) => {
           const fnBody = `
 return { type: ${event ? `"${event}"` : eventexpr}, ${params ? params : ''} }
             `;
@@ -198,7 +198,7 @@ return { type: ${event ? `"${event}"` : eventexpr}, ${params ? params : ''} }
       if ('delay' in element.attributes!) {
         convertedDelay = delayToMs(element.attributes!.delay);
       } else if (element.attributes!.delayexpr) {
-        convertedDelay = (context, _ev, meta) => {
+        convertedDelay = ({ context, event: _ev, meta }) => {
           const fnBody = `
 return (${delayToMs})(${element.attributes!.delayexpr});
             `;
@@ -217,12 +217,12 @@ return (${delayToMs})(${element.attributes!.delayexpr});
       const label = element.attributes!.label;
 
       return log<TContext, any>(
-        (context, e, meta) => {
+        ({ context, event, meta }) => {
           const fnBody = `
 return ${element.attributes!.expr};
             `;
 
-          return evaluateExecutableContent(context, e, meta, fnBody);
+          return evaluateExecutableContent(context, event, meta, fnBody);
         },
         label !== undefined ? String(label) : undefined
       );

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -128,8 +128,16 @@ function createGuard<
   TContext extends object,
   TEvent extends EventObject = EventObject
 >(guard: string) {
-  return (context: TContext, _event: TEvent, meta) => {
-    return evaluateExecutableContent(context, _event, meta, `return ${guard};`);
+  return ({
+    context,
+    event,
+    meta
+  }: {
+    context: TContext;
+    event: TEvent;
+    meta;
+  }) => {
+    return evaluateExecutableContent(context, event, meta, `return ${guard};`);
   };
 }
 

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -152,7 +152,7 @@ function mapAction<
       } as TEvent);
     }
     case 'assign': {
-      return assign<TContext, TEvent>((context, e, meta) => {
+      return assign<TContext, TEvent>(({ context, event, meta }) => {
         const fnBody = `
 
 ${element.attributes!.location};
@@ -160,7 +160,7 @@ ${element.attributes!.location};
 return {'${element.attributes!.location}': ${element.attributes!.expr}};
           `;
 
-        return evaluateExecutableContent(context, e, meta, fnBody);
+        return evaluateExecutableContent(context, event, meta, fnBody);
       });
     }
     case 'cancel':

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -152,7 +152,7 @@ function mapAction<
       } as TEvent);
     }
     case 'assign': {
-      return assign<TContext, TEvent>(({ context, event, meta }) => {
+      return assign<TContext, TEvent>(({ context, event, ...meta }) => {
         const fnBody = `
 
 ${element.attributes!.location};

--- a/packages/core/src/spawn.ts
+++ b/packages/core/src/spawn.ts
@@ -35,7 +35,9 @@ export function createSpawner<
           parent: self,
           input:
             typeof input === 'function'
-              ? input(context, _event.data, {
+              ? input({
+                  context,
+                  event: _event.data,
                   self
                 })
               : input

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1413,10 +1413,12 @@ export interface DynamicPureActionObject<
 > {
   type: ActionTypes.Pure;
   params: {
-    get: (
-      context: TContext,
-      event: TEvent
-    ) => SingleOrArray<BaseActionObject | BaseActionObject['type']> | undefined;
+    get: (arg: {
+      context: TContext;
+      event: TEvent;
+    }) =>
+      | SingleOrArray<BaseActionObject | BaseActionObject['type']>
+      | undefined;
   };
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1332,22 +1332,22 @@ export type Assigner<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
   TEvent extends EventObject = TExpressionEvent
-> = (
-  context: TContext,
-  event: TExpressionEvent,
-  meta: AssignMeta<TContext, TExpressionEvent, TEvent>
-) => Partial<TContext>;
+> = (arg: {
+  context: TContext;
+  event: TExpressionEvent;
+  meta: AssignMeta<TContext, TExpressionEvent, TEvent>;
+}) => Partial<TContext>;
 
 export type PartialAssigner<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
   TEvent extends EventObject,
   TKey extends keyof TContext
-> = (
-  context: TContext,
-  event: TExpressionEvent,
-  meta: AssignMeta<TContext, TExpressionEvent, TEvent>
-) => TContext[TKey];
+> = (arg: {
+  context: TContext;
+  event: TExpressionEvent;
+  meta: AssignMeta<TContext, TExpressionEvent, TEvent>;
+}) => TContext[TKey];
 
 export type PropertyAssigner<
   TContext extends MachineContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -104,7 +104,7 @@ export interface BaseDynamicActionObject<
 
   /** @deprecated an internal signature that doesn't exist at runtime. Its existence helps TS to choose a better code path in the inference algorithm  */
   (
-    arg: {
+    args: {
       context: TContext;
       event: TExpressionEvent;
     } & ActionMeta<TContext, TEvent, ParameterizedObject>
@@ -151,7 +151,7 @@ export type ActionFunction<
   TAction extends ParameterizedObject = ParameterizedObject,
   TEvent extends EventObject = TExpressionEvent
 > = (
-  arg: {
+  args: {
     context: TContext;
     event: TExpressionEvent;
   } & ActionMeta<TContext, TEvent, TAction>
@@ -208,23 +208,6 @@ export type BaseActions<
   TAction extends ParameterizedObject
 > = SingleOrArray<BaseAction<TContext, TExpressionEvent, TAction, TEvent>>;
 
-export type BaseActions2<
-  TContext extends MachineContext,
-  TExpressionEvent extends EventObject,
-  TEvent extends EventObject,
-  TAction extends ParameterizedObject
-> = SingleOrArray<
-  | TAction
-  | ((arg: { context: TContext; event: TExpressionEvent }) => void)
-  | BaseDynamicActionObject<
-      TContext,
-      TExpressionEvent,
-      TEvent,
-      any, // TODO: at the very least this should include TAction, but probably at a covariant position or something, we really need to rethink how action objects are typed
-      any
-    >
->;
-
 export type Actions<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
@@ -249,7 +232,7 @@ export type GuardPredicate<
   TContext extends MachineContext,
   TEvent extends EventObject
 > = (
-  arg: {
+  args: {
     context: TContext;
     event: TEvent;
   } & GuardMeta<TContext, TEvent>
@@ -1333,7 +1316,7 @@ export type Assigner<
   TExpressionEvent extends EventObject,
   TEvent extends EventObject = TExpressionEvent
 > = (
-  arg: {
+  args: {
     context: TContext;
     event: TExpressionEvent;
   } & AssignMeta<TContext, TExpressionEvent, TEvent>
@@ -1345,7 +1328,7 @@ export type PartialAssigner<
   TEvent extends EventObject,
   TKey extends keyof TContext
 > = (
-  arg: {
+  args: {
     context: TContext;
     event: TExpressionEvent;
   } & AssignMeta<TContext, TExpressionEvent, TEvent>
@@ -1413,7 +1396,7 @@ export interface DynamicPureActionObject<
 > {
   type: ActionTypes.Pure;
   params: {
-    get: (arg: {
+    get: (args: {
       context: TContext;
       event: TEvent;
     }) =>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -246,11 +246,12 @@ export type StateValue = string | StateValueMap;
 export type GuardPredicate<
   TContext extends MachineContext,
   TEvent extends EventObject
-> = (arg: {
-  context: TContext;
-  event: TEvent;
-  meta: GuardMeta<TContext, TEvent>;
-}) => boolean;
+> = (
+  arg: {
+    context: TContext;
+    event: TEvent;
+  } & GuardMeta<TContext, TEvent>
+) => boolean;
 
 export interface DefaultGuardObject<
   TContext extends MachineContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -103,11 +103,12 @@ export interface BaseDynamicActionObject<
   ) => [AnyState, TResolvedAction];
 
   /** @deprecated an internal signature that doesn't exist at runtime. Its existence helps TS to choose a better code path in the inference algorithm  */
-  (arg: {
-    context: TContext;
-    event: TExpressionEvent;
-    meta: ActionMeta<TContext, TEvent, ParameterizedObject>;
-  }): void;
+  (
+    arg: {
+      context: TContext;
+      event: TExpressionEvent;
+    } & ActionMeta<TContext, TEvent, ParameterizedObject>
+  ): void;
 }
 
 export type MachineContext = Record<string, any>;
@@ -149,11 +150,12 @@ export type ActionFunction<
   TExpressionEvent extends EventObject,
   TAction extends ParameterizedObject = ParameterizedObject,
   TEvent extends EventObject = TExpressionEvent
-> = (arg: {
-  context: TContext;
-  event: TExpressionEvent;
-  meta: ActionMeta<TContext, TEvent, TAction>;
-}) => void;
+> = (
+  arg: {
+    context: TContext;
+    event: TExpressionEvent;
+  } & ActionMeta<TContext, TEvent, TAction>
+) => void;
 
 export interface ChooseCondition<
   TContext extends MachineContext,
@@ -1262,10 +1264,7 @@ export type ExprWithMeta<
   TContext extends MachineContext,
   TEvent extends EventObject,
   T
-  // > = (context: TContext, event: TEvent, meta: StateMeta<TContext, TEvent>) => T;
-> = (
-  args: UnifiedArg<TContext, TEvent> & { meta: StateMeta<TContext, TEvent> }
-) => T;
+> = (args: UnifiedArg<TContext, TEvent> & StateMeta<TContext, TEvent>) => T;
 
 export type SendExpr<
   TContext extends MachineContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1332,22 +1332,24 @@ export type Assigner<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
   TEvent extends EventObject = TExpressionEvent
-> = (arg: {
-  context: TContext;
-  event: TExpressionEvent;
-  meta: AssignMeta<TContext, TExpressionEvent, TEvent>;
-}) => Partial<TContext>;
+> = (
+  arg: {
+    context: TContext;
+    event: TExpressionEvent;
+  } & AssignMeta<TContext, TExpressionEvent, TEvent>
+) => Partial<TContext>;
 
 export type PartialAssigner<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
   TEvent extends EventObject,
   TKey extends keyof TContext
-> = (arg: {
-  context: TContext;
-  event: TExpressionEvent;
-  meta: AssignMeta<TContext, TExpressionEvent, TEvent>;
-}) => TContext[TKey];
+> = (
+  arg: {
+    context: TContext;
+    event: TExpressionEvent;
+  } & AssignMeta<TContext, TExpressionEvent, TEvent>
+) => TContext[TKey];
 
 export type PropertyAssigner<
   TContext extends MachineContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -105,7 +105,7 @@ export interface BaseDynamicActionObject<
   /** @deprecated an internal signature that doesn't exist at runtime. Its existence helps TS to choose a better code path in the inference algorithm  */
   (arg: {
     context: TContext;
-    e: TExpressionEvent;
+    event: TExpressionEvent;
     meta: ActionMeta<TContext, TEvent, ParameterizedObject>;
   }): void;
 }
@@ -246,11 +246,11 @@ export type StateValue = string | StateValueMap;
 export type GuardPredicate<
   TContext extends MachineContext,
   TEvent extends EventObject
-> = (
-  context: TContext,
-  event: TEvent,
-  meta: GuardMeta<TContext, TEvent>
-) => boolean;
+> = (arg: {
+  context: TContext;
+  event: TEvent;
+  meta: GuardMeta<TContext, TEvent>;
+}) => boolean;
 
 export interface DefaultGuardObject<
   TContext extends MachineContext,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1365,7 +1365,7 @@ export type Mapper<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TParams extends {}
-> = (context: TContext, event: TEvent) => TParams;
+> = (args: { context: TContext; event: TEvent }) => TParams;
 
 export type PropertyMapper<
   TContext extends MachineContext,
@@ -1373,7 +1373,7 @@ export type PropertyMapper<
   TParams extends {}
 > = {
   [K in keyof TParams]?:
-    | ((context: TContext, event: TEvent) => TParams[K])
+    | ((args: { context: TContext; event: TEvent }) => TParams[K])
     | TParams[K];
 };
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -238,7 +238,7 @@ export function mapContext<
   _event: SCXML.Event<TEvent>
 ): any {
   if (isFunction(mapper)) {
-    return mapper(context, _event.data);
+    return mapper({ context, event: _event.data });
   }
 
   const result = {} as any;
@@ -247,7 +247,7 @@ export function mapContext<
     const subMapper = mapper[key];
 
     if (isFunction(subMapper)) {
-      result[key] = subMapper(context, _event.data);
+      result[key] = subMapper({ context, event: _event.data });
     } else {
       result[key] = subMapper;
     }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -242,12 +242,13 @@ export function mapContext<
   }
 
   const result = {} as any;
+  const args = { context, event: _event.data };
 
   for (const key of Object.keys(mapper)) {
     const subMapper = mapper[key];
 
     if (isFunction(subMapper)) {
-      result[key] = subMapper({ context, event: _event.data });
+      result[key] = subMapper(args);
     } else {
       result[key] = subMapper;
     }

--- a/packages/core/test/actionCreators.test.ts
+++ b/packages/core/test/actionCreators.test.ts
@@ -59,7 +59,8 @@ describe('action creators', () => {
       >(
         { type: 'RECEIVED' },
         {
-          delay: (ctx, e) => ctx.delay + ('value' in e ? e.value : 0)
+          delay: ({ context, event }) =>
+            context.delay + ('value' in event ? event.value : 0)
         }
       );
 
@@ -77,7 +78,7 @@ describe('action creators', () => {
             _event: {} as any,
             transitions: [],
             children: {}
-          }),
+          }) as any, // TODO: fix
           action,
           actorContext: undefined
         }

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2049,10 +2049,10 @@ describe('action meta', () => {
       },
       {
         actions: {
-          entryAction: ({ meta }) => {
-            expect(meta.state.value).toEqual('foo');
-            expect(meta.action.type).toEqual('entryAction');
-            expect(meta.action.params?.value).toEqual('something');
+          entryAction: ({ state, action }) => {
+            expect(state.value).toEqual('foo');
+            expect(action.type).toEqual('entryAction');
+            expect(action.params?.value).toEqual('something');
             done();
           }
         }
@@ -3314,8 +3314,8 @@ describe('action meta', () => {
     expect.assertions(1);
 
     const machine = createMachine({
-      entry: ({ meta }) => {
-        expect(meta.self.send).toBeDefined();
+      entry: ({ self }) => {
+        expect(self.send).toBeDefined();
       }
     });
 

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2083,35 +2083,35 @@ describe('purely defined actions', () => {
       idle: {
         on: {
           SINGLE: {
-            actions: pure<any, any>((ctx, e) => {
-              if (ctx.items.length > 0) {
+            actions: pure(({ context, event }) => {
+              if (context.items.length > 0) {
                 return {
                   type: 'SINGLE_EVENT',
-                  params: { length: ctx.items.length, id: e.id }
+                  params: { length: context.items.length, id: event.id }
                 };
               }
             })
           },
           NONE: {
-            actions: pure<any, any>((ctx, e) => {
-              if (ctx.items.length > 5) {
+            actions: pure(({ context, event }) => {
+              if (context.items.length > 5) {
                 return {
                   type: 'SINGLE_EVENT',
-                  params: { length: ctx.items.length, id: e.id }
+                  params: { length: context.items.length, id: event.id }
                 };
               }
             })
           },
           EACH: {
-            actions: pure<any, any>((ctx) =>
-              ctx.items.map((item: any, index: number) => ({
+            actions: pure(({ context }) =>
+              context.items.map((item: any, index: number) => ({
                 type: 'EVENT',
                 params: { item, index }
               }))
             )
           },
           AS_STRINGS: {
-            actions: pure<any, any>(() => ['SOME_ACTION'])
+            actions: pure(() => ['SOME_ACTION'])
           }
         }
       }
@@ -2803,13 +2803,8 @@ describe('sendTo', () => {
       context: ({ spawn }) => ({
         child: spawn(childMachine)
       }),
-      entry: pure<
-        {
-          child: ActorRefFrom<typeof childMachine>;
-        },
-        any
-      >((ctx) => {
-        return [sendTo(ctx.child, { type: 'EVENT' })];
+      entry: pure(({ context }) => {
+        return [sendTo(context.child, { type: 'EVENT' })];
       })
     });
 

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1614,7 +1614,7 @@ describe('entry/exit actions', () => {
         id: 'parent',
         context: {},
         exit: assign({
-          actorRef: ({ meta: { spawn } }) => spawn(grandchild)
+          actorRef: ({ spawn }) => spawn(grandchild)
         })
       });
 
@@ -2248,7 +2248,7 @@ describe('forwardTo()', () => {
       states: {
         first: {
           entry: assign({
-            child: ({ meta: { spawn } }) => spawn(child, { id: 'x' })
+            child: ({ spawn }) => spawn(child, { id: 'x' })
           }),
           on: {
             EVENT: {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2178,7 +2178,7 @@ describe('forwardTo()', () => {
           on: {
             EVENT: {
               actions: sendParent({ type: 'SUCCESS' }),
-              guard: (_, e) => e.value === 42
+              guard: ({ event }) => event.value === 42
             }
           }
         }
@@ -2223,7 +2223,7 @@ describe('forwardTo()', () => {
           on: {
             EVENT: {
               actions: sendParent({ type: 'SUCCESS' }),
-              guard: (_, e) => e.value === 42
+              guard: ({ event }) => event.value === 42
             }
           }
         }
@@ -2498,7 +2498,7 @@ describe('choose', () => {
         foo: {
           entry: choose([
             {
-              guard: (ctx) => ctx.counter > 100,
+              guard: ({ context }) => context.counter > 100,
               actions: assign<Ctx>({ answer: 42 })
             }
           ])
@@ -2530,7 +2530,7 @@ describe('choose', () => {
               target: 'bar',
               actions: choose([
                 {
-                  guard: (_, event) => event.counter > 100,
+                  guard: ({ event }) => event.counter > 100,
                   actions: assign({ answer: 42 })
                 }
               ])
@@ -2565,7 +2565,7 @@ describe('choose', () => {
             answering: {
               entry: choose([
                 {
-                  guard: (_, __, { state }) => state.matches('bar'),
+                  guard: ({ meta: { state } }) => state.matches('bar'),
                   actions: assign({ answer: 42 })
                 }
               ])
@@ -3003,7 +3003,7 @@ describe('raise', () => {
         a: {
           on: {
             NEXT: {
-              actions: raise<MachineContext, any>(({ context }) => ({
+              actions: raise(({ context }) => ({
                 type: context.eventType
               }))
             },

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2571,7 +2571,7 @@ describe('choose', () => {
             answering: {
               entry: choose([
                 {
-                  guard: ({ meta: { state } }) => state.matches('bar'),
+                  guard: ({ state }) => state.matches('bar'),
                   actions: assign({ answer: 42 })
                 }
               ])

--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -420,8 +420,8 @@ describe('invocations (activities)', () => {
           },
           on: {
             INC: {
-              actions: assign((ctx) => ({
-                counter: ctx.counter + 1
+              actions: assign(({ context }) => ({
+                counter: context.counter + 1
               }))
             }
           }

--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -415,7 +415,7 @@ describe('invocations (activities)', () => {
             })
           },
           always: {
-            guard: (ctx) => ctx.counter !== 0,
+            guard: ({ context }) => context.counter !== 0,
             target: 'b'
           },
           on: {

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -82,7 +82,7 @@ describe('spawning machines', () => {
       init: {
         entry: [
           assign({
-            server: (_, __, { spawn }) => spawn(serverMachine)
+            server: ({ meta: { spawn } }) => spawn(serverMachine)
           }),
           raise({ type: 'SUCCESS' })
         ],
@@ -141,9 +141,9 @@ describe('spawning machines', () => {
       on: {
         ADD: {
           actions: assign({
-            todoRefs: (ctx, e, { spawn }) => ({
-              ...ctx.todoRefs,
-              [e.id]: spawn(todoMachine)
+            todoRefs: ({ context, event, meta: { spawn } }) => ({
+              ...context.todoRefs,
+              [event.id]: spawn(todoMachine)
             })
           })
         },
@@ -183,7 +183,7 @@ describe('spawning machines', () => {
         states: {
           waiting: {
             entry: assign({
-              ref: (_, __, { spawn }) => spawn('child')
+              ref: ({ meta: { spawn } }) => spawn('child')
             }),
             on: {
               DONE: 'success'
@@ -228,7 +228,7 @@ describe('spawning promises', () => {
       states: {
         idle: {
           entry: assign({
-            promiseRef: (_, __, { spawn }) => {
+            promiseRef: ({ meta: { spawn } }) => {
               const ref = spawn(
                 fromPromise(
                   () =>
@@ -273,7 +273,7 @@ describe('spawning promises', () => {
         states: {
           idle: {
             entry: assign({
-              promiseRef: (_, __, { spawn }) =>
+              promiseRef: ({ meta: { spawn } }) =>
                 spawn('somePromise', { id: 'my-promise' })
             }),
             on: {
@@ -319,7 +319,7 @@ describe('spawning callbacks', () => {
       states: {
         idle: {
           entry: assign({
-            callbackRef: (_, __, { spawn }) =>
+            callbackRef: ({ meta: { spawn } }) =>
               spawn(
                 fromCallback((cb, receive) => {
                   receive((event) => {
@@ -368,7 +368,7 @@ describe('spawning observables', () => {
       states: {
         idle: {
           entry: assign({
-            observableRef: (_, __, { spawn }) => {
+            observableRef: ({ meta: { spawn } }) => {
               const ref = spawn(observableBehavior, { id: 'int' });
 
               return ref;
@@ -405,7 +405,7 @@ describe('spawning observables', () => {
         states: {
           idle: {
             entry: assign({
-              observableRef: (_, __, { spawn }) =>
+              observableRef: ({ meta: { spawn } }) =>
                 spawn('interval', { id: 'int' })
             }),
             on: {
@@ -445,7 +445,7 @@ describe('spawning observables', () => {
       states: {
         idle: {
           entry: assign({
-            observableRef: (_, __, { spawn }) => {
+            observableRef: ({ meta: { spawn } }) => {
               const ref = spawn(observableBehavior, { id: 'int' });
 
               return ref;
@@ -492,7 +492,7 @@ describe('spawning event observables', () => {
       states: {
         idle: {
           entry: assign({
-            observableRef: (_, __, { spawn }) => {
+            observableRef: ({ meta: { spawn } }) => {
               const ref = spawn(eventObservableBehavior, { id: 'int' });
 
               return ref;
@@ -529,7 +529,7 @@ describe('spawning event observables', () => {
         states: {
           idle: {
             entry: assign({
-              observableRef: (_, __, { spawn }) =>
+              observableRef: ({ meta: { spawn } }) =>
                 spawn('interval', { id: 'int' })
             }),
             on: {
@@ -731,9 +731,9 @@ describe('actors', () => {
       states: {
         start: {
           entry: assign({
-            refs: (ctx, _, { spawn }) => {
+            refs: ({ context, meta: { spawn } }) => {
               count++;
-              const c = ctx.items.map((item) =>
+              const c = context.items.map((item) =>
                 spawn(fromPromise(() => new Promise((res) => res(item))))
               );
 
@@ -764,7 +764,7 @@ describe('actors', () => {
       states: {
         bar: {
           entry: assign<TestContext>({
-            promise: (_, __, { spawn }) => {
+            promise: ({ meta: { spawn } }) => {
               return spawn(
                 fromPromise(() => {
                   spawnCounter++;
@@ -838,7 +838,7 @@ describe('actors', () => {
       states: {
         foo: {
           entry: assign({
-            ref: (_, __, { spawn }) =>
+            ref: ({ meta: { spawn } }) =>
               spawn(fromPromise(() => Promise.resolve(42)))
           })
         }
@@ -869,7 +869,7 @@ describe('actors', () => {
           count: undefined
         },
         entry: assign({
-          count: (_, __, { spawn }) => spawn(countBehavior)
+          count: ({ meta: { spawn } }) => spawn(countBehavior)
         }),
         on: {
           INC: {
@@ -898,7 +898,7 @@ describe('actors', () => {
           count: undefined
         },
         entry: assign({
-          count: (_, __, { spawn }) =>
+          count: ({ meta: { spawn } }) =>
             spawn(
               fromPromise(
                 () =>
@@ -992,7 +992,7 @@ describe('actors', () => {
           ponger: undefined
         },
         entry: assign({
-          ponger: (_, __, { spawn }) => spawn(pongBehavior)
+          ponger: ({ meta: { spawn } }) => spawn(pongBehavior)
         }),
         states: {
           waiting: {
@@ -1102,7 +1102,7 @@ describe('actors', () => {
       {
         actions: {
           setup: assign({
-            child: (_, __, { spawn }) => spawn(childMachine)
+            child: ({ meta: { spawn } }) => spawn(childMachine)
           })
         }
       }
@@ -1121,7 +1121,7 @@ describe('actors', () => {
         child: null
       },
       entry: assign({
-        child: (_, __, { spawn }) =>
+        child: ({ meta: { spawn } }) =>
           spawn(fromPromise(() => ({ then: (fn: any) => fn(null) } as any)))
       })
     });
@@ -1147,7 +1147,7 @@ describe('actors', () => {
         child: null
       },
       entry: assign({
-        child: (_, __, { spawn }) =>
+        child: ({ meta: { spawn } }) =>
           spawn(fromObservable(createEmptyObservable))
       })
     });
@@ -1165,7 +1165,7 @@ describe('actors', () => {
         child: null
       },
       entry: assign({
-        child: (_, __, { spawn }) =>
+        child: ({ meta: { spawn } }) =>
           spawn(
             fromObservable(() => EMPTY),
             { id: 'myactor' }

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -82,7 +82,7 @@ describe('spawning machines', () => {
       init: {
         entry: [
           assign({
-            server: ({ meta: { spawn } }) => spawn(serverMachine)
+            server: ({ spawn }) => spawn(serverMachine)
           }),
           raise({ type: 'SUCCESS' })
         ],
@@ -141,7 +141,7 @@ describe('spawning machines', () => {
       on: {
         ADD: {
           actions: assign({
-            todoRefs: ({ context, event, meta: { spawn } }) => ({
+            todoRefs: ({ context, event, spawn }) => ({
               ...context.todoRefs,
               [event.id]: spawn(todoMachine)
             })
@@ -183,7 +183,7 @@ describe('spawning machines', () => {
         states: {
           waiting: {
             entry: assign({
-              ref: ({ meta: { spawn } }) => spawn('child')
+              ref: ({ spawn }) => spawn('child')
             }),
             on: {
               DONE: 'success'
@@ -228,7 +228,7 @@ describe('spawning promises', () => {
       states: {
         idle: {
           entry: assign({
-            promiseRef: ({ meta: { spawn } }) => {
+            promiseRef: ({ spawn }) => {
               const ref = spawn(
                 fromPromise(
                   () =>
@@ -273,7 +273,7 @@ describe('spawning promises', () => {
         states: {
           idle: {
             entry: assign({
-              promiseRef: ({ meta: { spawn } }) =>
+              promiseRef: ({ spawn }) =>
                 spawn('somePromise', { id: 'my-promise' })
             }),
             on: {
@@ -319,7 +319,7 @@ describe('spawning callbacks', () => {
       states: {
         idle: {
           entry: assign({
-            callbackRef: ({ meta: { spawn } }) =>
+            callbackRef: ({ spawn }) =>
               spawn(
                 fromCallback((cb, receive) => {
                   receive((event) => {
@@ -368,7 +368,7 @@ describe('spawning observables', () => {
       states: {
         idle: {
           entry: assign({
-            observableRef: ({ meta: { spawn } }) => {
+            observableRef: ({ spawn }) => {
               const ref = spawn(observableBehavior, { id: 'int' });
 
               return ref;
@@ -405,8 +405,7 @@ describe('spawning observables', () => {
         states: {
           idle: {
             entry: assign({
-              observableRef: ({ meta: { spawn } }) =>
-                spawn('interval', { id: 'int' })
+              observableRef: ({ spawn }) => spawn('interval', { id: 'int' })
             }),
             on: {
               'xstate.snapshot.int': {
@@ -445,7 +444,7 @@ describe('spawning observables', () => {
       states: {
         idle: {
           entry: assign({
-            observableRef: ({ meta: { spawn } }) => {
+            observableRef: ({ spawn }) => {
               const ref = spawn(observableBehavior, { id: 'int' });
 
               return ref;
@@ -492,7 +491,7 @@ describe('spawning event observables', () => {
       states: {
         idle: {
           entry: assign({
-            observableRef: ({ meta: { spawn } }) => {
+            observableRef: ({ spawn }) => {
               const ref = spawn(eventObservableBehavior, { id: 'int' });
 
               return ref;
@@ -529,8 +528,7 @@ describe('spawning event observables', () => {
         states: {
           idle: {
             entry: assign({
-              observableRef: ({ meta: { spawn } }) =>
-                spawn('interval', { id: 'int' })
+              observableRef: ({ spawn }) => spawn('interval', { id: 'int' })
             }),
             on: {
               COUNT: {
@@ -731,7 +729,7 @@ describe('actors', () => {
       states: {
         start: {
           entry: assign({
-            refs: ({ context, meta: { spawn } }) => {
+            refs: ({ context, spawn }) => {
               count++;
               const c = context.items.map((item) =>
                 spawn(fromPromise(() => new Promise((res) => res(item))))
@@ -764,7 +762,7 @@ describe('actors', () => {
       states: {
         bar: {
           entry: assign<TestContext>({
-            promise: ({ meta: { spawn } }) => {
+            promise: ({ spawn }) => {
               return spawn(
                 fromPromise(() => {
                   spawnCounter++;
@@ -838,8 +836,7 @@ describe('actors', () => {
       states: {
         foo: {
           entry: assign({
-            ref: ({ meta: { spawn } }) =>
-              spawn(fromPromise(() => Promise.resolve(42)))
+            ref: ({ spawn }) => spawn(fromPromise(() => Promise.resolve(42)))
           })
         }
       }
@@ -869,7 +866,7 @@ describe('actors', () => {
           count: undefined
         },
         entry: assign({
-          count: ({ meta: { spawn } }) => spawn(countBehavior)
+          count: ({ spawn }) => spawn(countBehavior)
         }),
         on: {
           INC: {
@@ -898,7 +895,7 @@ describe('actors', () => {
           count: undefined
         },
         entry: assign({
-          count: ({ meta: { spawn } }) =>
+          count: ({ spawn }) =>
             spawn(
               fromPromise(
                 () =>
@@ -992,7 +989,7 @@ describe('actors', () => {
           ponger: undefined
         },
         entry: assign({
-          ponger: ({ meta: { spawn } }) => spawn(pongBehavior)
+          ponger: ({ spawn }) => spawn(pongBehavior)
         }),
         states: {
           waiting: {
@@ -1102,7 +1099,7 @@ describe('actors', () => {
       {
         actions: {
           setup: assign({
-            child: ({ meta: { spawn } }) => spawn(childMachine)
+            child: ({ spawn }) => spawn(childMachine)
           })
         }
       }
@@ -1121,7 +1118,7 @@ describe('actors', () => {
         child: null
       },
       entry: assign({
-        child: ({ meta: { spawn } }) =>
+        child: ({ spawn }) =>
           spawn(fromPromise(() => ({ then: (fn: any) => fn(null) } as any)))
       })
     });
@@ -1147,8 +1144,7 @@ describe('actors', () => {
         child: null
       },
       entry: assign({
-        child: ({ meta: { spawn } }) =>
-          spawn(fromObservable(createEmptyObservable))
+        child: ({ spawn }) => spawn(fromObservable(createEmptyObservable))
       })
     });
     const service = interpret(parentMachine);
@@ -1165,7 +1161,7 @@ describe('actors', () => {
         child: null
       },
       entry: assign({
-        child: ({ meta: { spawn } }) =>
+        child: ({ spawn }) =>
           spawn(
             fromObservable(() => EMPTY),
             { id: 'myactor' }

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -245,7 +245,7 @@ describe('spawning promises', () => {
           on: {
             [doneInvoke('my-promise')]: {
               target: 'success',
-              guard: (_, e) => e.data === 'response'
+              guard: ({ event }) => event.data === 'response'
             }
           }
         },
@@ -279,7 +279,7 @@ describe('spawning promises', () => {
             on: {
               [doneInvoke('my-promise')]: {
                 target: 'success',
-                guard: (_, e) => e.data === 'response'
+                guard: ({ event }) => event.data === 'response'
               }
             }
           },
@@ -377,7 +377,7 @@ describe('spawning observables', () => {
           on: {
             'xstate.snapshot.int': {
               target: 'success',
-              guard: (_, e) => e.data === 5
+              guard: ({ event }) => event.data === 5
             }
           }
         },
@@ -411,7 +411,7 @@ describe('spawning observables', () => {
             on: {
               'xstate.snapshot.int': {
                 target: 'success',
-                guard: (_, e) => e.data === 5
+                guard: ({ event }) => event.data === 5
               }
             }
           },
@@ -454,8 +454,10 @@ describe('spawning observables', () => {
           on: {
             'xstate.snapshot.int': {
               target: 'success',
-              guard: (ctx: any, e: any) => {
-                return e.data === 1 && ctx.observableRef.getSnapshot() === 1;
+              guard: ({ context, event }) => {
+                return (
+                  event.data === 1 && context.observableRef.getSnapshot() === 1
+                );
               }
             }
           }
@@ -499,7 +501,7 @@ describe('spawning event observables', () => {
           on: {
             COUNT: {
               target: 'success',
-              guard: (_: any, e: any) => e.val === 5
+              guard: ({ event }) => event.val === 5
             }
           }
         },
@@ -533,7 +535,7 @@ describe('spawning event observables', () => {
             on: {
               COUNT: {
                 target: 'success',
-                guard: (_: any, e: any) => e.val === 5
+                guard: ({ event }) => event.val === 5
               }
             }
           },
@@ -913,7 +915,7 @@ describe('actors', () => {
             on: {
               'done.invoke.test': {
                 target: 'success',
-                guard: (_, e) => e.data === 42
+                guard: ({ event }) => event.data === 42
               }
             }
           },
@@ -951,8 +953,8 @@ describe('actors', () => {
             on: {
               [error('test')]: {
                 target: 'success',
-                guard: (_, e) => {
-                  return e.data === errorMessage;
+                guard: ({ event }) => {
+                  return event.data === errorMessage;
                 }
               }
             }
@@ -971,7 +973,7 @@ describe('actors', () => {
 
     it('behaviors should have reference to the parent', (done) => {
       const pongBehavior: ActorBehavior<EventObject, undefined> = {
-        transition: (_, event, { self }) => {
+        transition: (_state, event, { self }) => {
           const _event = toSCXMLEvent(event);
           if (_event.name === 'PING') {
             self._parent?.send({ type: 'PONG' });

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -92,7 +92,7 @@ describe('spawning machines', () => {
       },
       sendPing: {
         entry: [
-          sendTo((ctx) => ctx.server!, { type: 'PING' }),
+          sendTo(({ context }) => context.server!, { type: 'PING' }),
           raise({ type: 'SUCCESS' })
         ],
         on: {
@@ -149,8 +149,10 @@ describe('spawning machines', () => {
         },
         SET_COMPLETE: {
           actions: sendTo(
-            (ctx, e: Extract<TodoEvent, { type: 'SET_COMPLETE' }>) => {
-              return ctx.todoRefs[e.id];
+            ({ context, event }) => {
+              return context.todoRefs[
+                (event as Extract<TodoEvent, { type: 'SET_COMPLETE' }>).id
+              ];
             },
             { type: 'SET_COMPLETE' }
           )
@@ -332,7 +334,9 @@ describe('spawning callbacks', () => {
           }),
           on: {
             START_CB: {
-              actions: sendTo((ctx) => ctx.callbackRef!, { type: 'START' })
+              actions: sendTo(({ context }) => context.callbackRef!, {
+                type: 'START'
+              })
             },
             SEND_BACK: 'success'
           }
@@ -590,7 +594,9 @@ describe('communicating with spawned actors', () => {
           },
           after: {
             100: {
-              actions: sendTo((ctx) => ctx.existingRef!, { type: 'ACTIVATE' })
+              actions: sendTo(({ context }) => context.existingRef!, {
+                type: 'ACTIVATE'
+              })
             }
           }
         },
@@ -686,7 +692,9 @@ describe('communicating with spawned actors', () => {
           },
           after: {
             100: {
-              actions: sendTo((ctx) => ctx.existingRef, { type: 'ACTIVATE' })
+              actions: sendTo(({ context }) => context.existingRef, {
+                type: 'ACTIVATE'
+              })
             }
           }
         },
@@ -863,7 +871,7 @@ describe('actors', () => {
         }),
         on: {
           INC: {
-            actions: forwardTo((ctx) => ctx.count!)
+            actions: forwardTo(({ context }) => context.count!)
           }
         }
       });
@@ -986,7 +994,7 @@ describe('actors', () => {
         }),
         states: {
           waiting: {
-            entry: sendTo((ctx) => ctx.ponger!, { type: 'PING' }),
+            entry: sendTo(({ context }) => context.ponger!, { type: 'PING' }),
             invoke: {
               id: 'ponger',
               src: pongBehavior

--- a/packages/core/test/after.test.ts
+++ b/packages/core/test/after.test.ts
@@ -212,7 +212,7 @@ describe('delayed transitions', () => {
           inactive: {
             after: [
               {
-                delay: (ctx) => ctx.delay,
+                delay: ({ context }) => context.delay,
                 target: 'active'
               }
             ],
@@ -241,7 +241,8 @@ describe('delayed transitions', () => {
       },
       {
         delays: {
-          someDelay: (ctx, event) => ctx.delay + (event as any).delay
+          someDelay: ({ context, event }) =>
+            context.delay + (event as any).delay
         }
       }
     );

--- a/packages/core/test/assign.test.ts
+++ b/packages/core/test/assign.test.ts
@@ -23,8 +23,8 @@ const createCounterMachine = (context: Partial<CounterContext> = {}) =>
           INC: [
             {
               target: 'counting',
-              actions: assign((ctx) => ({
-                count: ctx.count + 1
+              actions: assign(({ context }) => ({
+                count: context.count + 1
               }))
             }
           ],
@@ -33,7 +33,7 @@ const createCounterMachine = (context: Partial<CounterContext> = {}) =>
               target: 'counting',
               actions: [
                 assign({
-                  count: (ctx) => ctx.count - 1
+                  count: ({ context }) => context.count - 1
                 })
               ]
             }
@@ -247,7 +247,7 @@ describe('assign', () => {
           on: {
             INC: {
               actions: assign({
-                count: (_, event) => event.value
+                count: ({ event }) => event.value
               })
             }
           }
@@ -269,7 +269,7 @@ describe('assign meta', () => {
     states: {
       start: {
         entry: assign({
-          count: (_, __, { state }) => {
+          count: ({ meta: { state } }) => {
             return state === undefined ? 1 : -1;
           }
         }),
@@ -278,20 +278,20 @@ describe('assign meta', () => {
           NEXT: {
             target: 'two',
             actions: assign({
-              count: (_, __, { state }) => {
+              count: ({ meta: { state } }) => {
                 return state ? state.meta['assign.start'].test : -1;
               }
             })
           },
           NEXT_FN: {
             target: 'two',
-            actions: assign((_, __, { state }) => ({
+            actions: assign(({ meta: { state } }) => ({
               count: state ? state.meta['assign.start'].test : -1
             }))
           },
           NEXT_ASSIGNER: {
             target: 'two',
-            actions: assign((_, __, { action }) => ({
+            actions: assign(({ meta: { action } }) => ({
               count: action.params?.assignment ? 5 : -1
             }))
           }
@@ -337,7 +337,7 @@ describe('assign meta', () => {
       states: {
         start: {
           entry: assign({
-            count: (_, __, { state }) => {
+            count: ({ meta: { state } }) => {
               receivedCount = state.context.count;
               return 0;
             }
@@ -356,8 +356,8 @@ describe('assign meta', () => {
       eventLog: Array<{ event: string; origin?: ActorRef<any> }>;
     }
 
-    const assignEventLog = assign<Ctx>((ctx, event, meta) => ({
-      eventLog: ctx.eventLog.concat({
+    const assignEventLog = assign<Ctx>(({ context, event, meta }) => ({
+      eventLog: context.eventLog.concat({
         event: event.type,
         origin: meta._event.origin
       })
@@ -448,10 +448,10 @@ describe('assign meta', () => {
         },
         {
           actions: {
-            inc: assign((_, __, { action }) => {
+            inc: assign(({ context, meta: { action } }) => {
               expect(action).toEqual({ type: 'inc', params: { value: 5 } });
               done();
-              return _;
+              return context;
             })
           }
         }

--- a/packages/core/test/assign.test.ts
+++ b/packages/core/test/assign.test.ts
@@ -269,7 +269,7 @@ describe('assign meta', () => {
     states: {
       start: {
         entry: assign({
-          count: ({ meta: { state } }) => {
+          count: ({ state }) => {
             return state === undefined ? 1 : -1;
           }
         }),
@@ -278,20 +278,20 @@ describe('assign meta', () => {
           NEXT: {
             target: 'two',
             actions: assign({
-              count: ({ meta: { state } }) => {
+              count: ({ state }) => {
                 return state ? state.meta['assign.start'].test : -1;
               }
             })
           },
           NEXT_FN: {
             target: 'two',
-            actions: assign(({ meta: { state } }) => ({
+            actions: assign(({ state }) => ({
               count: state ? state.meta['assign.start'].test : -1
             }))
           },
           NEXT_ASSIGNER: {
             target: 'two',
-            actions: assign(({ meta: { action } }) => ({
+            actions: assign(({ action }) => ({
               count: action.params?.assignment ? 5 : -1
             }))
           }
@@ -337,7 +337,7 @@ describe('assign meta', () => {
       states: {
         start: {
           entry: assign({
-            count: ({ meta: { state } }) => {
+            count: ({ state }) => {
               receivedCount = state.context.count;
               return 0;
             }
@@ -356,10 +356,10 @@ describe('assign meta', () => {
       eventLog: Array<{ event: string; origin?: ActorRef<any> }>;
     }
 
-    const assignEventLog = assign<Ctx>(({ context, event, meta }) => ({
+    const assignEventLog = assign<Ctx>(({ context, event, _event }) => ({
       eventLog: context.eventLog.concat({
         event: event.type,
-        origin: meta._event.origin
+        origin: _event.origin
       })
     }));
 
@@ -448,7 +448,7 @@ describe('assign meta', () => {
         },
         {
           actions: {
-            inc: assign(({ context, meta: { action } }) => {
+            inc: assign(({ context, action }) => {
               expect(action).toEqual({ type: 'inc', params: { value: 5 } });
               done();
               return context;

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -31,7 +31,7 @@ describe('SCXML events', () => {
           on: {
             EVENT: {
               target: 'success',
-              guard: ({ meta: { _event } }: any) => {
+              guard: ({ _event }) => {
                 return !!_event.origin;
               }
             }

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -152,9 +152,9 @@ describe('SCXML events', () => {
           on: {
             CODE: {
               actions: sendTo(
-                (_ctx, ev) => {
-                  expect(ev.sender).toBeDefined();
-                  return ev.sender;
+                ({ event }) => {
+                  expect(event.sender).toBeDefined();
+                  return event.sender;
                 },
                 { type: 'TOKEN' },
                 { delay: 10 }
@@ -177,7 +177,7 @@ describe('SCXML events', () => {
             id: 'auth-server',
             src: authServerMachine
           },
-          entry: sendTo('auth-server', (_ctx, _ev, { self }) => ({
+          entry: sendTo('auth-server', ({ meta: { self } }) => ({
             type: 'CODE',
             sender: self
           })),

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -62,7 +62,7 @@ describe('SCXML events', () => {
             EVENT: {
               target: 'success',
               actions: assign({
-                childOrigin: (_, __, { _event }) => {
+                childOrigin: ({ meta: { _event } }) => {
                   return _event.origin?.id;
                 }
               })
@@ -248,7 +248,7 @@ const authMachine = createMachine<SignInContext, ChangePassword>(
   {
     actions: {
       assignPassword: assign<SignInContext, ChangePassword>({
-        password: (_, event) => event.password
+        password: ({ event }) => event.password
       })
     }
   }

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -31,7 +31,7 @@ describe('SCXML events', () => {
           on: {
             EVENT: {
               target: 'success',
-              guard: (_: any, __: any, { _event }: any) => {
+              guard: ({ meta: { _event } }: any) => {
                 return !!_event.origin;
               }
             }
@@ -232,7 +232,7 @@ const authMachine = createMachine<SignInContext, ChangePassword>(
         on: {
           changePassword: [
             {
-              guard: (_, event) => event.password.length >= 10,
+              guard: ({ event }) => event.password.length >= 10,
               target: '.invalid',
               actions: ['assignPassword']
             },

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -62,7 +62,7 @@ describe('SCXML events', () => {
             EVENT: {
               target: 'success',
               actions: assign({
-                childOrigin: ({ meta: { _event } }) => {
+                childOrigin: ({ _event }) => {
                   return _event.origin?.id;
                 }
               })

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -177,7 +177,7 @@ describe('SCXML events', () => {
             id: 'auth-server',
             src: authServerMachine
           },
-          entry: sendTo('auth-server', ({ meta: { self } }) => ({
+          entry: sendTo('auth-server', ({ self }) => ({
             type: 'CODE',
             sender: self
           })),

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -175,7 +175,7 @@ describe('final states', () => {
           onDone: {
             target: 'success',
             actions: assign<Ctx, AnyEventObject>({
-              revealedSecret: (_, event) => {
+              revealedSecret: ({ event }) => {
                 return event.data.secret;
               }
             })

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -33,7 +33,7 @@ const finalMachine = createMachine({
             }
           },
           onDone: {
-            guard: (_, e) => e.data.signal === 'stop',
+            guard: ({ event }) => event.data.signal === 'stop',
             actions: 'stopCrosswalk1'
           }
         },

--- a/packages/core/test/fixtures/factorial.ts
+++ b/packages/core/test/fixtures/factorial.ts
@@ -11,11 +11,11 @@ const factorialMachine = createMachine<{ n: number; fac: number }>({
         ITERATE: [
           {
             target: 'iteration',
-            guard: ({ context: xs }) => xs.n > 0,
+            guard: ({ context }) => context.n > 0,
             actions: [
               assign({
-                fac: (xs) => xs.n * xs.fac,
-                n: (xs) => xs.n - 1
+                fac: ({ context }) => context.n * context.fac,
+                n: ({ context }) => context.n - 1
               })
             ]
           },
@@ -24,7 +24,7 @@ const factorialMachine = createMachine<{ n: number; fac: number }>({
       }
     },
     done: {
-      entry: [({ context: xs }) => console.log(`The answer is ${xs.fac}`)]
+      entry: [({ context }) => console.log(`The answer is ${context.fac}`)]
     }
   }
 });
@@ -39,14 +39,14 @@ const testMachine = createMachine<{ count: number }>({
         ADD: [
           {
             target: 'one',
-            guard: ({ context: xs }) => xs.count === 1
+            guard: ({ context }) => context.count === 1
           },
           {
             target: 'init',
-            guard: ({ context: xs }) => xs.count % 2 === 0,
+            guard: ({ context }) => context.count % 2 === 0,
             actions: [
               assign({
-                count: (xs) => xs.count / 2
+                count: ({ context }) => context.count / 2
               })
             ]
           },
@@ -54,7 +54,7 @@ const testMachine = createMachine<{ count: number }>({
             target: 'init',
             actions: [
               assign({
-                count: (xs) => xs.count * 3 + 1
+                count: ({ context }) => context.count * 3 + 1
               })
             ]
           }

--- a/packages/core/test/fixtures/factorial.ts
+++ b/packages/core/test/fixtures/factorial.ts
@@ -11,7 +11,7 @@ const factorialMachine = createMachine<{ n: number; fac: number }>({
         ITERATE: [
           {
             target: 'iteration',
-            guard: (xs) => xs.n > 0,
+            guard: ({ context: xs }) => xs.n > 0,
             actions: [
               assign({
                 fac: (xs) => xs.n * xs.fac,
@@ -24,7 +24,7 @@ const factorialMachine = createMachine<{ n: number; fac: number }>({
       }
     },
     done: {
-      entry: [(xs) => console.log(`The answer is ${xs.fac}`)]
+      entry: [({ context: xs }) => console.log(`The answer is ${xs.fac}`)]
     }
   }
 });
@@ -39,11 +39,11 @@ const testMachine = createMachine<{ count: number }>({
         ADD: [
           {
             target: 'one',
-            guard: (xs) => xs.count === 1
+            guard: ({ context: xs }) => xs.count === 1
           },
           {
             target: 'init',
-            guard: (xs) => xs.count % 2 === 0,
+            guard: ({ context: xs }) => xs.count % 2 === 0,
             actions: [
               assign({
                 count: (xs) => xs.count / 2

--- a/packages/core/test/fixtures/omni.ts
+++ b/packages/core/test/fixtures/omni.ts
@@ -63,15 +63,26 @@ const omniMachine = createMachine({
             two: {
               after: {
                 2000: [
-                  { target: 'three', guard: (ctx) => ctx.count === 3 },
-                  { target: 'four', guard: (ctx) => ctx.count === 4 },
+                  {
+                    target: 'three',
+                    guard: ({ context }) => context.count === 3
+                  },
+                  {
+                    target: 'four',
+                    guard: ({ context }) => context.count === 4
+                  },
                   { target: 'one' }
                 ]
               }
             },
             three: {
               after: {
-                1000: [{ target: 'one', guard: (ctx) => ctx.count === -1 }],
+                1000: [
+                  {
+                    target: 'one',
+                    guard: ({ context }) => context.count === -1
+                  }
+                ],
                 2000: 'four'
               }
             },
@@ -86,8 +97,11 @@ const omniMachine = createMachine({
             },
             transientCond: {
               always: [
-                { target: 'two', guard: (ctx) => ctx.count === 2 },
-                { target: 'three', guard: (ctx) => ctx.count === 3 },
+                { target: 'two', guard: ({ context }) => context.count === 2 },
+                {
+                  target: 'three',
+                  guard: ({ context }) => context.count === 3
+                },
                 { target: 'one' }
               ]
             },

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -23,16 +23,17 @@ describe('guard conditions', () => {
             TIMER: [
               {
                 target: 'green',
-                guard: ({ elapsed }) => elapsed < 100
+                guard: ({ context: { elapsed } }) => elapsed < 100
               },
               {
                 target: 'yellow',
-                guard: ({ elapsed }) => elapsed >= 100 && elapsed < 200
+                guard: ({ context: { elapsed } }) =>
+                  elapsed >= 100 && elapsed < 200
               }
             ],
             EMERGENCY: {
               target: 'red',
-              guard: (_, event) => !!event.isEmergency
+              guard: ({ event }) => !!event.isEmergency
             }
           }
         },
@@ -62,7 +63,8 @@ describe('guard conditions', () => {
     },
     {
       guards: {
-        minTimeElapsed: ({ elapsed }) => elapsed >= 100 && elapsed < 200
+        minTimeElapsed: ({ context: { elapsed } }) =>
+          elapsed >= 100 && elapsed < 200
       }
     }
   );
@@ -222,29 +224,26 @@ describe('guard conditions', () => {
             always: [
               {
                 target: 'B4',
-                guard: (_state, _event, { state: s }) => s.matches('A.A4')
+                guard: ({ meta: { state: s } }) => s.matches('A.A4')
               }
             ],
             on: {
               T1: [
                 {
                   target: 'B1',
-                  guard: (_state: any, _event: any, { state: s }: any) =>
-                    s.matches('A.A1')
+                  guard: ({ meta: { state: s } }) => s.matches('A.A1')
                 }
               ],
               T2: [
                 {
                   target: 'B2',
-                  guard: (_state: any, _event: any, { state: s }: any) =>
-                    s.matches('A.A2')
+                  guard: ({ meta: { state: s } }) => s.matches('A.A2')
                 }
               ],
               T3: [
                 {
                   target: 'B3',
-                  guard: (_state: any, _event: any, { state: s }: any) =>
-                    s.matches('A.A3')
+                  guard: ({ meta: { state: s } }) => s.matches('A.A3')
                 }
               ]
             }
@@ -299,8 +298,7 @@ describe('guard conditions', () => {
           tags: 'theTag',
           on: {
             MICRO: {
-              guard: (_ctx: any, _event: any, { state }: any) =>
-                state.hasTag('theTag'),
+              guard: ({ meta: { state } }) => state.hasTag('theTag'),
               target: 'c'
             }
           }
@@ -348,10 +346,12 @@ describe('custom guards', () => {
     },
     {
       guards: {
-        custom: (ctx, e: Extract<Events, { type: 'EVENT' }>, meta) => {
+        custom: ({ context, event, meta }) => {
           const { prop, compare, op } = meta.guard.params;
           if (op === 'greaterThan') {
-            return ctx[prop as keyof typeof ctx] + e.value > compare;
+            return (
+              context[prop as keyof typeof context] + event.value > compare
+            );
           }
 
           return false;
@@ -497,7 +497,7 @@ describe('guards with child guards', () => {
                     },
                     { type: 'customGuard' }
                   ],
-                  predicate: (_: any, __: any, { guard }: any) => {
+                  predicate: ({ meta: { guard } }) => {
                     expect(guard.children).toHaveLength(2);
                     expect(
                       guard.children?.find(
@@ -594,7 +594,7 @@ describe('not() guard', () => {
       },
       {
         guards: {
-          greaterThan10: (_, __, { guard }) => {
+          greaterThan10: ({ meta: { guard } }) => {
             return guard.params.value > 10;
           }
         }
@@ -707,7 +707,7 @@ describe('and() guard', () => {
       },
       {
         guards: {
-          greaterThan10: (_, __, { guard }) => {
+          greaterThan10: ({ meta: { guard } }) => {
             return guard.params.value > 10;
           }
         }
@@ -825,7 +825,7 @@ describe('or() guard', () => {
       },
       {
         guards: {
-          greaterThan10: (_, __, { guard }) => {
+          greaterThan10: ({ meta: { guard } }) => {
             return guard.params.value > 10;
           }
         }

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -224,26 +224,26 @@ describe('guard conditions', () => {
             always: [
               {
                 target: 'B4',
-                guard: ({ meta: { state: s } }) => s.matches('A.A4')
+                guard: ({ state }) => state.matches('A.A4')
               }
             ],
             on: {
               T1: [
                 {
                   target: 'B1',
-                  guard: ({ meta: { state: s } }) => s.matches('A.A1')
+                  guard: ({ state }) => state.matches('A.A1')
                 }
               ],
               T2: [
                 {
                   target: 'B2',
-                  guard: ({ meta: { state: s } }) => s.matches('A.A2')
+                  guard: ({ state }) => state.matches('A.A2')
                 }
               ],
               T3: [
                 {
                   target: 'B3',
-                  guard: ({ meta: { state: s } }) => s.matches('A.A3')
+                  guard: ({ state }) => state.matches('A.A3')
                 }
               ]
             }
@@ -298,7 +298,7 @@ describe('guard conditions', () => {
           tags: 'theTag',
           on: {
             MICRO: {
-              guard: ({ meta: { state } }) => state.hasTag('theTag'),
+              guard: ({ state }) => state.hasTag('theTag'),
               target: 'c'
             }
           }
@@ -346,8 +346,8 @@ describe('custom guards', () => {
     },
     {
       guards: {
-        custom: ({ context, event, meta }) => {
-          const { prop, compare, op } = meta.guard.params;
+        custom: ({ context, event, guard }) => {
+          const { prop, compare, op } = guard.params;
           if (op === 'greaterThan') {
             return (
               context[prop as keyof typeof context] + event.value > compare
@@ -497,7 +497,7 @@ describe('guards with child guards', () => {
                     },
                     { type: 'customGuard' }
                   ],
-                  predicate: ({ meta: { guard } }) => {
+                  predicate: ({ guard }) => {
                     expect(guard.children).toHaveLength(2);
                     expect(
                       guard.children?.find(
@@ -594,7 +594,7 @@ describe('not() guard', () => {
       },
       {
         guards: {
-          greaterThan10: ({ meta: { guard } }) => {
+          greaterThan10: ({ guard }) => {
             return guard.params.value > 10;
           }
         }
@@ -707,7 +707,7 @@ describe('and() guard', () => {
       },
       {
         guards: {
-          greaterThan10: ({ meta: { guard } }) => {
+          greaterThan10: ({ guard }) => {
             return guard.params.value > 10;
           }
         }
@@ -825,7 +825,7 @@ describe('or() guard', () => {
       },
       {
         guards: {
-          greaterThan10: ({ meta: { guard } }) => {
+          greaterThan10: ({ guard }) => {
             return guard.params.value > 10;
           }
         }

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -101,7 +101,7 @@ describe('input', () => {
     });
 
     const machine = createMachine({
-      entry: assign((_ctx, _ev, { spawn }) => {
+      entry: assign(({ meta: { spawn } }) => {
         return {
           ref: spawn(spawnedMachine, { input: { greeting: 'hello' } })
         };
@@ -281,7 +281,7 @@ describe('input', () => {
 
     const machine = createMachine(
       {
-        entry: assign((_ctx, _ev, { spawn }) => ({
+        entry: assign(({ meta: { spawn } }) => ({
           childRef: spawn('child')
         }))
       },
@@ -340,7 +340,7 @@ describe('input', () => {
 
     const machine = createMachine(
       {
-        entry: assign((_ctx, _ev, { spawn }) => ({
+        entry: assign(({ meta: { spawn } }) => ({
           childRef: spawn('child', { input: 100 })
         }))
       },
@@ -384,7 +384,7 @@ describe('input', () => {
 
     const machine = createMachine(
       {
-        entry: assign((_ctx, _ev, { spawn }) => ({
+        entry: assign(({ meta: { spawn } }) => ({
           childRef: spawn('child')
         }))
       },

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -16,8 +16,8 @@ describe('input', () => {
       context: ({ input }) => ({
         count: input.startCount
       }),
-      entry: (ctx) => {
-        spy(ctx.count);
+      entry: ({ context }) => {
+        spy(context.count);
       }
     });
 
@@ -28,8 +28,8 @@ describe('input', () => {
 
   it('initial event should have input property', (done) => {
     const machine = createMachine({
-      entry: (_, ev) => {
-        expect(ev.input.greeting).toBe('hello');
+      entry: ({ event }) => {
+        expect(event.input.greeting).toBe('hello');
         done();
       }
     });
@@ -76,8 +76,8 @@ describe('input', () => {
 
   it('should provide input data to invoked machines', (done) => {
     const invokedMachine = createMachine({
-      entry: (_, ev) => {
-        expect(ev.input.greeting).toBe('hello');
+      entry: ({ event }) => {
+        expect(event.input.greeting).toBe('hello');
         done();
       }
     });
@@ -94,8 +94,8 @@ describe('input', () => {
 
   it('should provide input data to spawned machines', (done) => {
     const spawnedMachine = createMachine({
-      entry: (_, ev) => {
-        expect(ev.input.greeting).toBe('hello');
+      entry: ({ event }) => {
+        expect(event.input.greeting).toBe('hello');
         done();
       }
     });

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -101,7 +101,7 @@ describe('input', () => {
     });
 
     const machine = createMachine({
-      entry: assign(({ meta: { spawn } }) => {
+      entry: assign(({ spawn }) => {
         return {
           ref: spawn(spawnedMachine, { input: { greeting: 'hello' } })
         };
@@ -281,7 +281,7 @@ describe('input', () => {
 
     const machine = createMachine(
       {
-        entry: assign(({ meta: { spawn } }) => ({
+        entry: assign(({ spawn }) => ({
           childRef: spawn('child')
         }))
       },
@@ -340,7 +340,7 @@ describe('input', () => {
 
     const machine = createMachine(
       {
-        entry: assign(({ meta: { spawn } }) => ({
+        entry: assign(({ spawn }) => ({
           childRef: spawn('child', { input: 100 })
         }))
       },
@@ -384,7 +384,7 @@ describe('input', () => {
 
     const machine = createMachine(
       {
-        entry: assign(({ meta: { spawn } }) => ({
+        entry: assign(({ spawn }) => ({
           childRef: spawn('child')
         }))
       },

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -198,7 +198,9 @@ describe('input', () => {
       {
         invoke: {
           src: 'child',
-          input: (_, { input }) => input + 100
+          input: ({ event }) => {
+            return event.input + 100;
+          }
         }
       },
       {
@@ -265,7 +267,7 @@ describe('input', () => {
                 return {};
               }
             }),
-            input: (_, { input }) => input + 100
+            input: ({ event }) => event.input + 100
           }
         }
       }
@@ -294,7 +296,7 @@ describe('input', () => {
                 return {};
               }
             }),
-            input: (_, { input }) => input + 100
+            input: ({ event }) => event.input + 100
           }
         }
       }
@@ -370,7 +372,7 @@ describe('input', () => {
     const machine = createMachine({
       invoke: {
         src: createMachine({}),
-        input: (_, __, { self }) => spy(self)
+        input: ({ self }) => spy(self)
       }
     });
 
@@ -392,7 +394,7 @@ describe('input', () => {
         actors: {
           child: {
             src: createMachine({}),
-            input: (_, __, { self }) => spy(self)
+            input: ({ self }) => spy(self)
           }
         }
       }

--- a/packages/core/test/internalTransitions.test.ts
+++ b/packages/core/test/internalTransitions.test.ts
@@ -164,20 +164,20 @@ describe('internal transitions', () => {
         a1: {
           initial: 'a11',
           entry: assign({
-            sourceStateEntries: (ctx) => ctx.sourceStateEntries + 1
+            sourceStateEntries: ({ context }) => context.sourceStateEntries + 1
           }),
           states: {
             a11: {
               initial: 'a111',
               entry: assign({
-                directDescendantEntries: (ctx) =>
-                  ctx.directDescendantEntries + 1
+                directDescendantEntries: ({ context }) =>
+                  context.directDescendantEntries + 1
               }),
               states: {
                 a111: {
                   entry: assign({
-                    deepDescendantEntries: (ctx) =>
-                      ctx.deepDescendantEntries + 1
+                    deepDescendantEntries: ({ context }) =>
+                      context.deepDescendantEntries + 1
                   })
                 }
               }
@@ -217,18 +217,20 @@ describe('internal transitions', () => {
         a1: {
           initial: 'a11',
           exit: assign({
-            sourceStateExits: (ctx) => ctx.sourceStateExits + 1
+            sourceStateExits: ({ context }) => context.sourceStateExits + 1
           }),
           states: {
             a11: {
               initial: 'a111',
               exit: assign({
-                directDescendantExits: (ctx) => ctx.directDescendantExits + 1
+                directDescendantExits: ({ context }) =>
+                  context.directDescendantExits + 1
               }),
               states: {
                 a111: {
                   exit: assign({
-                    deepDescendantExits: (ctx) => ctx.deepDescendantExits + 1
+                    deepDescendantExits: ({ context }) =>
+                      context.deepDescendantExits + 1
                   })
                 }
               }

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -72,7 +72,7 @@ describe('interpreter', () => {
         states: {
           idle: {
             entry: assign({
-              actor: ({ meta: { spawn } }) => {
+              actor: ({ spawn }) => {
                 return spawn(
                   fromPromise(
                     () =>
@@ -1723,8 +1723,7 @@ describe('interpreter', () => {
         initial: 'idle',
         context: {},
         entry: assign({
-          firstNameRef: ({ meta: { spawn } }) =>
-            spawn(childMachine, { id: 'child' })
+          firstNameRef: ({ spawn }) => spawn(childMachine, { id: 'child' })
         }),
         states: {
           idle: {}
@@ -1756,9 +1755,9 @@ describe('interpreter', () => {
           observableRef: ActorRef<any, any>;
         },
         entry: assign({
-          machineRef: ({ meta: { spawn } }) =>
+          machineRef: ({ spawn }) =>
             spawn(childMachine, { id: 'machineChild' }),
-          promiseRef: ({ meta: { spawn } }) =>
+          promiseRef: ({ spawn }) =>
             spawn(
               fromPromise(
                 () =>
@@ -1768,7 +1767,7 @@ describe('interpreter', () => {
               ),
               { id: 'promiseChild' }
             ),
-          observableRef: ({ meta: { spawn } }) =>
+          observableRef: ({ spawn }) =>
             spawn(
               fromObservable(() => interval(1000)),
               { id: 'observableChild' }

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -361,7 +361,7 @@ describe('interpreter', () => {
             entry: send(
               { type: 'FINISH' },
               {
-                delay: ({ context, meta: { _event } }) =>
+                delay: ({ context, _event }) =>
                   context.initialDelay +
                   (
                     _event.data as Extract<
@@ -827,9 +827,9 @@ describe('interpreter', () => {
 
   it('should be able to log event origin (log action)', () => {
     const logs: any[] = [];
-    const logAction = log(({ event, meta }) => ({
+    const logAction = log(({ event, _event }) => ({
       event: event.type,
-      origin: meta._event.origin
+      origin: _event.origin
     }));
 
     const childMachine = createMachine({
@@ -900,7 +900,7 @@ describe('interpreter', () => {
 
   it('should receive correct _event (log action)', () => {
     const logs: any[] = [];
-    const logAction = log(({ meta }) => meta._event.data.type);
+    const logAction = log(({ _event }) => _event.data.type);
 
     const parentMachine = createMachine({
       initial: 'foo',

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -7,7 +7,6 @@ import {
   send,
   sendParent,
   StateValue,
-  AnyEventObject,
   createMachine,
   AnyState,
   InterpreterStatus,
@@ -954,7 +953,7 @@ describe('interpreter', () => {
           on: {
             NEXT: {
               target: 'finish',
-              guard: (_, e) => e.password === 'foo'
+              guard: ({ event }) => event.password === 'foo'
             }
           }
         },
@@ -1033,7 +1032,7 @@ describe('interpreter', () => {
             on: {
               NEXT: {
                 target: 'finish',
-                guard: (_, e) => e.password === 'foo'
+                guard: ({ event }) => event.password === 'foo'
               }
             }
           },
@@ -1064,7 +1063,7 @@ describe('interpreter', () => {
           on: {
             EVENT: {
               target: 'active',
-              guard: (_: any, e: any) => e.id === 42 // TODO: fix unknown event type
+              guard: ({ event }) => event.id === 42 // TODO: fix unknown event type
             },
             ACTIVATE: 'active'
           }
@@ -1414,7 +1413,7 @@ describe('interpreter', () => {
           },
           always: {
             target: 'finished',
-            guard: (ctx) => ctx.count >= 5
+            guard: ({ context }) => context.count >= 5
           }
         },
         finished: {
@@ -1468,7 +1467,7 @@ describe('interpreter', () => {
           active: {
             always: {
               target: 'finished',
-              guard: (ctx) => ctx.count >= 5
+              guard: ({ context }) => context.count >= 5
             },
             on: {
               INC: {
@@ -1639,8 +1638,8 @@ describe('interpreter', () => {
               onDone: [
                 {
                   target: 'success',
-                  guard: (_, e) => {
-                    return e.data === 42;
+                  guard: ({ event }) => {
+                    return event.data === 42;
                   }
                 },
                 { target: 'failure' }
@@ -1685,8 +1684,8 @@ describe('interpreter', () => {
               src: fromObservable(() => interval$),
               onSnapshot: {
                 target: 'success',
-                guard: (_: unknown, e: AnyEventObject) => {
-                  return e.data === 3;
+                guard: ({ event }) => {
+                  return event.data === 3;
                 }
               }
             }

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -72,7 +72,7 @@ describe('interpreter', () => {
         states: {
           idle: {
             entry: assign({
-              actor: (_, __, { spawn }) => {
+              actor: ({ meta: { spawn } }) => {
                 return spawn(
                   fromPromise(
                     () =>
@@ -805,7 +805,7 @@ describe('interpreter', () => {
           on: {
             LOG: {
               actions: [
-                assign({ count: (ctx) => ctx.count + 1 }),
+                assign({ count: ({ context }) => context.count + 1 }),
                 log(({ context }) => context)
               ]
             }
@@ -1408,7 +1408,7 @@ describe('interpreter', () => {
           after: {
             10: {
               target: 'active',
-              actions: assign({ count: (ctx) => ctx.count + 1 })
+              actions: assign({ count: ({ context }) => context.count + 1 })
             }
           },
           always: {
@@ -1471,7 +1471,7 @@ describe('interpreter', () => {
             },
             on: {
               INC: {
-                actions: assign({ count: (ctx) => ctx.count + 1 })
+                actions: assign({ count: ({ context }) => context.count + 1 })
               }
             }
           },
@@ -1723,7 +1723,7 @@ describe('interpreter', () => {
         initial: 'idle',
         context: {},
         entry: assign({
-          firstNameRef: (_, __, { spawn }) =>
+          firstNameRef: ({ meta: { spawn } }) =>
             spawn(childMachine, { id: 'child' })
         }),
         states: {
@@ -1756,9 +1756,9 @@ describe('interpreter', () => {
           observableRef: ActorRef<any, any>;
         },
         entry: assign({
-          machineRef: (_, __, { spawn }) =>
+          machineRef: ({ meta: { spawn } }) =>
             spawn(childMachine, { id: 'machineChild' }),
-          promiseRef: (_, __, { spawn }) =>
+          promiseRef: ({ meta: { spawn } }) =>
             spawn(
               fromPromise(
                 () =>
@@ -1768,7 +1768,7 @@ describe('interpreter', () => {
               ),
               { id: 'promiseChild' }
             ),
-          observableRef: (_, __, { spawn }) =>
+          observableRef: ({ meta: { spawn } }) =>
             spawn(
               fromObservable(() => interval(1000)),
               { id: 'observableChild' }

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -133,7 +133,9 @@ describe('invoke', () => {
               guard: ({ context }) => context.count === -3
             },
             on: {
-              DEC: { actions: assign({ count: (ctx) => ctx.count - 1 }) },
+              DEC: {
+                actions: assign({ count: ({ context }) => context.count - 1 })
+              },
               FORWARD_DEC: {
                 actions: sendTo('child', { type: 'FORWARD_DEC' })
               }
@@ -938,7 +940,7 @@ describe('invoke', () => {
                 ),
                 onDone: {
                   target: 'success',
-                  actions: assign({ count: (_, e) => e.data.count })
+                  actions: assign({ count: ({ event }) => event.data.count })
                 }
               }
             },
@@ -968,7 +970,7 @@ describe('invoke', () => {
                   src: 'somePromise',
                   onDone: {
                     target: 'success',
-                    actions: assign({ count: (_, e) => e.data.count })
+                    actions: assign({ count: ({ event }) => event.data.count })
                   }
                 }
               },
@@ -1146,8 +1148,8 @@ describe('invoke', () => {
                           src: 'getRandomNumber',
                           onDone: {
                             target: 'success',
-                            actions: assign((_ctx, ev) => ({
-                              result1: ev.data.result
+                            actions: assign(({ event }) => ({
+                              result1: event.data.result
                             }))
                           }
                         }
@@ -1165,8 +1167,8 @@ describe('invoke', () => {
                           src: 'getRandomNumber',
                           onDone: {
                             target: 'success',
-                            actions: assign((_ctx, ev) => ({
-                              result2: ev.data.result
+                            actions: assign(({ event }) => ({
+                              result2: event.data.result
                             }))
                           }
                         }
@@ -1447,7 +1449,9 @@ describe('invoke', () => {
               guard: ({ context }) => context.count === 3
             },
             on: {
-              INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) }
+              INC: {
+                actions: assign({ count: ({ context }) => context.count + 1 })
+              }
             }
           },
           finished: {
@@ -1618,7 +1622,7 @@ describe('invoke', () => {
               }),
               onDone: {
                 target: 'success',
-                actions: assign((_, { data: result }) => ({ result }))
+                actions: assign(({ event: { data: result } }) => ({ result }))
               }
             }
           },
@@ -1802,7 +1806,7 @@ describe('invoke', () => {
             invoke: {
               src: fromObservable(() => interval(10)),
               onSnapshot: {
-                actions: assign({ count: (_, e) => e.data })
+                actions: assign({ count: ({ event }) => event.data })
               }
             },
             always: {
@@ -1844,7 +1848,7 @@ describe('invoke', () => {
               src: fromObservable(() => interval(10).pipe(take(5))),
               onSnapshot: {
                 actions: assign({
-                  count: (_, e) => e.data
+                  count: ({ event }) => event.data
                 })
               },
               onDone: {
@@ -1893,7 +1897,7 @@ describe('invoke', () => {
                 )
               ),
               onSnapshot: {
-                actions: assign({ count: (_, e) => e.data })
+                actions: assign({ count: ({ event }) => event.data })
               },
               onError: {
                 target: 'success',
@@ -1939,7 +1943,7 @@ describe('invoke', () => {
             },
             on: {
               COUNT: {
-                actions: assign({ count: (_, e) => e.value })
+                actions: assign({ count: ({ event }) => event.value })
               }
             },
             always: {
@@ -1992,7 +1996,7 @@ describe('invoke', () => {
             on: {
               COUNT: {
                 actions: assign({
-                  count: (_, e) => e.value
+                  count: ({ event }) => event.value
                 })
               }
             }
@@ -2048,7 +2052,7 @@ describe('invoke', () => {
             },
             on: {
               COUNT: {
-                actions: assign({ count: (_, e) => e.value })
+                actions: assign({ count: ({ event }) => event.value })
               }
             }
           },
@@ -2555,7 +2559,7 @@ describe('invoke', () => {
             ]
           },
           inactive: {
-            entry: assign({ counter: (ctx) => ++ctx.counter }),
+            entry: assign({ counter: ({ context }) => ++context.counter }),
             always: 'active'
           }
         }

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -47,7 +47,7 @@ const fetchMachine = createMachine<{ userId: string | undefined }>({
     },
     success: {
       type: 'final',
-      data: { user: (_: any, e: any) => e.user }
+      data: { user: ({ event }) => event.user }
     },
     failure: {
       entry: sendParent({ type: 'REJECT' })
@@ -72,9 +72,9 @@ const fetcherMachine = createMachine({
     waiting: {
       invoke: {
         src: fetchMachine,
-        input: {
-          userId: (ctx: any) => ctx.selectedUserId
-        },
+        input: ({ context }) => ({
+          userId: context.selectedUserId
+        }),
         onDone: {
           target: 'received',
           guard: ({ event }) => {
@@ -193,7 +193,7 @@ describe('invoke', () => {
         },
         success: {
           type: 'final',
-          data: { user: (_: any, e: any) => e.user }
+          data: { user: ({ event }) => event.user }
         },
         failure: {
           entry: sendParent({ type: 'REJECT' })
@@ -217,9 +217,9 @@ describe('invoke', () => {
         waiting: {
           invoke: {
             src: childMachine,
-            input: {
-              userId: (ctx: any) => ctx.selectedUserId
-            },
+            input: ({ context }) => ({
+              userId: context.selectedUserId
+            }),
             onDone: {
               target: 'received',
               guard: ({ event }) => {
@@ -744,7 +744,7 @@ describe('invoke', () => {
                   }
                 })
               ),
-              input: (ctx) => ctx,
+              input: ({ context }) => context,
               onDone: {
                 target: 'success',
                 guard: ({ context, event }) => {
@@ -1093,9 +1093,9 @@ describe('invoke', () => {
               first: {
                 invoke: {
                   src: 'somePromise',
-                  input: (ctx, ev) => ({
-                    foo: ctx.foo,
-                    event: ev
+                  input: ({ context, event }) => ({
+                    foo: context.foo,
+                    event: event
                   }),
                   onDone: 'last'
                 }
@@ -1242,9 +1242,9 @@ describe('invoke', () => {
             first: {
               invoke: {
                 src: 'someCallback',
-                input: (ctx, ev) => ({
-                  foo: ctx.foo,
-                  event: ev
+                input: ({ context, event }) => ({
+                  foo: context.foo,
+                  event: event
                 })
               },
               on: {
@@ -2704,7 +2704,7 @@ describe('invoke', () => {
           searching: {
             invoke: {
               src: 'search',
-              input: (context) => ({ endpoint: context.url }),
+              input: ({ context }) => ({ endpoint: context.url }),
               onDone: 'success'
             }
           },
@@ -3096,9 +3096,9 @@ describe('actors option', () => {
           pending: {
             invoke: {
               src: 'stringService',
-              input: (ctx) => ({
+              input: ({ context }) => ({
                 staticVal: 'hello',
-                newCount: ctx.count * 2 // TODO: types
+                newCount: context.count * 2 // TODO: types
               }),
               onDone: 'success'
             }

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -1009,8 +1009,8 @@ describe('invoke', () => {
                 ),
                 onDone: {
                   target: 'success',
-                  actions: (_, e) => {
-                    count = e.data.count;
+                  actions: ({ event }) => {
+                    count = event.data.count;
                   }
                 }
               }
@@ -1042,8 +1042,8 @@ describe('invoke', () => {
                   src: 'somePromise',
                   onDone: {
                     target: 'success',
-                    actions: (_, e) => {
-                      count = e.data.count;
+                    actions: ({ event }) => {
+                      count = event.data.count;
                     }
                   }
                 }
@@ -2610,7 +2610,7 @@ describe('invoke', () => {
         context: { id: 42 },
         states: {
           die: {
-            entry: escalate((ctx) => ctx.id)
+            entry: escalate(({ context }) => context.id)
           }
         }
       });
@@ -2929,8 +2929,8 @@ describe('invoke', () => {
       },
       on: {
         '*': {
-          actions: (_ctx, ev) => {
-            actual.push(ev.type);
+          actions: ({ event }) => {
+            actual.push(event.type);
           }
         }
       }

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -41,7 +41,7 @@ const fetchMachine = createMachine<{ userId: string | undefined }>({
       on: {
         RESOLVE: {
           target: 'success',
-          guard: (ctx) => ctx.userId !== undefined
+          guard: ({ context }) => context.userId !== undefined
         }
       }
     },
@@ -77,9 +77,9 @@ const fetcherMachine = createMachine({
         },
         onDone: {
           target: 'received',
-          guard: (_, e) => {
+          guard: ({ event }) => {
             // Should receive { user: { name: 'David' } } as event data
-            return e.data.user.name === 'David';
+            return event.data.user.name === 'David';
           }
         }
       }
@@ -130,7 +130,7 @@ describe('invoke', () => {
             },
             always: {
               target: 'stop',
-              guard: (ctx) => ctx.count === -3
+              guard: ({ context }) => context.count === -3
             },
             on: {
               DEC: { actions: assign({ count: (ctx) => ctx.count - 1 }) },
@@ -183,8 +183,8 @@ describe('invoke', () => {
           on: {
             RESOLVE: {
               target: 'success',
-              guard: (ctx) => {
-                return ctx.userId !== undefined;
+              guard: ({ context }) => {
+                return context.userId !== undefined;
               }
             }
           }
@@ -220,9 +220,9 @@ describe('invoke', () => {
             },
             onDone: {
               target: 'received',
-              guard: (_, e) => {
+              guard: ({ event }) => {
                 // Should receive { user: { name: 'David' } } as event data
-                return e.data.user.name === 'David';
+                return event.data.user.name === 'David';
               }
             }
           }
@@ -273,8 +273,8 @@ describe('invoke', () => {
           on: {
             SUCCESS: {
               target: 'success',
-              guard: (_, e) => {
-                return e.data === 42;
+              guard: ({ event }) => {
+                return event.data === 42;
               }
             }
           }
@@ -324,8 +324,8 @@ describe('invoke', () => {
       on: {
         SUCCESS: {
           target: 'success',
-          guard: (_, e) => {
-            return e.data === 42;
+          guard: ({ event }) => {
+            return event.data === 42;
           }
         }
       }
@@ -524,7 +524,7 @@ describe('invoke', () => {
                   src: pongMachine,
                   onDone: {
                     target: 'success',
-                    guard: (_, e) => e.data.secret === 'pingpong'
+                    guard: ({ event }) => event.data.secret === 'pingpong'
                   }
                 }
               },
@@ -745,8 +745,8 @@ describe('invoke', () => {
               input: (ctx) => ctx,
               onDone: {
                 target: 'success',
-                guard: (ctx, e) => {
-                  return e.data === ctx.id;
+                guard: ({ context, event }) => {
+                  return event.data === context.id;
                 }
               },
               onError: 'failure'
@@ -1248,7 +1248,7 @@ describe('invoke', () => {
               on: {
                 CALLBACK: {
                   target: 'last',
-                  guard: (_, e) => e.data === 42
+                  guard: ({ event }) => event.data === 42
                 }
               }
             },
@@ -1444,7 +1444,7 @@ describe('invoke', () => {
             },
             always: {
               target: 'finished',
-              guard: (ctx) => ctx.count === 3
+              guard: ({ context }) => context.count === 3
             },
             on: {
               INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) }
@@ -1529,8 +1529,10 @@ describe('invoke', () => {
               }),
               onError: {
                 target: 'failed',
-                guard: (_, e) => {
-                  return e.data instanceof Error && e.data.message === 'test';
+                guard: ({ event }) => {
+                  return (
+                    event.data instanceof Error && event.data.message === 'test'
+                  );
                 }
               }
             }
@@ -1583,8 +1585,10 @@ describe('invoke', () => {
               }),
               onError: {
                 target: 'failed',
-                guard: (_, e) => {
-                  return e.data instanceof Error && e.data.message === 'test';
+                guard: ({ event }) => {
+                  return (
+                    event.data instanceof Error && event.data.message === 'test'
+                  );
                 }
               }
             }
@@ -1803,7 +1807,7 @@ describe('invoke', () => {
             },
             always: {
               target: 'counted',
-              guard: (ctx) => ctx.count === 5
+              guard: ({ context }) => context.count === 5
             }
           },
           counted: {
@@ -1845,7 +1849,7 @@ describe('invoke', () => {
               },
               onDone: {
                 target: 'counted',
-                guard: (ctx) => ctx.count === 4
+                guard: ({ context }) => context.count === 4
               }
             }
           },
@@ -1893,9 +1897,11 @@ describe('invoke', () => {
               },
               onError: {
                 target: 'success',
-                guard: (ctx, e) => {
-                  expect(e.data.message).toEqual('some error');
-                  return ctx.count === 4 && e.data.message === 'some error';
+                guard: ({ context, event }) => {
+                  expect(event.data.message).toEqual('some error');
+                  return (
+                    context.count === 4 && event.data.message === 'some error'
+                  );
                 }
               }
             }
@@ -1938,7 +1944,7 @@ describe('invoke', () => {
             },
             always: {
               target: 'counted',
-              guard: (ctx) => ctx.count === 5
+              guard: ({ context }) => context.count === 5
             }
           },
           counted: {
@@ -1980,7 +1986,7 @@ describe('invoke', () => {
               ),
               onDone: {
                 target: 'counted',
-                guard: (ctx) => ctx.count === 4
+                guard: ({ context }) => context.count === 4
               }
             },
             on: {
@@ -2032,9 +2038,11 @@ describe('invoke', () => {
               ),
               onError: {
                 target: 'success',
-                guard: (ctx, e) => {
-                  expect(e.data.message).toEqual('some error');
-                  return ctx.count === 4 && e.data.message === 'some error';
+                guard: ({ context, event }) => {
+                  expect(event.data.message).toEqual('some error');
+                  return (
+                    context.count === 4 && event.data.message === 'some error'
+                  );
                 }
               }
             },
@@ -2541,7 +2549,7 @@ describe('invoke', () => {
             },
             always: [
               {
-                guard: (ctx) => ctx.counter === 0,
+                guard: ({ context }) => context.counter === 0,
                 target: 'inactive'
               }
             ]
@@ -2583,7 +2591,7 @@ describe('invoke', () => {
               src: child,
               onError: {
                 target: 'two',
-                guard: (_, event) => event.data === 'oops'
+                guard: ({ event }) => event.data === 'oops'
               }
             }
           },
@@ -2625,7 +2633,7 @@ describe('invoke', () => {
               src: child,
               onError: {
                 target: 'two',
-                guard: (_, event) => {
+                guard: ({ event }) => {
                   expect(event.data).toEqual(42);
                   return true;
                 }
@@ -2692,7 +2700,7 @@ describe('invoke', () => {
           searching: {
             invoke: {
               src: 'search',
-              input: (ctx) => ({ endpoint: ctx.url }),
+              input: (context) => ({ endpoint: context.url }),
               onDone: 'success'
             }
           },
@@ -2760,11 +2768,11 @@ describe('invoke', () => {
             invoke: {
               src: 'someSrc',
               onDone: {
-                guard: (_, e) => {
+                guard: ({ event }) => {
                   // invoke ID should not be 'someSrc'
                   const expectedType = 'done.invoke.(machine).a:invocation[0]';
-                  expect(e.type).toEqual(expectedType);
-                  return e.type === expectedType;
+                  expect(event.type).toEqual(expectedType);
+                  return event.type === expectedType;
                 },
                 target: 'b'
               }

--- a/packages/core/test/json.test.ts
+++ b/packages/core/test/json.test.ts
@@ -51,7 +51,7 @@ describe('json', () => {
           on: {
             TO_FOO: {
               target: ['foo', 'bar'],
-              guard: (ctx) => !!ctx.string
+              guard: ({ context }) => !!context.string
             }
           },
           after: {

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -442,7 +442,7 @@ describe('machine', () => {
         context: { value: 42 },
         on: {
           INC: {
-            actions: assign({ value: (ctx) => ctx.value + 1 })
+            actions: assign({ value: ({ context }) => context.value + 1 })
           }
         }
       });

--- a/packages/core/test/parallel.test.ts
+++ b/packages/core/test/parallel.test.ts
@@ -650,7 +650,7 @@ describe('parallel states', () => {
           on: {
             CHANGE: {
               actions: assign({
-                value: (_, e) => e.value
+                value: ({ event }) => event.value
               })
             }
           }
@@ -910,7 +910,9 @@ describe('parallel states', () => {
                 }
               },
               foobaz: {
-                entry: assign({ log: (ctx) => [...ctx.log, 'entered foobaz'] }),
+                entry: assign({
+                  log: ({ context }) => [...context.log, 'entered foobaz']
+                }),
                 on: {
                   GOTO_FOOBAZ: 'foobaz'
                 }

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -280,7 +280,7 @@ describe('predictableExec', () => {
                   return context.actorRef;
                 }),
                 assign({
-                  actorRef: ({ meta: { spawn } }) => {
+                  actorRef: ({ spawn }) => {
                     const localId = ++invokeCounter;
 
                     return spawn(
@@ -340,7 +340,7 @@ describe('predictableExec', () => {
               actions: [
                 stop(({ context }) => context.actorRef),
                 assign({
-                  actorRef: ({ meta: { spawn } }) => {
+                  actorRef: ({ spawn }) => {
                     const localId = ++invokeCounter;
 
                     return spawn(
@@ -400,7 +400,7 @@ describe('predictableExec', () => {
               actions: [
                 stop('my_name'),
                 assign({
-                  actorRef: ({ meta: { spawn } }) => {
+                  actorRef: ({ spawn }) => {
                     const localId = ++invokeCounter;
 
                     return spawn(
@@ -460,7 +460,7 @@ describe('predictableExec', () => {
               actions: [
                 stop(() => 'my_name'),
                 assign({
-                  actorRef: ({ meta: { spawn } }) => {
+                  actorRef: ({ spawn }) => {
                     const localId = ++invokeCounter;
 
                     return spawn(

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -154,7 +154,7 @@ describe('predictableExec', () => {
             src: fromCallback((_sendBack, _receive, { input }) => {
               eventArg = input.event;
             }),
-            input: (_, event) => ({ event })
+            input: ({ event }) => ({ event })
           }
         }
       }
@@ -679,9 +679,9 @@ describe('predictableExec', () => {
               expect(input.updated).toBe(true);
               return Promise.resolve();
             }),
-            input: {
-              updated: (ctx) => ctx.updated
-            }
+            input: ({ context }) => ({
+              updated: context.updated
+            })
           }
         }
       }

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -84,7 +84,7 @@ describe('predictableExec', () => {
           on: {
             RAISED: {
               target: 'c',
-              actions: (_ctx, ev) => (eventArg = ev)
+              actions: ({ event }) => (eventArg = event)
             }
           },
           entry: raise({ type: 'RAISED' })
@@ -237,7 +237,7 @@ describe('predictableExec', () => {
         b: {
           entry: [
             assign({ counter: 1 }),
-            (context) => (calledWith = context.counter),
+            ({ context }) => (calledWith = context.counter),
             assign({ counter: 2 })
           ]
         }
@@ -276,8 +276,8 @@ describe('predictableExec', () => {
           on: {
             update: {
               actions: [
-                stop((ctx) => {
-                  return ctx.actorRef;
+                stop(({ context }) => {
+                  return context.actorRef;
                 }),
                 assign({
                   actorRef: (_ctx: any, _ev: any, { spawn }: any) => {
@@ -338,7 +338,7 @@ describe('predictableExec', () => {
           on: {
             update: {
               actions: [
-                stop((ctx) => ctx.actorRef),
+                stop(({ context }) => context.actorRef),
                 assign({
                   actorRef: (_ctx: any, _ev: any, { spawn }: any) => {
                     const localId = ++invokeCounter;
@@ -543,11 +543,11 @@ describe('predictableExec', () => {
     const machine = createMachine({
       context: { count: 0 },
       entry: [
-        (ctx) => actual.push(ctx.count),
+        ({ context }) => actual.push(context.count),
         assign({ count: 1 }),
-        (ctx) => actual.push(ctx.count),
+        ({ context }) => actual.push(context.count),
         assign({ count: 2 }),
-        (ctx) => actual.push(ctx.count)
+        ({ context }) => actual.push(context.count)
       ]
     });
 

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -290,7 +290,7 @@ describe('predictableExec', () => {
                           actual.push(`stop ${localId}`);
                         };
                       }),
-                      'callback-2'
+                      { id: 'callback-2' }
                     );
                   }
                 })
@@ -350,7 +350,7 @@ describe('predictableExec', () => {
                           actual.push(`stop ${localId}`);
                         };
                       }),
-                      'my_name'
+                      { id: 'my_name' }
                     );
                   }
                 })

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -114,8 +114,8 @@ describe('predictableExec', () => {
           on: {
             RAISED: {
               target: 'c',
-              actions: assign((_ctx, ev) => {
-                eventArg = ev;
+              actions: assign(({ event }) => {
+                eventArg = event;
                 return {};
               })
             }
@@ -280,7 +280,7 @@ describe('predictableExec', () => {
                   return context.actorRef;
                 }),
                 assign({
-                  actorRef: (_ctx: any, _ev: any, { spawn }: any) => {
+                  actorRef: ({ meta: { spawn } }) => {
                     const localId = ++invokeCounter;
 
                     return spawn(
@@ -340,7 +340,7 @@ describe('predictableExec', () => {
               actions: [
                 stop(({ context }) => context.actorRef),
                 assign({
-                  actorRef: (_ctx: any, _ev: any, { spawn }: any) => {
+                  actorRef: ({ meta: { spawn } }) => {
                     const localId = ++invokeCounter;
 
                     return spawn(
@@ -400,7 +400,7 @@ describe('predictableExec', () => {
               actions: [
                 stop('my_name'),
                 assign({
-                  actorRef: (_ctx: any, _ev: any, { spawn }: any) => {
+                  actorRef: ({ meta: { spawn } }) => {
                     const localId = ++invokeCounter;
 
                     return spawn(
@@ -410,7 +410,7 @@ describe('predictableExec', () => {
                           actual.push(`stop ${localId}`);
                         };
                       }),
-                      'my_name'
+                      { id: 'my_name' }
                     );
                   }
                 })
@@ -460,7 +460,7 @@ describe('predictableExec', () => {
               actions: [
                 stop(() => 'my_name'),
                 assign({
-                  actorRef: (_ctx: any, _ev: any, { spawn }: any) => {
+                  actorRef: ({ meta: { spawn } }) => {
                     const localId = ++invokeCounter;
 
                     return spawn(
@@ -470,7 +470,7 @@ describe('predictableExec', () => {
                           actual.push(`stop ${localId}`);
                         };
                       }),
-                      'my_name'
+                      { id: 'my_name' }
                     );
                   }
                 })

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -757,7 +757,7 @@ describe('State', () => {
           a: {
             on: {
               SPAWN: {
-                actions: assign(({ meta: { spawn } }) => ({
+                actions: assign(({ spawn }) => ({
                   ref: spawn(
                     fromCallback(() => {
                       spawned = true;

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -200,7 +200,7 @@ describe('State', () => {
           same: {
             on: {
               EVENT: {
-                actions: assign({ count: (ctx) => ctx.count + 1 })
+                actions: assign({ count: ({ context }) => context.count + 1 })
               }
             }
           }
@@ -238,8 +238,8 @@ describe('State', () => {
             on: {
               CHANGE: {
                 actions: assign({
-                  value: (_, e) => {
-                    return e.value;
+                  value: ({ event }) => {
+                    return event.value;
                   }
                 })
               }
@@ -757,7 +757,7 @@ describe('State', () => {
           a: {
             on: {
               SPAWN: {
-                actions: assign((_, __, { spawn }) => ({
+                actions: assign(({ meta: { spawn } }) => ({
                   ref: spawn(
                     fromCallback(() => {
                       spawned = true;

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -34,7 +34,7 @@ describe('system', () => {
             {
               src: createMachine({
                 id: 'childmachine',
-                entry: (_ctx, _ev, { system }) => {
+                entry: ({ meta: { system } }) => {
                   const receiver = (system as MySystem)?.get('receiver');
 
                   if (receiver) {
@@ -136,7 +136,7 @@ describe('system', () => {
         src: createMachine({}),
         systemId: 'test'
       },
-      entry: (_, __, { system }) => {
+      entry: ({ meta: { system } }) => {
         expect(system!.get('test')).toBeDefined();
       }
     });
@@ -155,7 +155,7 @@ describe('system', () => {
       },
       {
         actions: {
-          myAction: (_, __, { system }) => {
+          myAction: ({ meta: { system } }) => {
             expect(system!.get('test')).toBeDefined();
           }
         }
@@ -186,7 +186,7 @@ describe('system', () => {
         systemId: 'test'
       },
       entry: sendTo(
-        (_, __, { system }) => {
+        ({ meta: { system } }) => {
           expect(system!.get('test')).toBeDefined();
           return system!.get('test');
         },

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -171,7 +171,7 @@ describe('system', () => {
         src: createMachine({}),
         systemId: 'test'
       },
-      entry: assign(({ meta: { system } }) => {
+      entry: assign(({ system }) => {
         expect(system!.get('test')).toBeDefined();
       })
     });

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -171,7 +171,7 @@ describe('system', () => {
         src: createMachine({}),
         systemId: 'test'
       },
-      entry: assign((_, __, { system }) => {
+      entry: assign(({ meta: { system } }) => {
         expect(system!.get('test')).toBeDefined();
       })
     });

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -34,7 +34,7 @@ describe('system', () => {
             {
               src: createMachine({
                 id: 'childmachine',
-                entry: ({ meta: { system } }) => {
+                entry: ({ system }) => {
                   const receiver = (system as MySystem)?.get('receiver');
 
                   if (receiver) {
@@ -136,7 +136,7 @@ describe('system', () => {
         src: createMachine({}),
         systemId: 'test'
       },
-      entry: ({ meta: { system } }) => {
+      entry: ({ system }) => {
         expect(system!.get('test')).toBeDefined();
       }
     });
@@ -155,7 +155,7 @@ describe('system', () => {
       },
       {
         actions: {
-          myAction: ({ meta: { system } }) => {
+          myAction: ({ system }) => {
             expect(system!.get('test')).toBeDefined();
           }
         }
@@ -186,7 +186,7 @@ describe('system', () => {
         systemId: 'test'
       },
       entry: sendTo(
-        ({ meta: { system } }) => {
+        ({ system }) => {
           expect(system!.get('test')).toBeDefined();
           return system!.get('test');
         },

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -550,7 +550,7 @@ describe('transient states (eventless transitions)', () => {
         first: {
           on: {
             ADD: {
-              actions: assign({ count: (ctx) => ctx.count + 1 })
+              actions: assign({ count: ({ context }) => context.count + 1 })
             }
           }
         },
@@ -586,7 +586,7 @@ describe('transient states (eventless transitions)', () => {
         first: {
           on: {
             ADD: {
-              actions: assign({ count: (ctx) => ctx.count + 1 })
+              actions: assign({ count: ({ context }) => context.count + 1 })
             }
           }
         },

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -11,8 +11,8 @@ const greetingMachine = createMachine<typeof greetingContext>({
   states: {
     pending: {
       always: [
-        { target: 'morning', guard: (ctx) => ctx.hour < 12 },
-        { target: 'afternoon', guard: (ctx) => ctx.hour < 18 },
+        { target: 'morning', guard: ({ context }) => context.hour < 12 },
+        { target: 'afternoon', guard: ({ context }) => context.hour < 18 },
         { target: 'evening' }
       ]
     },
@@ -35,9 +35,9 @@ describe('transient states (eventless transitions)', () => {
       },
       E: {
         always: [
-          { target: 'D', guard: ({ data }) => !data }, // no data returned
-          { target: 'B', guard: ({ status }) => status === 'Y' },
-          { target: 'C', guard: ({ status }) => status === 'X' },
+          { target: 'D', guard: ({ context: { data } }) => !data }, // no data returned
+          { target: 'B', guard: ({ context: { status } }) => status === 'Y' },
+          { target: 'C', guard: ({ context: { status } }) => status === 'X' },
           { target: 'F' } // default, or just the string 'F'
         ]
       },
@@ -561,8 +561,8 @@ describe('transient states (eventless transitions)', () => {
       always: [
         {
           target: '.success',
-          guard: (ctx) => {
-            return ctx.count > 0;
+          guard: ({ context }) => {
+            return context.count > 0;
           }
         }
       ]
@@ -598,8 +598,8 @@ describe('transient states (eventless transitions)', () => {
       always: [
         {
           target: '.success',
-          guard: (ctx) => {
-            return ctx.count > 0;
+          guard: ({ context }) => {
+            return context.count > 0;
           }
         }
       ]
@@ -628,7 +628,7 @@ describe('transient states (eventless transitions)', () => {
           always: [
             {
               target: `finished`,
-              guard: (ctx) => ctx.duration < 1000
+              guard: ({ context }) => context.duration < 1000
             },
             {
               target: `active`
@@ -732,9 +732,9 @@ describe('transient states (eventless transitions)', () => {
         },
         c: {
           always: {
-            guard: (_, e) => {
-              expect(e.type).toEqual('EVENT');
-              return e.type === 'EVENT';
+            guard: ({ event }) => {
+              expect(event.type).toEqual('EVENT');
+              return event.type === 'EVENT';
             },
             target: 'd'
           }

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -762,16 +762,16 @@ describe('transient states (eventless transitions)', () => {
         b: {
           always: {
             target: 'c',
-            actions: (_, event) => {
+            actions: ({ event }) => {
               expect(event).toEqual({ type: 'EVENT', value: 42 });
             }
           },
-          exit: (_, event) => {
+          exit: ({ event }) => {
             expect(event).toEqual({ type: 'EVENT', value: 42 });
           }
         },
         c: {
-          entry: (_, event) => {
+          entry: ({ event }) => {
             expect(event).toEqual({ type: 'EVENT', value: 42 });
           }
         }

--- a/packages/core/test/typeHelpers.test.ts
+++ b/packages/core/test/typeHelpers.test.ts
@@ -160,16 +160,16 @@ describe('MachineImplementationsFrom', () => {
     });
     acceptMachineImplementations({
       actions: {
-        foo: assign((ctx) => {
-          ((_accept: number) => {})(ctx.count);
+        foo: assign(({ context }) => {
+          ((_accept: number) => {})(context.count);
           return {};
         })
       }
     });
     acceptMachineImplementations({
       actions: {
-        foo: assign((_ctx, ev) => {
-          ((_accept: 'FOO' | 'BAR') => {})(ev.type);
+        foo: assign(({ event }) => {
+          ((_accept: 'FOO' | 'BAR') => {})(event.type);
           return {};
         })
       }
@@ -215,9 +215,9 @@ describe('MachineImplementationsFrom', () => {
     });
     acceptMachineImplementations({
       actions: {
-        myAction: assign((ctx, ev) => {
-          ((_accept: number) => {})(ctx.count);
-          ((_accept: 'FOO') => {})(ev.type);
+        myAction: assign(({ context, event }) => {
+          ((_accept: number) => {})(context.count);
+          ((_accept: 'FOO') => {})(event.type);
           return {};
         })
       }
@@ -264,9 +264,9 @@ describe('MachineImplementationsFrom', () => {
     });
     acceptMachineImplementations({
       actions: {
-        myAction: assign((ctx, ev) => {
-          ((_accept: number) => {})(ctx.count);
-          ((_accept: 'FOO') => {})(ev.type);
+        myAction: assign(({ context, event }) => {
+          ((_accept: number) => {})(context.count);
+          ((_accept: 'FOO') => {})(event.type);
           return {};
         })
       }

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -47,7 +47,7 @@ describe('typegen types', () => {
       },
       {
         actions: {
-          myAction: (_ctx, event) => {
+          myAction: ({ event }) => {
             event.type === 'FOO';
             event.type === 'BAR';
             // @ts-expect-error
@@ -81,7 +81,7 @@ describe('typegen types', () => {
       },
       {
         delays: {
-          myDelay: (_ctx, event) => {
+          myDelay: ({ event }) => {
             event.type === 'FOO';
             event.type === 'BAR';
             // @ts-expect-error
@@ -117,7 +117,7 @@ describe('typegen types', () => {
       },
       {
         guards: {
-          myGuard: (_ctx, event) => {
+          myGuard: ({ event }) => {
             event.type === 'FOO';
             event.type === 'BAR';
             // @ts-expect-error
@@ -602,7 +602,7 @@ describe('typegen types', () => {
       },
       {
         actions: {
-          myAction: (_ctx, event) => {
+          myAction: ({ event }) => {
             event.type === 'xstate.init';
           }
         }
@@ -636,7 +636,7 @@ describe('typegen types', () => {
       },
       {
         actions: {
-          myAction: (_ctx, event) => {
+          myAction: ({ event }) => {
             if (event.type === 'FOO') {
               return;
             }
@@ -682,7 +682,7 @@ describe('typegen types', () => {
       },
       {
         actions: {
-          myAction: (_ctx, event) => {
+          myAction: ({ event }) => {
             if (event.type === 'FOO') {
               return;
             }

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -764,7 +764,7 @@ describe('typegen types', () => {
       {
         actors: {
           // @ts-expect-error
-          myActor: (_ctx) => Promise.resolve(42)
+          myActor: () => Promise.resolve(42)
         }
       }
     );

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -861,7 +861,7 @@ describe('typegen types', () => {
       },
       {
         actions: {
-          actionName: assign((_context, event) => {
+          actionName: assign(({ event }) => {
             ((_accept: 'BAR') => {})(event.type);
             return {};
           })
@@ -1189,9 +1189,9 @@ describe('typegen types', () => {
       },
       {
         actions: {
-          increment: assign((ctx, ev) => {
+          increment: assign(({ context, event }) => {
             return {
-              count: ctx.count + ev.value
+              count: context.count + event.value
             };
           })
         }

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -61,11 +61,8 @@ describe('StateSchema', () => {
             on: {
               PED_COUNTDOWN: {
                 target: 'stop',
-                guard: (
-                  ctx,
-                  e: { type: 'PED_COUNTDOWN'; duration: number }
-                ) => {
-                  return e.duration === 0 && ctx.elapsed > 0;
+                guard: ({ context, event }) => {
+                  return event.duration === 0 && context.elapsed > 0;
                 }
               }
             }
@@ -198,10 +195,10 @@ describe('Raise events', () => {
       },
       on: {
         FOO: {
-          actions: raise((_ctx, ev) => {
-            ((_arg: 'FOO') => {})(ev.type);
+          actions: raise(({ event }) => {
+            ((_arg: 'FOO') => {})(event.type);
             // @ts-expect-error
-            ((_arg: 'BAR') => {})(ev.type);
+            ((_arg: 'BAR') => {})(event.type);
 
             return {
               type: 'BAR'
@@ -265,10 +262,10 @@ describe('context', () => {
       },
       {
         actions: {
-          someAction: (ctx) => {
-            ((_accept: string) => {})(ctx.foo);
+          someAction: ({ context }) => {
+            ((_accept: string) => {})(context.foo);
             // @ts-expect-error
-            ((_accept: number) => {})(ctx.foo);
+            ((_accept: number) => {})(context.foo);
           }
         }
       }
@@ -287,10 +284,10 @@ describe('context', () => {
       },
       {
         actions: {
-          someAction: (ctx) => {
-            ((_accept: number) => {})(ctx.count);
+          someAction: ({ context }) => {
+            ((_accept: number) => {})(context.count);
             // @ts-expect-error
-            ((_accept: string) => {})(ctx.count);
+            ((_accept: string) => {})(context.count);
           }
         }
       }
@@ -347,7 +344,7 @@ describe('events', () => {
           type: 'FOO';
         }
       },
-      entry: (_ctx, _ev: any) => {}
+      entry: () => {}
     });
 
     const service = interpret(machine).start();
@@ -389,7 +386,7 @@ describe('events', () => {
       },
       on: {
         EVENT_WITH_FLAG: {
-          actions: (_context, event) => {
+          actions: ({ event }) => {
             ((_accept: 'EVENT_WITH_FLAG') => {})(event.type);
             ((_accept: boolean) => {})(event.flag);
             // @ts-expect-error
@@ -414,7 +411,7 @@ describe('events', () => {
       },
       on: {
         '*': {
-          actions: (_context, event) => {
+          actions: ({ event }) => {
             ((_accept: 'EVENT_WITH_FLAG' | 'EVENT_WITHOUT_FLAG') => {})(
               event.type
             );
@@ -458,7 +455,7 @@ describe('events', () => {
       },
       on: {
         FOO: {
-          actions: (_context, event) => {
+          actions: ({ event }) => {
             ((_accept: string) => {})(event.type);
           }
         }
@@ -643,11 +640,11 @@ describe('actions', () => {
           childRef: ActorRefFrom<typeof childMachine>;
         }
       },
-      entry: stop((ctx) => {
-        ((_accept: number) => {})(ctx.count);
+      entry: stop(({ context }) => {
+        ((_accept: number) => {})(context.count);
         // @ts-expect-error
-        ((_accept: "ain't any") => {})(ctx.count);
-        return ctx.childRef;
+        ((_accept: "ain't any") => {})(context.count);
+        return context.childRef;
       })
     });
   });
@@ -669,11 +666,11 @@ describe('actions', () => {
       },
       on: {
         FOO: {
-          actions: stop((ctx) => {
-            ((_accept: number) => {})(ctx.count);
+          actions: stop(({ context }) => {
+            ((_accept: number) => {})(context.count);
             // @ts-expect-error
-            ((_accept: "ain't any") => {})(ctx.count);
-            return ctx.childRef;
+            ((_accept: "ain't any") => {})(context.count);
+            return context.childRef;
           })
         }
       }
@@ -689,8 +686,8 @@ describe('actions', () => {
       },
       entry: stop(
         // @ts-expect-error
-        (ctx) => {
-          return ctx.count;
+        ({ context }) => {
+          return context.count;
         }
       )
     });
@@ -708,17 +705,17 @@ describe('actions', () => {
         }
       },
       entry: [
-        stop((ctx) => {
-          ((_accept: number) => {})(ctx.count);
+        stop(({ context }) => {
+          ((_accept: number) => {})(context.count);
           // @ts-expect-error
-          ((_accept: "ain't any") => {})(ctx.count);
-          return ctx.childRef;
+          ((_accept: "ain't any") => {})(context.count);
+          return context.childRef;
         }),
-        stop((ctx) => {
-          ((_accept: number) => {})(ctx.count);
+        stop(({ context }) => {
+          ((_accept: number) => {})(context.count);
           // @ts-expect-error
-          ((_accept: "ain't any") => {})(ctx.count);
-          return ctx.promiseRef;
+          ((_accept: "ain't any") => {})(context.count);
+          return context.promiseRef;
         })
       ]
     });

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -434,7 +434,7 @@ describe('events', () => {
       {
         actions: {
           addNumber: assign({
-            numbers: (context, event) => {
+            numbers: ({ context, event }) => {
               ((_accept: number) => {})(event.number);
               // @ts-expect-error
               ((_accept: string) => {})(event.number);
@@ -556,10 +556,10 @@ describe('actions', () => {
       context: {
         count: 0
       },
-      entry: assign((ctx) => {
-        ((_accept: number) => {})(ctx.count);
+      entry: assign(({ context }) => {
+        ((_accept: number) => {})(context.count);
         // @ts-expect-error
-        ((_accept: "ain't any") => {})(ctx.count);
+        ((_accept: "ain't any") => {})(context.count);
         return {};
       })
     });
@@ -576,10 +576,10 @@ describe('actions', () => {
       },
       on: {
         FOO: {
-          actions: assign((ctx) => {
-            ((_accept: number) => {})(ctx.count);
+          actions: assign(({ context }) => {
+            ((_accept: number) => {})(context.count);
             // @ts-expect-error
-            ((_accept: "ain't any") => {})(ctx.count);
+            ((_accept: "ain't any") => {})(context.count);
             return {};
           })
         }
@@ -594,10 +594,10 @@ describe('actions', () => {
       },
       entry: [
         'foo',
-        assign((ctx) => {
-          ((_accept: number) => {})(ctx.count);
+        assign(({ context }) => {
+          ((_accept: number) => {})(context.count);
           // @ts-expect-error
-          ((_accept: "ain't any") => {})(ctx.count);
+          ((_accept: "ain't any") => {})(context.count);
           return {};
         })
       ]
@@ -613,10 +613,10 @@ describe('actions', () => {
         FOO: {
           actions: [
             'foo',
-            assign((ctx) => {
-              ((_accept: number) => {})(ctx.count);
+            assign(({ context }) => {
+              ((_accept: number) => {})(context.count);
               // @ts-expect-error
-              ((_accept: "ain't any") => {})(ctx.count);
+              ((_accept: "ain't any") => {})(context.count);
               return {};
             })
           ]
@@ -756,7 +756,7 @@ describe('actions', () => {
         skip: true
       },
       entry: assign({
-        count: (context) => context.count + 1,
+        count: ({ context }) => context.count + 1,
         skip: true
       })
     });

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -280,7 +280,7 @@ describe('context', () => {
             count: number;
           }
         },
-        entry: (_ctx: any) => {}
+        entry: () => {}
       },
       {
         actions: {

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -406,7 +406,7 @@ describe('@xstate/graph', () => {
             on: {
               INC: {
                 actions: assign({
-                  count: (context) => context.count + 1
+                  count: ({ context }) => context.count + 1
                 })
               }
             }
@@ -559,7 +559,7 @@ describe('filtering', () => {
           on: {
             INC: {
               actions: assign({
-                count: (ctx) => ctx.count + 1
+                count: ({ context }) => context.count + 1
               })
             }
           }

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -107,14 +107,14 @@ describe('@xstate/graph', () => {
           EVENT: [
             {
               target: 'foo',
-              guard: (_, e) => e.id === 'foo'
+              guard: ({ event }) => event.id === 'foo'
             },
             { target: 'bar' }
           ],
           STATE: [
             {
               target: 'foo',
-              guard: (s) => s.id === 'foo'
+              guard: ({ context }) => context.id === 'foo'
             },
             { target: 'bar' }
           ]
@@ -227,14 +227,14 @@ describe('@xstate/graph', () => {
               EVENT: [
                 {
                   target: 'foo',
-                  guard: (_, e) => e.id === 'foo'
+                  guard: ({ event }) => event.id === 'foo'
                 },
                 { target: 'bar' }
               ],
               STATE: [
                 {
                   target: 'foo',
-                  guard: (s) => s.id === 'foo'
+                  guard: ({ context }) => context.id === 'foo'
                 },
                 { target: 'bar' }
               ]
@@ -401,12 +401,12 @@ describe('@xstate/graph', () => {
           start: {
             always: {
               target: 'finish',
-              guard: (ctx) => ctx.count === 3
+              guard: ({ context }) => context.count === 3
             },
             on: {
               INC: {
                 actions: assign({
-                  count: (ctx) => ctx.count + 1
+                  count: (context) => context.count + 1
                 })
               }
             }

--- a/packages/xstate-graph/test/shortestPaths.test.ts
+++ b/packages/xstate-graph/test/shortestPaths.test.ts
@@ -30,7 +30,7 @@ describe('getMachineShortestPaths', () => {
             NEXT: {
               target: 'd',
               actions: assign({
-                count: (ctx) => ctx.count + 1
+                count: ({ context }) => context.count + 1
               })
             }
           }

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -13,9 +13,11 @@ export type ImmerAssigner<
   TExpressionEvent extends EventObject,
   TEvent extends EventObject
 > = (
-  context: Draft<TContext>,
-  event: TExpressionEvent,
-  meta: AssignMeta<TContext, TExpressionEvent, TEvent>
+  args: { context: Draft<TContext>; event: TExpressionEvent } & AssignMeta<
+    TContext,
+    TExpressionEvent,
+    TEvent
+  >
 ) => void;
 
 export interface ImmerAssignAction<
@@ -32,8 +34,15 @@ function immerAssign<
   TEvent extends EventObject = TExpressionEvent
 >(recipe: ImmerAssigner<TContext, TExpressionEvent, TEvent>) {
   return xstateAssign<TContext, TExpressionEvent, TEvent>(
-    ({ context, event, ...meta }) => {
-      return produce(context, (draft) => void recipe(draft, event, meta));
+    ({ context, ...rest }) => {
+      return produce(
+        context,
+        (draft) =>
+          void recipe({
+            context: draft,
+            ...rest
+          })
+      );
     }
   );
 }
@@ -73,9 +82,7 @@ export function createUpdater<
 
   return {
     update,
-    action: immerAssign<TContext, TEvent>((ctx, event, meta) => {
-      recipe(ctx, event, meta);
-    }),
+    action: immerAssign<TContext, TEvent>(recipe),
     type
   };
 }

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -32,7 +32,7 @@ function immerAssign<
   TEvent extends EventObject = TExpressionEvent
 >(recipe: ImmerAssigner<TContext, TExpressionEvent, TEvent>) {
   return xstateAssign<TContext, TExpressionEvent, TEvent>(
-    ({ context, event, meta }) => {
+    ({ context, event, ...meta }) => {
       return produce(context, (draft) => void recipe(draft, event, meta));
     }
   );

--- a/packages/xstate-immer/src/index.ts
+++ b/packages/xstate-immer/src/index.ts
@@ -32,7 +32,7 @@ function immerAssign<
   TEvent extends EventObject = TExpressionEvent
 >(recipe: ImmerAssigner<TContext, TExpressionEvent, TEvent>) {
   return xstateAssign<TContext, TExpressionEvent, TEvent>(
-    (context, event, meta) => {
+    ({ context, event, meta }) => {
       return produce(context, (draft) => void recipe(draft, event, meta));
     }
   );

--- a/packages/xstate-immer/test/immer.test.ts
+++ b/packages/xstate-immer/test/immer.test.ts
@@ -186,8 +186,8 @@ describe('@xstate/immer', () => {
         submitting: {
           always: {
             target: 'success',
-            guard: (ctx) => {
-              return ctx.name === 'David' && ctx.age === 0;
+            guard: ({ context }) => {
+              return context.name === 'David' && context.age === 0;
             }
           }
         },

--- a/packages/xstate-immer/test/immer.test.ts
+++ b/packages/xstate-immer/test/immer.test.ts
@@ -14,7 +14,7 @@ describe('@xstate/immer', () => {
         active: {
           on: {
             INC: {
-              actions: assign<typeof context>((ctx) => ctx.count++)
+              actions: assign<typeof context>(({ context }) => context.count++)
             }
           }
         }
@@ -51,7 +51,7 @@ describe('@xstate/immer', () => {
       },
       {
         actions: {
-          increment: assign<typeof context>((ctx) => ctx.count++)
+          increment: assign<typeof context>(({ context }) => context.count++)
         }
       }
     );
@@ -88,7 +88,9 @@ describe('@xstate/immer', () => {
       },
       {
         actions: {
-          pushBaz: assign<typeof context>((ctx) => ctx.foo.bar.baz.push(0))
+          pushBaz: assign<typeof context>(({ context }) =>
+            context.foo.bar.baz.push(0)
+          )
         }
       }
     );
@@ -112,8 +114,8 @@ describe('@xstate/immer', () => {
     const bazUpdater = createUpdater<
       typeof context,
       ImmerUpdateEvent<'UPDATE_BAZ', number>
-    >('UPDATE_BAZ', (ctx, { input }) => {
-      ctx.foo.bar.baz.push(input);
+    >('UPDATE_BAZ', ({ context, event }) => {
+      context.foo.bar.baz.push(event.input);
     });
 
     const countMachine = createMachine<typeof context>({
@@ -150,15 +152,15 @@ describe('@xstate/immer', () => {
 
     const nameUpdater = createUpdater<FormContext, NameUpdateEvent>(
       'UPDATE_NAME',
-      (ctx, { input }) => {
-        ctx.name = input;
+      ({ context, event }) => {
+        context.name = event.input;
       }
     );
 
     const ageUpdater = createUpdater<FormContext, AgeUpdateEvent>(
       'UPDATE_AGE',
-      (ctx, { input }) => {
-        ctx.age = input;
+      ({ context, event }) => {
+        context.age = event.input;
       }
     );
 

--- a/packages/xstate-immer/test/typegenTypes.test.ts
+++ b/packages/xstate-immer/test/typegenTypes.test.ts
@@ -29,10 +29,10 @@ describe('@xstate/immer', () => {
       },
       {
         actions: {
-          doSomething: assign((ctx, event) => {
+          doSomething: assign(({ context, event }) => {
             ((_accept: 'update') => {})(event.type);
             // no error
-            ctx.count += event.data.count;
+            context.count += event.data.count;
             // @ts-expect-error
             ((_accept: "test that this isn't any") => {})(event);
             // @ts-expect-error

--- a/packages/xstate-inspect/src/inspectMachine.ts
+++ b/packages/xstate-inspect/src/inspectMachine.ts
@@ -77,10 +77,7 @@ export function createInspectMachine(
         target: '.connected',
         actions: [
           assign({
-            client: (
-              _,
-              e: InspectMachineEvent & { type: 'xstate.inspecting' }
-            ) => e.client
+            client: ({ event }) => event.client
           }),
           ({ context }) => {
             devTools.services.forEach((service) => {

--- a/packages/xstate-inspect/src/inspectMachine.ts
+++ b/packages/xstate-inspect/src/inspectMachine.ts
@@ -38,19 +38,19 @@ export function createInspectMachine(
       connected: {
         on: {
           'service.state': {
-            actions: (ctx, e) => ctx.client!.send(e)
+            actions: ({ context, event }) => context.client!.send(event)
           },
           'service.event': {
-            actions: (ctx, e) => ctx.client!.send(e)
+            actions: ({ context, event }) => context.client!.send(event)
           },
           'service.register': {
-            actions: (ctx, e) => ctx.client!.send(e)
+            actions: ({ context, event }) => context.client!.send(event)
           },
           'service.stop': {
-            actions: (ctx, e) => ctx.client!.send(e)
+            actions: ({ context, event }) => context.client!.send(event)
           },
           'xstate.event': {
-            actions: (_, e) => {
+            actions: ({ event: e }) => {
               const { event } = e;
               const scxmlEventObject = JSON.parse(event) as SCXML.Event<any>;
               const service = serviceMap.get(scxmlEventObject.origin?.id!);
@@ -58,8 +58,8 @@ export function createInspectMachine(
             }
           },
           unload: {
-            actions: (ctx) => {
-              ctx.client!.send({ type: 'xstate.disconnect' });
+            actions: ({ context }) => {
+              context.client!.send({ type: 'xstate.disconnect' });
             }
           },
           disconnect: 'disconnected'
@@ -82,9 +82,9 @@ export function createInspectMachine(
               e: InspectMachineEvent & { type: 'xstate.inspecting' }
             ) => e.client
           }),
-          (ctx) => {
+          ({ context }) => {
             devTools.services.forEach((service) => {
-              ctx.client?.send({
+              context.client?.send({
                 type: 'service.register',
                 machine: stringifyMachine(service.behavior, options?.serialize),
                 state: stringifyState(

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -243,10 +243,13 @@ describe('@xstate/inspect', () => {
   it('should successfully serialize value with unsafe toJSON when serializer manages to replace it', () => {
     const machine = createMachine({
       context: {},
+      schema: {} as {
+        events: { type: 'EV'; value: any };
+      },
       on: {
         EV: {
           actions: assign({
-            value: (_ctx, ev: any) => ev.value
+            value: ({ event }) => event.value
           })
         }
       }
@@ -304,7 +307,10 @@ describe('@xstate/inspect', () => {
 
     // this is important because this moves the previous `state` to `state.history` (this was the case in v4)
     // and serializing a `state` with a `state.history` containing unsafe value should still work
-    service.send({ type: 'UNKNOWN' });
+    service.send({
+      // @ts-expect-error
+      type: 'UNKNOWN'
+    });
 
     expect(iframeMock.flushMessages()).toMatchInlineSnapshot(`
       [

--- a/packages/xstate-react/test/createActorContext.test.tsx
+++ b/packages/xstate-react/test/createActorContext.test.tsx
@@ -137,15 +137,15 @@ describe('createActorContext', () => {
       },
       on: {
         INC: {
-          actions: assign<MachineContext>((ctx) => ({
+          actions: assign<MachineContext>(({ context }) => ({
             obj: {
-              counter: ctx.obj.counter + 1
+              counter: context.obj.counter + 1
             }
           }))
         },
         PUSH: {
-          actions: assign<MachineContext>((ctx) => ({
-            arr: [...ctx.arr, Math.random().toString(36).slice(2)]
+          actions: assign<MachineContext>(({ context }) => ({
+            arr: [...context.arr, Math.random().toString(36).slice(2)]
           }))
         }
       }

--- a/packages/xstate-react/test/typegenTypes.test.tsx
+++ b/packages/xstate-react/test/typegenTypes.test.tsx
@@ -199,10 +199,10 @@ describe('useMachine', () => {
     function App() {
       useMachine(machine, {
         actions: {
-          fooAction: assign((_context, _event) => {
-            ((_accept: 'FOO') => {})(_event.type);
+          fooAction: assign(({ event }) => {
+            ((_accept: 'FOO') => {})(event.type);
             // @ts-expect-error
-            ((_accept: "test that this isn't any") => {})(_event.type);
+            ((_accept: "test that this isn't any") => {})(event.type);
           })
         }
       });
@@ -410,10 +410,10 @@ describe('useInterpret', () => {
     function App() {
       useInterpret(machine, {
         actions: {
-          fooAction: assign((_context, _event) => {
-            ((_accept: 'FOO') => {})(_event.type);
+          fooAction: assign(({ event }) => {
+            ((_accept: 'FOO') => {})(event.type);
             // @ts-expect-error
-            ((_accept: "test that this isn't any") => {})(_event.type);
+            ((_accept: "test that this isn't any") => {})(event.type);
           })
         }
       });
@@ -773,10 +773,10 @@ describe('createActorContext', () => {
         <Context.Provider
           options={{
             actions: {
-              fooAction: assign((_context, _event) => {
-                ((_accept: 'FOO') => {})(_event.type);
+              fooAction: assign(({ event }) => {
+                ((_accept: 'FOO') => {})(event.type);
                 // @ts-expect-error
-                ((_accept: "test that this isn't any") => {})(_event.type);
+                ((_accept: "test that this isn't any") => {})(event.type);
               })
             }
           }}

--- a/packages/xstate-react/test/typegenTypes.test.tsx
+++ b/packages/xstate-react/test/typegenTypes.test.tsx
@@ -167,7 +167,7 @@ describe('useMachine', () => {
       useMachine(machine, {
         actions: {
           // it's important to use `event` here somehow to make this a possible source of information for inference
-          fooAction: (_context, _event) => {}
+          fooAction: () => {}
         }
       });
       return null;
@@ -378,7 +378,7 @@ describe('useInterpret', () => {
       useInterpret(machine, {
         actions: {
           // it's important to use `event` here somehow to make this a possible source of information for inference
-          fooAction: (_context, _event) => {}
+          fooAction: () => {}
         }
       });
       return null;
@@ -734,7 +734,7 @@ describe('createActorContext', () => {
           options={{
             actions: {
               // it's important to use `event` here somehow to make this a possible source of information for inference
-              fooAction: (_context, _event) => {}
+              fooAction: () => {}
             }
           }}
         >

--- a/packages/xstate-react/test/types.test.tsx
+++ b/packages/xstate-react/test/types.test.tsx
@@ -72,7 +72,7 @@ describe('useMachine', () => {
       {
         actions: {
           spawnActor: assign({
-            actor: ({ meta: { spawn } }) => spawn(child)
+            actor: ({ spawn }) => spawn(child)
           })
         }
       }

--- a/packages/xstate-react/test/types.test.tsx
+++ b/packages/xstate-react/test/types.test.tsx
@@ -72,7 +72,7 @@ describe('useMachine', () => {
       {
         actions: {
           spawnActor: assign({
-            actor: (_, __, { spawn }) => spawn(child)
+            actor: ({ meta: { spawn } }) => spawn(child)
           })
         }
       }

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -142,7 +142,7 @@ describeEachReactMode('useActor (%s)', ({ render, suiteKey }) => {
       states: {
         active: {
           entry: assign({
-            actorRef: (_, __, { spawn }) => spawn(childMachine)
+            actorRef: ({ meta: { spawn } }) => spawn(childMachine)
           })
         }
       }
@@ -195,7 +195,7 @@ describeEachReactMode('useActor (%s)', ({ render, suiteKey }) => {
         states: {
           active: {
             entry: assign({
-              actorRef: (_, __, { spawn }) =>
+              actorRef: ({ meta: { spawn } }) =>
                 spawn(childMachine, { id: 'child' })
             }),
             on: { FINISH: 'success' }
@@ -386,7 +386,9 @@ describeEachReactMode('useActor (%s)', ({ render, suiteKey }) => {
         states: {
           active: {
             on: {
-              INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) },
+              INC: {
+                actions: assign({ count: ({ context }) => context.count + 1 })
+              },
               SOMETHING: { actions: 'doSomething' }
             }
           }

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -142,7 +142,7 @@ describeEachReactMode('useActor (%s)', ({ render, suiteKey }) => {
       states: {
         active: {
           entry: assign({
-            actorRef: ({ meta: { spawn } }) => spawn(childMachine)
+            actorRef: ({ spawn }) => spawn(childMachine)
           })
         }
       }
@@ -195,8 +195,7 @@ describeEachReactMode('useActor (%s)', ({ render, suiteKey }) => {
         states: {
           active: {
             entry: assign({
-              actorRef: ({ meta: { spawn } }) =>
-                spawn(childMachine, { id: 'child' })
+              actorRef: ({ spawn }) => spawn(childMachine, { id: 'child' })
             }),
             on: { FINISH: 'success' }
           },

--- a/packages/xstate-react/test/useInterpret.test.tsx
+++ b/packages/xstate-react/test/useInterpret.test.tsx
@@ -171,7 +171,7 @@ describeEachReactMode('useInterpret (%s)', ({ suiteKey, render }) => {
       }),
       on: {
         SEND_TO_CHILD: {
-          actions: sendTo((ctx) => ctx.childRef, { type: 'EVENT' })
+          actions: sendTo(({ context }) => context.childRef, { type: 'EVENT' })
         }
       }
     });
@@ -227,7 +227,7 @@ describeEachReactMode('useInterpret (%s)', ({ suiteKey, render }) => {
       }),
       on: {
         SEND_TO_CHILD: {
-          actions: sendTo((ctx) => ctx.childRef, { type: 'EVENT' })
+          actions: sendTo(({ context }) => context.childRef, { type: 'EVENT' })
         }
       }
     });

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -43,7 +43,7 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
           onDone: {
             target: 'success',
             actions: assign({
-              data: (_, e) => e.data
+              data: ({ event }) => event.data
             }),
             guard: ({ event }) => event.data.length
           }
@@ -198,7 +198,7 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
       states: {
         start: {
           entry: assign({
-            ref: (_, __, { spawn }) =>
+            ref: ({ meta: { spawn } }) =>
               spawn(
                 fromPromise(() => {
                   return new Promise((res) => res(42));
@@ -420,7 +420,7 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
       {
         actions: {
           setup: assign({
-            stuff: (context: any) => [...context.stuff, 4]
+            stuff: ({ context }) => [...context.stuff, 4]
           })
         }
       }
@@ -465,10 +465,10 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
       {
         actions: {
           setup: assign({
-            stuff: (context: any) => [...context.stuff, 4]
+            stuff: ({ context }) => [...context.stuff, 4]
           }),
           increase: assign({
-            counter: (context: any) => ++context.counter
+            counter: ({ context }) => ++context.counter
           })
         }
       }
@@ -926,7 +926,7 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
       on: {
         INC: {
           actions: [
-            assign({ count: (ctx) => ctx.count + 1 }),
+            assign({ count: ({ context }) => context.count + 1 }),
             send({ type: 'UNHANDLED' })
           ]
         }

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -45,7 +45,7 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
             actions: assign({
               data: (_, e) => e.data
             }),
-            guard: (_, e) => e.data.length
+            guard: ({ event }) => event.data.length
           }
         }
       },

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -198,7 +198,7 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
       states: {
         start: {
           entry: assign({
-            ref: ({ meta: { spawn } }) =>
+            ref: ({ spawn }) =>
               spawn(
                 fromPromise(() => {
                   return new Promise((res) => res(42));

--- a/packages/xstate-react/test/useSelector.test.tsx
+++ b/packages/xstate-react/test/useSelector.test.tsx
@@ -35,10 +35,10 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
       },
       on: {
         OTHER: {
-          actions: assign({ other: (ctx) => ctx.other + 1 })
+          actions: assign({ other: ({ context }) => context.other + 1 })
         },
         INCREMENT: {
-          actions: assign({ count: (ctx) => ctx.count + 1 })
+          actions: assign({ count: ({ context }) => context.count + 1 })
         }
       }
     });
@@ -98,7 +98,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
       },
       on: {
         CHANGE: {
-          actions: assign({ name: (_, e) => e.value })
+          actions: assign({ name: ({ event }) => event.value })
         }
       }
     });
@@ -238,7 +238,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
       on: {
         UPDATE_COUNT: {
           actions: assign({
-            count: (ctx) => ctx.count + 1
+            count: ({ context }) => context.count + 1
           })
         }
       }
@@ -329,7 +329,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
       on: {
         INC: {
           actions: assign({
-            count: (ctx) => ctx.count + 1
+            count: ({ context }) => context.count + 1
           })
         }
       }
@@ -373,7 +373,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
       on: {
         INC: {
           actions: assign({
-            count: (ctx) => ctx.count + 1
+            count: ({ context }) => context.count + 1
           })
         }
       }
@@ -538,7 +538,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
       on: {
         INC: {
           actions: assign({
-            foo: (context) => ++context.foo
+            foo: ({ context }) => ++context.foo
           })
         }
       }

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -150,8 +150,16 @@ function createGuard<
   TContext extends object,
   TEvent extends EventObject = EventObject
 >(guard: string) {
-  return (context: TContext, _event: TEvent, meta) => {
-    return evaluateExecutableContent(context, _event, meta, `return ${guard};`);
+  return ({
+    context,
+    event,
+    meta
+  }: {
+    context: TContext;
+    event: TEvent;
+    meta;
+  }) => {
+    return evaluateExecutableContent(context, event, meta, `return ${guard};`);
   };
 }
 
@@ -180,12 +188,12 @@ function mapAction<
       if ('sendid' in element.attributes!) {
         return actions.cancel(element.attributes!.sendid! as string);
       }
-      return actions.cancel((context, e, meta) => {
+      return actions.cancel(({ context, event, meta }) => {
         const fnBody = `
             return ${element.attributes!.sendidexpr};
           `;
 
-        return evaluateExecutableContent(context, e, meta, fnBody);
+        return evaluateExecutableContent(context, event, meta, fnBody);
       });
     case 'send': {
       const { event, eventexpr, target, id } = element.attributes!;
@@ -207,26 +215,26 @@ function mapAction<
       if (event && !params) {
         convertedEvent = { type: event } as TEvent;
       } else {
-        convertedEvent = (context, _ev, meta) => {
+        convertedEvent = ({ context, event, meta }) => {
           const fnBody = `
               return { type: ${event ? `"${event}"` : eventexpr}, ${
             params ? params : ''
           } }
             `;
 
-          return evaluateExecutableContent(context, _ev, meta, fnBody);
+          return evaluateExecutableContent(context, event, meta, fnBody);
         };
       }
 
       if ('delay' in element.attributes!) {
         convertedDelay = delayToMs(element.attributes!.delay);
       } else if (element.attributes!.delayexpr) {
-        convertedDelay = (context, _ev, meta) => {
+        convertedDelay = ({ context, event, meta }) => {
           const fnBody = `
               return (${delayToMs})(${element.attributes!.delayexpr});
             `;
 
-          return evaluateExecutableContent(context, _ev, meta, fnBody);
+          return evaluateExecutableContent(context, event, meta, fnBody);
         };
       }
 
@@ -240,12 +248,12 @@ function mapAction<
       const label = element.attributes!.label;
 
       return actions.log<TContext, any, any>(
-        (context, e, meta) => {
+        ({ context, event, meta }) => {
           const fnBody = `
               return ${element.attributes!.expr};
             `;
 
-          return evaluateExecutableContent(context, e, meta, fnBody);
+          return evaluateExecutableContent(context, event, meta, fnBody);
         },
         label !== undefined ? String(label) : undefined
       );

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -153,13 +153,17 @@ function createGuard<
   return ({
     context,
     event,
-    meta
+    ...meta
   }: {
     context: TContext;
     event: TEvent;
-    meta;
   }) => {
-    return evaluateExecutableContent(context, event, meta, `return ${guard};`);
+    return evaluateExecutableContent(
+      context,
+      event,
+      meta as any,
+      `return ${guard};`
+    );
   };
 }
 

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -174,14 +174,14 @@ function mapAction<
       } as TEvent);
     }
     case 'assign': {
-      return actions.assign<TContext, TEvent>((context, e, meta) => {
+      return actions.assign<TContext, TEvent>(({ context, event, meta }) => {
         const fnBody = `
             return {'${element.attributes!.location}': ${
           element.attributes!.expr
         }};
           `;
 
-        return evaluateExecutableContent(context, e, meta, fnBody);
+        return evaluateExecutableContent(context, event, meta, fnBody);
       });
     }
     case 'cancel':

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -174,7 +174,7 @@ function mapAction<
       } as TEvent);
     }
     case 'assign': {
-      return actions.assign<TContext, TEvent>(({ context, event, meta }) => {
+      return actions.assign<TContext, TEvent>(({ context, event, ...meta }) => {
         const fnBody = `
             return {'${element.attributes!.location}': ${
           element.attributes!.expr

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -192,7 +192,7 @@ function mapAction<
       if ('sendid' in element.attributes!) {
         return actions.cancel(element.attributes!.sendid! as string);
       }
-      return actions.cancel(({ context, event, meta }) => {
+      return actions.cancel(({ context, event, ...meta }) => {
         const fnBody = `
             return ${element.attributes!.sendidexpr};
           `;
@@ -219,7 +219,7 @@ function mapAction<
       if (event && !params) {
         convertedEvent = { type: event } as TEvent;
       } else {
-        convertedEvent = ({ context, event, meta }) => {
+        convertedEvent = ({ context, event, ...meta }) => {
           const fnBody = `
               return { type: ${event ? `"${event}"` : eventexpr}, ${
             params ? params : ''
@@ -233,7 +233,7 @@ function mapAction<
       if ('delay' in element.attributes!) {
         convertedDelay = delayToMs(element.attributes!.delay);
       } else if (element.attributes!.delayexpr) {
-        convertedDelay = ({ context, event, meta }) => {
+        convertedDelay = ({ context, event, ...meta }) => {
           const fnBody = `
               return (${delayToMs})(${element.attributes!.delayexpr});
             `;
@@ -252,7 +252,7 @@ function mapAction<
       const label = element.attributes!.label;
 
       return actions.log<TContext, any, any>(
-        ({ context, event, meta }) => {
+        ({ context, event, ...meta }) => {
           const fnBody = `
               return ${element.attributes!.expr};
             `;

--- a/packages/xstate-scxml/test/fixtures/assign-current-small-step/test0.ts
+++ b/packages/xstate-scxml/test/fixtures/assign-current-small-step/test0.ts
@@ -12,8 +12,8 @@ export default createMachine<any>({
       on: {
         t: {
           target: 'b',
-          guard: (ctx) => {
-            return ctx.x === 99;
+          guard: ({ context }) => {
+            return context.x === 99;
           },
           actions: assign({
             x: (ctx) => ctx.x + 1
@@ -31,7 +31,7 @@ export default createMachine<any>({
       always: [
         {
           target: 'c',
-          guard: (ctx) => ctx.x === 200
+          guard: ({ context }) => context.x === 200
         },
         { target: 'f' }
       ]

--- a/packages/xstate-scxml/test/fixtures/assign-current-small-step/test0.ts
+++ b/packages/xstate-scxml/test/fixtures/assign-current-small-step/test0.ts
@@ -16,7 +16,7 @@ export default createMachine<any>({
             return context.x === 99;
           },
           actions: assign({
-            x: (ctx) => ctx.x + 1
+            x: ({ context }) => context.x + 1
           })
         }
       }
@@ -26,7 +26,7 @@ export default createMachine<any>({
       //   ctx.x *= 2;
       // },
       entry: assign({
-        x: (ctx) => ctx.x * 2
+        x: ({ context }) => context.x * 2
       }),
       always: [
         {

--- a/packages/xstate-scxml/test/fixtures/assign-current-small-step/test1.ts
+++ b/packages/xstate-scxml/test/fixtures/assign-current-small-step/test1.ts
@@ -20,8 +20,8 @@ export default createMachine<any>({
       always: [
         {
           target: 'b',
-          guard: (ctx) => {
-            return ctx.i < 10;
+          guard: ({ context }) => {
+            return context.i < 10;
           },
           actions: [
             assign({
@@ -32,7 +32,7 @@ export default createMachine<any>({
         },
         {
           target: '#c',
-          guard: (ctx) => ctx.i === 10
+          guard: ({ context }) => context.i === 10
         }
       ]
     },

--- a/packages/xstate-scxml/test/fixtures/assign-current-small-step/test1.ts
+++ b/packages/xstate-scxml/test/fixtures/assign-current-small-step/test1.ts
@@ -25,7 +25,7 @@ export default createMachine<any>({
           },
           actions: [
             assign({
-              i: (ctx) => ctx.i + 1
+              i: ({ context }) => context.i + 1
             }),
             log()
           ]

--- a/packages/xstate-scxml/test/fixtures/assign/assign_obj_literal.ts
+++ b/packages/xstate-scxml/test/fixtures/assign/assign_obj_literal.ts
@@ -12,7 +12,7 @@ export default createMachine({
         '*': {
           target: '#fail',
           actions: actions.log(
-            (_, e) => `unhandled input ${JSON.stringify(e)}`,
+            ({ event }) => `unhandled input ${JSON.stringify(event)}`,
             'TEST'
           )
         }

--- a/packages/xstate-solid/test/from._test.tsx
+++ b/packages/xstate-solid/test/from._test.tsx
@@ -125,8 +125,8 @@ describe("usage of interpret from core with Solid's from", () => {
             INC: {
               actions: [
                 assign({
-                  latestValue: (ctx: Context) => ({
-                    value: ctx.latestValue.value + 1
+                  latestValue: ({ context }) => ({
+                    value: context.latestValue.value + 1
                   })
                 })
               ]

--- a/packages/xstate-solid/test/selector.test.tsx
+++ b/packages/xstate-solid/test/selector.test.tsx
@@ -151,7 +151,7 @@ describe('usage of selectors with reactive service state', () => {
       childActor: ActorRefFrom<typeof childMachine>;
     }>({
       entry: assign({
-        childActor: ({ meta: { spawn } }) => spawn(childMachine)
+        childActor: ({ spawn }) => spawn(childMachine)
       })
     });
 
@@ -201,7 +201,7 @@ describe('usage of selectors with reactive service state', () => {
       childActor: ActorRefFrom<typeof childMachine>;
     }>({
       entry: assign({
-        childActor: ({ meta: { spawn } }) => spawn(childMachine)
+        childActor: ({ spawn }) => spawn(childMachine)
       })
     });
     const [prop, setProp] = createSignal('first');
@@ -244,13 +244,13 @@ describe('usage of selectors with reactive service state', () => {
       states: {
         active: {
           entry: assign({
-            actorRef: ({ meta: { spawn } }) => spawn(childMachine(1))
+            actorRef: ({ spawn }) => spawn(childMachine(1))
           }),
           on: {
             CHANGE: {
               actions: [
                 assign({
-                  actorRef: ({ meta: { spawn } }) => spawn(childMachine(0))
+                  actorRef: ({ spawn }) => spawn(childMachine(0))
                 })
               ]
             }
@@ -303,7 +303,7 @@ describe('usage of selectors with reactive service state', () => {
       childActor: ActorRefFrom<typeof childMachine>;
     }>({
       entry: assign({
-        childActor: ({ meta: { spawn } }) => spawn(childMachine)
+        childActor: ({ spawn }) => spawn(childMachine)
       })
     });
     const [prop, setProp] = createSignal('first');

--- a/packages/xstate-solid/test/selector.test.tsx
+++ b/packages/xstate-solid/test/selector.test.tsx
@@ -18,10 +18,10 @@ describe('usage of selectors with reactive service state', () => {
       },
       on: {
         OTHER: {
-          actions: assign({ other: (ctx) => ctx.other + 1 })
+          actions: assign({ other: ({ context }) => context.other + 1 })
         },
         INCREMENT: {
-          actions: assign({ count: (ctx) => ctx.count + 1 })
+          actions: assign({ count: ({ context }) => context.count + 1 })
         }
       }
     });
@@ -83,7 +83,7 @@ describe('usage of selectors with reactive service state', () => {
       },
       on: {
         CHANGE: {
-          actions: assign({ name: (_, e) => e.value })
+          actions: assign({ name: ({ event }) => event.value })
         }
       }
     });
@@ -141,7 +141,7 @@ describe('usage of selectors with reactive service state', () => {
       on: {
         UPDATE_COUNT: {
           actions: assign({
-            count: (ctx) => ctx.count + 1
+            count: ({ context }) => context.count + 1
           })
         }
       }
@@ -151,7 +151,7 @@ describe('usage of selectors with reactive service state', () => {
       childActor: ActorRefFrom<typeof childMachine>;
     }>({
       entry: assign({
-        childActor: (_, __, { spawn }) => spawn(childMachine)
+        childActor: ({ meta: { spawn } }) => spawn(childMachine)
       })
     });
 
@@ -191,7 +191,7 @@ describe('usage of selectors with reactive service state', () => {
       on: {
         INC: {
           actions: assign({
-            count: (ctx) => ctx.count + 1
+            count: ({ context }) => context.count + 1
           })
         }
       }
@@ -201,7 +201,7 @@ describe('usage of selectors with reactive service state', () => {
       childActor: ActorRefFrom<typeof childMachine>;
     }>({
       entry: assign({
-        childActor: (_, __, { spawn }) => spawn(childMachine)
+        childActor: ({ meta: { spawn } }) => spawn(childMachine)
       })
     });
     const [prop, setProp] = createSignal('first');
@@ -244,13 +244,13 @@ describe('usage of selectors with reactive service state', () => {
       states: {
         active: {
           entry: assign({
-            actorRef: (_, __, { spawn }) => spawn(childMachine(1))
+            actorRef: ({ meta: { spawn } }) => spawn(childMachine(1))
           }),
           on: {
             CHANGE: {
               actions: [
                 assign({
-                  actorRef: (_, __, { spawn }) => spawn(childMachine(0))
+                  actorRef: ({ meta: { spawn } }) => spawn(childMachine(0))
                 })
               ]
             }
@@ -293,7 +293,7 @@ describe('usage of selectors with reactive service state', () => {
       on: {
         INC: {
           actions: assign({
-            count: (ctx) => ctx.count + 1
+            count: ({ context }) => context.count + 1
           })
         }
       }
@@ -303,7 +303,7 @@ describe('usage of selectors with reactive service state', () => {
       childActor: ActorRefFrom<typeof childMachine>;
     }>({
       entry: assign({
-        childActor: (_, __, { spawn }) => spawn(childMachine)
+        childActor: ({ meta: { spawn } }) => spawn(childMachine)
       })
     });
     const [prop, setProp] = createSignal('first');

--- a/packages/xstate-solid/test/useActor.test.tsx
+++ b/packages/xstate-solid/test/useActor.test.tsx
@@ -220,7 +220,7 @@ describe('useActor', () => {
       states: {
         active: {
           entry: assign({
-            actorRef: ({ meta: { spawn } }) => spawn(childMachine)
+            actorRef: ({ spawn }) => spawn(childMachine)
           }),
           on: { FINISH: 'success' }
         },
@@ -303,7 +303,7 @@ describe('useActor', () => {
       states: {
         active: {
           entry: assign({
-            actorRef: ({ meta: { spawn } }) => spawn(childMachine)
+            actorRef: ({ spawn }) => spawn(childMachine)
           })
         }
       }
@@ -602,7 +602,7 @@ describe('useActor', () => {
       states: {
         active: {
           entry: assign({
-            actorRef: ({ meta: { spawn } }) => spawn(childMachine)
+            actorRef: ({ spawn }) => spawn(childMachine)
           }),
           on: { FINISH: 'success' }
         },

--- a/packages/xstate-solid/test/useActor.test.tsx
+++ b/packages/xstate-solid/test/useActor.test.tsx
@@ -187,7 +187,10 @@ describe('useActor', () => {
             FINISH: {
               actions: [
                 assign({
-                  item: (ctx) => ({ ...ctx.item, total: ctx.item.total + 1 })
+                  item: ({ context }) => ({
+                    ...context.item,
+                    total: context.item.total + 1
+                  })
                 }),
 
                 sendParent({ type: 'FINISH' })
@@ -196,7 +199,10 @@ describe('useActor', () => {
             COUNT: {
               actions: [
                 assign({
-                  item: (ctx) => ({ ...ctx.item, count: ctx.item.count + 1 })
+                  item: ({ context }) => ({
+                    ...context.item,
+                    count: context.item.count + 1
+                  })
                 })
               ]
             }
@@ -214,7 +220,7 @@ describe('useActor', () => {
       states: {
         active: {
           entry: assign({
-            actorRef: (_, __, { spawn }) => spawn(childMachine)
+            actorRef: ({ meta: { spawn } }) => spawn(childMachine)
           }),
           on: { FINISH: 'success' }
         },
@@ -297,7 +303,7 @@ describe('useActor', () => {
       states: {
         active: {
           entry: assign({
-            actorRef: (_, __, { spawn }) => spawn(childMachine)
+            actorRef: ({ meta: { spawn } }) => spawn(childMachine)
           })
         }
       }
@@ -596,7 +602,7 @@ describe('useActor', () => {
       states: {
         active: {
           entry: assign({
-            actorRef: (_, __, { spawn }) => spawn(childMachine)
+            actorRef: ({ meta: { spawn } }) => spawn(childMachine)
           }),
           on: { FINISH: 'success' }
         },
@@ -806,8 +812,8 @@ describe('useActor', () => {
           on: {
             CHANGE: {
               actions: [
-                assign((ctx, event) => {
-                  const newCtx = { ...ctx };
+                assign(({ context, event }) => {
+                  const newCtx = { ...context };
                   newCtx.arr = [...newCtx.arr];
                   newCtx.arr[event.index] = {
                     ...newCtx.arr[event.index],
@@ -1092,7 +1098,9 @@ describe('useActor', () => {
         states: {
           active: {
             on: {
-              INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) },
+              INC: {
+                actions: assign({ count: ({ context }) => context.count + 1 })
+              },
               SOMETHING: { actions: 'doSomething' }
             }
           }
@@ -1164,7 +1172,7 @@ describe('useActor', () => {
           on: {
             INC: {
               actions: assign({
-                counter: (ctx) => ctx.counter + 1
+                counter: ({ context }) => context.counter + 1
               })
             }
           }
@@ -1214,7 +1222,9 @@ describe('useActor', () => {
       states: {
         active: {
           on: {
-            INC: { actions: assign({ count: (ctx) => ctx.count + 1 }) },
+            INC: {
+              actions: assign({ count: ({ context }) => context.count + 1 })
+            },
             SOMETHING: { actions: 'doSomething' }
           }
         }
@@ -1275,13 +1285,13 @@ describe('useActor', () => {
           on: {
             INC: {
               actions: assign({
-                subCount: (ctx) => ({
-                  ...ctx.subCount,
+                subCount: ({ context }) => ({
+                  ...context.subCount,
                   subCount1: {
-                    ...ctx.subCount.subCount1,
+                    ...context.subCount.subCount1,
                     subCount2: {
-                      ...ctx.subCount.subCount1.subCount2,
-                      count: ctx.subCount.subCount1.subCount2.count + 1
+                      ...context.subCount.subCount1.subCount2,
+                      count: context.subCount.subCount1.subCount2.count + 1
                     }
                   }
                 })
@@ -1350,13 +1360,13 @@ describe('useActor', () => {
           on: {
             INC: {
               actions: assign({
-                subCount: (ctx) => ({
-                  ...ctx.subCount,
+                subCount: ({ context }) => ({
+                  ...context.subCount,
                   subCount1: {
-                    ...ctx.subCount.subCount1,
+                    ...context.subCount.subCount1,
                     subCount2: {
-                      ...ctx.subCount.subCount1.subCount2,
-                      count: ctx.subCount.subCount1.subCount2.count + 1
+                      ...context.subCount.subCount1.subCount2,
+                      count: context.subCount.subCount1.subCount2.count + 1
                     }
                   }
                 })
@@ -1425,8 +1435,8 @@ describe('useActor', () => {
             INC: {
               actions: [
                 assign({
-                  latestValue: (ctx: Context) => ({
-                    value: ctx.latestValue.value + 1
+                  latestValue: ({ context }) => ({
+                    value: context.latestValue.value + 1
                   })
                 })
               ]

--- a/packages/xstate-solid/test/useMachine.test.tsx
+++ b/packages/xstate-solid/test/useMachine.test.tsx
@@ -208,7 +208,7 @@ describe('useMachine hook', () => {
       states: {
         start: {
           entry: assign({
-            ref: ({ meta: { spawn } }) =>
+            ref: ({ spawn }) =>
               spawn(
                 fromPromise(() => new Promise((res) => res(42))),
                 { id: 'my-promise' }

--- a/packages/xstate-solid/test/useMachine.test.tsx
+++ b/packages/xstate-solid/test/useMachine.test.tsx
@@ -51,7 +51,7 @@ describe('useMachine hook', () => {
           onDone: {
             target: 'success',
             actions: assign({
-              data: (_, e) => e.data
+              data: ({ event }) => event.data
             }),
             guard: ({ event }) => event.data.length
           }
@@ -208,7 +208,7 @@ describe('useMachine hook', () => {
       states: {
         start: {
           entry: assign({
-            ref: (_, __, { spawn }) =>
+            ref: ({ meta: { spawn } }) =>
               spawn(
                 fromPromise(() => new Promise((res) => res(42))),
                 { id: 'my-promise' }
@@ -410,11 +410,11 @@ describe('useMachine hook', () => {
             COUNT: {
               actions: [
                 assign({
-                  item: (ctx) => ({
-                    ...ctx.item,
+                  item: ({ context }) => ({
+                    ...context.item,
                     counts: [
-                      ...ctx.item.counts,
-                      { value: ctx.item.counts.length + 1 }
+                      ...context.item.counts,
+                      { value: context.item.counts.length + 1 }
                     ]
                   })
                 })
@@ -423,11 +423,11 @@ describe('useMachine hook', () => {
             TOTAL: {
               actions: [
                 assign({
-                  item: (ctx) => ({
-                    ...ctx.item,
+                  item: ({ context }) => ({
+                    ...context.item,
                     totals: [
-                      ...ctx.item.totals,
-                      { value: ctx.item.totals.length + 1 }
+                      ...context.item.totals,
+                      { value: context.item.totals.length + 1 }
                     ]
                   })
                 })
@@ -480,13 +480,13 @@ describe('useMachine hook', () => {
           on: {
             INC: {
               actions: assign({
-                subCount: (ctx) => ({
-                  ...ctx.subCount,
+                subCount: ({ context }) => ({
+                  ...context.subCount,
                   subCount1: {
-                    ...ctx.subCount.subCount1,
+                    ...context.subCount.subCount1,
                     subCount2: {
-                      ...ctx.subCount.subCount1.subCount2,
-                      count: ctx.subCount.subCount1.subCount2.count + 1
+                      ...context.subCount.subCount1.subCount2,
+                      count: context.subCount.subCount1.subCount2.count + 1
                     }
                   }
                 })
@@ -556,14 +556,20 @@ describe('useMachine hook', () => {
             COUNT: {
               actions: [
                 assign({
-                  item: (ctx) => ({ ...ctx.item, count: ctx.item.count + 1 })
+                  item: ({ context }) => ({
+                    ...context.item,
+                    count: context.item.count + 1
+                  })
                 })
               ]
             },
             TOTAL: {
               actions: [
                 assign({
-                  item: (ctx) => ({ ...ctx.item, total: ctx.item.total + 1 })
+                  item: ({ context }) => ({
+                    ...context.item,
+                    total: context.item.total + 1
+                  })
                 })
               ]
             }
@@ -948,7 +954,7 @@ describe('useMachine hook', () => {
           on: {
             INC: {
               actions: assign({
-                counter: (ctx) => ctx.counter + 1
+                counter: ({ context }) => context.counter + 1
               })
             }
           }
@@ -1278,7 +1284,7 @@ describe('useMachine hook', () => {
       on: {
         INC: {
           actions: [
-            assign({ count: (ctx) => ++ctx.count }),
+            assign({ count: ({ context }) => ++context.count }),
             xsend({ type: 'UNHANDLED' })
           ]
         }
@@ -1352,8 +1358,8 @@ describe('useMachine hook', () => {
             INC: {
               actions: [
                 assign({
-                  latestValue: (ctx: Context) => ({
-                    value: ctx.latestValue.value + 1
+                  latestValue: ({ context }) => ({
+                    value: context.latestValue.value + 1
                   })
                 })
               ]
@@ -1479,9 +1485,11 @@ describe('useMachine hook', () => {
       },
       {
         actions: {
-          toggleIsAwesome: assign((ctx) => ({ isAwesome: !ctx.isAwesome })),
-          toggleIsNotAwesome: assign((ctx) => ({
-            isNotAwesome: !ctx.isNotAwesome
+          toggleIsAwesome: assign(({ context }) => ({
+            isAwesome: !context.isAwesome
+          })),
+          toggleIsNotAwesome: assign(({ context }) => ({
+            isNotAwesome: !context.isNotAwesome
           }))
         },
         guards: {

--- a/packages/xstate-solid/test/useMachine.test.tsx
+++ b/packages/xstate-solid/test/useMachine.test.tsx
@@ -53,7 +53,7 @@ describe('useMachine hook', () => {
             actions: assign({
               data: (_, e) => e.data
             }),
-            guard: (_, e) => e.data.length
+            guard: ({ event }) => event.data.length
           }
         }
       },
@@ -1485,7 +1485,7 @@ describe('useMachine hook', () => {
           }))
         },
         guards: {
-          isAwesome: (ctx) => !!ctx.isAwesome
+          isAwesome: ({ context }) => !!context.isAwesome
         }
       }
     );

--- a/packages/xstate-svelte/test/UseMachineNonPersistentSubcription.svelte
+++ b/packages/xstate-svelte/test/UseMachineNonPersistentSubcription.svelte
@@ -15,7 +15,7 @@
     on: {
       INC: {
         actions: assign({
-          count: (ctx: { count: number }) => ++ctx.count
+          count: ({ context }) => ++context.count
         })
       }
     }

--- a/packages/xstate-svelte/test/UseSelector.svelte
+++ b/packages/xstate-svelte/test/UseSelector.svelte
@@ -18,11 +18,11 @@
       idle: {
         on: {
           INCREMENT: {
-            actions: assign({ count: ({ count }) => count + 1 })
+            actions: assign({ count: ({ context: { count } }) => count + 1 })
           },
           INCREMENT_ANOTHER: {
             actions: assign({
-              anotherCount: ({ anotherCount }) => anotherCount + 1
+              anotherCount: ({ context: { anotherCount } }) => anotherCount + 1
             })
           }
         }

--- a/packages/xstate-svelte/test/UseSelectorCustomFn.svelte
+++ b/packages/xstate-svelte/test/UseSelectorCustomFn.svelte
@@ -12,7 +12,7 @@
     },
     on: {
       CHANGE: {
-        actions: assign({ name: (_, e) => e.value })
+        actions: assign({ name: ({ event }) => event.value })
       }
     }
   });

--- a/packages/xstate-svelte/test/fetchMachine.ts
+++ b/packages/xstate-svelte/test/fetchMachine.ts
@@ -19,7 +19,7 @@ export const fetchMachine = createMachine<typeof context, any>({
         onDone: {
           target: 'success',
           actions: assign({
-            data: (_, event) => event.data
+            data: ({ event }) => event.data
           }),
           guard: ({ event }) => event.data.length
         }

--- a/packages/xstate-svelte/test/fetchMachine.ts
+++ b/packages/xstate-svelte/test/fetchMachine.ts
@@ -19,9 +19,9 @@ export const fetchMachine = createMachine<typeof context, any>({
         onDone: {
           target: 'success',
           actions: assign({
-            data: (_, e) => e.data
+            data: (_, event) => event.data
           }),
-          guard: (_, e) => e.data.length
+          guard: ({ event }) => event.data.length
         }
       }
     },

--- a/packages/xstate-test/test/dieHard.test.ts
+++ b/packages/xstate-test/test/dieHard.test.ts
@@ -104,7 +104,7 @@ describe('die hard example', () => {
       },
       {
         guards: {
-          weHave4Gallons: (ctx) => ctx.five === 4
+          weHave4Gallons: ({ context }) => context.five === 4
         }
       }
     );

--- a/packages/xstate-test/test/dieHard.test.ts
+++ b/packages/xstate-test/test/dieHard.test.ts
@@ -9,20 +9,20 @@ describe('die hard example', () => {
     five: number;
   }
 
-  const pour3to5 = assign<DieHardContext>((ctx) => {
-    const poured = Math.min(5 - ctx.five, ctx.three);
+  const pour3to5 = assign<DieHardContext>(({ context }) => {
+    const poured = Math.min(5 - context.five, context.three);
 
     return {
-      three: ctx.three - poured,
-      five: ctx.five + poured
+      three: context.three - poured,
+      five: context.five + poured
     };
   });
-  const pour5to3 = assign<DieHardContext>((ctx) => {
-    const poured = Math.min(3 - ctx.three, ctx.five);
+  const pour5to3 = assign<DieHardContext>(({ context }) => {
+    const poured = Math.min(3 - context.three, context.five);
 
     const res = {
-      three: ctx.three + poured,
-      five: ctx.five - poured
+      three: context.three + poured,
+      five: context.five - poured
     };
 
     return res;

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -31,7 +31,7 @@ describe('events', () => {
             SUBMIT: [
               {
                 target: 'thanks',
-                guard: (_, e) => !!e.value.length
+                guard: ({ event }) => !!event.value.length
               },
               {
                 target: '.invalid'
@@ -99,9 +99,9 @@ describe('events', () => {
         a: {
           on: {
             EVENT: [
-              { guard: (_, e) => e.value === 1, target: 'b' },
-              { guard: (_, e) => e.value === 2, target: 'c' },
-              { guard: (_, e) => e.value === 3, target: 'd' }
+              { guard: ({ event }) => event.value === 1, target: 'b' },
+              { guard: ({ event }) => event.value === 2, target: 'c' },
+              { guard: ({ event }) => event.value === 3, target: 'd' }
             ]
           }
         },

--- a/packages/xstate-test/test/index.test.ts
+++ b/packages/xstate-test/test/index.test.ts
@@ -160,7 +160,7 @@ describe('state limiting', () => {
           on: {
             INC: {
               actions: assign({
-                count: (ctx) => ctx.count + 1
+                count: ({ context }) => context.count + 1
               })
             }
           }
@@ -189,7 +189,7 @@ it('prevents infinite recursion based on a provided limit', () => {
     },
     on: {
       TOGGLE: {
-        actions: assign({ count: (ctx) => ctx.count + 1 })
+        actions: assign({ count: ({ context }) => context.count + 1 })
       }
     }
   });

--- a/packages/xstate-test/test/paths.test.ts
+++ b/packages/xstate-test/test/paths.test.ts
@@ -162,7 +162,7 @@ describe('transition coverage', () => {
       },
       {
         guards: {
-          valid: (_, event) => {
+          valid: ({ event }) => {
             return event.value > 10;
           }
         }

--- a/packages/xstate-vue/test/UseMachine.vue
+++ b/packages/xstate-vue/test/UseMachine.vue
@@ -38,7 +38,7 @@ const fetchMachine = createMachine<typeof context, any>({
           actions: assign({
             data: (_, e) => e.data
           }),
-          guard: (_, e) => e.data.length
+          guard: ({event}) => event.data.length
         }
       }
     },

--- a/packages/xstate-vue/test/UseMachine.vue
+++ b/packages/xstate-vue/test/UseMachine.vue
@@ -36,7 +36,7 @@ const fetchMachine = createMachine<typeof context, any>({
         onDone: {
           target: 'success',
           actions: assign({
-            data: (_, e) => e.data
+            data: ({event}) => event.data
           }),
           guard: ({event}) => event.data.length
         }

--- a/packages/xstate-vue/test/UseSelector.vue
+++ b/packages/xstate-vue/test/UseSelector.vue
@@ -24,10 +24,10 @@ const machine = createMachine<{ count: number; other: number }>({
   },
   on: {
     OTHER: {
-      actions: assign({ other: (ctx) => ctx.other + 1 })
+      actions: assign({ other: ({context}) => context.other + 1 })
     },
     INCREMENT: {
-      actions: assign({ count: (ctx) => ctx.count + 1 })
+      actions: assign({ count: ({context}) => context.count + 1 })
     }
   }
 });

--- a/packages/xstate-vue/test/UseSelectorCustomFn.vue
+++ b/packages/xstate-vue/test/UseSelectorCustomFn.vue
@@ -25,7 +25,7 @@ const machine = createMachine<{ name: string }>({
   },
   on: {
     CHANGE: {
-      actions: assign({ name: (_, e) => e.value })
+      actions: assign({ name: ({event}) => event.value })
     }
   }
 });

--- a/packages/xstate-vue/test/typegenTypes.test.tsx
+++ b/packages/xstate-vue/test/typegenTypes.test.tsx
@@ -165,7 +165,7 @@ describe('useMachine', () => {
         useMachine(machine, {
           actions: {
             // it's important to use `event` here somehow to make this a possible source of information for inference
-            fooAction: (_context, _event) => {}
+            fooAction: ({ event: _event }) => {}
           }
         });
       }
@@ -370,7 +370,8 @@ describe('useInterpret', () => {
         useInterpret(machine, {
           actions: {
             // it's important to use `event` here somehow to make this a possible source of information for inference
-            fooAction: (_context, _event) => {}
+            // TODO: is it though?
+            fooAction: () => {}
           }
         });
       }

--- a/packages/xstate-vue/test/typegenTypes.test.tsx
+++ b/packages/xstate-vue/test/typegenTypes.test.tsx
@@ -196,8 +196,8 @@ describe('useMachine', () => {
       setup: () => {
         useMachine(machine, {
           actions: {
-            fooAction: assign((_context, _event) => {
-              ((_accept: 'FOO') => {})(_event.type);
+            fooAction: assign(({ event }) => {
+              ((_accept: 'FOO') => {})(event.type);
               // @ts-expect-error
               ((_accept: "test that this isn't any") => {})(_event.type);
             })
@@ -402,10 +402,10 @@ describe('useInterpret', () => {
       setup: () => {
         useInterpret(machine, {
           actions: {
-            fooAction: assign((_context, _event) => {
-              ((_accept: 'FOO') => {})(_event.type);
+            fooAction: assign(({ event }) => {
+              ((_accept: 'FOO') => {})(event.type);
               // @ts-expect-error
-              ((_accept: "test that this isn't any") => {})(_event.type);
+              ((_accept: "test that this isn't any") => {})(event.type);
             })
           }
         });

--- a/packages/xstate-vue/test/useMachine.test.ts
+++ b/packages/xstate-vue/test/useMachine.test.ts
@@ -24,7 +24,7 @@ describe('useMachine composition function', () => {
             actions: assign({
               data: (_, e) => e.data
             }),
-            guard: (_, e) => e.data.length
+            guard: ({ event }) => event.data.length
           }
         }
       },

--- a/packages/xstate-vue/test/useMachine.test.ts
+++ b/packages/xstate-vue/test/useMachine.test.ts
@@ -22,7 +22,7 @@ describe('useMachine composition function', () => {
           onDone: {
             target: 'success',
             actions: assign({
-              data: (_, e) => e.data
+              data: ({ event }) => event.data
             }),
             guard: ({ event }) => event.data.length
           }


### PR DESCRIPTION
This PR unifies arguments. Everywhere that you used to write `(context, event, other)` is now `({ context, event, other })`:

```diff
-actions: (_ctx, event) => { ... }
+actions: ({ event }) => { ... }
```