### PR TITLE
[v5] implement action groups

### DIFF
--- a/.changeset/wild-roses-sort.md
+++ b/.changeset/wild-roses-sort.md
@@ -1,0 +1,103 @@
+---
+'xstate': major
+---
+
+Actions can now be implemented as an _action group_.
+
+An _action group_ is a named array of actions. When the action group is executed, each action in the group is executed in order:
+
+```js
+import { createMachine, interpret, log } from 'xstate';
+
+const machine = createMachine(
+  {
+    // reference the action group by name (`someGroup`)
+    entry: 'someGroup'
+  },
+  {
+    actions: {
+      // executes `action1`, then `action2`
+      someGroup: ['action1', 'action2'],
+      action1: log('action1'),
+      action2: log('action2')
+    }
+  }
+);
+
+interpret(machine).start(); // logs "action1", then "action2"
+```
+
+Action groups allow us to avoid error-prone repetition of actions, instead defining the group once and reusing it anywhere—like a single source of truth for the algorithm the group represents:
+
+```diff
+ const machine = createMachine(
+   {
+     context: { count: 0 },
+     on: {
+-      // increment count, then print it
+-      incrementClick: { actions: ['incrementCount', 'printCount'] },
++       incrementClick: { actions: 'increment' },
+-      // increment count, then print it
+-      // oops! we accidentally put the actions in the wrong order
+-      tick: { actions: ['printCount', 'incrementCount'] },
++      tick: { actions: 'increment' }
+     }
+   },
+   {
+     actions: {
++      // increment count, then print it. single source of truth for the `increment` algorithm
++      increment: ['incrementCount', 'printCount'],
+       incrementCount: assign({
+         count: ({ context }) => context.count + 1
+       }),
+       printCount: log(({ context }) => `Count: ${context.count}`)
+     }
+   }
+ );
+```
+
+Action groups can reference other action groups by name. The referenced group's actions will be executed in order from the point of reference—like spreading the referenced group's actions in the group:
+
+```js
+const machine = createMachine(
+  {
+    entry: 'initialize'
+  },
+  {
+    actions: {
+      // executes `load` group actions, then `listen` group actions
+      initialize: ['load', 'listen'],
+      load: ['loadConfig', 'loadData'],
+      listen: ['startApp', 'listenOnPort']
+    }
+  }
+);
+
+interpret(machine).start();
+// actions: (load) loadConfig -> loadData -> (listen) startApp -> listenOnPort
+```
+
+With a mix of actions, action groups, and action group references, we can compose our algorithms in flexible and reusable ways:
+
+```js
+import { assign, createMachine, log } from 'xstate';
+
+const machine = createMachine(
+  {
+    entry: 'initialize',
+    exit: 'terminate',
+    on: {
+      timeout: { actions: 'reconnect' },
+      reload: { actions: 'reload' }
+    }
+  },
+  {
+    actions: {
+      initialize: ['load', 'connect'],
+      terminate: ['disconnect', 'save', 'exitProgram'],
+      reconnect: ['disconnect', 'connect'],
+      reload: ['disconnect', 'save', 'initialize']
+    }
+  }
+);
+```

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -69,6 +69,17 @@ export function resolveActionObject(
         return [state, a];
       }
     );
