### PR TITLE
Allow Svelte 4 in the specified peer dependency range

### DIFF
--- a/.changeset/forty-knives-remain.md
+++ b/.changeset/forty-knives-remain.md
@@ -1,0 +1,5 @@
+---
+"@xstate/svelte": minor
+---
+
+Allow Svelte 4 in the specified peer dependency range.

--- a/packages/xstate-svelte/package.json
+++ b/packages/xstate-svelte/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "@xstate/fsm": "^2.1.0",
-    "svelte": "^3.24.1",
+    "svelte": "3.24.1 - 4",
     "xstate": "^4.38.0"
   },
   "peerDependenciesMeta": {

--- a/packages/xstate-svelte/package.json
+++ b/packages/xstate-svelte/package.json
@@ -46,7 +46,7 @@
   },
   "peerDependencies": {
     "@xstate/fsm": "^2.1.0",
-    "svelte": "3.24.1 - 4",
+    "svelte": "^3.24.1 || ^4",
     "xstate": "^4.38.0"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
closes: https://github.com/statelyai/xstate/issues/4105, make xstate-svelte compatible with svelte 4.