### PR TITLE
Add support for wildcard transitions to xstate-fsm

### DIFF
--- a/.changeset/tall-flies-occur.md
+++ b/.changeset/tall-flies-occur.md
@@ -1,5 +1,5 @@
 ---
-'@xstate/fsm': major
+'@xstate/fsm': minor
 ---
 
 This change adds support for using "\*" as a wildcard event type in machine configs.

--- a/.changeset/tall-flies-occur.md
+++ b/.changeset/tall-flies-occur.md
@@ -1,0 +1,7 @@
+---
+'@xstate/fsm': major
+---
+
+This change adds support for using "\*" as a wildcard event type in machine configs.
+
+Because that event type previously held no special meaning, it was allowed as an event type both in configs and when transitioning and matched as any other would. As a result of changing it to be a wildcard, any code which uses "\*" as an ordinary event type will break, making this a major change.

--- a/docs/packages/xstate-fsm/index.md
+++ b/docs/packages/xstate-fsm/index.md
@@ -23,6 +23,7 @@ The [@xstate/fsm package](https://github.com/statelyai/xstate/tree/main/packages
 | Transitions (string target) |       ✅        |                      ✅                       |
 | Delayed transitions         |       ❌        |                      ✅                       |
 | Eventless transitions       |       ❌        |                      ✅                       |
+| Wildcard transitions        |       ✅        |                      ✅                       |
 | Nested states               |       ❌        |                      ✅                       |
 | Parallel states             |       ❌        |                      ✅                       |
 | History states              |       ❌        |                      ✅                       |
@@ -149,7 +150,7 @@ The machine config has this schema:
 
 ### State config
 
-- `on` (object) - an object mapping event types (keys) to [transitions](#transition-config)
+- `on` (object) - an object mapping event types (keys) to [transitions](#transition-config); an event type of `"*"` is special, indicating a "wildcard" transition which occurs when no other transition applies
 
 ### Transition config
 

--- a/docs/packages/xstate-fsm/index.md
+++ b/docs/packages/xstate-fsm/index.md
@@ -11,7 +11,10 @@
   </a>
 </p>
 
-The [@xstate/fsm package](https://github.com/statelyai/xstate/tree/main/packages/xstate-fsm) contains a minimal, 1kb implementation of [XState](https://github.com/statelyai/xstate) for **finite state machines**.
+This package contains a minimal, 1kb implementation of [XState](https://github.com/statelyai/xstate) for **finite state machines**.
+
+- [Read the full documentation in the XState docs](https://xstate.js.org/docs/packages/xstate-fsm/).
+- [Read our contribution guidelines](https://github.com/statelyai/xstate/blob/main/CONTRIBUTING.md).
 
 ## Features
 
@@ -49,15 +52,15 @@ The [@xstate/fsm package](https://github.com/statelyai/xstate/tree/main/packages
 
 If you want to use statechart features such as nested states, parallel states, history states, activities, invoked services, delayed transitions, transient transitions, etc. please use [`XState`](https://github.com/statelyai/xstate).
 
-## Super quick start
+## Quick start
 
-**Installation**
+### Installation
 
 ```bash
 npm i @xstate/fsm
 ```
 
-**Usage (machine):**
+### Usage (machine)
 
 ```js
 import { createMachine } from '@xstate/fsm';
@@ -80,7 +83,7 @@ untoggledState.value;
 // => 'inactive'
 ```
 
-**Usage (service):**
+### Usage (service)
 
 ```js
 import { createMachine, interpret } from '@xstate/fsm';
@@ -101,9 +104,12 @@ toggleService.stop();
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Super quick start](#super-quick-start)
+- [Quick start](#quick-start)
+  - [Installation](#installation)
+  - [Usage (machine)](#usage-machine)
+  - [Usage (service)](#usage-service)
 - [API](#api)
-  - [`createMachine(config)`](#createmachineconfig)
+  - [`createMachine(config, options)`](#createmachineconfig-options)
   - [Machine config](#machine-config)
   - [State config](#state-config)
   - [Transition config](#transition-config)

--- a/packages/xstate-fsm/README.md
+++ b/packages/xstate-fsm/README.md
@@ -26,7 +26,7 @@ This package contains a minimal, 1kb implementation of [XState](https://github.c
 | Transitions (string target) |       ✅        |                      ✅                       |
 | Delayed transitions         |       ❌        |                      ✅                       |
 | Eventless transitions       |       ❌        |                      ✅                       |
-| Wildcard event descriptors  |       ❌        |                      ✅                       |
+| Wildcard transitions        |       ✅        |                      ✅                       |
 | Nested states               |       ❌        |                      ✅                       |
 | Parallel states             |       ❌        |                      ✅                       |
 | History states              |       ❌        |                      ✅                       |
@@ -50,7 +50,7 @@ This package contains a minimal, 1kb implementation of [XState](https://github.c
 - Transition actions
 - `state.changed`
 
-If you want to use statechart features such as nested states, parallel states, history states, activities, invoked services, delayed transitions, transient transitions, wildcard event descriptors, etc. please use [`XState`](https://github.com/statelyai/xstate).
+If you want to use statechart features such as nested states, parallel states, history states, activities, invoked services, delayed transitions, transient transitions, etc. please use [`XState`](https://github.com/statelyai/xstate).
 
 ## Quick start
 

--- a/packages/xstate-fsm/src/index.ts
+++ b/packages/xstate-fsm/src/index.ts
@@ -25,6 +25,7 @@ export {
 
 const INIT_EVENT: InitEvent = { type: 'xstate.init' };
 const ASSIGN_ACTION: StateMachine.AssignAction = 'xstate.assign';
+const WILDCARD = '*';
 
 function toArray<T>(item: T | T[] | undefined): T[] {
   return item === undefined ? [] : ([] as T[]).concat(item);
@@ -180,10 +181,20 @@ export function createMachine<
         );
       }
 
+      if (!IS_PRODUCTION && eventObject.type === WILDCARD) {
+        throw new Error(
+          `An event cannot have the wildcard type ('${WILDCARD}')`
+        );
+      }
+
       if (stateConfig.on) {
         const transitions: Array<
           StateMachine.Transition<TContext, TEvent, TState['value']>
         > = toArray(stateConfig.on[eventObject.type]);
+
+        if (WILDCARD in stateConfig.on) {
+          transitions.push(...toArray(stateConfig.on[WILDCARD]));
+        }
 
         for (const transition of transitions) {
           if (transition === undefined) {

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -136,7 +136,7 @@ export namespace StateMachine {
     states: {
       [key in TState['value']]: {
         on?: {
-          [K in TEvent['type']]?: SingleOrArray<
+          [K in TEvent['type'] | '*']?: SingleOrArray<
             Transition<
               TContext,
               TEvent extends { type: K } ? TEvent : never,

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -139,7 +139,11 @@ export namespace StateMachine {
           [K in TEvent['type'] | '*']?: SingleOrArray<
             Transition<
               TContext,
-              TEvent extends { type: K } ? TEvent : never,
+              K extends '*'
+                ? TEvent
+                : TEvent extends { type: K }
+                ? TEvent
+                : never,
               TState['value']
             >
           >;

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -137,15 +137,13 @@ export namespace StateMachine {
       [key in TState['value']]: {
         on?: {
           [K in TEvent['type'] | '*']?: SingleOrArray<
-            Transition<
-              TContext,
-              K extends '*'
-                ? TEvent
-                : TEvent extends { type: K }
-                ? TEvent
-                : never,
-              TState['value']
-            >
+            K extends '*'
+              ? Transition<TContext, TEvent, TState['value']>
+              : Transition<
+                  TContext,
+                  TEvent extends { type: K } ? TEvent : never,
+                  TState['value']
+                >
           >;
         };
         exit?: SingleOrArray<Action<TContext, TEvent>>;

--- a/packages/xstate-fsm/test/types.test.ts
+++ b/packages/xstate-fsm/test/types.test.ts
@@ -60,6 +60,8 @@ describe('matches', () => {
     }
   });
 
+  // This test only works if "strictFunctionTypes" is enabled. Once that has
+  // been done, the ts-expect-error comment below turned on.
   it('should require actions on wildcard transitions to handle all event types', () => {
     type Context = {};
     type FooEvent = { type: 'foo'; foo: string };
@@ -76,7 +78,7 @@ describe('matches', () => {
               target: 'one',
               actions: (_context: Context, _event: InitEvent | FooEvent) => {}
             },
-            // @ts-expect-error
+            // @x-ts-expect-error
             '*': {
               target: 'one',
               actions: (_context: Context, _event: InitEvent | FooEvent) => {}

--- a/packages/xstate-fsm/test/types.test.ts
+++ b/packages/xstate-fsm/test/types.test.ts
@@ -74,12 +74,12 @@ describe('matches', () => {
           on: {
             foo: {
               target: 'one',
-              actions: (context: Context, event: InitEvent | FooEvent) => {}
+              actions: (_context: Context, _event: InitEvent | FooEvent) => {}
             },
             // @ts-expect-error
             '*': {
               target: 'one',
-              actions: (context: Context, event: InitEvent | FooEvent) => {}
+              actions: (_context: Context, _event: InitEvent | FooEvent) => {}
             }
           }
         }

--- a/packages/xstate-fsm/test/types.test.ts
+++ b/packages/xstate-fsm/test/types.test.ts
@@ -1,4 +1,5 @@
 import { createMachine } from '../src';
+import { InitEvent } from '../src/types';
 
 describe('matches', () => {
   it('should allow matches to be called multiple times in a single branch of code', () => {
@@ -57,5 +58,32 @@ describe('matches', () => {
       // @ts-expect-error
       ((_accept: string) => {})(state.context.count);
     }
+  });
+
+  it('should require actions on wildcard transitions to handle all event types', () => {
+    type Context = {};
+    type FooEvent = { type: 'foo'; foo: string };
+    type BarEvent = { type: 'bar'; bar: number };
+    type Event = FooEvent | BarEvent;
+    type State = { value: 'one'; context: Context };
+    createMachine<Context, Event, State>({
+      context: {},
+      initial: 'one',
+      states: {
+        one: {
+          on: {
+            foo: {
+              target: 'one',
+              actions: (context: Context, event: InitEvent | FooEvent) => {}
+            },
+            // @ts-expect-error
+            '*': {
+              target: 'one',
+              actions: (context: Context, event: InitEvent | FooEvent) => {}
+            }
+          }
+        }
+      }
+    });
   });
 });

--- a/packages/xstate-fsm/tsconfig.json
+++ b/packages/xstate-fsm/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*"],
   "compilerOptions": {
+    "strictFunctionTypes": true,
     "target": "es6",
     "outDir": "./lib",
     "rootDir": "./src"

--- a/packages/xstate-fsm/tsconfig.json
+++ b/packages/xstate-fsm/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src/**/*"],
   "compilerOptions": {
-    "strictFunctionTypes": true,
     "target": "es6",
     "outDir": "./lib",
     "rootDir": "./src"


### PR DESCRIPTION
After a recent discussion regarding how to handle unexpected events (#4057) brought wildcard transitions to my attention, I wanted to see what it would take to add them to the @xstate/fsm package. Fortunately, it turned out to be pretty straightforward.

This PR introduces three behavioral changes, in addition to the supporting tests and documentation:

1. If a machine is created with transitions whose event type is a single asterisk, those transitions are added to the list of transitions attempted regardless of event type. This has the effect that, if no other transition has occurred, the wildcard transitions are checked before giving up and returning an unchanged state.
2. To prevent the above from causing typing problems, a single asterisk is considered a valid key in the transitions objects in the machine config.
3. If the transition method is called with an event whose type is a single asterisk, it will throw in non-production mode. (This matches the behavior of the full XState library.)

(Also, while updating "docs/packages/xstate-fsm/index.md", I noticed that it had gotten out of sync with "packages/xstate-fsm/README.md"; I corrected that while I was in there, but as a separate commit, so that it can be easily dropped if you'd prefer to keep the PR clean.)