### PR TITLE
[v5] System for all actor logic

### DIFF
--- a/.changeset/slow-peas-repair.md
+++ b/.changeset/slow-peas-repair.md
@@ -1,0 +1,17 @@
+---
+'xstate': major
+---
+
+The `system` can now be accessed in all available actor logic creator functions:
+
+```ts
+fromPromise(({ system }) => { ... });
+
+fromTransition((state, event, { system }) => { ... });
+
+fromObservable(({ system }) => { ... });
+
+fromEventObservable(({ system }) => { ... });
+
+fromCallback((sendBack, receive, { system }) => { ... });
+```

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -24,7 +24,7 @@ export function fromCallback<TEvent extends EventObject>(
     start: (_state, { self }) => {
       self.send({ type: startSignalType } as TEvent);
     },
-    transition: (state, event, { self, id }) => {
+    transition: (state, event, { self, id, system }) => {
       if (event.type === startSignalType) {
         const sender = (eventForParent: AnyEventObject) => {
           if (state.canceled) {
@@ -39,7 +39,8 @@ export function fromCallback<TEvent extends EventObject>(
         };
 
         state.dispose = invokeCallback(sender, receiver, {
-          input: state.input
+          input: state.input,
+          system
         });
 
         if (isPromiseLike(state.dispose)) {

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -1,4 +1,4 @@
-import { ActorLogic } from '../types';
+import { ActorLogic, AnyActorSystem } from '../types';
 import { stopSignalType } from '../actors';
 
 export interface PromiseInternalState<T> {
@@ -9,7 +9,13 @@ export interface PromiseInternalState<T> {
 
 export function fromPromise<T>(
   // TODO: add types
-  promiseCreator: ({ input }: { input: any }) => PromiseLike<T>
+  promiseCreator: ({
+    input,
+    system
+  }: {
+    input: any;
+    system: AnyActorSystem;
+  }) => PromiseLike<T>
 ): ActorLogic<{ type: string }, T | undefined, PromiseInternalState<T>> {
   const resolveEventType = '$$xstate.resolve';
   const rejectEventType = '$$xstate.reject';
@@ -58,7 +64,7 @@ export function fromPromise<T>(
           return state;
       }
     },
-    start: (state, { self }) => {
+    start: (state, { self, system }) => {
       // TODO: determine how to allow customizing this so that promises
       // can be restarted if necessary
       if (state.status !== 'active') {
@@ -66,7 +72,7 @@ export function fromPromise<T>(
       }
 
       const resolvedPromise = Promise.resolve(
-        promiseCreator({ input: state.input })
+        promiseCreator({ input: state.input, system })
       );
 
       resolvedPromise.then(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -379,23 +379,6 @@ export type InvokeCallback<
   { input }: { input: any }
 ) => (() => void) | Promise<any> | void;
 
-export type ActorLogicCreator<
-  TContext extends MachineContext,
-  TEvent extends EventObject,
-  TActorLogic extends AnyActorLogic = AnyActorLogic
-> = (
-  context: TContext,
-  event: TEvent,
-  meta: {
-    id: string;
-    data?: any;
-    src: string;
-    event: TEvent;
-    meta: MetaObject | undefined;
-    input: any;
-  }
-) => TActorLogic;
-
 export interface InvokeMeta {
   src: string;
   meta: MetaObject | undefined;
@@ -1912,6 +1895,9 @@ export interface ActorSystem<T extends ActorSystemInfo> {
   _set: <K extends keyof T['actors']>(key: K, actorRef: T['actors'][K]) => void;
   get: <K extends keyof T['actors']>(key: K) => T['actors'][K] | undefined;
 }
+
+export type AnyActorSystem = ActorSystem<any>;
+
 export type PersistedMachineState<TState extends AnyState> = Pick<
   TState,
   'value' | 'output' | 'context' | 'event' | 'done' | 'historyValue'

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -376,7 +376,7 @@ export type InvokeCallback<
 > = (
   sendBack: (event: TSentEvent) => void,
   onReceive: Receiver<TEvent>,
-  { input }: { input: any }
+  { input, system }: { input: any; system: AnyActorSystem }
 ) => (() => void) | Promise<any> | void;
 
 export interface InvokeMeta {

--- a/packages/core/test/actorLogic.test.ts
+++ b/packages/core/test/actorLogic.test.ts
@@ -2,6 +2,7 @@ import { EMPTY, interval, of, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { createMachine, interpret } from '../src/index.ts';
 import {
+  fromCallback,
   fromEventObservable,
   fromObservable,
   fromPromise,
@@ -365,6 +366,31 @@ describe('eventObservable logic (fromEventObservable)', () => {
     });
 
     interpret(observableLogic).start();
+  });
+});
+
+describe('callback logic (fromCallback)', () => {
+  it('should interpret a callback', () => {
+    expect.assertions(1);
+
+    const callbackLogic = fromCallback((_, receive) => {
+      receive((event) => {
+        expect(event).toEqual({ type: 'a' });
+      });
+    });
+
+    const actor = interpret(callbackLogic).start();
+
+    actor.send({ type: 'a' });
+  });
+
+  it('should have access to the system', () => {
+    expect.assertions(1);
+    const callbackLogic = fromCallback((_sendBack, _receive, { system }) => {
+      expect(system).toBeDefined();
+    });
+
+    interpret(callbackLogic).start();
   });
 });
 

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -275,8 +275,8 @@ describe('system', () => {
     interpret(machine).start();
   });
 
-  it('should be accessible in other actors', () => {
-    expect.assertions(6);
+  it('should be accessible in promise logic', () => {
+    expect.assertions(2);
     const machine = createMachine({
       invoke: [
         {
@@ -288,25 +288,95 @@ describe('system', () => {
             expect(system.get('test')).toBeDefined();
             return Promise.resolve();
           })
+        }
+      ]
+    });
+
+    const actor = interpret(machine).start();
+
+    expect(actor.system.get('test')).toBeDefined();
+  });
+
+  it('should be accessible in transition logic', () => {
+    expect.assertions(2);
+    const machine = createMachine({
+      invoke: [
+        {
+          src: createMachine({}),
+          systemId: 'test'
         },
+
         {
           src: fromTransition((_state, _event, { system }) => {
             expect(system.get('test')).toBeDefined();
             return 0;
           }, 0),
           systemId: 'reducer'
+        }
+      ]
+    });
+
+    const actor = interpret(machine).start();
+
+    expect(actor.system.get('test')).toBeDefined();
+
+    // The assertion won't be checked until the transition function gets an event
+    actor.system.get('reducer')!.send({ type: 'a' });
+  });
+
+  it('should be accessible in observable logic', () => {
+    expect.assertions(2);
+    const machine = createMachine({
+      invoke: [
+        {
+          src: createMachine({}),
+          systemId: 'test'
         },
+
         {
           src: fromObservable(({ system }) => {
             expect(system.get('test')).toBeDefined();
             return of(0);
           })
+        }
+      ]
+    });
+
+    const actor = interpret(machine).start();
+
+    expect(actor.system.get('test')).toBeDefined();
+  });
+
+  it('should be accessible in event observable logic', () => {
+    expect.assertions(2);
+    const machine = createMachine({
+      invoke: [
+        {
+          src: createMachine({}),
+          systemId: 'test'
         },
+
         {
           src: fromEventObservable(({ system }) => {
             expect(system.get('test')).toBeDefined();
             return of({ type: 'a' });
           })
+        }
+      ]
+    });
+
+    const actor = interpret(machine).start();
+
+    expect(actor.system.get('test')).toBeDefined();
+  });
+
+  it('should be accessible in callback logic', () => {
+    expect.assertions(2);
+    const machine = createMachine({
+      invoke: [
+        {
+          src: createMachine({}),
+          systemId: 'test'
         },
         {
           src: fromCallback((_sendBack, _receive, { system }) => {
@@ -319,8 +389,5 @@ describe('system', () => {
     const actor = interpret(machine).start();
 
     expect(actor.system.get('test')).toBeDefined();
-
-    // The assertion won't be checked until the transition function gets an event
-    actor.system.get('reducer')!.send({ type: 'a' });
   });
 });

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -276,7 +276,7 @@ describe('system', () => {
   });
 
   it('should be accessible in other actors', () => {
-    expect.assertions(5);
+    expect.assertions(6);
     const machine = createMachine({
       invoke: [
         {
@@ -306,6 +306,11 @@ describe('system', () => {
           src: fromEventObservable(({ system }) => {
             expect(system.get('test')).toBeDefined();
             return of({ type: 'a' });
+          })
+        },
+        {
+          src: fromCallback((_sendBack, _receive, { system }) => {
+            expect(system.get('test')).toBeDefined();
           })
         }
       ]


### PR DESCRIPTION
This PR provides access to `system` for all actor logic.

```ts
fromPromise(({ system }) => { ... });

fromTransition((state, event, { system }) => { ... });

fromObservable(({ system }) => { ... });

fromEventObservable(({ system }) => { ... });

fromCallback((sendBack, receive, { system }) => { ... });
```