### PR TITLE
[v5] Throw when sending strings

### DIFF
--- a/.changeset/eighty-trainers-compare.md
+++ b/.changeset/eighty-trainers-compare.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+Sending a string event to `actor.send('some string')` will now throw a proper error message.

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -74,6 +74,11 @@ export function raise<
       const delaysMap = state.machine.options.delays;
 
       // TODO: helper function for resolving Expr
+      if (typeof eventOrExpr === 'string') {
+        throw new Error(
+          `Only event objects may be sent to actors; use .send({ type: "${eventOrExpr}" }) instead`
+        );
+      }
       const resolvedEvent = toSCXMLEvent(
         typeof eventOrExpr === 'function' ? eventOrExpr(args) : eventOrExpr
       );

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -76,7 +76,7 @@ export function raise<
       // TODO: helper function for resolving Expr
       if (typeof eventOrExpr === 'string') {
         throw new Error(
-          `Only event objects may be sent to actors; use .send({ type: "${eventOrExpr}" }) instead`
+          `Only event objects may be used with raise; use raise({ type: "${eventOrExpr}" }) instead`
         );
       }
       const resolvedEvent = toSCXMLEvent(

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -95,6 +95,11 @@ export function send<
       const delaysMap = state.machine.options.delays;
 
       // TODO: helper function for resolving Expr
+      if (typeof eventOrExpr === 'string') {
+        throw new Error(
+          `Only event objects may be sent to actors; use .send({ type: "${eventOrExpr}" }) instead`
+        );
+      }
       const resolvedEvent = toSCXMLEvent(
         isFunction(eventOrExpr) ? eventOrExpr(args) : eventOrExpr
       );

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -97,7 +97,7 @@ export function send<
       // TODO: helper function for resolving Expr
       if (typeof eventOrExpr === 'string') {
         throw new Error(
-          `Only event objects may be sent to actors; use .send({ type: "${eventOrExpr}" }) instead`
+          `Only event objects may be used with sendTo; use sendTo({ type: "${eventOrExpr}" }) instead`
         );
       }
       const resolvedEvent = toSCXMLEvent(

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -409,6 +409,12 @@ export class Interpreter<
    * @param event The event to send
    */
   public send(event: TEvent | SCXML.Event<TEvent>) {
+    if (typeof event === 'string') {
+      throw new Error(
+        `Only event objects may be sent to actors; use .send({ type: "${event}" }) instead`
+      );
+    }
+
     const _event = toSCXMLEvent(event);
 
     if (this.status === ActorStatus.Stopped) {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -3078,7 +3078,7 @@ describe('sendTo', () => {
     expect(() => {
       interpret(machine).start();
     }).toThrowErrorMatchingInlineSnapshot(
-      `"Only event objects may be sent to actors; use .send({ type: "a string" }) instead"`
+      `"Only event objects may be used with sendTo; use sendTo({ type: "a string" }) instead"`
     );
   });
 });
@@ -3301,7 +3301,7 @@ describe('raise', () => {
     expect(() => {
       interpret(machine).start();
     }).toThrowErrorMatchingInlineSnapshot(
-      `"Only event objects may be sent to actors; use .send({ type: "a string" }) instead"`
+      `"Only event objects may be used with raise; use raise({ type: "a string" }) instead"`
     );
   });
 });

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -3065,6 +3065,22 @@ describe('sendTo', () => {
 
     service.send({ type: 'EVENT', value: 'foo' });
   });
+
+  it('should throw if given a string', () => {
+    const machine = createMachine({
+      invoke: {
+        id: 'child',
+        src: fromCallback(() => {})
+      },
+      entry: sendTo('child', 'a string')
+    });
+
+    expect(() => {
+      interpret(machine).start();
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Only event objects may be sent to actors; use .send({ type: "a string" }) instead"`
+    );
+  });
 });
 
 describe('raise', () => {
@@ -3272,6 +3288,21 @@ describe('raise', () => {
     setTimeout(() => {
       expect(actor.getSnapshot().value).toBe('a');
     }, 10);
+  });
+
+  it('should throw if given a string', () => {
+    const machine = createMachine({
+      entry: raise(
+        // @ts-ignore
+        'a string'
+      )
+    });
+
+    expect(() => {
+      interpret(machine).start();
+    }).toThrowErrorMatchingInlineSnapshot(
+      `"Only event objects may be sent to actors; use .send({ type: "a string" }) instead"`
+    );
   });
 });
 

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1873,3 +1873,21 @@ describe('interpreter', () => {
     });
   });
 });
+
+it('should throw if an event is received', () => {
+  const machine = createMachine({});
+
+  const actor = interpret(machine).start();
+
+  actor.send(
+    // @ts-ignore
+    'EVENT'
+  );
+
+  expect(() =>
+    actor.send(
+      // @ts-ignore
+      'EVENT'
+    )
+  ).toThrow();
+});

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1850,11 +1850,6 @@ it('should throw if an event is received', () => {
 
   const actor = interpret(machine).start();
 
-  actor.send(
-    // @ts-ignore
-    'EVENT'
-  );
-
   expect(() =>
     actor.send(
       // @ts-ignore


### PR DESCRIPTION
Event objects should be sent; sending strings is no longer allowed.