### PR TITLE
Improve control over console logs in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ const os = require('os');
  * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
+  setupFilesAfterEnv: ['@xstate-repo/jest-utils/setup'],
   transform: {
     [constants.DEFAULT_JS_PATTERN]: 'babel-jest',
     '^.+\\.vue$': '@vue/vue3-jest',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Finite State Machines and Statecharts for the Modern Web.",
   "workspaces": {
     "packages": [
-      "packages/*"
+      "packages/*",
+      "scripts/*"
     ]
   },
   "preconstruct": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -63,6 +63,7 @@
   "homepage": "https://github.com/statelyai/xstate/tree/main/packages/core#readme",
   "devDependencies": {
     "@scion-scxml/test-framework": "^2.0.15",
+    "@xstate-repo/jest-utils": "*",
     "jsdom": "^14.0.0",
     "jsdom-global": "^3.0.2",
     "pkg-up": "^3.1.0",

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -76,12 +76,14 @@ export function fromPromise<T>(
 
       resolvedPromise.then(
         (response) => {
+          // TODO: remove this condition once dead letter queue lands
           if ((self as any)._state.status !== 'active') {
             return;
           }
           self.send({ type: resolveEventType, data: response });
         },
         (errorData) => {
+          // TODO: remove this condition once dead letter queue lands
           if ((self as any)._state.status !== 'active') {
             return;
           }

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -76,9 +76,15 @@ export function fromPromise<T>(
 
       resolvedPromise.then(
         (response) => {
+          if ((self as any)._state.status !== 'active') {
+            return;
+          }
           self.send({ type: resolveEventType, data: response });
         },
         (errorData) => {
+          if ((self as any)._state.status !== 'active') {
+            return;
+          }
           self.send({ type: rejectEventType, data: errorData });
         }
       );

--- a/packages/core/test/eventDescriptors.test.ts
+++ b/packages/core/test/eventDescriptors.test.ts
@@ -251,11 +251,43 @@ describe('event descriptors', () => {
         .transition(undefined, { type: 'event.foo.bar.first.second' })
         .matches('success')
     ).toBeFalsy();
+
+    expect(console.warn).toMatchMockCallsInlineSnapshot(`
+      [
+        [
+          "Warning: Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "event.*.bar.*" event.",
+        ],
+        [
+          "Warning: Infix wildcards in transition events are not allowed. Check the "event.*.bar.*" event.",
+        ],
+        [
+          "Warning: Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "*.event.*" event.",
+        ],
+        [
+          "Warning: Infix wildcards in transition events are not allowed. Check the "*.event.*" event.",
+        ],
+      ]
+    `);
+
     expect(
       machine
         .transition(undefined, { type: 'whatever.event' })
         .matches('success')
     ).toBeFalsy();
+
+    expect(console.warn).toMatchMockCallsInlineSnapshot(`
+      [
+        [
+          "Warning: Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "event.*.bar.*" event.",
+        ],
+        [
+          "Warning: Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "*.event.*" event.",
+        ],
+        [
+          "Warning: Infix wildcards in transition events are not allowed. Check the "*.event.*" event.",
+        ],
+      ]
+    `);
   });
 
   it('should not match wildcards as part of tokens', () => {
@@ -279,10 +311,33 @@ describe('event descriptors', () => {
         .transition(undefined, { type: 'eventually.bar.baz' })
         .matches('success')
     ).toBeFalsy();
+
+    expect(console.warn).toMatchMockCallsInlineSnapshot(`
+      [
+        [
+          "Warning: Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "event*.bar.*" event.",
+        ],
+        [
+          "Warning: Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "*event.*" event.",
+        ],
+      ]
+    `);
+
     expect(
       machine
         .transition(undefined, { type: 'prevent.whatever' })
         .matches('success')
     ).toBeFalsy();
+
+    expect(console.warn).toMatchMockCallsInlineSnapshot(`
+      [
+        [
+          "Warning: Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "event*.bar.*" event.",
+        ],
+        [
+          "Warning: Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "*event.*" event.",
+        ],
+      ]
+    `);
   });
 });

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -784,6 +784,15 @@ describe('interpreter', () => {
     } catch (e) {
       expect(service.getSnapshot().value).toEqual('yellow');
     }
+
+    expect(console.warn).toMatchMockCallsInlineSnapshot(`
+      [
+        [
+          "Warning: Event "TIMER" was sent to stopped actor "x:0 (x:0)". This actor has already reached its final state, and will not transition.
+      Event: {"type":"TIMER"}",
+        ],
+      ]
+    `);
   });
 
   it('should be able to log (log action)', () => {
@@ -1239,6 +1248,14 @@ describe('interpreter', () => {
 
       setTimeout(() => {
         expect(called).toBeFalsy();
+        expect(console.warn).toMatchMockCallsInlineSnapshot(`
+          [
+            [
+              "Warning: Event "TRIGGER" was sent to stopped actor "x:0 (x:0)". This actor has already reached its final state, and will not transition.
+          Event: {"type":"TRIGGER"}",
+            ],
+          ]
+        `);
         done();
       }, 10);
     });

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -1,4 +1,4 @@
-import { clearConsoleMocks } from '@xstate-repo/jest-utils';
+// import { clearConsoleMocks } from '@xstate-repo/jest-utils';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as pkgUp from 'pkg-up';
@@ -474,7 +474,7 @@ describe('scxml', () => {
           console.log(JSON.stringify(machine.config, null, 2));
           throw e;
         } finally {
-          clearConsoleMocks();
+          // clearConsoleMocks();
         }
       });
     });

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -1,9 +1,10 @@
+import { clearConsoleMocks } from '@xstate-repo/jest-utils';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as pkgUp from 'pkg-up';
+import { SimulatedClock } from '../src/SimulatedClock';
 import { AnyState, AnyStateMachine, interpret } from '../src/index.ts';
 import { toMachine } from '../src/scxml';
-import { SimulatedClock } from '../src/SimulatedClock';
 import { getStateNodes } from '../src/stateUtils';
 
 const TEST_FRAMEWORK = path.dirname(
@@ -472,6 +473,8 @@ describe('scxml', () => {
         } catch (e) {
           console.log(JSON.stringify(machine.config, null, 2));
           throw e;
+        } finally {
+          clearConsoleMocks();
         }
       });
     });

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -1,4 +1,4 @@
-// import { clearConsoleMocks } from '@xstate-repo/jest-utils';
+import { clearConsoleMocks } from '@xstate-repo/jest-utils';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as pkgUp from 'pkg-up';
@@ -474,7 +474,7 @@ describe('scxml', () => {
           console.log(JSON.stringify(machine.config, null, 2));
           throw e;
         } finally {
-          // clearConsoleMocks();
+          clearConsoleMocks();
         }
       });
     });

