### PR TITLE
[v5] Final `.data` to `.output`

### DIFF
--- a/.changeset/five-mirrors-join.md
+++ b/.changeset/five-mirrors-join.md
@@ -1,0 +1,21 @@
+---
+'xstate': major
+'@xstate/fsm': major
+'@xstate/react': major
+'@xstate/vue': major
+---
+
+The output data on final states is now specified as `.output` instead of `.data`:
+
+```diff
+const machine = createMachine({
+  // ...
+  states: {
+    // ...
+    success: {
+-     data: { message: 'Success!' }
++     output: { message: 'Success!' }
+    }
+  }
+})
+```

--- a/.changeset/five-mirrors-join.md
+++ b/.changeset/five-mirrors-join.md
@@ -1,8 +1,5 @@
 ---
 'xstate': major
-'@xstate/fsm': major
-'@xstate/react': major
-'@xstate/vue': major
 ---
 
 The output data on final states is now specified as `.output` instead of `.data`:

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -111,7 +111,7 @@ export class StateNode<
   /**
    * The data sent with the "done.state._id_" event if this is a final state node.
    */
-  public doneData?:
+  public output?:
     | Mapper<TContext, TEvent, any>
     | PropertyMapper<TContext, TEvent, any>;
   /**
@@ -185,7 +185,7 @@ export class StateNode<
     this.exit = toActionObjects(this.config.exit);
 
     this.meta = this.config.meta;
-    this.doneData =
+    this.output =
       this.type === 'final'
         ? (this.config as FinalStateNodeConfig<TContext, TEvent>).output
         : undefined;
@@ -239,7 +239,7 @@ export class StateNode<
       exit: this.exit,
       meta: this.meta,
       order: this.order || -1,
-      output: this.doneData,
+      output: this.output,
       invoke: this.invoke,
       description: this.description,
       tags: this.tags

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -109,7 +109,7 @@ export class StateNode<
    */
   public meta?: any;
   /**
-   * The data sent with the "done.state._id_" event if this is a final state node.
+   * The output data sent with the "done.state._id_" event if this is a final state node.
    */
   public output?:
     | Mapper<TContext, TEvent, any>

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -187,7 +187,7 @@ export class StateNode<
     this.meta = this.config.meta;
     this.doneData =
       this.type === 'final'
-        ? (this.config as FinalStateNodeConfig<TContext, TEvent>).data
+        ? (this.config as FinalStateNodeConfig<TContext, TEvent>).output
         : undefined;
     this.tags = toArray(config.tags);
   }
@@ -239,7 +239,7 @@ export class StateNode<
       exit: this.exit,
       meta: this.meta,
       order: this.order || -1,
