### PR TITLE
[v5] Data actor

### DIFF
--- a/packages/core/src/actors/data.ts
+++ b/packages/core/src/actors/data.ts
@@ -1,0 +1,43 @@
+import { toSCXMLEvent } from '..';
+import { ActorBehavior } from '../types';
+
+export function fromData<T>(initialData: T): ActorBehavior<
+  | {
+      type: 'set';
+      data: T;
+    }
+  | { type: 'reset' },
+  T,
+  {
+    initialData: T;
+    data: T;
+  }
+> {
+  return {
+    transition: (state, _event) => {
+      const scxmlEvent = toSCXMLEvent(_event);
+      const event = scxmlEvent.data;
+
+      if (event.type === 'set') {
+        return {
+          ...state,
+          data: event.data
+        };
+      }
+      if (event.type === 'reset') {
+        return {
+          ...state,
+          data: state.initialData
+        };
+      }
+      return state;
+    },
+    getInitialState: () => ({
+      initialData,
+      data: initialData
+    }),
+    getSnapshot: (state) => state.data,
+    getPersistedState: (state) => state,
+    restoreState: (state) => state
+  };
+}

--- a/packages/core/src/actors/data.ts
+++ b/packages/core/src/actors/data.ts
@@ -1,4 +1,3 @@
-import { toSCXMLEvent } from '..';
 import { ActorBehavior } from '../types';
 
 export function fromData<T>(initialData: T): ActorBehavior<
@@ -14,10 +13,7 @@ export function fromData<T>(initialData: T): ActorBehavior<
   }
 > {
   return {
-    transition: (state, _event) => {
-      const scxmlEvent = toSCXMLEvent(_event);
-      const event = scxmlEvent.data;
-
+    transition: (state, event) => {
       if (event.type === 'set') {
         return {
           ...state,

--- a/packages/core/src/actors/data.ts
+++ b/packages/core/src/actors/data.ts
@@ -1,4 +1,4 @@
-import { ActorBehavior } from '../types';
+import { ActorBehavior } from '../types.ts';
 
 export function fromData<T>(initialData: T): ActorBehavior<
   | {

--- a/packages/core/src/actors/index.ts
+++ b/packages/core/src/actors/index.ts
@@ -11,6 +11,7 @@ export { fromTransition } from './transition.ts';
 export { fromPromise } from './promise.ts';
 export { fromObservable, fromEventObservable } from './observable.ts';
 export { fromCallback } from './callback.ts';
+export { fromData } from './data.ts';
 
 export const startSignalType = 'xstate.init';
 export const stopSignalType = 'xstate.stop';

--- a/packages/core/test/behaviors.test.ts
+++ b/packages/core/test/behaviors.test.ts
@@ -2,6 +2,7 @@ import { EMPTY, interval, of, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { createMachine, interpret } from '../src/index.ts';
 import {
+  fromData,
   fromObservable,
   fromPromise,
   fromTransition
@@ -525,5 +526,44 @@ describe('machine behavior', () => {
     expect(actor2.getSnapshot().children.child.getSnapshot().value).toBe(
       'inner'
     );
+  });
+});
+
+describe('data behavior', () => {
+  it('should read data', () => {
+    const dataActor = interpret(fromData({ count: 42 })).start();
+
+    expect(dataActor.getSnapshot()).toEqual({
+      count: 42
+    });
+  });
+
+  it('should set data', () => {
+    const dataActor = interpret(fromData({ count: 42, foo: 'bar' })).start();
+
+    dataActor.send({ type: 'set', data: { count: 43, foo: 'baz' } });
+
+    expect(dataActor.getSnapshot()).toEqual({
+      count: 43,
+      foo: 'baz'
+    });
+  });
+
+  it('should reset data', () => {
+    const dataActor = interpret(fromData({ count: 42, foo: 'bar' })).start();
+
+    dataActor.send({ type: 'set', data: { count: 43, foo: 'baz' } });
+
+    expect(dataActor.getSnapshot()).toEqual({
+      count: 43,
+      foo: 'baz'
+    });
+
+    dataActor.send({ type: 'reset' });
+
+    expect(dataActor.getSnapshot()).toEqual({
+      count: 42,
+      foo: 'bar'
+    });
   });
 });


### PR DESCRIPTION
This PR adds `fromData(...)`, which makes it easy to work with plain data:

```js
const dataActor = interpret(fromData({ count: 0 }));

dataActor.send({
  type: 'set',
  data: { count: dataActor.getSnapshot().count + 1 }
});

dataActor.getSnapshot();
// { count: 1 }
```