### PR TITLE
Make options params optional in useMachine hook type

### DIFF
--- a/.changeset/eight-books-relate.md
+++ b/.changeset/eight-books-relate.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': major
+---
+
+Make options params optional in useMachine hook type

--- a/packages/xstate-react/index.v3.d.ts
+++ b/packages/xstate-react/index.v3.d.ts
@@ -16,62 +16,70 @@ type UseMachineReturn<
   TInterpreter = InterpreterFrom<TMachine>
 > = [StateFrom<TMachine>, Prop<TInterpreter, 'send'>, TInterpreter];
 
-type UseMachineRestParams<
-  TMachine extends AnyStateMachine
-> = AreAllImplementationsAssumedToBeProvided<
-  TMachine['__TResolvedTypesMeta']
-> extends false
-  ? [
-      InterpreterOptions &
-        UseMachineOptions<TMachine['__TContext'], TMachine['__TEvent']> &
-        InternalMachineOptions<
-          TMachine['__TContext'],
-          TMachine['__TEvent'],
-          TMachine['__TResolvedTypesMeta'],
-          true
-        >
-    ]
-  : [
-      (InterpreterOptions &
-        UseMachineOptions<TMachine['__TContext'], TMachine['__TEvent']> &
-        InternalMachineOptions<
-          TMachine['__TContext'],
-          TMachine['__TEvent'],
-          TMachine['__TResolvedTypesMeta']
-        >)?
-    ];
+type UseMachineRestParams<TMachine extends AnyStateMachine> =
+  AreAllImplementationsAssumedToBeProvided<
+    TMachine['__TResolvedTypesMeta']
+  > extends false
+    ? [
+        InterpreterOptions &
+          UseMachineOptions<TMachine['__TContext'], TMachine['__TEvent']> &
+          InternalMachineOptions<
+            TMachine['__TContext'],
+            TMachine['__TEvent'],
+            TMachine['__TResolvedTypesMeta'],
+            true
+          >
+      ]
+    : [
+        (InterpreterOptions &
+          UseMachineOptions<TMachine['__TContext'], TMachine['__TEvent']> &
+          InternalMachineOptions<
+            TMachine['__TContext'],
+            TMachine['__TEvent'],
+            TMachine['__TResolvedTypesMeta']
+          >)?
+      ];
+
+export declare function useMachine<TMachine extends AnyStateMachine>(
+  getMachine: MaybeLazy<TMachine>
+): UseMachineReturn<TMachine>;
 
 export declare function useMachine<TMachine extends AnyStateMachine>(
   getMachine: MaybeLazy<TMachine>,
   ...options: UseMachineRestParams<TMachine>
 ): UseMachineReturn<TMachine>;
 
-type UseInterpretRestParams<
-  TMachine extends AnyStateMachine
-> = AreAllImplementationsAssumedToBeProvided<
-  TMachine['__TResolvedTypesMeta']
-> extends false
-  ? [
-      InterpreterOptions &
-        UseMachineOptions<TMachine['__TContext'], TMachine['__TEvent']> &
-        InternalMachineOptions<
-          TMachine['__TContext'],
-          TMachine['__TEvent'],
-          TMachine['__TResolvedTypesMeta'],
-          true
-        >,
-      (Observer<StateFrom<TMachine>> | ((value: StateFrom<TMachine>) => void))?
-    ]
-  : [
-      (InterpreterOptions &
-        UseMachineOptions<TMachine['__TContext'], TMachine['__TEvent']> &
-        InternalMachineOptions<
-          TMachine['__TContext'],
-          TMachine['__TEvent'],
-          TMachine['__TResolvedTypesMeta']
-        >)?,
-      (Observer<StateFrom<TMachine>> | ((value: StateFrom<TMachine>) => void))?
-    ];
+type UseInterpretRestParams<TMachine extends AnyStateMachine> =
+  AreAllImplementationsAssumedToBeProvided<
+    TMachine['__TResolvedTypesMeta']
+  > extends false
+    ? [
+        InterpreterOptions &
+          UseMachineOptions<TMachine['__TContext'], TMachine['__TEvent']> &
+          InternalMachineOptions<
+            TMachine['__TContext'],
+            TMachine['__TEvent'],
+            TMachine['__TResolvedTypesMeta'],
+            true
+          >,
+        (
+          | Observer<StateFrom<TMachine>>
+          | ((value: StateFrom<TMachine>) => void)
+        )?
+      ]
+    : [
+        (InterpreterOptions &
+          UseMachineOptions<TMachine['__TContext'], TMachine['__TEvent']> &
+          InternalMachineOptions<
+            TMachine['__TContext'],
+            TMachine['__TEvent'],
+            TMachine['__TResolvedTypesMeta']
+          >)?,
+        (
+          | Observer<StateFrom<TMachine>>
+          | ((value: StateFrom<TMachine>) => void)
+        )?
+      ];
 
 export declare function useInterpret<TMachine extends AnyStateMachine>(
   getMachine: MaybeLazy<TMachine>,


### PR DESCRIPTION
Currently, the useMachine hook's second parameter is optional and has a default fallback value of `{}`. However, this fallback value is not declared in the type definition file, causing a type error when it is used.

This pull request addresses the issue by updating the type definition file to include the fallback value {} for the second parameter of the useMachine hook. This change ensures that the type declarations align with the actual behavior of the hook, preventing type errors in usage.

To provide more context, the screenshot below illustrates the current type error:

![image](https://github.com/statelyai/xstate/assets/39930145/719539f0-b35e-4fcc-af26-554ef9a2dd2f)

This fix will enhance the developer experience and prevent potential issues related to incorrect typings when using the useMachine hook.