### PR TITLE
[v5] `createEmptyActor()`

### DIFF
--- a/.changeset/odd-pigs-brush.md
+++ b/.changeset/odd-pigs-brush.md
@@ -1,0 +1,16 @@
+---
+'xstate': major
+---
+
+The `createNullActor()` function has been added to make it easier to create actors that do nothing ("null" actors). This is useful for testing, or for some integrations such as `useActor(actor)` in `@xstate/react` that require an actor:
+
+```jsx
+import { createNullActor } from 'xstate';
+
+const SomeComponent = (props) => {
+  // props.actor may be undefined
+  const [state, send] = useActor(props.actor ?? createNullActor());
+
+  // ...
+};
+```

--- a/.changeset/odd-pigs-brush.md
+++ b/.changeset/odd-pigs-brush.md
@@ -5,7 +5,7 @@
 The `createEmptyActor()` function has been added to make it easier to create actors that do nothing ("empty" actors). This is useful for testing, or for some integrations such as `useActor(actor)` in `@xstate/react` that require an actor:
 
 ```jsx
-import { createNullActor } from 'xstate';
+import { createEmptyActor } from 'xstate';
 
 const SomeComponent = (props) => {
   // props.actor may be undefined

--- a/.changeset/odd-pigs-brush.md
+++ b/.changeset/odd-pigs-brush.md
@@ -2,7 +2,7 @@
 'xstate': major
 ---
 
-The `createNullActor()` function has been added to make it easier to create actors that do nothing ("null" actors). This is useful for testing, or for some integrations such as `useActor(actor)` in `@xstate/react` that require an actor:
+The `createEmptyActor()` function has been added to make it easier to create actors that do nothing ("empty" actors). This is useful for testing, or for some integrations such as `useActor(actor)` in `@xstate/react` that require an actor:
 
 ```jsx
 import { createNullActor } from 'xstate';

--- a/.changeset/odd-pigs-brush.md
+++ b/.changeset/odd-pigs-brush.md
@@ -9,7 +9,7 @@ import { createNullActor } from 'xstate';
 
 const SomeComponent = (props) => {
   // props.actor may be undefined
-  const [state, send] = useActor(props.actor ?? createNullActor());
+  const [state, send] = useActor(props.actor ?? createEmptyActor());
 
   // ...
 };

--- a/packages/core/src/actors/index.ts
+++ b/packages/core/src/actors/index.ts
@@ -70,8 +70,8 @@ export function toActorRef<
   };
 }
 
-const nullBehavior = fromTransition((_) => undefined, undefined);
+const emptyBehavior = fromTransition((_) => undefined, undefined);
 
-export function createNullActor(): ActorRef<AnyEventObject, undefined> {
-  return interpret(nullBehavior);
+export function createEmptyActor(): ActorRef<AnyEventObject, undefined> {
+  return interpret(emptyBehavior);
 }

--- a/packages/core/src/actors/index.ts
+++ b/packages/core/src/actors/index.ts
@@ -1,6 +1,12 @@
-import type { EventObject, ActorRef, BaseActorRef } from '../types.ts';
+import type {
+  EventObject,
+  ActorRef,
+  BaseActorRef,
+  AnyEventObject
+} from '../types.ts';
 import { symbolObservable } from '../symbolObservable.ts';
-import { ActorStatus } from '../interpreter.ts';
+import { ActorStatus, interpret } from '../interpreter.ts';
+import { fromTransition } from './transition.ts';
 export { fromTransition } from './transition.ts';
 export { fromPromise } from './promise.ts';
 export { fromObservable, fromEventObservable } from './observable.ts';
@@ -62,4 +68,10 @@ export function toActorRef<
     stop: () => void 0,
     ...actorRefLike
   };
+}
+
+const nullBehavior = fromTransition((_) => undefined, undefined);
+
+export function createNullActor(): ActorRef<AnyEventObject, undefined> {
+  return interpret(nullBehavior);
 }

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -11,7 +11,7 @@ import {
 } from 'xstate';
 import { useMachine, useInterpret, useActor } from '../src/index.ts';
 import { describeEachReactMode } from './utils';
-import { createNullActor, fromTransition } from 'xstate/actors';
+import { createEmptyActor, fromTransition } from 'xstate/actors';
 
 const originalConsoleError = console.error;
 
@@ -517,7 +517,7 @@ describeEachReactMode('useActor (%s)', ({ render, suiteKey }) => {
     const Child = (props: {
       actor: ActorRef<any, { count: number }> | undefined;
     }) => {
-      const [state] = useActor(props.actor ?? createNullActor());
+      const [state] = useActor(props.actor ?? createEmptyActor());
 
       // @ts-expect-error
       ((_accept: { count: number }) => {})(state);

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -519,15 +519,9 @@ describeEachReactMode('useActor (%s)', ({ render, suiteKey }) => {
     }) => {
       const [state] = useActor(props.actor ?? createNullActor());
 
-      try {
-        // @ts-expect-error (state can be undefined)
-        state.count;
-      } catch (_) {}
-
-      if (state) {
-        // another type test... probably a better way to do this
-        ((_count: number) => void 0)(state.count);
-      }
+      // @ts-expect-error
+      ((_accept: { count: number }) => {})(state);
+      ((_accept: { count: number } | undefined) => {})(state);
 
       return <div data-testid="state">{state?.count ?? 'undefined'}</div>;
     };


### PR DESCRIPTION
This PR makes it easy to create null actors which only emit `undefined`.

Especially in `@xstate/react`, this makes working with maybe-undefined actors easier:

```jsx
import { createEmptyActor } from 'xstate/actors';

// ...
function Comp({ maybeActor }) {
  const [state, send] = useActor(maybeActor ?? createEmptyActor());

  state?.count; // strongly-typed; state can be undefined
}
```