### PR TITLE
Add a reference to the root actor on the system object

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -123,6 +123,8 @@ export class Interpreter<
 
   public src?: string;
 
+  public root: any;
+
   /**
    * Creates a new Interpreter instance (i.e., service) for the given logic with the provided options, if any.
    *
@@ -139,6 +141,7 @@ export class Interpreter<
     const self = this;
 
     this.system = parent?.system ?? createSystem();
+    this.system.root = this;
 
     if (systemId) {
       this._systemId = systemId;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1893,6 +1893,7 @@ export interface ActorSystem<T extends ActorSystemInfo> {
   _unregister: (actorRef: AnyActorRef) => void;
   _set: <K extends keyof T['actors']>(key: K, actorRef: T['actors'][K]) => void;
   get: <K extends keyof T['actors']>(key: K) => T['actors'][K] | undefined;
+  root?: T['actors'][keyof T['actors']];
 }
 
 export type AnyActorSystem = ActorSystem<any>;

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -126,6 +126,12 @@ describe('system', () => {
     expect(actor.system.get('test')).toBe(actor);
   });
 
+  it('root actor can be directly referenced by a root propoerty on the system', () => {
+    const machine = createMachine({});
+    const actor = interpret(machine, { systemId: 'test' });
+    expect(actor.system.root).toBe(actor);
+  });
+
   it('should remove invoked actor from receptionist if stopped', () => {
     const machine = createMachine({
       initial: 'active',


### PR DESCRIPTION
This would allow any actor within the system to send events to the system's root actor without needing to know the `systemId` of of the root actor that was passed into `interpret(rootActor, { systemId: 'root-id' })`

`sendTo(({ system } ) => system.root, { type: 'to root', message: 'Message to root' });`
