### PR TITLE
Add missing actions to main export

### DIFF
--- a/.changeset/kind-donkeys-fetch.md
+++ b/.changeset/kind-donkeys-fetch.md
@@ -1,0 +1,9 @@
+---
+'xstate': minor
+---
+
+The `log`, `pure`, `choose`, and `stop` actions were added to the main export:
+
+```ts
+import { log, pure, choose, stop } from 'xstate';
+```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -31,6 +31,10 @@ export {
   sendParent,
   sendUpdate,
   raise,
+  log,
+  pure,
+  choose,
+  stop,
   forwardTo,
   interpret,
   Interpreter,
@@ -51,7 +55,11 @@ const {
   sendUpdate,
   forwardTo,
   doneInvoke,
-  raise
+  raise,
+  log,
+  pure,
+  choose,
+  stop
 } = actions;
 
 declare global {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -8,9 +8,7 @@ import {
   ActorRefFrom,
   AnyStateMachine,
   StateNode,
-  actions
-} from '../src/index';
-import {
+  actions,
   pure,
   sendParent,
   log,
@@ -19,7 +17,7 @@ import {
   stop,
   send,
   raise
-} from '../src/actions';
+} from '../src/index';
 
 const seen = new WeakSet<AnyStateMachine>();
 


### PR DESCRIPTION
The `log`, `pure`, `choose`, and `stop` actions were added to the main export:

```ts
import { log, pure, choose, stop } from 'xstate';
```