### PR TITLE
Drop support for `TransitionsConfigArray`

### DIFF
--- a/.changeset/tender-cups-obey.md
+++ b/.changeset/tender-cups-obey.md
@@ -1,0 +1,23 @@
+---
+'xstate': patch
+---
+
+Removed the ability to configure transitions using arrays:
+
+```ts
+createMachine({
+  on: [{ event: 'FOO', target: '#id' }]
+  // ...
+});
+```
+
+Only regular object-based configs will be supported from now on:
+
+```ts
+createMachine({
+  on: {
+    FOO: '#id'
+  }
+  // ...
+});
+```

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -122,7 +122,7 @@ export class StateNode<
   public description?: string;
 
   public tags: string[] = [];
-  public transitions!: Array<TransitionDefinition<TContext, TEvent>>;
+  public transitions!: Map<string, TransitionDefinition<TContext, TEvent>[]>;
   public always?: Array<TransitionDefinition<TContext, TEvent>>;
 
   constructor(
@@ -194,8 +194,8 @@ export class StateNode<
   public _initialize() {
     this.transitions = formatTransitions(this);
     if (this.config.always) {
-      this.always = toTransitionConfigArray(NULL_EVENT, this.config.always).map(
-        (t) => formatTransition(this, t)
+      this.always = toTransitionConfigArray(this.config.always).map((t) =>
+        formatTransition(this, NULL_EVENT, t)
       );
     }
 
@@ -233,7 +233,7 @@ export class StateNode<
         return state.definition;
       }) as StatesDefinition<TContext, TEvent>,
       on: this.on,
-      transitions: this.transitions,
+      transitions: [...this.transitions.values()].flat(),
       entry: this.entry,
       exit: this.exit,
       meta: this.meta,
@@ -306,11 +306,13 @@ export class StateNode<
     return memo(this, 'on', () => {
       const transitions = this.transitions;
 
-      return transitions.reduce((map, transition) => {
-        map[transition.eventType] = map[transition.eventType] || [];
-        map[transition.eventType].push(transition as any);
-        return map;
-      }, {} as TransitionDefinitionMap<TContext, TEvent>);
+      return [...transitions]
+        .flatMap(([descriptor, t]) => t.map((t) => [descriptor, t] as const))
+        .reduce((map: any, [descriptor, transition]) => {
+          map[descriptor] = map[descriptor] || [];
+          map[descriptor].push(transition);
+          return map;
+        }, {} as TransitionDefinitionMap<TContext, TEvent>);
     });
   }
 
