### PR TITLE
Rename machine in stopwatch example

### DIFF
--- a/examples/stopwatch/src/stopwatchMachine.ts
+++ b/examples/stopwatch/src/stopwatchMachine.ts
@@ -1,7 +1,7 @@
 import { assign, createMachine, fromCallback } from 'xstate';
 
 export const stopwatchMachine = createMachine({
-  id: 'toggle',
+  id: 'stopwatch',
   initial: 'stopped',
   context: {
     elapsed: 0


### PR DESCRIPTION
Tiny fix to update the machine name in the stopwatch example.