### PR TITLE
Add function action type to pure

### DIFF
--- a/.changeset/big-coats-fetch.md
+++ b/.changeset/big-coats-fetch.md
@@ -1,0 +1,12 @@
+---
+'xstate': patch
+---
+
+The `pure(...)` action creator is now properly typed so that it allows function actions:
+
+```ts
+actions: pure(() => [
+  // now allowed!
+  (context, event) => { ... }
+])
+```

--- a/packages/core/src/actions.ts
+++ b/packages/core/src/actions.ts
@@ -609,6 +609,7 @@ export function pure<
         | BaseActionObject
         | BaseActionObject['type']
         | ActionObject<TContext, TExpressionEvent, TEvent>
+        | ActionFunction<TContext, TExpressionEvent>
       >
     | undefined
 ): PureAction<TContext, TExpressionEvent, TEvent> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1453,7 +1453,9 @@ export interface PureAction<
     event: TEvent
   ) =>
     | SingleOrArray<
-        ActionObject<TContext, TEvent> | ActionObject<TContext, TEvent>['type']
+        | ActionObject<TContext, TEvent>
+        | ActionObject<TContext, TEvent>['type']
+        | ActionFunction<TContext, TEvent>
       >
     | undefined;
 }

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2945,19 +2945,15 @@ describe('assign action order', () => {
       count: number;
     }
 
-    const machine = createMachine({
-      schema: {} as {
-        context: CountCtx;
-      },
+    const machine = createMachine<CountCtx>({
       context: { count: 0 },
       entry: [
         (ctx) => captured.push(ctx.count), // 0
         pure(() => {
           return [
-            assign({ count: (ctx) => ctx.count + 1 }),
+            assign<CountCtx>({ count: (ctx) => ctx.count + 1 }),
             { type: 'capture', exec: (ctx: any) => captured.push(ctx.count) }, // 1
-            assign({ count: (ctx) => ctx.count + 1 }),
-            () => {}
+            assign<CountCtx>({ count: (ctx) => ctx.count + 1 })
           ];
         }),
         (ctx) => captured.push(ctx.count) // 2

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1874,7 +1874,7 @@ describe('purely defined actions', () => {
       idle: {
         on: {
           SINGLE: {
-            actions: pure<any, any>((ctx, e) => {
+            actions: pure((ctx, e) => {
               if (ctx.items.length > 0) {
                 return {
                   type: 'SINGLE_EVENT',
@@ -1885,7 +1885,7 @@ describe('purely defined actions', () => {
             })
           },
           NONE: {
-            actions: pure<any, any>((ctx, e) => {
+            actions: pure((ctx, e) => {
               if (ctx.items.length > 5) {
                 return {
                   type: 'SINGLE_EVENT',
@@ -1896,7 +1896,7 @@ describe('purely defined actions', () => {
             })
           },
           EACH: {
-            actions: pure<any, any>((ctx) =>
+            actions: pure((ctx) =>
               ctx.items.map((item: any, index: number) => ({
                 type: 'EVENT',
                 item,
@@ -1905,7 +1905,7 @@ describe('purely defined actions', () => {
             )
           },
           AS_STRINGS: {
-            actions: pure<any, any>(() => ['SOME_ACTION'])
+            actions: pure(() => ['SOME_ACTION'])
           }
         }
       }
@@ -1968,6 +1968,21 @@ describe('purely defined actions', () => {
     );
 
     expect(nextState.actions).toEqual([{ type: 'SOME_ACTION' }]);
+  });
+
+  it('should allow function actions in pure', () => {
+    let called = false;
+    const machine = createMachine({
+      entry: pure(() => [
+        () => {
+          called = true;
+        }
+      ])
+    });
+
+    interpret(machine).start();
+
+    expect(called).toBeTruthy();
   });
 });
 
@@ -2930,15 +2945,19 @@ describe('assign action order', () => {
       count: number;
     }
 
-    const machine = createMachine<CountCtx>({
+    const machine = createMachine({
+      schema: {} as {
+        context: CountCtx;
+      },
       context: { count: 0 },
       entry: [
         (ctx) => captured.push(ctx.count), // 0
         pure(() => {
           return [
-            assign<CountCtx>({ count: (ctx) => ctx.count + 1 }),
+            assign({ count: (ctx) => ctx.count + 1 }),
             { type: 'capture', exec: (ctx: any) => captured.push(ctx.count) }, // 1
-            assign<CountCtx>({ count: (ctx) => ctx.count + 1 })
+            assign({ count: (ctx) => ctx.count + 1 }),
+            () => {}
           ];
         }),
         (ctx) => captured.push(ctx.count) // 2


### PR DESCRIPTION
This PR allows function actions to be typed in `pure()`:

```ts
actions: pure(() => [
  // now allowed!
  (context, event) => { ... }
])
```