### PR TITLE
[v5] `useSnapshot`

### DIFF
--- a/.changeset/fifty-flies-count.md
+++ b/.changeset/fifty-flies-count.md
@@ -2,7 +2,7 @@
 '@xstate/react': major
 ---
 
-The Context object returned from `createActorContext(...)` now provides a `.useSnapshot()` hook, which replaces `useActor()`:
+The Context object returned from `createActorContext(...)` now provides a `.useSnapshot()` hook, which replaces what was previously provided as `.useActor()`:
 
 ```ts
 // instead of this:

--- a/.changeset/fifty-flies-count.md
+++ b/.changeset/fifty-flies-count.md
@@ -1,0 +1,11 @@
+---
+'@xstate/react': major
+---
+
+The Context object returned from `createActorContext(...)` now provides a `.useSnapshot()` hook, which replaces `useActor()`:
+
+```ts
+// instead of this:
+// const [state, send] = SomeContext.useActor();
+const [state, send] = SomeContext.useSnapshot();
+```

--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -11,7 +11,8 @@ import {
   MarkAllImplementationsAsProvided,
   StateMachine,
   EventFromBehavior,
-  AnyActorBehavior
+  AnyActorBehavior,
+  AnyActorRef
 } from 'xstate';
 
 type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
@@ -91,7 +92,7 @@ export function createActorContext<TBehavior extends AnyActorBehavior>(
   }
 
   Provider.displayName = `ActorProvider(${
-    machine.id ?? machine.transition.name
+    (machine as unknown as AnyStateMachine).id ?? machine.transition.name
   })`;
 
   function useContext(): ActorRefFrom<TBehavior> {
@@ -122,7 +123,7 @@ export function createActorContext<TBehavior extends AnyActorBehavior>(
     const actor = useContext();
     const state = useSelector((s) => s);
 
-    return [state, actor.send, actor];
+    return [state, (actor as AnyActorRef).send, actor];
   }
 
   return {

--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -35,7 +35,7 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
     : never;
 
 export function createActorContext<TBehavior extends AnyActorBehavior>(
-  machine: TBehavior,
+  behavior: TBehavior,
   interpreterOptions?: InterpreterOptions<TBehavior>,
   observerOrListener?:
     | Observer<SnapshotFrom<TBehavior>>
@@ -59,13 +59,13 @@ export function createActorContext<TBehavior extends AnyActorBehavior>(
           TBehavior['__TResolvedTypesMeta']
         > extends true
         ? {
-            machine?: TBehavior;
+            logic?: TBehavior;
           }
         : {
-            machine: ToMachinesWithProvidedImplementations<TBehavior>;
+            logic: ToMachinesWithProvidedImplementations<TBehavior>;
           }
       : {
-          machine?: TBehavior;
+          logic?: TBehavior;
         })
   ) => React.ReactElement<any, any>;
 } {
@@ -77,13 +77,13 @@ export function createActorContext<TBehavior extends AnyActorBehavior>(
 
   function Provider({
     children,
-    machine: providedMachine = machine
+    logic = behavior
   }: {
     children: React.ReactNode;
-    machine: TBehavior;
+    logic: TBehavior;
   }) {
     const actor = (useActorRef as any)(
-      providedMachine,
+      logic,
       interpreterOptions,
       observerOrListener
     ) as ActorRefFrom<TBehavior>;
@@ -91,9 +91,7 @@ export function createActorContext<TBehavior extends AnyActorBehavior>(
     return React.createElement(OriginalProvider, { value: actor, children });
   }
 
-  Provider.displayName = `ActorProvider(${
-    (machine as unknown as AnyStateMachine).id ?? machine.transition.name
-  })`;
+  Provider.displayName = 'ActorProvider'; // TODO: specific display names based on actor ID?
 
   function useContext(): ActorRefFrom<TBehavior> {
     const actor = React.useContext(ReactContext);

--- a/packages/xstate-react/test/createActorContext.test.tsx
+++ b/packages/xstate-react/test/createActorContext.test.tsx
@@ -300,4 +300,46 @@ describe('createActorContext', () => {
 
     expect(stubFn).toHaveBeenCalledTimes(1);
   });
+
+  it('should work with useSnapshot', () => {
+    const someMachine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            next: 'b'
+          }
+        },
+        b: {}
+      }
+    });
+
+    const SomeContext = createActorContext(someMachine);
+
+    const Component = () => {
+      const [snapshot, send] = SomeContext.useSnapshot();
+
+      return (
+        <div data-testid="value" onClick={() => send({ type: 'next' })}>
+          {snapshot.value}
+        </div>
+      );
+    };
+
+    const App = () => {
+      return (
+        <SomeContext.Provider>
+          <Component />
+        </SomeContext.Provider>
+      );
+    };
+
+    render(<App />);
+
+    expect(screen.getByTestId('value').textContent).toBe('a');
+
+    fireEvent.click(screen.getByTestId('value'));
+
+    expect(screen.getByTestId('value').textContent).toBe('b');
+  });
 });

--- a/packages/xstate-react/test/createActorContext.test.tsx
+++ b/packages/xstate-react/test/createActorContext.test.tsx
@@ -11,10 +11,10 @@ afterEach(() => {
 function checkConsoleErrorOutputForMissingProvider() {
   expect(console.error).toHaveBeenCalledTimes(3);
   expect((console.error as any).mock.calls[0][0].message.split('\n')[0]).toBe(
-    `Uncaught [Error: You used a hook from \"ActorProvider((machine))\" but it's not inside a <ActorProvider((machine))> component.]`
+    `Uncaught [Error: You used a hook from \"ActorProvider\" but it's not inside a <ActorProvider> component.]`
   );
   expect((console.error as any).mock.calls[1][0].message.split('\n')[0]).toBe(
-    `Uncaught [Error: You used a hook from \"ActorProvider((machine))\" but it's not inside a <ActorProvider((machine))> component.]`
+    `Uncaught [Error: You used a hook from \"ActorProvider\" but it's not inside a <ActorProvider> component.]`
   );
   expect((console.error as any).mock.calls[2][0].split('\n')[0]).toBe(
     `The above error occurred in the <App> component:`
@@ -225,7 +225,7 @@ describe('createActorContext', () => {
 
     const App = () => {
       return (
-        <SomeContext.Provider machine={otherMachine}>
+        <SomeContext.Provider logic={otherMachine}>
           <Component />
         </SomeContext.Provider>
       );
@@ -246,7 +246,7 @@ describe('createActorContext', () => {
     };
 
     expect(() => render(<App />)).toThrowErrorMatchingInlineSnapshot(
-      `"You used a hook from \"ActorProvider((machine))\" but it's not inside a <ActorProvider((machine))> component."`
+      `"You used a hook from "ActorProvider" but it's not inside a <ActorProvider> component."`
     );
     checkConsoleErrorOutputForMissingProvider();
   });
@@ -261,7 +261,7 @@ describe('createActorContext', () => {
     };
 
     expect(() => render(<App />)).toThrowErrorMatchingInlineSnapshot(
-      `"You used a hook from \"ActorProvider((machine))\" but it's not inside a <ActorProvider((machine))> component."`
+      `"You used a hook from "ActorProvider" but it's not inside a <ActorProvider> component."`
     );
     checkConsoleErrorOutputForMissingProvider();
   });
@@ -285,7 +285,7 @@ describe('createActorContext', () => {
     const App = () => {
       return (
         <SomeContext.Provider
-          machine={someMachine.provide({
+          logic={someMachine.provide({
             actions: {
               testAction: stubFn
             }


### PR DESCRIPTION
The Context object returned from `createActorContext(...)` now provides a `.useSnapshot()` hook, which replaces `useActor()`:

```ts
// instead of this:
// const [state, send] = SomeContext.useActor();
const [state, send] = SomeContext.useSnapshot();
```