-      data: this.doneData,
+      output: this.doneData,
       invoke: this.invoke,
       description: this.description,
       tags: this.tags

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -147,13 +147,13 @@ export function after(delayRef: number | string, id?: string) {
  * has been reached in the parent state node.
  *
  * @param id The final state node's parent state node `id`
- * @param data The data to pass into the event
+ * @param output The data to pass into the event
  */
-export function done(id: string, data?: any): DoneEventObject {
+export function done(id: string, output?: any): DoneEventObject {
   const type = `${ActionTypes.DoneState}.${id}`;
   const eventObject = {
     type,
-    data
+    output
   };
 
   eventObject.toString = () => type;
@@ -168,13 +168,13 @@ export function done(id: string, data?: any): DoneEventObject {
  * but not when it is canceled.
  *
  * @param invokeId The invoked service ID
- * @param data The data to pass into the event
+ * @param output The data to pass into the event
  */
-export function doneInvoke(invokeId: string, data?: any): DoneEvent {
+export function doneInvoke(invokeId: string, output?: any): DoneEvent {
   const type = `${ActionTypes.DoneInvoke}.${invokeId}`;
   const eventObject = {
     type,
-    data
+    output
   };
 
   eventObject.toString = () => type;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -81,8 +81,8 @@ function getOutput<TContext extends MachineContext, TEvent extends EventObject>(
   );
 
   const doneData =
-    finalChildStateNode && finalChildStateNode.doneData
-      ? mapContext(finalChildStateNode.doneData, context, _event)
+    finalChildStateNode && finalChildStateNode.output
+      ? mapContext(finalChildStateNode.output, context, _event)
       : undefined;
 
   return doneData;
@@ -1266,9 +1266,9 @@ function enterStates(
         toSCXMLEvent(
           done(
             parent!.id,
-            stateNodeToEnter.doneData
+            stateNodeToEnter.output
               ? mapContext(
-                  stateNodeToEnter.doneData,
+                  stateNodeToEnter.output,
                   currentState.context,
                   currentState._event
                 )

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -80,12 +80,9 @@ function getOutput<TContext extends MachineContext, TEvent extends EventObject>(
       stateNode.type === 'final' && stateNode.parent === machine.root
   );
 
-  const doneData =
-    finalChildStateNode && finalChildStateNode.output
-      ? mapContext(finalChildStateNode.output, context, _event)
-      : undefined;
-
-  return doneData;
+  return finalChildStateNode && finalChildStateNode.output
+    ? mapContext(finalChildStateNode.output, context, _event)
+    : undefined;
 }
 
 const isAtomicStateNode = (stateNode: StateNode<any, any>) =>

--- a/packages/core/src/typegenTypes.ts
+++ b/packages/core/src/typegenTypes.ts
@@ -193,11 +193,11 @@ export interface ResolveTypegenMeta<
       AllowAllEvents & {
         indexedActions: IndexByType<TAction>;
         indexedEvents: Record<string, TEvent> & {
-          __XSTATE_ALLOW_ANY_INVOKE_DATA_HACK__: { data: any };
+          __XSTATE_ALLOW_ANY_INVOKE_OUTPUT_HACK__: { output: any };
         };
         invokeSrcNameMap: Record<
           string,
-          '__XSTATE_ALLOW_ANY_INVOKE_DATA_HACK__'
+          '__XSTATE_ALLOW_ANY_INVOKE_OUTPUT_HACK__'
         >;
       };
   }[IsNever<TTypesMeta> extends true

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -553,7 +553,7 @@ export interface InvokeConfig<
   onError?:
     | string
     | SingleOrArray<
-        TransitionConfigOrTarget<TContext, DoneInvokeEvent<any>, TEvent>
+        TransitionConfigOrTarget<TContext, ErrorEvent<any>, TEvent>
       >;
 
   onSnapshot?:
@@ -1104,7 +1104,7 @@ export interface RaiseActionObject<
 
 export interface DoneInvokeEvent<TData> extends EventObject {
   type: `done.invoke.${string}`;
-  data: TData;
+  output: TData;
 }
 
 export interface ErrorEvent<TErrorData> {
@@ -1136,7 +1136,7 @@ export interface SCXMLErrorEvent extends SCXML.Event<any> {
 }
 
 export interface DoneEventObject extends EventObject {
-  data?: any;
+  output?: any;
   toString(): string;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -643,12 +643,14 @@ export interface StateNodeConfig<
    */
   meta?: any;
   /**
-   * The data sent with the "done.state._id_" event if this is a final state node.
+   * The output data sent with the "done.state._id_" event if this is a final state node.
    *
-   * The data will be evaluated with the current `context` and placed on the `.data` property
+   * The output data will be evaluated with the current `context` and placed on the `.data` property
    * of the event.
    */
-  data?: Mapper<TContext, TEvent, any> | PropertyMapper<TContext, TEvent, any>;
+  output?:
+    | Mapper<TContext, TEvent, any>
+    | PropertyMapper<TContext, TEvent, any>;
   /**
    * The unique ID of the state node, which can be referenced as a transition target via the
    * `#id` syntax.
@@ -695,7 +697,7 @@ export interface StateNodeDefinition<
   exit: BaseActionObject[];
   meta: any;
   order: number;
-  data?: FinalStateNodeConfig<TContext, TEvent>['data'];
+  output?: FinalStateNodeConfig<TContext, TEvent>['output'];
   invoke: Array<InvokeDefinition<TContext, TEvent>>;
   description?: string;
   tags: string[];
@@ -745,7 +747,9 @@ export interface FinalStateNodeConfig<
    * The data to be sent with the "done.state.<id>" event. The data can be
    * static or dynamic (based on assigners).
    */
-  data?: Mapper<TContext, TEvent, any> | PropertyMapper<TContext, TEvent, any>;
+  output?:
+    | Mapper<TContext, TEvent, any>
+    | PropertyMapper<TContext, TEvent, any>;
 }
 
 export type SimpleOrStateNodeConfig<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1029,7 +1029,7 @@ export interface MachineConfig<
   tsTypes?: TTypesMeta;
 }
 
-export type ActorMap = Record<string, { data: any }>;
+export type ActorMap = Record<string, { output: any }>;
 export interface MachineSchema<
   TContext extends MachineContext,
   TEvent extends EventObject,

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -248,7 +248,7 @@ describe('spawning promises', () => {
           on: {
             [doneInvoke('my-promise')]: {
               target: 'success',
-              guard: ({ event }) => event.data === 'response'
+              guard: ({ event }) => event.output === 'response'
             }
           }
         },
@@ -282,7 +282,7 @@ describe('spawning promises', () => {
             on: {
               [doneInvoke('my-promise')]: {
                 target: 'success',
-                guard: ({ event }) => event.data === 'response'
+                guard: ({ event }) => event.output === 'response'
               }
             }
           },
@@ -915,7 +915,7 @@ describe('actors', () => {
             on: {
               'done.invoke.test': {
                 target: 'success',
-                guard: ({ event }) => event.data === 42
+                guard: ({ event }) => event.output === 42
               }
             }
           },

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -1,9 +1,4 @@
-import {
-  createMachine,
-  interpret,
-  assign,
-  AnyEventObject
-} from '../src/index.ts';
+import { createMachine, interpret, assign } from '../src/index.ts';
 
 describe('final states', () => {
   it('should emit the "done.state.*" event when all nested states are in their final states', () => {

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -117,7 +117,7 @@ describe('final states', () => {
             },
             reveal: {
               type: 'final',
-              data: {
+              output: {
                 secret: () => 'the secret'
               }
             }
@@ -161,7 +161,7 @@ describe('final states', () => {
         },
         end: {
           type: 'final',
-          data: spy
+          output: spy
         }
       }
     });

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -124,9 +124,9 @@ describe('final states', () => {
           },
           onDone: {
             target: 'success',
-            actions: assign<Ctx, AnyEventObject>({
+            actions: assign({
               revealedSecret: ({ event }) => {
-                return event.data.secret;
+                return event.output.secret;
               }
             })
           }

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1632,7 +1632,7 @@ describe('interpreter', () => {
                 {
                   target: 'success',
                   guard: ({ event }) => {
-                    return event.data === 42;
+                    return event.output === 42;
                   }
                 },
                 { target: 'failure' }

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -81,7 +81,7 @@ const fetcherMachine = createMachine({
           target: 'received',
           guard: ({ event }) => {
             // Should receive { user: { name: 'David' } } as event data
-            return event.data.user.name === 'David';
+            return event.output.user.name === 'David';
           }
         }
       }
@@ -226,7 +226,7 @@ describe('invoke', () => {
               target: 'received',
               guard: ({ event }) => {
                 // Should receive { user: { name: 'David' } } as event data
-                return event.data.user.name === 'David';
+                return event.output.user.name === 'David';
               }
             }
           }
@@ -528,7 +528,7 @@ describe('invoke', () => {
                   src: pongMachine,
                   onDone: {
                     target: 'success',
-                    guard: ({ event }) => event.data.secret === 'pingpong'
+                    guard: ({ event }) => event.output.secret === 'pingpong'
                   }
                 }
               },
@@ -750,7 +750,7 @@ describe('invoke', () => {
               onDone: {
                 target: 'success',
                 guard: ({ context, event }) => {
-                  return event.data === context.id;
+                  return event.output === context.id;
                 }
               },
               onError: 'failure'
@@ -941,7 +941,7 @@ describe('invoke', () => {
                 ),
                 onDone: {
                   target: 'success',
-                  actions: assign({ count: ({ event }) => event.data.count })
+                  actions: assign({ count: ({ event }) => event.output.count })
                 }
               }
             },
@@ -971,7 +971,9 @@ describe('invoke', () => {
                   src: 'somePromise',
                   onDone: {
                     target: 'success',
-                    actions: assign({ count: ({ event }) => event.data.count })
+                    actions: assign({
+                      count: ({ event }) => event.output.count
+                    })
                   }
                 }
               },
@@ -1013,7 +1015,7 @@ describe('invoke', () => {
                 onDone: {
                   target: 'success',
                   actions: ({ event }) => {
-                    count = event.data.count;
+                    count = event.output.count;
                   }
                 }
               }
@@ -1046,7 +1048,7 @@ describe('invoke', () => {
                   onDone: {
                     target: 'success',
                     actions: ({ event }) => {
-                      count = event.data.count;
+                      count = event.output.count;
                     }
                   }
                 }
@@ -1150,7 +1152,7 @@ describe('invoke', () => {
                           onDone: {
                             target: 'success',
                             actions: assign(({ event }) => ({
-                              result1: event.data.result
+                              result1: event.output.result
                             }))
                           }
                         }
@@ -1169,7 +1171,7 @@ describe('invoke', () => {
                           onDone: {
                             target: 'success',
                             actions: assign(({ event }) => ({
-                              result2: event.data.result
+                              result2: event.output.result
                             }))
                           }
                         }
@@ -1623,7 +1625,7 @@ describe('invoke', () => {
               }),
               onDone: {
                 target: 'success',
-                actions: assign(({ event: { data: result } }) => ({ result }))
+                actions: assign(({ event: { output: result } }) => ({ result }))
               }
             }
           },

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -49,7 +49,7 @@ const fetchMachine = createMachine<{ userId: string | undefined }>({
     },
     success: {
       type: 'final',
-      data: { user: ({ event }) => event.user }
+      output: { user: ({ event }) => event.user }
     },
     failure: {
       entry: sendParent({ type: 'REJECT' })
@@ -195,7 +195,7 @@ describe('invoke', () => {
         },
         success: {
           type: 'final',
-          data: { user: ({ event }) => event.user }
+          output: { user: ({ event }) => event.user }
         },
         failure: {
           entry: sendParent({ type: 'REJECT' })
@@ -510,7 +510,7 @@ describe('invoke', () => {
         states: {
           active: {
             type: 'final',
-            data: { secret: 'pingpong' }
+            output: { secret: 'pingpong' }
           }
         }
       });

--- a/packages/core/test/json.test.ts
+++ b/packages/core/test/json.test.ts
@@ -66,7 +66,7 @@ describe('json', () => {
         },
         testFinal: {
           type: 'final',
-          data: {
+          output: {
             something: 'else'
           }
         },

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -618,7 +618,7 @@ describe('typegen types', () => {
       internalEvents: {
         'done.invoke.myActor': {
           type: 'done.invoke.myActor';
-          data: unknown;
+          output: unknown;
           __tip: 'Declare the type.';
         };
       };
@@ -641,10 +641,10 @@ describe('typegen types', () => {
               return;
             }
             event.type === 'done.invoke.myActor';
-            event.data;
+            event.output;
             // indirectly check that it's not any
             // @ts-expect-error
-            ((_accept: string) => {})(event.data);
+            ((_accept: string) => {})(event.output);
           }
         }
       }
@@ -659,7 +659,7 @@ describe('typegen types', () => {
       internalEvents: {
         'done.invoke.myActor': {
           type: 'done.invoke.myActor';
-          data: unknown;
+          output: unknown;
           __tip: 'Declare the type.';
         };
       };
@@ -675,7 +675,7 @@ describe('typegen types', () => {
           events: {} as { type: 'FOO' } | { type: 'BAR' },
           actors: {
             myActor: {
-              data: {} as string
+              output: {} as string
             }
           }
         }
@@ -687,8 +687,8 @@ describe('typegen types', () => {
               return;
             }
             event.type === 'done.invoke.myActor';
-            event.data;
-            ((_accept: string) => {})(event.data);
+            event.output;
+            ((_accept: string) => {})(event.output);
           }
         }
       }
@@ -703,7 +703,7 @@ describe('typegen types', () => {
       internalEvents: {
         'done.invoke.myActor': {
           type: 'done.invoke.myActor';
-          data: unknown;
+          output: unknown;
           __tip: 'Declare the type.';
         };
       };
@@ -719,7 +719,7 @@ describe('typegen types', () => {
           events: {} as { type: 'FOO' },
           actors: {
             myActor: {
-              data: {} as string
+              output: {} as string
             }
           }
         }
@@ -740,7 +740,7 @@ describe('typegen types', () => {
       internalEvents: {
         'done.invoke.myActor': {
           type: 'done.invoke.myActor';
-          data: unknown;
+          output: unknown;
           __tip: 'Declare the type.';
         };
       };
@@ -756,7 +756,7 @@ describe('typegen types', () => {
           events: {} as { type: 'FOO' },
           actors: {
             myActor: {
-              data: {} as string
+              output: {} as string
             }
           }
         }
@@ -770,7 +770,7 @@ describe('typegen types', () => {
     );
   });
 
-  it('should allow a machine actor returning the explicitly declared data in the given schema.actors', () => {
+  it('should allow a machine actor returning the explicitly declared output in the given schema.actors', () => {
     interface TypesMeta extends TypegenMeta {
       eventsCausingActors: {
         myActor: 'FOO';
@@ -778,7 +778,7 @@ describe('typegen types', () => {
       internalEvents: {
         'done.invoke.myActor': {
           type: 'done.invoke.myActor';
-          data: unknown;
+          output: unknown;
           __tip: 'Declare the type.';
         };
       };
@@ -794,7 +794,7 @@ describe('typegen types', () => {
           events: {} as { type: 'FOO' },
           actors: {
             myActor: {
-              data: {} as { foo: string }
+              output: {} as { foo: string }
             }
           }
         }
@@ -815,7 +815,7 @@ describe('typegen types', () => {
   //     internalEvents: {
   //       'done.invoke.myActor': {
   //         type: 'done.invoke.myActor';
-  //         data: unknown;
+  //         output: unknown;
   //         __tip: 'Declare the type.';
   //       };
   //     };
@@ -831,7 +831,7 @@ describe('typegen types', () => {
   //         events: {} as { type: 'FOO' },
   //         actors: {
   //           myActor: {
-  //             data: {} as { foo: string }
+  //             output: {} as { foo: string }
   //           }
   //         }
   //       }
@@ -1012,9 +1012,9 @@ describe('typegen types', () => {
   //       actions: {
   //         myAction: (_context, event) => {
   //           ((_accept: 'done.invoke.invocation') => {})(event.type);
-  //           ((_accept: string) => {})(event.data);
+  //           ((_accept: string) => {})(event.output);
   //           // @ts-expect-error
-  //           ((_accept: number) => {})(event.data);
+  //           ((_accept: number) => {})(event.output);
   //         }
   //       }
   //     }

--- a/packages/xstate-react/test/useMachine.test.tsx
+++ b/packages/xstate-react/test/useMachine.test.tsx
@@ -43,9 +43,11 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
           onDone: {
             target: 'success',
             actions: assign({
-              data: ({ event }) => event.data
+              data: ({ event }) => {
+                return event.output;
+              }
             }),
-            guard: ({ event }) => event.data.length
+            guard: ({ event }) => event.output.length
           }
         }
       },
@@ -57,7 +59,7 @@ describeEachReactMode('useMachine (%s)', ({ suiteKey, render }) => {
 
   const successFetchState = fetchMachine.transition('loading', {
     type: 'done.invoke.fetchData',
-    data: 'persisted data'
+    output: 'persisted data'
   });
 
   const persistedSuccessFetchState =

--- a/packages/xstate-scxml/src/index.ts
+++ b/packages/xstate-scxml/src/index.ts
@@ -136,8 +136,8 @@ function stateNodeToSCXML(stateNode: StateNode<any, any>): XMLElement {
   elements.push(...transitionElements);
   elements.push(...childStates);
 
-  if (stateNode.type === 'final' && stateNode.doneData) {
-    elements.push(doneDataToSCXML(stateNode.doneData));
+  if (stateNode.type === 'final' && stateNode.output) {
+    elements.push(doneDataToSCXML(stateNode.output));
   }
 
   return {

--- a/packages/xstate-solid/test/useMachine.test.tsx
+++ b/packages/xstate-solid/test/useMachine.test.tsx
@@ -51,9 +51,9 @@ describe('useMachine hook', () => {
           onDone: {
             target: 'success',
             actions: assign({
-              data: ({ event }) => event.data
+              data: ({ event }) => event.output
             }),
-            guard: ({ event }) => event.data.length
+            guard: ({ event }) => event.output.length
           }
         }
       },

--- a/packages/xstate-svelte/test/fetchMachine.ts
+++ b/packages/xstate-svelte/test/fetchMachine.ts
@@ -19,9 +19,9 @@ export const fetchMachine = createMachine<typeof context, any>({
         onDone: {
           target: 'success',
           actions: assign({
-            data: ({ event }) => event.data
+            data: ({ event }) => event.output
           }),
-          guard: ({ event }) => event.data.length
+          guard: ({ event }) => event.output.length
         }
       }
     },

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -49,7 +49,7 @@ export interface TestStateNodeConfig<
     | 'exit'
     | 'meta'
     | 'always'
-    | 'data'
+    | 'output'
     | 'id'
     | 'tags'
     | 'description'

--- a/packages/xstate-vue/test/UseMachine.vue
+++ b/packages/xstate-vue/test/UseMachine.vue
@@ -36,9 +36,9 @@ const fetchMachine = createMachine<typeof context, any>({
         onDone: {
           target: 'success',
           actions: assign({
-            data: ({event}) => event.data
+            data: ({event}) => event.output
           }),
-          guard: ({event}) => event.data.length
+          guard: ({event}) => event.output.length
         }
       }
     },

--- a/packages/xstate-vue/test/useMachine.test.ts
+++ b/packages/xstate-vue/test/useMachine.test.ts
@@ -22,9 +22,9 @@ describe('useMachine composition function', () => {
           onDone: {
             target: 'success',
             actions: assign({
-              data: ({ event }) => event.data
+              data: ({ event }) => event.output
             }),
-            guard: ({ event }) => event.data.length
+            guard: ({ event }) => event.output.length
           }
         }
       },


### PR DESCRIPTION
This PR renames `.data` to `.output` on final states:

```diff
const machine = createMachine({
  // ...
  states: {
    // ...
    success: {
-     data: { message: 'Success!' }
+     output: { message: 'Success!' }
    }
  }
})
```