@@ -427,15 +429,18 @@ export class StateNode<
    */
   public get ownEvents(): Array<TEvent['type']> {
     const events = new Set(
-      this.transitions
-        .filter((transition) => {
-          return !(
-            !transition.target &&
-            !transition.actions.length &&
-            !transition.reenter
+      [...this.transitions.keys()].filter((descriptor) => {
+        return this.transitions
+          .get(descriptor)!
+          .some(
+            (transition) =>
+              !(
+                !transition.target &&
+                !transition.actions.length &&
+                !transition.reenter
+              )
           );
-        })
-        .map((transition) => transition.eventType)
+      })
     );
 
     return Array.from(events);

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -232,59 +232,58 @@ export function getCandidates<TEvent extends EventObject>(
   stateNode: StateNode<any, TEvent>,
   receivedEventType: TEvent['type']
 ): Array<TransitionDefinition<any, TEvent>> {
-  const candidates = stateNode.transitions.filter((transition) => {
-    const { eventType } = transition;
-    // First, check the trivial case: event names are exactly equal
-    if (eventType === receivedEventType) {
-      return true;
-    }
+  const candidates =
+    stateNode.transitions.get(receivedEventType) ||
+    [...stateNode.transitions.keys()]
+      .filter((descriptor) => {
+        // check if transition is a wildcard transition,
+        // which matches any non-transient events
+        if (descriptor === WILDCARD) {
+          return true;
+        }
 
-    // Then, check if transition is a wildcard transition,
-    // which matches any non-transient events
-    if (eventType === WILDCARD) {
-      return true;
-    }
+        if (!descriptor.endsWith('.*')) {
+          return false;
+        }
 
-    if (!eventType.endsWith('.*')) {
-      return false;
-    }
-
-    if (isDevelopment && /.*\*.+/.test(eventType)) {
-      console.warn(
-        `Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "${eventType}" event.`
-      );
-    }
-
-    const partialEventTokens = eventType.split('.');
-    const eventTokens = receivedEventType.split('.');
-
-    for (
-      let tokenIndex = 0;
-      tokenIndex < partialEventTokens.length;
-      tokenIndex++
-    ) {
-      const partialEventToken = partialEventTokens[tokenIndex];
-      const eventToken = eventTokens[tokenIndex];
-
-      if (partialEventToken === '*') {
-        const isLastToken = tokenIndex === partialEventTokens.length - 1;
-
-        if (isDevelopment && !isLastToken) {
+        if (isDevelopment && /.*\*.+/.test(descriptor)) {
           console.warn(
-            `Infix wildcards in transition events are not allowed. Check the "${eventType}" event.`
+            `Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "${descriptor}" event.`
           );
         }
 
-        return isLastToken;
-      }
+        const partialEventTokens = descriptor.split('.');
+        const eventTokens = receivedEventType.split('.');
 
-      if (partialEventToken !== eventToken) {
-        return false;
-      }
-    }
+        for (
+          let tokenIndex = 0;
+          tokenIndex < partialEventTokens.length;
+          tokenIndex++
+        ) {
+          const partialEventToken = partialEventTokens[tokenIndex];
+          const eventToken = eventTokens[tokenIndex];
 
-    return true;
-  });
+          if (partialEventToken === '*') {
+            const isLastToken = tokenIndex === partialEventTokens.length - 1;
+
+            if (isDevelopment && !isLastToken) {
+              console.warn(
+                `Infix wildcards in transition events are not allowed. Check the "${descriptor}" transition.`
+              );
+            }
+
+            return isLastToken;
+          }
+
+          if (partialEventToken !== eventToken) {
+            return false;
+          }
+        }
+
+        return true;
+      })
+      .sort((a, b) => b.length - a.length)
+      .flatMap((key) => stateNode.transitions.get(key)!);
 
   return candidates;
 }
@@ -335,7 +334,11 @@ export function getDelayedTransitions<
   return delayedTransitions.map((delayedTransition) => {
     const { delay } = delayedTransition;
     return {
-      ...formatTransition(stateNode, delayedTransition),
+      ...formatTransition(
+        stateNode,
+        delayedTransition.event,
+        delayedTransition
+      ),
       delay
     };
   });
@@ -346,9 +349,8 @@ export function formatTransition<
   TEvent extends EventObject
 >(
   stateNode: AnyStateNode,
-  transitionConfig: TransitionConfig<TContext, TEvent> & {
-    event: TEvent['type'] | typeof NULL_EVENT | '*';
-  }
+  descriptor: string,
+  transitionConfig: TransitionConfig<TContext, TEvent>
 ): AnyTransitionDefinition {
   const normalizedTarget = normalizeTarget(transitionConfig.target);
   const reenter = transitionConfig.reenter ?? false;
@@ -373,7 +375,7 @@ export function formatTransition<
     target,
     source: stateNode,
     reenter,
-    eventType: transitionConfig.event,
+    eventType: descriptor,
     toJSON: () => ({
       ...transition,
       source: `#${stateNode.id}`,
@@ -387,95 +389,76 @@ export function formatTransition<
 export function formatTransitions<
   TContext extends MachineContext,
   TEvent extends EventObject
->(stateNode: AnyStateNode): Array<AnyTransitionDefinition> {
-  const transitionConfigs: Array<
-    TransitionConfig<TContext, TEvent> & {
-      event: string;
-    }
-  > = [];
-  if (Array.isArray(stateNode.config.on)) {
-    transitionConfigs.push(...stateNode.config.on);
-  } else if (stateNode.config.on) {
-    const { [WILDCARD]: wildcardConfigs = [], ...namedTransitionConfigs } =
-      stateNode.config.on;
-    for (const eventType of Object.keys(namedTransitionConfigs)) {
-      if (eventType === NULL_EVENT) {
+>(
+  stateNode: AnyStateNode
+): Map<string, TransitionDefinition<TContext, TEvent>[]> {
+  const transitions = new Map<
+    string,
+    TransitionDefinition<TContext, AnyEventObject>[]
+  >();
+  if (stateNode.config.on) {
+    for (const descriptor of Object.keys(stateNode.config.on)) {
+      if (descriptor === NULL_EVENT) {
         throw new Error(
           'Null events ("") cannot be specified as a transition key. Use `always: { ... }` instead.'
         );
       }
-      const eventTransitionConfigs = toTransitionConfigArray<TContext, TEvent>(
-        eventType,
-        namedTransitionConfigs![eventType as string]
+      const transitionsConfig = stateNode.config.on[descriptor];
+      transitions.set(
+        descriptor,
+        toTransitionConfigArray(transitionsConfig).map((t) =>
+          formatTransition(stateNode, descriptor, t)
+        )
       );
-
-      transitionConfigs.push(...eventTransitionConfigs);
-      // TODO: add dev-mode validation for unreachable transitions
     }
-    transitionConfigs.push(
-      ...toTransitionConfigArray(
-        WILDCARD,
-        wildcardConfigs as SingleOrArray<
-          TransitionConfig<TContext, TEvent> & {
-            event: '*';
-          }
-        >
+  }
+  if (stateNode.config.onDone) {
+    const descriptor = String(done(stateNode.id));
+    transitions.set(
+      descriptor,
+      toTransitionConfigArray(stateNode.config.onDone).map((t) =>
+        formatTransition(stateNode, descriptor, t)
       )
     );
   }
-  const doneConfig = stateNode.config.onDone
-    ? toTransitionConfigArray(
-        String(done(stateNode.id)),
-        stateNode.config.onDone
-      )
-    : [];
-  const invokeConfig = stateNode.invoke.flatMap((invokeDef) => {
-    const settleTransitions: any[] = [];
+  for (const invokeDef of stateNode.invoke) {
     if (invokeDef.onDone) {
-      settleTransitions.push(
-        ...toTransitionConfigArray(
-          `done.invoke.${invokeDef.id}`,
-          invokeDef.onDone
+      const descriptor = `done.invoke.${invokeDef.id}`;
+      transitions.set(
+        descriptor,
+        toTransitionConfigArray(invokeDef.onDone).map((t) =>
+          formatTransition(stateNode, descriptor, t)
         )
       );
     }
     if (invokeDef.onError) {
-      settleTransitions.push(
-        ...toTransitionConfigArray(
-          `error.platform.${invokeDef.id}`,
-          invokeDef.onError
+      const descriptor = `error.platform.${invokeDef.id}`;
+      transitions.set(
+        descriptor,
+        toTransitionConfigArray(invokeDef.onError).map((t) =>
+          formatTransition(stateNode, descriptor, t)
         )
       );
     }
     if (invokeDef.onSnapshot) {
-      settleTransitions.push(
-        ...toTransitionConfigArray(
-          `xstate.snapshot.${invokeDef.id}`,
-          invokeDef.onSnapshot
+      const descriptor = `xstate.snapshot.${invokeDef.id}`;
+      transitions.set(
+        descriptor,
+        toTransitionConfigArray(invokeDef.onSnapshot).map((t) =>
+          formatTransition(stateNode, descriptor, t)
         )
       );
     }
-    return settleTransitions;
-  });
-  const delayedTransitions = stateNode.after;
-  const formattedTransitions = [
-    ...doneConfig,
-    ...invokeConfig,
-    ...transitionConfigs
-  ].flatMap(
-    (
-      transitionConfig: TransitionConfig<TContext, TEvent> & {
-        event: TEvent['type'] | '*';
-      }
-    ) =>
-      toArray(transitionConfig).map((transition) =>
-        formatTransition(stateNode, transition)
-      )
-  );
-  for (const delayedTransition of delayedTransitions) {
-    formattedTransitions.push(delayedTransition as any);
   }
-  return formattedTransitions;
+  for (const delayedTransition of stateNode.after) {
+    let existing = transitions.get(delayedTransition.eventType);
+    if (!existing) {
+      existing = [];
+      transitions.set(delayedTransition.eventType, existing);
+    }
+    existing.push(delayedTransition);
+  }
+  return transitions as Map<string, TransitionDefinition<TContext, any>[]>;
 }
 
 export function formatInitialTransition<
@@ -529,7 +512,7 @@ export function formatInitialTransition<
     return transition;
   }
 
-  return formatTransition(stateNode, {
+  return formatTransition(stateNode, '__INITIAL__', {
     target: toArray(_target.target).map((t) => {
       if (isString(t)) {
         return isStateId(t) ? t : `${STATE_DELIMITER}${t}`;
@@ -537,8 +520,7 @@ export function formatInitialTransition<
 
       return t;
     }),
-    actions: _target.actions,
-    event: null as any
+    actions: _target.actions
   }) as InitialTransitionDefinition<TContext, TEvent>;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -478,7 +478,7 @@ export type TransitionConfigOrTarget<
   TransitionConfigTarget | TransitionConfig<TContext, TExpressionEvent, TEvent>
 >;
 
-export type TransitionsConfigMap<
+export type TransitionsConfig<
   TContext extends MachineContext,
   TEvent extends EventObject
 > = {
@@ -486,24 +486,6 @@ export type TransitionsConfigMap<
     ? TransitionConfigOrTarget<TContext, TEvent>
     : TransitionConfigOrTarget<TContext, ExtractEvent<TEvent, K>, TEvent>;
 };
-
-type TransitionsConfigArray<
-  TContext extends MachineContext,
-  TEvent extends EventObject
-> = Array<
-  // distribute the union
-  | (TEvent extends EventObject
-      ? TransitionConfig<TContext, TEvent> & { event: TEvent['type'] }
-      : never)
-  | (TransitionConfig<TContext, TEvent> & { event: '*' })
->;
-
-export type TransitionsConfig<
-  TContext extends MachineContext,
-  TEvent extends EventObject
-> =
-  | TransitionsConfigMap<TContext, TEvent>
-  | TransitionsConfigArray<TContext, TEvent>;
 
 export interface InvokeConfig<
   TContext extends MachineContext,

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -338,31 +338,20 @@ export function toTransitionConfigArray<
   TContext extends MachineContext,
   TEvent extends EventObject
 >(
-  event: TEvent['type'] | typeof NULL_EVENT | '*',
   configLike: SingleOrArray<
     TransitionConfig<TContext, TEvent> | TransitionConfigTarget
   >
-): Array<
-  TransitionConfig<TContext, TEvent> & {
-    event: TEvent['type'] | typeof NULL_EVENT | '*';
-  }
-> {
-  const transitions = toArrayStrict(configLike).map((transitionLike) => {
+): Array<TransitionConfig<TContext, TEvent>> {
+  return toArrayStrict(configLike).map((transitionLike) => {
     if (
       typeof transitionLike === 'undefined' ||
       typeof transitionLike === 'string'
     ) {
-      return { target: transitionLike, event };
+      return { target: transitionLike };
     }
 
-    return { ...transitionLike, event };
-  }) as Array<
-    TransitionConfig<TContext, TEvent> & {
-      event: TEvent['type'] | typeof NULL_EVENT | '*';
-    } // TODO: fix 'as' (remove)
-  >;
-
-  return transitions;
+    return transitionLike;
+  });
 }
 
 export function normalizeTarget<

--- a/packages/core/test/after.test.ts
+++ b/packages/core/test/after.test.ts
@@ -47,9 +47,7 @@ describe('delayed transitions', () => {
 
     const transitions = greenNode.transitions;
 
-    expect(transitions.map((t) => t.eventType)).toEqual([
-      after(1000, greenNode.id)
-    ]);
+    expect([...transitions.keys()]).toEqual([after(1000, greenNode.id)]);
   });
 
   it('should be able to transition with delay from nested initial state', (done) => {

--- a/packages/core/test/deterministic.test.ts
+++ b/packages/core/test/deterministic.test.ts
@@ -281,27 +281,6 @@ describe('deterministic machine', () => {
     });
   });
 
-  describe('machine.transition() with array `.on` configs', () => {
-    it('should properly transition based on an event', () => {
-      const machine = createMachine({
-        initial: 'a',
-        states: {
-          a: {
-            on: [{ event: 'NEXT', target: 'pass' }]
-          },
-          pass: {}
-        }
-      });
-      expect(
-        machine.transition(
-          machine.resolveStateValue('a'),
-          { type: 'NEXT' },
-          undefined as any // TODO: figure out the simulation API
-        ).value
-      ).toBe('pass');
-    });
-  });
-
   describe('state key names', () => {
     const machine = createMachine({
       initial: 'test',

--- a/packages/core/test/eventDescriptors.test.ts
+++ b/packages/core/test/eventDescriptors.test.ts
@@ -41,26 +41,6 @@ describe('event descriptors', () => {
     expect(service.getSnapshot().value).toBe('pass');
   });
 
-  it('should select wildcard over explicit event type for array `.on` config (according to document order)', () => {
-    const machine = createMachine({
-      initial: 'A',
-      states: {
-        A: {
-          on: [
-            { event: '*', target: 'pass' },
-            { event: 'NEXT', target: 'fail' }
-          ]
-        },
-        fail: {},
-        pass: {}
-      }
-    });
-
-    const service = interpret(machine).start();
-    service.send({ type: 'NEXT' });
-    expect(service.getSnapshot().value).toBe('pass');
-  });
-
   it('should NOT support non-tokenized wildcards', () => {
     const machine = createMachine({
       initial: 'start',
@@ -223,13 +203,13 @@ describe('event descriptors', () => {
           "Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "event.*.bar.*" event.",
         ],
         [
-          "Infix wildcards in transition events are not allowed. Check the "event.*.bar.*" event.",
+          "Infix wildcards in transition events are not allowed. Check the "event.*.bar.*" transition.",
         ],
         [
           "Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "*.event.*" event.",
         ],
         [
-          "Infix wildcards in transition events are not allowed. Check the "*.event.*" event.",
+          "Infix wildcards in transition events are not allowed. Check the "*.event.*" transition.",
         ],
       ]
     `);
@@ -249,7 +229,7 @@ describe('event descriptors', () => {
           "Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "*.event.*" event.",
         ],
         [
-          "Infix wildcards in transition events are not allowed. Check the "*.event.*" event.",
+          "Infix wildcards in transition events are not allowed. Check the "*.event.*" transition.",
         ],
       ]
     `);

--- a/packages/core/test/json.test.ts
+++ b/packages/core/test/json.test.ts
@@ -139,11 +139,22 @@ describe('json', () => {
 
     const revivedMachine = createMachine(machineObject);
 
-    expect(revivedMachine.states.active.transitions).toMatchInlineSnapshot(`
+    expect([...revivedMachine.states.active.transitions.values()].flat())
+      .toMatchInlineSnapshot(`
       [
         {
           "actions": [],
-          "event": "done.invoke.active:invocation[0]",
+          "eventType": "EVENT",
+          "guard": undefined,
+          "reenter": false,
+          "source": "#active",
+          "target": [
+            "#(machine).foo",
+          ],
+          "toJSON": [Function],
+        },
+        {
+          "actions": [],
           "eventType": "done.invoke.active:invocation[0]",
           "guard": undefined,
           "reenter": false,
@@ -155,7 +166,6 @@ describe('json', () => {
         },
         {
           "actions": [],
-          "event": "error.platform.active:invocation[0]",
           "eventType": "error.platform.active:invocation[0]",
           "guard": undefined,
           "reenter": false,
@@ -165,26 +175,16 @@ describe('json', () => {
           ],
           "toJSON": [Function],
         },
-        {
-          "actions": [],
-          "event": "EVENT",
-          "eventType": "EVENT",
-          "guard": undefined,
-          "reenter": false,
-          "source": "#active",
-          "target": [
-            "#(machine).foo",
-          ],
-          "toJSON": [Function],
-        },
       ]
     `);
 
     // 1. onDone
     // 2. onError
     // 3. EVENT
-    expect(revivedMachine.getStateNodeById('active').transitions.length).toBe(
-      3
-    );
+    expect(
+      [
+        ...revivedMachine.getStateNodeById('active').transitions.values()
+      ].flatMap((t) => t).length
+    ).toBe(3);
   });
 });

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -460,7 +460,7 @@ describe('StateNode', () => {
 
     const transitions = greenNode.transitions;
 
-    expect(transitions.map((t) => t.eventType)).toEqual([
+    expect([...transitions.keys()]).toEqual([
       'TIMER',
       'POWER_OUTAGE',
       'FORBIDDEN_EVENT'

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -120,7 +120,7 @@ const testGroups: Record<string, string[]> = {
   // script: ['test0', 'test1', 'test2'], // <script/> conversion not implemented
   // 'script-src': ['test0', 'test1', 'test2', 'test3'], // <script/> conversion not implemented
   'scxml-prefix-event-name-matching': [
-    'star0'
+    // 'star0' // this relies on the source order of transitions where * is first and it's supposed to get macthed over an explicit descriptor
     // prefix event matching not implemented yet
     // 'test0',
     // 'test1'

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -470,7 +470,7 @@ describe('transient states (eventless transitions)', () => {
     expect(actorRef.getSnapshot().value).toBe('b');
   });
 
-  it('should not select wildcard for eventless transition (array `.on`)', () => {
+  it('should not select wildcard for eventless transition', () => {
     const machine = createMachine({
       initial: 'a',
       states: {
@@ -479,29 +479,9 @@ describe('transient states (eventless transitions)', () => {
         },
         b: {
           always: 'pass',
-          on: [{ event: '*', target: 'fail' }]
-        },
-        fail: {},
-        pass: {}
-      }
-    });
-
-    const actorRef = interpret(machine).start();
-    actorRef.send({ type: 'FOO' });
-
-    expect(actorRef.getSnapshot().value).toBe('pass');
-  });
-
-  it('should not select wildcard for eventless transition (with `always`)', () => {
-    const machine = createMachine({
-      initial: 'a',
-      states: {
-        a: {
-          on: { FOO: 'b' }
-        },
-        b: {
-          always: 'pass',
-          on: [{ event: '*', target: 'fail' }]
+          on: {
+            '*': 'fail'
+          }
         },
         fail: {},
         pass: {}

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -116,7 +116,7 @@ export function toDirectedGraph(
     stateMachine instanceof StateMachine ? stateMachine.root : stateMachine; // TODO: accept only machines
 
   const edges: DirectedGraphEdge[] = flatten(
-    stateNode.transitions.map((t, transitionIndex) => {
+    [...stateNode.transitions.values()].flat().map((t, transitionIndex) => {
       const targets = t.target ? t.target : [stateNode];
 
       return targets.map((target, targetIndex) => {

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -19,16 +19,17 @@ import {
 import { not, stateIn } from 'xstate/guards';
 
 function appendWildcards(state: AnyStateNode) {
-  for (const t of state.transitions) {
-    if (
-      typeof t.eventType === 'string' &&
-      !!t.eventType &&
-      t.eventType !== '*' &&
-      !t.eventType.endsWith('.*')
-    ) {
-      t.eventType = `${t.eventType}.*`;
+  const newTransitions: typeof state.transitions = new Map();
+
+  for (const [descriptor, transitions] of state.transitions) {
+    if (descriptor !== '*' && !descriptor.endsWith('.*')) {
+      newTransitions.set(`${descriptor}.*`, transitions);
+    } else {
+      newTransitions.set(descriptor, transitions);
     }
   }
+
+  state.transitions = newTransitions;
 
   for (const key of Object.keys(state.states)) {
     appendWildcards(state.states[key]);
@@ -422,7 +423,10 @@ function toConfig(nodeJson: XMLElement, id: string): StateNodeConfig<any, any> {
       initial = stateElements[0].attributes!.id;
     }
 
-    const on = transitionElements.flatMap((value) => {
+    const always: any[] = [];
+    const on: Record<string, any> = {};
+
+    transitionElements.flatMap((value) => {
       const events = ((getAttribute(value, 'event') as string) || '').split(
         /\s+/
       );
@@ -458,13 +462,23 @@ function toConfig(nodeJson: XMLElement, id: string): StateNodeConfig<any, any> {
           }
         }
 
-        return {
-          event,
+        const transitionConfig = {
           target: getTargets(targets),
           ...(value.elements ? executableContent(value.elements) : undefined),
           ...guardObject,
           internal
         };
+
+        if (event === '') {
+          always.push(transitionConfig);
+        } else {
+          let existing = on[event];
+          if (!existing) {
+            existing = [];
+            on[event] = existing;
+          }
+          existing.push(transitionConfig);
+        }
       });
     });
 
@@ -516,7 +530,7 @@ function toConfig(nodeJson: XMLElement, id: string): StateNodeConfig<any, any> {
             states: mapValues(states, (state, key) => toConfig(state, key))
           }
         : undefined),
-      ...(transitionElements.length ? { on } : undefined),
+      on,
       ...(onEntry ? { entry: onEntry } : undefined),
       ...(onExit ? { exit: onExit } : undefined),
       ...(invoke.length ? { invoke } : undefined)

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -144,7 +144,7 @@ export interface TestTransitionConfig<
   test?: (state: State<TContext, TEvent>, testContext: TTestContext) => void;
 }
 
-export type TestTransitionsConfigMap<
+export type TestTransitionsConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TTestContext

--- a/packages/xstate-test/src/validateMachine.ts
+++ b/packages/xstate-test/src/validateMachine.ts
@@ -12,13 +12,14 @@ export const validateMachine = (machine: AnyStateMachine) => {
     if (state.after.length > 0) {
       throw new Error('After events on test machines are not supported');
     }
-    const actions = [...state.entry, ...state.exit];
-
-    state.transitions.forEach((transition) => {
-      actions.push(...transition.actions);
-    });
-
-    actions.forEach((action) => {
+    // TODO: this doesn't account for always transitions
+    [
+      ...state.entry,
+      ...state.exit,
+      ...[...state.transitions.values()].flatMap((t) =>
+        t.flatMap((t) => t.actions)
+      )
+    ].forEach((action) => {
       if (
         action.type.startsWith('xstate.') &&
         typeof (action as any).params.delay === 'number'


### PR DESCRIPTION
I think that:
1. `TransitionsConfigArray` complicated our types
2. it also complicated our implementation and slowed down the most basic scenario (we were searching for candidates with explicit descriptors in the array instead of just looking it up in a map)
3. it's **rarely** used feature (if used at all)
4. its existence it makes vizualization harder/less obvious. We don't visually order (nor denote order) anyhow. By removing the ability to order transitions arbitrarily in an array we make it more intuitive to interpret the visualization: explicit descriptions > longest-to-shortest partial descriptors > wildcard

This PR is not meant to refactor all inner bits. The main goal here was to remove this from the types and the public API, the internals could still use some further cleanups but that can be done at any time.