### PR TITLE
[v5] Input types

### DIFF
--- a/.changeset/odd-readers-behave.md
+++ b/.changeset/odd-readers-behave.md
@@ -1,0 +1,29 @@
+---
+'xstate': minor
+---
+
+Input types can now be specified for machines:
+
+```ts
+const emailMachine = createMachine({
+  types: {} as {
+    input: {
+      subject: string;
+      message: string;
+    };
+  },
+  context: ({ input }) => ({
+    // Strongly-typed input!
+    emailSubject: input.subject,
+    emailBody: input.message.trim()
+  })
+});
+
+const emailActor = interpret(emailMachine, {
+  input: {
+    // Strongly-typed input!
+    subject: 'Hello, world!',
+    message: 'This is a test.'
+  }
+}).start();
+```

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -1,11 +1,11 @@
 import {
   MachineConfig,
   EventObject,
-  AnyEventObject,
   MachineContext,
   InternalMachineImplementations,
   ParameterizedObject,
-  ProvidedActor
+  ProvidedActor,
+  AnyEventObject
 } from './types.ts';
 import {
   TypegenConstraint,
@@ -18,6 +18,7 @@ export function createMachine<
   TContext extends MachineContext,
   TEvent extends EventObject = AnyEventObject,
   TActor extends ProvidedActor = ProvidedActor,
+  TInput = any,
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 >(
   config: MachineConfig<
@@ -25,6 +26,7 @@ export function createMachine<
     TEvent,
     ParameterizedObject,
     TActor,
+    TInput,
     TTypesMeta
   >,
   implementations?: InternalMachineImplementations<
@@ -39,9 +41,10 @@ export function createMachine<
   TEvent,
   ParameterizedObject,
   TActor,
+  TInput,
   ResolveTypegenMeta<TTypesMeta, TEvent, ParameterizedObject, TActor>
 > {
-  return new StateMachine<any, any, any, any, any>(
+  return new StateMachine<any, any, any, any, any, any>(
     config as any,
     implementations as any
   );

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -43,7 +43,8 @@ import type {
   AnyEventObject,
   ProvidedActor,
   AnyActorRef,
-  Equals
+  Equals,
+  TODO
 } from './types.ts';
 import { isErrorEvent, resolveReferencedActor } from './utils.ts';
 
@@ -52,9 +53,10 @@ export const WILDCARD = '*';
 
 export class StateMachine<
   TContext extends MachineContext,
-  TEvent extends EventObject = EventObject,
-  TAction extends ParameterizedObject = ParameterizedObject,
-  TActor extends ProvidedActor = ProvidedActor,
+  TEvent extends EventObject,
+  TAction extends ParameterizedObject,
+  TActor extends ProvidedActor,
+  TInput,
   TResolvedTypesMeta = ResolveTypegenMeta<
     TypegenDisabled,
     NoInfer<TEvent>,
@@ -66,7 +68,12 @@ export class StateMachine<
       TEvent,
       State<TContext, TEvent, TActor, TResolvedTypesMeta>,
       State<TContext, TEvent, TActor, TResolvedTypesMeta>,
-      PersistedMachineState<State<TContext, TEvent, TActor, TResolvedTypesMeta>>
+      PersistedMachineState<
+        State<TContext, TEvent, TActor, TResolvedTypesMeta>
+      >,
+      TODO,
+      TInput,
+      TODO
     >
 {
   /**
@@ -76,7 +83,7 @@ export class StateMachine<
 
   public implementations: MachineImplementationsSimplified<TContext, TEvent>;
 
-  public types: MachineTypes<TContext, TEvent, TActor>;
+  public types: MachineTypes<TContext, TEvent, TActor, TInput>;
 
   public __xstatenode: true = true;
 
@@ -109,7 +116,7 @@ export class StateMachine<
 
     this.root = new StateNode(config, {
       _key: this.id,
-      _machine: this
+      _machine: this as any
     });
 
     this.root._initialize();
@@ -141,6 +148,7 @@ export class StateMachine<
     TEvent,
     TAction,
     TActor,
+    TInput,
     AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
       ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
       : TResolvedTypesMeta
@@ -454,4 +462,6 @@ export class StateMachine<
   __TActor!: TActor;
   /** @deprecated an internal property acting as a "phantom" type, not meant to be used at runtime */
   __TResolvedTypesMeta!: TResolvedTypesMeta;
+
+  __TInput!: TInput;
 }

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -286,7 +286,7 @@ export class StateMachine<
       TEvent,
       State<TContext, TEvent, TActor, TResolvedTypesMeta>
     >,
-    input?: any
+    input?: TInput
   ): State<TContext, TEvent, TActor, TResolvedTypesMeta> {
     const initEvent = createInitEvent(input) as unknown as TEvent; // TODO: fix;
 

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -125,9 +125,8 @@ export class StateNode<
   /**
    * The output data sent with the "done.state._id_" event if this is a final state node.
    */
-  public output?:
-    | Mapper<TContext, TEvent, any>
-    | PropertyMapper<TContext, TEvent, any>;
+  public output?: Mapper<TContext, TEvent, any>;
+
   /**
    * The order this state node appears. Corresponds to the implicit document order.
    */

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -143,7 +143,7 @@ export class StateNode<
     /**
      * The raw config used to create the machine.
      */
-    public config: StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
+    public config: StateNodeConfig<TContext, TEvent, TODO, TODO>,
     options: StateNodeOptions<TContext, TEvent>
   ) {
     this.parent = options._parent;
@@ -169,7 +169,7 @@ export class StateNode<
         ? mapValues(
             this.config.states,
             (
-              stateConfig: StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
+              stateConfig: StateNodeConfig<TContext, TEvent, TODO, TODO>,
               key
             ) => {
               const stateNode = new StateNode(stateConfig, {

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -117,7 +117,7 @@ export class StateNode<
   /**
    * The root machine node.
    */
-  public machine: StateMachine<TContext, TEvent, any, any>;
+  public machine: StateMachine<TContext, TEvent, any, any, TODO, TODO>;
   /**
    * The meta data associated with this state node, which will be returned in State instances.
    */
@@ -143,7 +143,7 @@ export class StateNode<
     /**
      * The raw config used to create the machine.
      */
-    public config: StateNodeConfig<TContext, TEvent, TODO, TODO>,
+    public config: StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
     options: StateNodeOptions<TContext, TEvent>
   ) {
     this.parent = options._parent;
@@ -169,7 +169,7 @@ export class StateNode<
         ? mapValues(
             this.config.states,
             (
-              stateConfig: StateNodeConfig<TContext, TEvent, TODO, TODO>,
+              stateConfig: StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
               key
             ) => {
               const stateNode = new StateNode(stateConfig, {

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -78,6 +78,6 @@ export function error(id: string, data?: any): ErrorPlatformEvent & string {
   return eventObject as ErrorPlatformEvent & string;
 }
 
-export function createInitEvent(input: any) {
+export function createInitEvent(input: unknown) {
   return { type: INIT_TYPE, input } as const;
 }

--- a/packages/core/src/actions/invoke.ts
+++ b/packages/core/src/actions/invoke.ts
@@ -26,7 +26,7 @@ function resolve(
     id: string;
     systemId: string | undefined;
     src: string;
-    input?: any;
+    input?: unknown;
   }
 ) {
   const referenced = resolveReferencedActor(
@@ -107,7 +107,7 @@ export function invoke<
   id: string;
   systemId: string | undefined;
   src: string;
-  input?: any;
+  input?: unknown;
 }) {
   function invoke(_: ActionArgs<TContext, TExpressionEvent>) {
     if (isDevelopment) {

--- a/packages/core/src/actors/observable.ts
+++ b/packages/core/src/actors/observable.ts
@@ -21,7 +21,7 @@ export type ObservablePersistedState<T> = Omit<
 >;
 
 export type ObservableActorLogic<T, TInput> = ActorLogic<
-  EventObject,
+  { type: string; [k: string]: unknown },
   T | undefined,
   ObservableInternalState<T>,
   ObservablePersistedState<T>,

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -6,10 +6,10 @@ import {
 } from '../types';
 import { stopSignalType } from '../actors';
 
-export interface PromiseInternalState<T> {
+export interface PromiseInternalState<T, TInput = unknown> {
   status: 'active' | 'error' | 'done' | 'canceled';
   data: T | undefined;
-  input?: any;
+  input: TInput | undefined;
 }
 
 const resolveEventType = '$$xstate.resolve';
@@ -31,8 +31,8 @@ export type PromiseActorEvents<T> =
 export type PromiseActorLogic<T, TInput = unknown> = ActorLogic<
   { type: string; [k: string]: unknown },
   T | undefined,
-  PromiseInternalState<T>, // internal state
-  PromiseInternalState<T>, // persisted state
+  PromiseInternalState<T, TInput>, // internal state
+  PromiseInternalState<T, TInput>, // persisted state
   ActorSystem<any>,
   TInput, // input
   T // output
@@ -71,7 +71,7 @@ export function fromPromise<T, TInput>(
           return {
             ...state,
             status: 'error',
-            data: (event as any).data,
+            data: (event as any).data, // TODO: if we keep this as `data` we should reflect this in the type
             input: undefined
           };
         case stopSignalType:
@@ -92,7 +92,7 @@ export function fromPromise<T, TInput>(
       }
 
       const resolvedPromise = Promise.resolve(
-        promiseCreator({ input: state.input, system, self })
+        promiseCreator({ input: state.input!, system, self })
       );
 
       resolvedPromise.then(

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -334,7 +334,7 @@ type HistoryAttributeValue = 'shallow' | 'deep' | undefined;
 function toConfig(
   nodeJson: XMLElement,
   id: string
-): StateNodeConfig<any, any, any, any, any> {
+): StateNodeConfig<any, any, any, any> {
   const parallel = nodeJson.name === 'parallel';
   let initial = parallel ? undefined : nodeJson.attributes!.initial;
   const { elements } = nodeJson;

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -334,7 +334,7 @@ type HistoryAttributeValue = 'shallow' | 'deep' | undefined;
 function toConfig(
   nodeJson: XMLElement,
   id: string
-): StateNodeConfig<any, any, any, any> {
+): StateNodeConfig<any, any, any, any, any> {
   const parallel = nodeJson.name === 'parallel';
   let initial = parallel ? undefined : nodeJson.attributes!.initial;
   const { elements } = nodeJson;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1067,7 +1067,7 @@ function microstepProcedure(
     currentState,
     historyValue,
     isInitial,
-    actorCtx.self
+    actorCtx
   );
 
   const nextConfiguration = [...mutConfiguration];
@@ -1120,7 +1120,7 @@ function enterStates(
   currentState: AnyState,
   historyValue: HistoryValue<any, any>,
   isInitial: boolean,
-  self: AnyActorRef
+  actorContext: AnyActorContext
 ): void {
   const statesToEnter = new Set<AnyStateNode>();
   const statesForDefaultEntry = new Set<AnyStateNode>();
@@ -1170,7 +1170,7 @@ function enterStates(
                 stateNodeToEnter.output,
                 currentState.context,
                 event,
-                self
+                actorContext.self
               )
             : undefined
         )

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1235,7 +1235,7 @@ export type PropertyMapper<
 > = {
   [K in keyof TParams]?:
     | ((args: { context: TContext; event: TEvent }) => TParams[K])
-    | AnythingButAFunction<TParams[K]>;
+    | TParams[K];
 };
 
 export interface TransitionDefinition<
@@ -1793,7 +1793,3 @@ export type PersistedMachineState<TState extends AnyState> = Pick<
     };
   };
 };
-
-export type AnythingButAFunction<T> = IsAny<T> extends true
-  ? string | number | boolean | object | symbol
-  : T;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -645,9 +645,7 @@ export interface StateNodeConfig<
    * The output data will be evaluated with the current `context` and placed on the `.data` property
    * of the event.
    */
-  output?:
-    | Mapper<TContext, TEvent, any>
-    | PropertyMapper<TContext, TEvent, any>;
+  output?: Mapper<TContext, TEvent, any> | NonReducibleUnknown;
   /**
    * The unique ID of the state node, which can be referenced as a transition target via the
    * `#id` syntax.
@@ -739,9 +737,7 @@ export interface FinalStateNodeConfig<
    * The data to be sent with the "done.state.<id>" event. The data can be
    * static or dynamic (based on assigners).
    */
-  output?:
-    | Mapper<TContext, TEvent, any>
-    | PropertyMapper<TContext, TEvent, any>;
+  output?: Mapper<TContext, TEvent, any>;
 }
 
 export type SimpleOrStateNodeConfig<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1222,9 +1222,7 @@ export type PropertyMapper<
   TEvent extends EventObject,
   TParams extends {}
 > = {
-  [K in keyof TParams]?:
-    | ((args: { context: TContext; event: TEvent }) => TParams[K])
-    | TParams[K];
+  [K in keyof TParams]?: Mapper<TContext, TEvent, TParams[K]> | TParams[K];
 };
 
 export interface TransitionDefinition<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -402,10 +402,9 @@ export type StatesConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TAction extends ParameterizedObject,
-  TActor extends ProvidedActor,
-  TInput
+  TActor extends ProvidedActor
 > = {
-  [K in string]: StateNodeConfig<TContext, TEvent, TAction, TActor, TInput>;
+  [K in string]: StateNodeConfig<TContext, TEvent, TAction, TActor>;
 };
 
 export type StatesDefinition<
@@ -504,8 +503,7 @@ type DistributeActors<
 export type InvokeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TActor extends ProvidedActor,
-  _TInput
+  TActor extends ProvidedActor
 > = IsLiteralString<TActor['src']> extends true
   ? DistributeActors<TContext, TEvent, TActor>
   : {
@@ -554,8 +552,7 @@ export interface StateNodeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TAction extends ParameterizedObject,
-  TActor extends ProvidedActor,
-  TInput
+  TActor extends ProvidedActor
 > {
   /**
    * The initial state transition.
@@ -583,12 +580,12 @@ export interface StateNodeConfig<
   /**
    * The mapping of state node keys to their state node configurations (recursive).
    */
-  states?: StatesConfig<TContext, TEvent, TAction, TActor, TInput> | undefined;
+  states?: StatesConfig<TContext, TEvent, TAction, TActor> | undefined;
   /**
    * The services to invoke upon entering this state node. These services will be stopped upon exiting this state node.
    */
   invoke?: SingleOrArray<
-    TActor['src'] | InvokeConfig<TContext, TEvent, TActor, TInput>
+    TActor['src'] | InvokeConfig<TContext, TEvent, TActor>
   >;
   /**
    * The mapping of event types to their potential transition(s).
@@ -705,7 +702,7 @@ export type AnyStateConfig = StateConfig<any, AnyEventObject>;
 export interface AtomicStateNodeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject
-> extends StateNodeConfig<TContext, TEvent, TODO, TODO, TODO> {
+> extends StateNodeConfig<TContext, TEvent, TODO, TODO> {
   initial?: undefined;
   parallel?: false | undefined;
   states?: undefined;
@@ -739,7 +736,7 @@ export type SimpleOrStateNodeConfig<
   TEvent extends EventObject
 > =
   | AtomicStateNodeConfig<TContext, TEvent>
-  | StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>;
+  | StateNodeConfig<TContext, TEvent, TODO, TODO>;
 
 export type ActionFunctionMap<
   TContext extends MachineContext,
@@ -1008,7 +1005,7 @@ export type ContextFactory<TContext extends MachineContext, TInput> = ({
   input
 }: {
   spawn: Spawner;
-  input: TInput; // TODO: fix
+  input: TInput;
 }) => TContext;
 
 export type MachineConfig<
@@ -1022,8 +1019,7 @@ export type MachineConfig<
   NoInfer<TContext>,
   NoInfer<TEvent>,
   NoInfer<TAction>,
-  NoInfer<TActor>,
-  NoInfer<TInput>
+  NoInfer<TActor>
 > & {
   /**
    * The initial context (extended state)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -541,7 +541,7 @@ export type InvokeConfig<
        */
       src: AnyActorLogic | string; // TODO: fix types
 
-      input?: Mapper<TContext, TEvent, any> | any;
+      input?: Mapper<TContext, TEvent, {}> | {};
       /**
        * The transition to take upon the invoked child machine reaching its final top-level state.
        */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1235,7 +1235,7 @@ export type PropertyMapper<
 > = {
   [K in keyof TParams]?:
     | ((args: { context: TContext; event: TEvent }) => TParams[K])
-    | TParams[K];
+    | AnythingButAFunction<TParams[K]>;
 };
 
 export interface TransitionDefinition<
@@ -1793,3 +1793,7 @@ export type PersistedMachineState<TState extends AnyState> = Pick<
     };
   };
 };
+
+export type AnythingButAFunction<T> = IsAny<T> extends true
+  ? string | number | boolean | object | symbol
+  : T;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -344,7 +344,7 @@ export interface InvokeDefinition<
    */
   src: string;
 
-  input?: Mapper<TContext, TEvent, any> | any;
+  input?: Mapper<TContext, TEvent, NonReducibleUnknown> | NonReducibleUnknown;
   /**
    * The transition to take upon the invoked child machine reaching its final top-level state.
    */

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -389,12 +389,9 @@ export function toInvokeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject
 >(
-  invocable:
-    | InvokeConfig<TContext, TEvent, TODO, TODO>
-    | string
-    | AnyActorLogic,
+  invocable: InvokeConfig<TContext, TEvent, TODO> | string | AnyActorLogic,
   id: string
-): InvokeConfig<TContext, TEvent, TODO, TODO> {
+): InvokeConfig<TContext, TEvent, TODO> {
   if (typeof invocable === 'object') {
     if ('src' in invocable) {
       return invocable;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -239,24 +239,24 @@ export function mapContext<
     return mapper({ context, event, self });
   }
 
-  if (isDevelopment) {
-    if (typeof mapper === 'object') {
-      if (Object.values(mapper).some((val) => typeof val === 'function')) {
-        console.warn(
-          `Dynamically mapping values to individual properties is deprecated. Use a single function that returns the mapped object instead.\nFound object containing properties whose values are possibly mapping functions: ${Object.entries(
-            mapper
-          )
-            .filter(([key, value]) => typeof value === 'function')
-            .map(
-              ([key, value]) =>
-                `\n - ${key}: ${(value as () => any)
-                  .toString()
-                  .replace(/\n\s*/g, '')}`
-            )
-            .join('')}`
-        );
-      }
-    }
+  if (
+    isDevelopment &&
+    typeof mapper === 'object' &&
+    Object.values(mapper).some((val) => typeof val === 'function')
+  ) {
+    console.warn(
+      `Dynamically mapping values to individual properties is deprecated. Use a single function that returns the mapped object instead.\nFound object containing properties whose values are possibly mapping functions: ${Object.entries(
+        mapper
+      )
+        .filter(([key, value]) => typeof value === 'function')
+        .map(
+          ([key, value]) =>
+            `\n - ${key}: ${(value as () => any)
+              .toString()
+              .replace(/\n\s*/g, '')}`
+        )
+        .join('')}`
+    );
   }
 
   return mapper;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -240,7 +240,7 @@ export function mapContext<
   }
 
   const result = {} as any;
-  const args = { context, event };
+  const args = { context, event, self };
 
   for (const key of Object.keys(mapper)) {
     const subMapper = mapper[key];

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,7 +1,7 @@
 import isDevelopment from '#is-development';
 import { AnyActorLogic, AnyState } from './index.ts';
 import { errorExecution, errorPlatform } from './constantPrefixes.ts';
-import { NULL_EVENT, STATE_DELIMITER, TARGETLESS_KEY } from './constants.ts';
+import { STATE_DELIMITER, TARGETLESS_KEY } from './constants.ts';
 import type { StateNode } from './StateNode.ts';
 import type {
   ActorLogic,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -20,7 +20,8 @@ import type {
   Subscribable,
   TransitionConfig,
   TransitionConfigTarget,
-  TODO
+  TODO,
+  AnyActorRef
 } from './types.ts';
 
 export function keys<T extends object>(value: T): Array<keyof T & string> {
@@ -231,10 +232,11 @@ export function mapContext<
 >(
   mapper: Mapper<TContext, TEvent, any> | PropertyMapper<TContext, TEvent, any>,
   context: TContext,
-  event: TEvent
+  event: TEvent,
+  self: AnyActorRef
 ): any {
   if (typeof mapper === 'function') {
-    return mapper({ context, event });
+    return mapper({ context, event, self });
   }
 
   const result = {} as any;
@@ -387,9 +389,12 @@ export function toInvokeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject
 >(
-  invocable: InvokeConfig<TContext, TEvent, TODO> | string | AnyActorLogic,
+  invocable:
+    | InvokeConfig<TContext, TEvent, TODO, TODO>
+    | string
+    | AnyActorLogic,
   id: string
-): InvokeConfig<TContext, TEvent, TODO> {
+): InvokeConfig<TContext, TEvent, TODO, TODO> {
   if (typeof invocable === 'object') {
     if ('src' in invocable) {
       return invocable;

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1218,18 +1218,19 @@ describe('actors', () => {
   });
 
   it('should receive done event from an immediately completed observable when self-initializing', () => {
-    const parentMachine = createMachine<{
-      child: ActorRef<EventObject, unknown> | null;
-    }>({
+    const emptyObservable = fromObservable(() => EMPTY);
+
+    const parentMachine = createMachine({
+      types: {
+        context: {} as {
+          child: ActorRefFrom<typeof emptyObservable> | null;
+        }
+      },
       context: {
         child: null
       },
       entry: assign({
-        child: ({ spawn }) =>
-          spawn(
-            fromObservable(() => EMPTY),
-            { id: 'myactor' }
-          )
+        child: ({ spawn }) => spawn(emptyObservable, { id: 'myactor' })
       }),
       initial: 'init',
       states: {

--- a/packages/core/test/deterministic.test.ts
+++ b/packages/core/test/deterministic.test.ts
@@ -63,13 +63,14 @@ describe('deterministic machine', () => {
 
   describe('machine.transition()', () => {
     it('should properly transition states based on event-like object', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue('green'),
           {
             type: 'TIMER'
           },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual('yellow');
     });
@@ -98,21 +99,23 @@ describe('deterministic machine', () => {
     });
 
     it('should throw an error if not given an event', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(() =>
         lightMachine.transition(
           testMachine.resolveStateValue('red'),
           undefined as any,
-          {} as any // TODO: figure out the simulation API
+          actorContext
         )
       ).toThrow();
     });
 
     it('should transition to nested states as target', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         testMachine.transition(
           testMachine.resolveStateValue('a'),
           { type: 'T' },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual({
         b: 'b1'
@@ -120,47 +123,47 @@ describe('deterministic machine', () => {
     });
 
     it('should throw an error for transitions from invalid states', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(() =>
         testMachine.transition(
           testMachine.resolveStateValue('fake'),
           { type: 'T' },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         )
       ).toThrow();
     });
 
     it('should throw an error for transitions from invalid substates', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(() =>
         testMachine.transition(
           testMachine.resolveStateValue('a.fake'),
           {
             type: 'T'
           },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         )
       ).toThrow();
     });
 
     it('should use the machine.initialState when an undefined state is given', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
-          lightMachine.getInitialState(
-            {} as any // TODO: figure out the simulation API
-          ),
+          lightMachine.getInitialState(actorContext),
           { type: 'TIMER' },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual('yellow');
     });
 
     it('should use the machine.initialState when an undefined state is given (unhandled event)', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
-          lightMachine.getInitialState(
-            {} as any // TODO: figure out the simulation API
-          ),
+          lightMachine.getInitialState(actorContext),
           { type: 'TIMER' },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual('yellow');
     });
@@ -169,23 +172,25 @@ describe('deterministic machine', () => {
   // TODO: figure out the simulation API
   describe('machine.transition() with nested states', () => {
     it('should properly transition a nested state', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue({ red: 'walk' }),
           { type: 'PED_COUNTDOWN' },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual({ red: 'wait' });
     });
 
     it('should transition from initial nested states', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue('red'),
           {
             type: 'PED_COUNTDOWN'
           },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual({
         red: 'wait'
@@ -193,13 +198,14 @@ describe('deterministic machine', () => {
     });
 
     it('should transition from deep initial nested states', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue('red'),
           {
             type: 'PED_COUNTDOWN'
           },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual({
         red: 'wait'
@@ -207,11 +213,12 @@ describe('deterministic machine', () => {
     });
 
     it('should bubble up events that nested states cannot handle', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue({ red: 'stop' }),
           { type: 'TIMER' },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual('green');
     });
@@ -245,13 +252,14 @@ describe('deterministic machine', () => {
     });
 
     it('should transition to the deepest initial state', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue('yellow'),
           {
             type: 'TIMER'
           },
-          {} as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual({
         red: 'walk'
@@ -259,21 +267,20 @@ describe('deterministic machine', () => {
     });
 
     it('should return the same state if no transition occurs', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       const initialState = lightMachine.transition(
-        lightMachine.getInitialState(
-          {} as any // TODO: figure out the simulation API
-        ),
+        lightMachine.getInitialState(actorContext),
         {
           type: 'NOTHING'
         },
-        {} as any // TODO: figure out the simulation API
+        actorContext
       );
       const nextState = lightMachine.transition(
         initialState,
         {
           type: 'NOTHING'
         },
-        {} as any // TODO: figure out the simulation API
+        actorContext
       );
 
       expect(initialState.value).toEqual(nextState.value);
@@ -304,13 +311,12 @@ describe('deterministic machine', () => {
     );
 
     it('should work with substate nodes that have the same key', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
       expect(
         machine.transition(
-          machine.getInitialState(
-            { self: {} } as any // TODO: figure out the simulation API
-          ),
+          machine.getInitialState(actorContext),
           { type: 'NEXT' },
-          { self: {} } as any // TODO: figure out the simulation API
+          actorContext
         ).value
       ).toEqual('test');
     });
@@ -318,10 +324,12 @@ describe('deterministic machine', () => {
 
   describe('forbidden events', () => {
     it('undefined transitions should forbid events', () => {
+      const actorContext = null as any; // TODO: figure out the simulation API
+
       const walkState = lightMachine.transition(
         lightMachine.resolveStateValue({ red: 'walk' }),
         { type: 'TIMER' },
-        {} as any // TODO: figure out the simulation API
+        actorContext
       );
 
       expect(walkState.value).toEqual({ red: 'walk' });

--- a/packages/core/test/deterministic.test.ts
+++ b/packages/core/test/deterministic.test.ts
@@ -69,7 +69,7 @@ describe('deterministic machine', () => {
           {
             type: 'TIMER'
           },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual('yellow');
     });
@@ -102,7 +102,7 @@ describe('deterministic machine', () => {
         lightMachine.transition(
           testMachine.resolveStateValue('red'),
           undefined as any,
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         )
       ).toThrow();
     });
@@ -112,7 +112,7 @@ describe('deterministic machine', () => {
         testMachine.transition(
           testMachine.resolveStateValue('a'),
           { type: 'T' },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual({
         b: 'b1'
@@ -124,7 +124,7 @@ describe('deterministic machine', () => {
         testMachine.transition(
           testMachine.resolveStateValue('fake'),
           { type: 'T' },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         )
       ).toThrow();
     });
@@ -136,7 +136,7 @@ describe('deterministic machine', () => {
           {
             type: 'T'
           },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         )
       ).toThrow();
     });
@@ -145,10 +145,10 @@ describe('deterministic machine', () => {
       expect(
         lightMachine.transition(
           lightMachine.getInitialState(
-            undefined as any // TODO: figure out the simulation API
+            {} as any // TODO: figure out the simulation API
           ),
           { type: 'TIMER' },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual('yellow');
     });
@@ -157,10 +157,10 @@ describe('deterministic machine', () => {
       expect(
         lightMachine.transition(
           lightMachine.getInitialState(
-            undefined as any // TODO: figure out the simulation API
+            {} as any // TODO: figure out the simulation API
           ),
           { type: 'TIMER' },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual('yellow');
     });
@@ -173,7 +173,7 @@ describe('deterministic machine', () => {
         lightMachine.transition(
           lightMachine.resolveStateValue({ red: 'walk' }),
           { type: 'PED_COUNTDOWN' },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual({ red: 'wait' });
     });
@@ -185,7 +185,7 @@ describe('deterministic machine', () => {
           {
             type: 'PED_COUNTDOWN'
           },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual({
         red: 'wait'
@@ -199,7 +199,7 @@ describe('deterministic machine', () => {
           {
             type: 'PED_COUNTDOWN'
           },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual({
         red: 'wait'
@@ -211,7 +211,7 @@ describe('deterministic machine', () => {
         lightMachine.transition(
           lightMachine.resolveStateValue({ red: 'stop' }),
           { type: 'TIMER' },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual('green');
     });
@@ -251,7 +251,7 @@ describe('deterministic machine', () => {
           {
             type: 'TIMER'
           },
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ).value
       ).toEqual({
         red: 'walk'
@@ -261,19 +261,19 @@ describe('deterministic machine', () => {
     it('should return the same state if no transition occurs', () => {
       const initialState = lightMachine.transition(
         lightMachine.getInitialState(
-          undefined as any // TODO: figure out the simulation API
+          {} as any // TODO: figure out the simulation API
         ),
         {
           type: 'NOTHING'
         },
-        undefined as any // TODO: figure out the simulation API
+        {} as any // TODO: figure out the simulation API
       );
       const nextState = lightMachine.transition(
         initialState,
         {
           type: 'NOTHING'
         },
-        undefined as any // TODO: figure out the simulation API
+        {} as any // TODO: figure out the simulation API
       );
 
       expect(initialState.value).toEqual(nextState.value);
@@ -307,10 +307,10 @@ describe('deterministic machine', () => {
       expect(
         machine.transition(
           machine.getInitialState(
-            undefined as any // TODO: figure out the simulation API
+            { self: {} } as any // TODO: figure out the simulation API
           ),
           { type: 'NEXT' },
-          undefined as any // TODO: figure out the simulation API
+          { self: {} } as any // TODO: figure out the simulation API
         ).value
       ).toEqual('test');
     });
@@ -321,7 +321,7 @@ describe('deterministic machine', () => {
       const walkState = lightMachine.transition(
         lightMachine.resolveStateValue({ red: 'walk' }),
         { type: 'TIMER' },
-        undefined as any // TODO: figure out the simulation API
+        {} as any // TODO: figure out the simulation API
       );
 
       expect(walkState.value).toEqual({ red: 'walk' });

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -91,7 +91,7 @@ describe('final states', () => {
     expect(actual).toEqual(['bazAction', 'barAction', 'fooAction']);
   });
 
-  it('should call data expressions on nested final nodes', (done) => {
+  it('should call output expressions on nested final nodes', (done) => {
     interface Ctx {
       revealedSecret?: string;
     }
@@ -112,9 +112,9 @@ describe('final states', () => {
             },
             reveal: {
               type: 'final',
-              output: {
+              output: () => ({
                 secret: 'the secret'
-              }
+              })
             }
           },
           onDone: {

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -113,7 +113,7 @@ describe('final states', () => {
             reveal: {
               type: 'final',
               output: {
-                secret: () => 'the secret'
+                secret: 'the secret'
               }
             }
           },
@@ -175,24 +175,6 @@ describe('final states', () => {
         done: {
           type: 'final',
           output: ({ self }) => ({ selfRef: self })
-        }
-      }
-    });
-
-    const actor = interpret(machine).start();
-
-    expect(actor.getSnapshot().output.selfRef.send).toBeDefined();
-  });
-
-  it('output property mapper should receive self', () => {
-    const machine = createMachine({
-      initial: 'done',
-      states: {
-        done: {
-          type: 'final',
-          output: {
-            selfRef: ({ self }) => self
-          }
         }
       }
     });

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -167,4 +167,20 @@ describe('final states', () => {
     service.send({ type: 'FINISH', value: 1 });
     expect(spy).toBeCalledTimes(1);
   });
+
+  it('output mapper should receive self', () => {
+    const machine = createMachine({
+      initial: 'done',
+      states: {
+        done: {
+          type: 'final',
+          output: ({ self }) => ({ selfRef: self })
+        }
+      }
+    });
+
+    const actor = interpret(machine).start();
+
+    expect(actor.getSnapshot().output.selfRef.send).toBeDefined();
+  });
 });

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -183,4 +183,22 @@ describe('final states', () => {
 
     expect(actor.getSnapshot().output.selfRef.send).toBeDefined();
   });
+
+  it('output property mapper should receive self', () => {
+    const machine = createMachine({
+      initial: 'done',
+      states: {
+        done: {
+          type: 'final',
+          output: {
+            selfRef: ({ self }) => self
+          }
+        }
+      }
+    });
+
+    const actor = interpret(machine).start();
+
+    expect(actor.getSnapshot().output.selfRef.send).toBeDefined();
+  });
 });

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -22,8 +22,8 @@ describe('guard conditions', () => {
         context: LightMachineCtx;
         events: LightMachineEvents;
       },
-      context: ({ input = {} }) => ({
-        elapsed: input.elapsed || 0
+      context: ({ input }) => ({
+        elapsed: input.elapsed ?? 0
       }),
       initial: 'green',
       types: {} as {

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -22,7 +22,7 @@ describe('guard conditions', () => {
         context: LightMachineCtx;
         events: LightMachineEvents;
       },
-      context: ({ input }) => ({
+      context: ({ input = {} }) => ({
         elapsed: input.elapsed ?? 0
       }),
       initial: 'green',

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -17,6 +17,11 @@ describe('guard conditions', () => {
 
   const lightMachine = createMachine(
     {
+      types: {} as {
+        input: { elapsed?: number };
+        context: LightMachineCtx;
+        events: LightMachineEvents;
+      },
       context: ({ input = {} }) => ({
         elapsed: input.elapsed || 0
       }),

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -26,10 +26,6 @@ describe('guard conditions', () => {
         elapsed: input.elapsed ?? 0
       }),
       initial: 'green',
-      types: {} as {
-        context: LightMachineCtx;
-        events: LightMachineEvents;
-      },
       states: {
         green: {
           on: {

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -1,5 +1,11 @@
 import { of } from 'rxjs';
-import { AnyActorRef, AnyActorLogic, assign, interpret } from '../src';
+import {
+  AnyActorLogic,
+  AnyActorRef,
+  AnyEventObject,
+  assign,
+  interpret
+} from '../src';
 import { createMachine } from '../src/Machine';
 import {
   fromCallback,
@@ -15,8 +21,9 @@ describe('input', () => {
     const machine = createMachine({
       types: {} as {
         context: { count: number };
+        input: { startCount: number };
       },
-      context: ({ input }: { input: { startCount: number } }) => ({
+      context: ({ input }) => ({
         count: input.startCount
       }),
       entry: ({ context }) => {
@@ -153,8 +160,8 @@ describe('input', () => {
   });
 
   it('should create a promise with input', async () => {
-    const promiseLogic = fromPromise(
-      ({ input }: { input: { count: number } }) => Promise.resolve(input)
+    const promiseLogic = fromPromise<{ count: number }, { count: number }>(
+      ({ input }) => Promise.resolve(input)
     );
 
     const promiseActor = interpret(promiseLogic, {
@@ -180,9 +187,10 @@ describe('input', () => {
   });
 
   it('should create an observable actor with input', (done) => {
-    const observableLogic = fromObservable(
-      ({ input }: { input: { count: number } }) => of(input)
-    );
+    const observableLogic = fromObservable<
+      { count: number },
+      { count: number }
+    >(({ input }) => of(input));
 
     const observableActor = interpret(observableLogic, {
       input: { count: 42 }
@@ -199,10 +207,12 @@ describe('input', () => {
   });
 
   it('should create a callback actor with input', (done) => {
-    const callbackLogic = fromCallback((_sendBack, _receive, { input }) => {
-      expect(input).toEqual({ count: 42 });
-      done();
-    });
+    const callbackLogic = fromCallback<AnyEventObject, { count: number }>(
+      (_sendBack, _receive, { input }) => {
+        expect(input).toEqual({ count: 42 });
+        done();
+      }
+    );
 
     interpret(callbackLogic, {
       input: { count: 42 }

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -31,13 +31,6 @@ describe('input', () => {
       }
     });
 
-    interpret(machine, {
-      input: {
-        // @ts-expect-error
-        wrongCountProperty: 42
-      }
-    });
-
     interpret(machine, { input: { startCount: 42 } }).start();
 
     expect(spy).toHaveBeenCalledWith(42);
@@ -45,23 +38,9 @@ describe('input', () => {
 
   it('initial event should have input property', (done) => {
     const machine = createMachine({
-      types: {} as {
-        input: { greeting: string };
-        context: { greeting: string };
-      },
-      context({ input }) {
-        return input;
-      },
-      entry: ({ context }) => {
-        expect(context.greeting).toBe('hello');
+      entry: ({ event }) => {
+        expect(event.input.greeting).toBe('hello');
         done();
-      }
-    });
-
-    interpret(machine, {
-      input: {
-        // @ts-expect-error
-        wrongGreeting: 'hello'
       }
     });
 
@@ -75,9 +54,6 @@ describe('input', () => {
         context: { message: string };
       },
       context: ({ input }) => {
-        // @ts-expect-error
-        input.notAGreeting;
-
         return { message: `Hello, ${input.greeting}` };
       }
     });
@@ -117,8 +93,9 @@ describe('input', () => {
         context: { greeting: string };
       },
       context: ({ input }) => input,
-      entry: ({ context }) => {
+      entry: ({ context, event }) => {
         expect(context.greeting).toBe('hello');
+        expect(event.input.greeting).toBe('hello');
         done();
       }
     });
@@ -142,8 +119,9 @@ describe('input', () => {
       context({ input }) {
         return input;
       },
-      entry: ({ context }) => {
+      entry: ({ context, event }) => {
         expect(context.greeting).toBe('hello');
+        expect(event.input.greeting).toBe('hello');
         done();
       }
     });

--- a/packages/core/test/invalid.test.ts
+++ b/packages/core/test/invalid.test.ts
@@ -25,7 +25,7 @@ describe('invalid or resolved states', () => {
       machine.transition(
         machine.resolveStateValue('A'),
         { type: 'E' },
-        undefined as any // TODO: figure out the simulation API
+        {} as any // TODO: figure out the simulation API
       ).value
     ).toEqual({
       A: 'A1',
@@ -57,7 +57,7 @@ describe('invalid or resolved states', () => {
       machine.transition(
         machine.resolveStateValue({ A: {}, B: {} }),
         { type: 'E' },
-        undefined as any // TODO: figure out the simulation API
+        {} as any // TODO: figure out the simulation API
       ).value
     ).toEqual({
       A: 'A1',
@@ -88,7 +88,7 @@ describe('invalid or resolved states', () => {
     machine.transition(
       machine.resolveStateValue({ A: 'A1', B: 'B1' }),
       { type: 'E' },
-      undefined as any // TODO: figure out the simulation API
+      {} as any // TODO: figure out the simulation API
     );
   });
 
@@ -116,7 +116,7 @@ describe('invalid or resolved states', () => {
       machine.transition(
         machine.resolveStateValue({ A: 'A3', B: 'B3' }),
         { type: 'E' },
-        undefined as any // TODO: figure out the simulation API
+        {} as any // TODO: figure out the simulation API
       )
     ).toThrow();
   });
@@ -145,7 +145,7 @@ describe('invalid or resolved states', () => {
       machine.transition(
         machine.resolveStateValue({ A: 'A1', B: {} }),
         { type: 'E' },
-        undefined as any // TODO: figure out the simulation API
+        {} as any // TODO: figure out the simulation API
       ).value
     ).toEqual({
       A: 'A1',

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -182,8 +182,15 @@ describe('invoke', () => {
   });
 
   it('should start services (explicit machine, invoke = config)', (done) => {
-    const childMachine = createMachine<{ userId: string | undefined }>({
+    const childMachine = createMachine({
       id: 'fetch',
+      types: {} as {
+        context: { userId: string | undefined };
+        events: {
+          type: 'RESOLVE';
+          user: typeof user;
+        };
+      },
       context: ({ input }) => ({
         userId: input.userId
       }),

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -3298,7 +3298,7 @@ describe('invoke', () => {
   });
 });
 
-describe('actors option', () => {
+describe('invoke input', () => {
   it('should provide input to an actor creator', (done) => {
     const machine = createMachine(
       {
@@ -3354,5 +3354,21 @@ describe('actors option', () => {
     });
 
     service.start();
+  });
+
+  it('should provide self to input mapper', (done) => {
+    const machine = createMachine({
+      invoke: {
+        src: fromCallback(({ input }) => {
+          expect(input.responder.send).toBeDefined();
+          done();
+        }),
+        input: ({ self }) => ({
+          responder: self
+        })
+      }
+    });
+
+    interpret(machine).start();
   });
 });

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -43,7 +43,7 @@ const fetchMachine = createMachine<{ userId: string | undefined }>({
     },
     success: {
       type: 'final',
-      output: { user: ({ event }: any) => event.user }
+      output: ({ event }) => ({ user: event.user })
     },
     failure: {
       entry: sendParent({ type: 'REJECT' })

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -209,7 +209,7 @@ describe('invoke', () => {
         },
         success: {
           type: 'final',
-          output: { user: ({ event }: any) => event.user }
+          output: ({ event }) => ({ user: event.user })
         },
         failure: {
           entry: sendParent({ type: 'REJECT' })

--- a/packages/core/test/microstep.test.ts
+++ b/packages/core/test/microstep.test.ts
@@ -30,7 +30,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = undefined as any; // TODO: figure out the simulation API
+    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.getInitialState(actorContext),
       { type: 'GO' },
@@ -56,7 +56,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = undefined as any; // TODO: figure out the simulation API
+    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.resolveStateValue('first'),
       { type: 'TRIGGER' },
@@ -87,7 +87,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = undefined as any; // TODO: figure out the simulation API
+    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.resolveStateValue('first'),
       { type: 'TRIGGER' },
@@ -110,7 +110,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = undefined as any; // TODO: figure out the simulation API
+    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.getInitialState(actorContext),
       { type: 'TRIGGER' },
@@ -153,7 +153,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = undefined as any; // TODO: figure out the simulation API
+    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.getInitialState(actorContext),
       { type: 'TRIGGER' },

--- a/packages/core/test/microstep.test.ts
+++ b/packages/core/test/microstep.test.ts
@@ -30,7 +30,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
+    const actorContext = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.getInitialState(actorContext),
       { type: 'GO' },
@@ -56,7 +56,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
+    const actorContext = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.resolveStateValue('first'),
       { type: 'TRIGGER' },
@@ -87,7 +87,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
+    const actorContext = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.resolveStateValue('first'),
       { type: 'TRIGGER' },
@@ -110,7 +110,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
+    const actorContext = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.getInitialState(actorContext),
       { type: 'TRIGGER' },
@@ -153,7 +153,7 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = { self: {} } as any; // TODO: figure out the simulation API
+    const actorContext = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.getInitialState(actorContext),
       { type: 'TRIGGER' },

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -596,9 +596,9 @@ describe('transient states (eventless transitions)', () => {
         active: {
           invoke: {
             src: timerMachine,
-            input: {
-              duration: (context: any) => context.customDuration
-            }
+            input: ({ context }) => ({
+              duration: context.customDuration
+            })
           }
         }
       }

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -1087,7 +1087,7 @@ describe('typegen types', () => {
     function acceptMachine<
       TContext extends MachineContext,
       TEvent extends { type: string }
-    >(machine: StateMachine<TContext, any, TEvent>) {
+    >(machine: StateMachine<TContext, TEvent, any, any, any, any>) {
       return machine;
     }
 

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -235,7 +235,7 @@ it('should not use actions as possible inference sites', () => {
 it('should work with generic context', () => {
   function createMachineWithExtras<TContext extends MachineContext>(
     context: TContext
-  ): StateMachine<TContext, any, any> {
+  ): StateMachine<TContext, any, any, any, any> {
     return createMachine({ context });
   }
 
@@ -309,7 +309,7 @@ describe('events', () => {
     function acceptMachine<
       TContext extends {},
       TEvent extends { type: string }
-    >(_machine: StateMachine<TContext, any, TEvent>) {}
+    >(_machine: StateMachine<TContext, TEvent, any, any, any>) {}
 
     acceptMachine(toggleMachine);
   });

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1659,3 +1659,50 @@ describe('actions', () => {
     });
   });
 });
+
+describe('input', () => {
+  it('should provide the input type to the context factory', () => {
+    createMachine({
+      types: {
+        input: {} as {
+          count: number;
+        }
+      },
+      context: ({ input }) => {
+        ((_accept: number) => {})(input.count);
+        // @ts-expect-error
+        ((_accept: string) => {})(input.count);
+        return {};
+      }
+    });
+  });
+
+  it('should accept valid input type when interpreting an actor', () => {
+    const machine = createMachine({
+      types: {
+        input: {} as {
+          count: number;
+        }
+      }
+    });
+
+    interpret(machine, { input: { count: 100 } });
+  });
+
+  it('should reject invalid input type when interpreting an actor', () => {
+    const machine = createMachine({
+      types: {
+        input: {} as {
+          count: number;
+        }
+      }
+    });
+
+    interpret(machine, {
+      input: {
+        // @ts-expect-error
+        count: ''
+      }
+    });
+  });
+});

--- a/packages/core/test/utils.ts
+++ b/packages/core/test/utils.ts
@@ -26,7 +26,7 @@ export function testMultiTransition(
     const nextState = machine.transition(
       state,
       { type: eventType },
-      undefined as any // TODO: figure out the simulation API
+      {} as any // TODO: figure out the simulation API
     );
     return nextState;
   };

--- a/packages/xstate-graph/src/adjacency.ts
+++ b/packages/xstate-graph/src/adjacency.ts
@@ -21,7 +21,7 @@ export function getAdjacencyMap<
     fromState: customFromState,
     stopCondition
   } = resolveTraversalOptions(options);
-  const actorContext = undefined as any; // TODO: figure out the simulation API
+  const actorContext = { self: {} } as any; // TODO: figure out the simulation API
   const fromState =
     customFromState ?? logic.getInitialState(actorContext, undefined);
   const adj: AdjacencyMap<TInternalState, TEvent> = {};

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -94,7 +94,7 @@ export function createDefaultMachineOptions<TMachine extends AnyStateMachine>(
       ) as any[];
     },
     fromState: machine.getInitialState(
-      undefined as any // TODO: figure out the simulation API
+      {} as any // TODO: figure out the simulation API
     ) as StateFrom<TMachine>,
     ...otherOptions
   };

--- a/packages/xstate-graph/src/pathFromEvents.ts
+++ b/packages/xstate-graph/src/pathFromEvents.ts
@@ -37,7 +37,7 @@ export function getPathsFromEvents<
       ? createDefaultMachineOptions(logic)
       : createDefaultLogicOptions()) as TraversalOptions<TInternalState, TEvent>
   );
-  const actorContext = undefined as any; // TODO: figure out the simulation API
+  const actorContext = { self: {} } as any; // TODO: figure out the simulation API
   const fromState =
     resolvedOptions.fromState ?? logic.getInitialState(actorContext, undefined);
 

--- a/packages/xstate-graph/src/shortestPaths.ts
+++ b/packages/xstate-graph/src/shortestPaths.ts
@@ -26,7 +26,7 @@ export function getShortestPaths<TState, TEvent extends EventObject>(
   const fromState =
     resolvedOptions.fromState ??
     logic.getInitialState(
-      undefined as any, // TODO: figure out the simulation API
+      {} as any, // TODO: figure out the simulation API
       undefined
     );
   const adjacency = getAdjacencyMap(logic, resolvedOptions);

--- a/packages/xstate-graph/src/simplePaths.ts
+++ b/packages/xstate-graph/src/simplePaths.ts
@@ -32,7 +32,7 @@ export function getSimplePaths<TState, TEvent extends EventObject>(
   options: TraversalOptions<TState, TEvent>
 ): Array<StatePath<TState, TEvent>> {
   const resolvedOptions = resolveTraversalOptions(options);
-  const actorContext = undefined as any; // TODO: figure out the simulation API
+  const actorContext = { self: {} } as any; // TODO: figure out the simulation API
   const fromState =
     resolvedOptions.fromState ?? logic.getInitialState(actorContext, undefined);
   const serializeState = resolvedOptions.serializeState as (

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -208,7 +208,7 @@ describe('@xstate/graph', () => {
         shortestPaths.find((path) =>
           path.state.matches(
             lightMachine.getInitialState(
-              undefined as any // TODO: figure out the simulation API
+              {} as any // TODO: figure out the simulation API
             ).value
           )
         )!.steps
@@ -368,7 +368,7 @@ describe('@xstate/graph', () => {
         getMachineSimplePaths(lightMachine).find((p) =>
           p.state.matches(
             lightMachine.getInitialState(
-              undefined as any // TODO: figure out the simulation API
+              {} as any // TODO: figure out the simulation API
             ).value
           )
         )
@@ -377,7 +377,7 @@ describe('@xstate/graph', () => {
         getMachineSimplePaths(lightMachine).find((p) =>
           p.state.matches(
             lightMachine.getInitialState(
-              undefined as any // TODO: figure out the simulation API
+              {} as any // TODO: figure out the simulation API
             ).value
           )
         )!.steps
@@ -386,7 +386,7 @@ describe('@xstate/graph', () => {
         getMachineSimplePaths(equivMachine).find((p) =>
           p.state.matches(
             equivMachine.getInitialState(
-              undefined as any // TODO: figure out the simulation API
+              {} as any // TODO: figure out the simulation API
             ).value
           )
         )!
@@ -395,7 +395,7 @@ describe('@xstate/graph', () => {
         getMachineSimplePaths(equivMachine).find((p) =>
           p.state.matches(
             equivMachine.getInitialState(
-              undefined as any // TODO: figure out the simulation API
+              {} as any // TODO: figure out the simulation API
             ).value
           )
         )!.steps

--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -18,6 +18,7 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
     infer TEvent,
     infer TAction,
     infer TActorMap,
+    infer TInput,
     infer TResolvedTypesMeta
   >
     ? StateMachine<
@@ -25,6 +26,7 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
         TEvent,
         TAction,
         TActorMap,
+        TInput,
         AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
           ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
           : TResolvedTypesMeta

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -167,7 +167,11 @@ describeEachReactMode('useActor (%s)', ({ suiteKey, render }) => {
   });
 
   it('should accept input and provide it to the context factory', () => {
-    const testMachine = createMachine<{ foo: string; test: boolean }>({
+    const testMachine = createMachine({
+      types: {} as {
+        context: { foo: string; test: boolean };
+        input: { test: boolean };
+      },
       context: ({ input }) => ({
         foo: 'bar',
         test: input.test ?? false

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -350,7 +350,7 @@ type HistoryAttributeValue = 'shallow' | 'deep' | undefined;
 function toConfig(
   nodeJson: XMLElement,
   id: string
-): StateNodeConfig<any, any, any, any> {
+): StateNodeConfig<any, any, any, any, any> {
   const parallel = nodeJson.name === 'parallel';
   let initial = parallel ? undefined : nodeJson.attributes!.initial;
   const { elements } = nodeJson;

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -350,7 +350,7 @@ type HistoryAttributeValue = 'shallow' | 'deep' | undefined;
 function toConfig(
   nodeJson: XMLElement,
   id: string
-): StateNodeConfig<any, any, any, any, any> {
+): StateNodeConfig<any, any, any, any> {
   const parallel = nodeJson.name === 'parallel';
   let initial = parallel ? undefined : nodeJson.attributes!.initial;
   const { elements } = nodeJson;

--- a/packages/xstate-solid/test/useMachine.test.tsx
+++ b/packages/xstate-solid/test/useMachine.test.tsx
@@ -184,7 +184,11 @@ describe('useMachine hook', () => {
   });
 
   it('should accept input', () => {
-    const testMachine = createMachine<{ foo: string; test: boolean }>({
+    const testMachine = createMachine({
+      types: {} as {
+        context: { foo: string; test: boolean };
+        input: { test?: boolean };
+      },
       context: ({ input }) => ({
         foo: 'bar',
         test: false,

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -36,7 +36,7 @@ export interface TestStateNodeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject
 > extends Pick<
-    StateNodeConfig<TContext, TEvent, TODO, TODO>,
+    StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
     | 'type'
     | 'history'
     | 'on'

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -36,7 +36,7 @@ export interface TestStateNodeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject
 > extends Pick<
-    StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
+    StateNodeConfig<TContext, TEvent, TODO, TODO>,
     | 'type'
     | 'history'
     | 'on'

--- a/packages/xstate-test/test/paths.test.ts
+++ b/packages/xstate-test/test/paths.test.ts
@@ -43,7 +43,7 @@ describe('testModel.testPaths(...)', () => {
     );
 
     const paths = testModel.getPaths((logic, options) => {
-      const actorContext = undefined as any; // TODO: figure out the simulation API
+      const actorContext = { self: {} } as any; // TODO: figure out the simulation API
       const initialState = logic.getInitialState(actorContext, undefined);
       const events =
         typeof options.events === 'function'


### PR DESCRIPTION
This PR strongly types `input` values:

```ts
const machine = createMachine({
  types: {} as {
    input: { count: number }
  },
  context: ({ input }) => ({
    value: input.count // strongly-typed
  })
});

interpret(machine, {
  input: { count: 42 } // strongly-typed
}).start();
```