+  } else if (isArray(dereferencedAction)) {
+    return createDynamicAction(
+      { type: ActionTypes.ActionGroup, params: actionObject.params ?? {} },
+      (_event, { state }) => {
+        const action: BaseActionObject = {
+          type: actionObject.type,
+          params: { actions: dereferencedAction }
+        };
+        return [state, action];
+      }
+    );
   } else if (dereferencedAction) {
     return dereferencedAction;
   } else {

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -70,12 +70,21 @@ export function resolveActionObject(
       }
     );
   } else if (isArray(dereferencedAction)) {
+    const params = actionObject.params ?? {};
     return createDynamicAction(
-      { type: ActionTypes.ActionGroup, params: actionObject.params ?? {} },
+      { type: ActionTypes.ActionGroup, params },
       (_event, { state }) => {
         const action: BaseActionObject = {
           type: actionObject.type,
-          params: { actions: dereferencedAction }
+          params: {
+            actions: toActionObjects(dereferencedAction).map((object) => ({
+              ...object,
+              params: {
+                ...object.params,
+                ...params
+              }
+            }))
+          }
         };
         return [state, action];
       }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -768,6 +768,15 @@ export type ActionFunctionMap<
         TContext,
         TEvent,
         TAction extends { type: K } ? TAction : never
+      >
+    | Array<
+        | BaseDynamicActionObject<TContext, TEvent, TEvent, TAction, any>
+        | ActionFunction<
+            TContext,
+            TEvent,
+            TAction extends { type: K } ? TAction : never
+          >
+        | K
       >;
 };
 
@@ -806,7 +815,7 @@ type MachineImplementationsActions<
   >,
   TIndexedEvents = Prop<Prop<TResolvedTypesMeta, 'resolved'>, 'indexedEvents'>
 > = {
-  [K in keyof TEventsCausingActions]?:
+  [K in keyof TEventsCausingActions]?: SingleOrArray<
     | BaseDynamicActionObject<
         TContext,
         Cast<Prop<TIndexedEvents, TEventsCausingActions[K]>, EventObject>,
@@ -819,7 +828,9 @@ type MachineImplementationsActions<
         Cast<Prop<TIndexedEvents, TEventsCausingActions[K]>, EventObject>,
         ParameterizedObject, // TODO: when bringing back parametrized actions this should accept something like `Cast<Prop<TIndexedActions, K>, ParameterizedObject>`. At the moment we need to keep this type argument consistent with what is provided to the fake callable signature within `BaseDynamicActionObject`
         Cast<Prop<TIndexedEvents, keyof TIndexedEvents>, EventObject>
-      >;
+      >
+    | keyof TEventsCausingActions
+  >;
 };
 
 type MachineImplementationsDelays<
@@ -1086,7 +1097,8 @@ export enum ActionTypes {
   ErrorPlatform = 'error.platform',
   ErrorCustom = 'xstate.error',
   Pure = 'xstate.pure',
-  Choose = 'xstate.choose'
+  Choose = 'xstate.choose',
+  ActionGroup = 'xstate.group'
 }
 
 export interface RaiseActionObject<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -821,15 +821,7 @@ export type ActionFunctionMap<
         TEvent,
         TAction extends { type: K } ? TAction : never
       >
-    | Array<
-        | BaseDynamicActionObject<TContext, TEvent, TEvent, TAction, any>
-        | ActionFunction<
-            TContext,
-            TEvent,
-            TAction extends { type: K } ? TAction : never
-          >
-        | K
-      >;
+    | ActionGroup<TContext, TEvent, TEvent, K>;
 };
 
 export type DelayFunctionMap<

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -3666,7 +3666,7 @@ it('should call a referenced action responding to an initial raise with updated 
 });
 
 describe('action groups', () => {
-  it('should execute actions provided as type strings in a group', () => {
+  it('should execute actions from action type strings in a group', () => {
     const action1 = jest.fn();
     const action2 = jest.fn();
 
@@ -3689,7 +3689,30 @@ describe('action groups', () => {
     expect(action2).toHaveBeenCalled();
   });
 
-  it('should execute actions provided as action functions in a group', () => {
+  it('should execute actions from action objects in a group', () => {
+    const action1 = jest.fn();
+    const action2 = jest.fn();
+
+    const machine = createMachine(
+      {
+        entry: 'group'
+      },
+      {
+        actions: {
+          group: [{ type: 'action1' }, { type: 'action2' }],
+          action1,
+          action2
+        }
+      }
+    );
+
+    interpret(machine).start();
+
+    expect(action1).toHaveBeenCalled();
+    expect(action2).toHaveBeenCalled();
+  });
+
+  it('should execute actions from action functions in a group', () => {
     const action1 = jest.fn();
     const action2 = jest.fn();
 
@@ -3721,7 +3744,7 @@ describe('action groups', () => {
     expect(action2).toHaveBeenCalledWith(event);
   });
 
-  it('should execute a mix of actions in a group', () => {
+  it('should execute a mix of action types in a group', () => {
     const action1 = jest.fn();
     const action2 = jest.fn();
 
@@ -3739,7 +3762,7 @@ describe('action groups', () => {
             assign({
               value: ({ context }) => `${context.value}!`
             }),
-            'action2'
+            { type: 'action2' }
           ],
           action1: ({ context }) => action1(context.value),
           action2: ({ context }) => action2(context.value)

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -3779,6 +3779,35 @@ describe('action groups', () => {
     expect(action).toHaveBeenNthCalledWith(3, 'b');
   });
 
+  it('should pass params to executed group actions', () => {
+    const handler1 = jest.fn();
+    const handler2 = jest.fn();
+
+    const machine = createMachine(
+      {
+        entry: {
+          type: 'messageHandlers',
+          params: {
+            message: 'Hello world!'
+          }
+        }
+      },
+      {
+        actions: {
+          messageHandlers: ['handler1', 'otherHandlers'],
+          otherHandlers: ['handler2'],
+          handler1: ({ action }) => handler1(action.params!.message),
+          handler2: ({ action }) => handler2(action.params!.message)
+        }
+      }
+    );
+
+    interpret(machine).start();
+
+    expect(handler1).toHaveBeenCalledWith('Hello world!');
+    expect(handler2).toHaveBeenCalledWith('Hello world!');
+  });
+
   it('should play nicely with typegen', () => {
     interface Typegen0 {
       '@@xstate/typegen': true;

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -3794,18 +3794,24 @@ describe('action groups', () => {
       },
       {
         actions: {
-          messageHandlers: ['handler1', 'otherHandlers'],
+          messageHandlers: [
+            'handler1',
+            { type: 'otherHandlers', params: { level: 'info' } }
+          ],
           otherHandlers: ['handler2'],
-          handler1: ({ action }) => handler1(action.params!.message),
-          handler2: ({ action }) => handler2(action.params!.message)
+          handler1: ({ action }) => handler1(action.params),
+          handler2: ({ action }) => handler2(action.params)
         }
       }
     );
 
     interpret(machine).start();
 
-    expect(handler1).toHaveBeenCalledWith('Hello world!');
-    expect(handler2).toHaveBeenCalledWith('Hello world!');
+    expect(handler1).toHaveBeenCalledWith({ message: 'Hello world!' });
+    expect(handler2).toHaveBeenCalledWith({
+      message: 'Hello world!',
+      level: 'info'
+    });
   });
 
   it('should play nicely with typegen', () => {


### PR DESCRIPTION
This PR implements #3996, enabling actions to be implemented as an _action group_. (replaces #3561)

An _action group_ is a named array of actions. When the action group is executed, each action in the group is executed in order:

```js
import { createMachine, interpret, log } from 'xstate';

const machine = createMachine(
  {
    // reference the action group by name (`someGroup`)
    entry: 'someGroup'
  },
  {
    actions: {
      // executes `action1`, then `action2`
      someGroup: ['action1', 'action2'],
      action1: log('action1'),
      action2: log('action2')
    }
  }
);

interpret(machine).start(); // logs "action1", then "action2"
```

Action groups allow us to avoid error-prone repetition of actions, instead defining the group once and reusing it anywhere—like a single source of truth for the algorithm the group represents:

```diff
 const machine = createMachine(
   {
     context: { count: 0 },
     on: {
-      // increment count, then print it
-      incrementClick: { actions: ['incrementCount', 'printCount'] },
+       incrementClick: { actions: 'increment' },
-      // increment count, then print it
-      // oops! we accidentally put the actions in the wrong order
-      tick: { actions: ['printCount', 'incrementCount'] },
+      tick: { actions: 'increment' }
     }
   },
   {
     actions: {
+      // increment count, then print it. single source of truth for the `increment` algorithm
+      increment: ['incrementCount', 'printCount'],
       incrementCount: assign({
         count: ({ context }) => context.count + 1
       }),
       printCount: log(({ context }) => `Count: ${context.count}`)
     }
   }
 );
```

Action groups can reference other action groups by name. The referenced group's actions will be executed in order from the point of reference—like spreading the referenced group's actions in the group:

```js
const machine = createMachine(
  {
    entry: 'initialize'
  },
  {
    actions: {
      // executes `load` group actions, then `listen` group actions
      initialize: ['load', 'listen'],
      load: ['loadConfig', 'loadData'],
      listen: ['startApp', 'listenOnPort']
    }
  }
);

interpret(machine).start();
// actions: (load) loadConfig -> loadData -> (listen) startApp -> listenOnPort
```

With a mix of actions, action groups, and action group references, we can compose our algorithms in flexible and reusable ways:

```js
import { assign, createMachine, log } from 'xstate';

const machine = createMachine(
  {
    entry: 'initialize',
    exit: 'terminate',
    on: {
      timeout: { actions: 'reconnect' },
      reload: { actions: 'reload' }
    }
  },
  {
    actions: {
      initialize: ['load', 'connect'],
      terminate: ['disconnect', 'save', 'exitProgram'],
      reconnect: ['disconnect', 'connect'],
      reload: ['disconnect', 'save', 'initialize']
    }
  }
);
```

I feel like there's something powerful to thinking about action groups as composable algorithms, though I'm not entirely sure what that is yet, so I'm excited for this to land so more people can play with it!