--- a/packages/core/test/tsconfig.json
+++ b/packages/core/test/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "extends": "../../../tsconfig.json",
-  "include": ["../src/**/*", "../src/**/*.json", "**/*"],
+  "include": [
+    "../src/**/*",
+    "../src/**/*.json",
+    "**/*",
+    "../../../scripts/*/*.d.ts"
+  ],
   "compilerOptions": {
     "strict": true,
     "noEmit": true,

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -97,7 +97,7 @@ export interface TestParam<TState, TEvent extends EventObject> {
   events?: {
     [TEventType in TEvent['type']]?: EventExecutor<
       TState,
-      ExtractEvent<TEvent, TEventType>
+      { type: ExtractEvent<TEvent, TEventType>['type'] }
     >;
   };
 }

--- a/packages/xstate-test/test/types.test.ts
+++ b/packages/xstate-test/test/types.test.ts
@@ -30,10 +30,14 @@ describe('types', () => {
       path.test({
         events: {
           a: ({ event }) => {
-            console.log(event.valueA);
+            ((_accept: 'a') => {})(event.type);
+            // @ts-expect-error
+            ((_accept: 'b') => {})(event.type);
           },
           b: ({ event }) => {
-            console.log(event.valueB);
+            // @ts-expect-error
+            ((_accept: 'a') => {})(event.type);
+            ((_accept: 'b') => {})(event.type);
           }
         }
       });

--- a/scripts/jest-utils/console-spies.js
+++ b/scripts/jest-utils/console-spies.js
@@ -1,0 +1,11 @@
+const spyOnConsole = (method) =>
+  jest.spyOn(console, method).mockImplementation(() => {});
+
+module.exports.spyOnConsole = spyOnConsole;
+
+module.exports.consoleSpies = {
+  error: spyOnConsole('error'),
+  info: spyOnConsole('info'),
+  log: spyOnConsole('log'),
+  warn: spyOnConsole('warn')
+};

--- a/scripts/jest-utils/index.d.ts
+++ b/scripts/jest-utils/index.d.ts
@@ -1,0 +1,1 @@
+export declare function clearConsoleMocks(): void;

--- a/scripts/jest-utils/index.js
+++ b/scripts/jest-utils/index.js
@@ -1,0 +1,4 @@
+const { consoleSpies } = require('./console-spies');
+
+module.exports.clearConsoleMocks = () =>
+  Object.values(consoleSpies).forEach((spy) => spy.mockClear());

--- a/scripts/jest-utils/package.json
+++ b/scripts/jest-utils/package.json
@@ -1,0 +1,5 @@
+{
+  "private": true,
+  "name": "@xstate-repo/jest-utils",
+  "version": "0.0.0"
+}

--- a/scripts/jest-utils/setup.d.ts
+++ b/scripts/jest-utils/setup.d.ts
@@ -1,0 +1,9 @@
+import 'jest';
+
+declare global {
+  namespace jest {
+    interface Matchers<R, T> {
+      toMatchMockCallsInlineSnapshot(snapshot?: string): R;
+    }
+  }
+}

--- a/scripts/jest-utils/setup.js
+++ b/scripts/jest-utils/setup.js
@@ -1,0 +1,39 @@
+const { toMatchInlineSnapshot } = require('jest-snapshot');
+const { consoleSpies, spyOnConsole } = require('./console-spies');
+
+expect.extend({
+  toMatchMockCallsInlineSnapshot(received, ...rest) {
+    if (!jest.isMockFunction(received)) {
+      throw new Error(
+        '`toMatchMockCallsInlineSnapshot` can only be used on mocked functions'
+      );
+    }
+
+    const calls = received.mock.calls;
+    received.mockClear();
+    return toMatchInlineSnapshot.call(this, calls, ...rest);
+  }
+});
+
+afterEach(() => {
+  Object.keys(consoleSpies).forEach((method) => {
+    const spy = consoleSpies[method];
+
+    if (spy.mock.calls.length) {
+      const calls = spy.mock.calls;
+
+      spy.mockRestore();
+      // actually log the "unobserved" calls to the console to make them observable in the test output
+      calls.forEach((args) => console[method](...args));
+      // as we just restored the mock, we need to setup a new spy
+      consoleSpies[method] = spyOnConsole(method);
+
+      throw new Error(
+        [
+          `console.${method} was called unexpectedly ${calls.length} times without observing its calls with \`expect(console.${method}).toMatchMockCallsInlineSnapshot()\`.`,
+          `You can check the observed calls above.`
+        ].join(' ')
+      );
+    }
+  });
+});

--- a/scripts/jest-utils/setup.js
+++ b/scripts/jest-utils/setup.js
@@ -28,12 +28,14 @@ afterEach(() => {
       // as we just restored the mock, we need to setup a new spy
       consoleSpies[method] = spyOnConsole(method);
 
-      throw new Error(
-        [
-          `console.${method} was called unexpectedly ${calls.length} times without observing its calls with \`expect(console.${method}).toMatchMockCallsInlineSnapshot()\`.`,
-          `You can check the observed calls above.`
-        ].join(' ')
-      );
+      if (process.env.CI) {
+        throw new Error(
+          [
+            `console.${method} was called unexpectedly ${calls.length} times without observing its calls with \`expect(console.${method}).toMatchMockCallsInlineSnapshot()\`.`,
+            `You can check the observed calls above.`
+          ].join(' ')
+        );
+      }
     }
   });
 });


### PR DESCRIPTION
I find our test output to be spammy and at times I feel like it's likely that some of the logged messages indicate logical errors in tests. I yet have to verify that - this PR lays out a foundation for deliberate console outputs.

With this PR we will be **forced** to either use `expect(console.warn).toMatchMockCallsInlineSnapshot()` (and similar) or `clearConsoleMocks()` (although that should be done *rarely*, I only used this in our SCXML tests). This should force us to be thoughtful about the logged things and to take appropriate action for each logged information