### PR TITLE
Bump XState-immer immer peer dependency

### DIFF
--- a/.changeset/silver-dolphins-fry.md
+++ b/.changeset/silver-dolphins-fry.md
@@ -1,0 +1,5 @@
+---
+'@xstate/immer': patch
+---
+
+Bump immer peer dependency to allow v10

--- a/packages/xstate-immer/package.json
+++ b/packages/xstate-immer/package.json
@@ -37,11 +37,11 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "immer": "^9.0.6",
+    "immer": "^9.0.6 || ^10",
     "xstate": "^4.37.2"
   },
   "devDependencies": {
-    "immer": "^9.0.6",
+    "immer": "^10.0.2",
     "lerna-alias": "3.0.3-0",
     "typescript": "^4.8.4",
     "xstate": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5232,10 +5232,10 @@ ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immer@^9.0.6:
-  version "9.0.6"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
-  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
+immer@^10.0.2:
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-10.0.2.tgz#11636c5b77acf529e059582d76faf338beb56141"
+  integrity sha512-Rx3CqeqQ19sxUtYV9CU911Vhy8/721wRFnJv3REVGWUmoAcIwzifTsdmJte/MV+0/XpM35LZdQMBGkRIoLPwQA==
 
 import-fresh@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Just bumping to allow v9 and v10. The breaking changes for this don't affect XState-immer as we don't use the default export of immer or the other features.