### PR TITLE
Update README.md

### DIFF
--- a/packages/xstate-fsm/README.md
+++ b/packages/xstate-fsm/README.md
@@ -26,6 +26,7 @@ This package contains a minimal, 1kb implementation of [XState](https://github.c
 | Transitions (string target) |       ✅        |                      ✅                       |
 | Delayed transitions         |       ❌        |                      ✅                       |
 | Eventless transitions       |       ❌        |                      ✅                       |
+| Wildcard event descriptors  |       ❌        |                      ✅                       |
 | Nested states               |       ❌        |                      ✅                       |
 | Parallel states             |       ❌        |                      ✅                       |
 | History states              |       ❌        |                      ✅                       |
@@ -49,7 +50,7 @@ This package contains a minimal, 1kb implementation of [XState](https://github.c
 - Transition actions
 - `state.changed`
 
-If you want to use statechart features such as nested states, parallel states, history states, activities, invoked services, delayed transitions, transient transitions, etc. please use [`XState`](https://github.com/statelyai/xstate).
+If you want to use statechart features such as nested states, parallel states, history states, activities, invoked services, delayed transitions, transient transitions, Wildcard event descriptors, etc. please use [`XState`](https://github.com/statelyai/xstate).
 
 ## Quick start
 

--- a/packages/xstate-fsm/README.md
+++ b/packages/xstate-fsm/README.md
@@ -50,7 +50,7 @@ This package contains a minimal, 1kb implementation of [XState](https://github.c
 - Transition actions
 - `state.changed`
 
-If you want to use statechart features such as nested states, parallel states, history states, activities, invoked services, delayed transitions, transient transitions, Wildcard event descriptors, etc. please use [`XState`](https://github.com/statelyai/xstate).
+If you want to use statechart features such as nested states, parallel states, history states, activities, invoked services, delayed transitions, transient transitions, wildcard event descriptors, etc. please use [`XState`](https://github.com/statelyai/xstate).
 
 ## Quick start
 


### PR DESCRIPTION
There had been a discussion about the availability of `Wildcard event descriptors` in `@xstate/fsm`. So, I thought that it would be better to make it clear in the `README.md` of `@xstate/fsm` on whether the feature is available or not because there is already a table for it.