### PR TITLE
[v5] Rename `interpret` to `createActor`

### DIFF
--- a/.changeset/ten-singers-rhyme.md
+++ b/.changeset/ten-singers-rhyme.md
@@ -1,0 +1,13 @@
+---
+'xstate': major
+---
+
+The `interpret(...)` function has been deprecated and renamed to `createActor(...)`:
+
+```diff
+-import { interpret } from 'xstate';
++import { createActor } from 'xstate';
+
+-const actor = interpret(machine);
++const actor = createActor(machine);
+```

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -2,7 +2,7 @@ import { error, createInitEvent, assign } from './actions.ts';
 import { STATE_DELIMITER } from './constants.ts';
 import { cloneState, getPersistedState, State } from './State.ts';
 import { StateNode } from './StateNode.ts';
-import { interpret } from './interpreter.ts';
+import { createActor } from './interpreter.ts';
 import {
   getConfiguration,
   getStateNodeByPath,
@@ -405,7 +405,7 @@ export class StateMachine<
 
       const actorState = logic.restoreState?.(childState, _actorCtx);
 
-      const actorRef = interpret(logic, {
+      const actorRef = createActor(logic, {
         id: actorId,
         state: actorState
       });
@@ -431,7 +431,7 @@ export class StateMachine<
           );
 
           if (referenced) {
-            const actorRef = interpret(referenced.src, {
+            const actorRef = createActor(referenced.src, {
               id,
               parent: _actorCtx?.self,
               input:

--- a/packages/core/src/actions/invoke.ts
+++ b/packages/core/src/actions/invoke.ts
@@ -1,7 +1,7 @@
 import isDevelopment from '#is-development';
 import { cloneState } from '../State.ts';
 import { error } from '../actions.ts';
-import { ActorStatus, interpret } from '../interpreter.ts';
+import { ActorStatus, createActor } from '../interpreter.ts';
 import {
   ActionArgs,
   AnyActorContext,
@@ -38,7 +38,7 @@ function resolve(
   if (referenced) {
     // TODO: inline `input: undefined` should win over the referenced one
     const configuredInput = input || referenced.input;
-    actorRef = interpret(referenced.src, {
+    actorRef = createActor(referenced.src, {
       id,
       src,
       parent: actorContext?.self,

--- a/packages/core/src/actors/index.ts
+++ b/packages/core/src/actors/index.ts
@@ -1,4 +1,4 @@
-import { ActorStatus, interpret } from '../interpreter.ts';
+import { ActorStatus, createActor } from '../interpreter.ts';
 import { symbolObservable } from '../symbolObservable.ts';
 import type {
   ActorRef,
@@ -73,5 +73,5 @@ export function toActorRef<
 const emptyLogic = fromTransition((_) => undefined, undefined);
 
 export function createEmptyActor(): ActorRef<AnyEventObject, undefined> {
-  return interpret(emptyLogic);
+  return createActor(emptyLogic);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,12 @@ export { log } from './actions/log.ts';
 export { pure } from './actions/pure.ts';
 export { raise } from './actions/raise.ts';
 export { stop } from './actions/stop.ts';
-import { interpret, Interpreter, ActorStatus } from './interpreter.ts';
+import {
+  createActor,
+  interpret,
+  Interpreter,
+  ActorStatus
+} from './interpreter.ts';
 import { createMachine } from './Machine.ts';
 import { mapState } from './mapState.ts';
 import { State } from './State.ts';
@@ -26,7 +31,8 @@ export {
   sendTo,
   sendParent,
   forwardTo,
-  interpret,
+  createActor,
+  interpret, // deprecated
   Interpreter,
   ActorStatus as InterpreterStatus,
   doneInvoke,

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -534,6 +534,34 @@ export class Interpreter<
  * @param machine The machine to interpret
  * @param options Interpreter options
  */
+export function createActor<TMachine extends AnyStateMachine>(
+  machine: AreAllImplementationsAssumedToBeProvided<
+    TMachine['__TResolvedTypesMeta']
+  > extends true
+    ? TMachine
+    : MissingImplementationsError<TMachine['__TResolvedTypesMeta']>,
+  options?: InterpreterOptions<TMachine>
+): InterpreterFrom<TMachine>;
+export function createActor<TLogic extends AnyActorLogic>(
+  logic: TLogic,
+  options?: InterpreterOptions<TLogic>
+): Interpreter<TLogic>;
+export function createActor(
+  logic: any,
+  options?: InterpreterOptions<any>
+): any {
+  const interpreter = new Interpreter(logic, options);
+
+  return interpreter;
+}
+
+/**
+ * Creates a new Interpreter instance for the given machine with the provided options, if any.
+ *
+ * @deprecated Use `createActor` instead
+ * @param machine The machine to interpret
+ * @param options Interpreter options
+ */
 export function interpret<TMachine extends AnyStateMachine>(
   machine: AreAllImplementationsAssumedToBeProvided<
     TMachine['__TResolvedTypesMeta']

--- a/packages/core/src/spawn.ts
+++ b/packages/core/src/spawn.ts
@@ -1,5 +1,5 @@
 import { error } from './actions.ts';
-import { ActorStatus, interpret } from './interpreter.ts';
+import { ActorStatus, createActor } from './interpreter.ts';
 import {
   AnyActorContext,
   AnyActorRef,
@@ -32,7 +32,7 @@ export function createSpawner(
       const input = 'input' in options ? options.input : referenced.input;
 
       // TODO: this should also receive `src`
-      const actor = interpret(referenced.src, {
+      const actor = createActor(referenced.src, {
         id: options.id,
         parent: actorContext.self,
         input:
@@ -49,7 +49,7 @@ export function createSpawner(
       return actor;
     } else {
       // TODO: this should also receive `src`
-      return interpret(src, {
+      return createActor(src, {
         id: options.id,
         parent: actorContext.self,
         input: options.input,

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -14,7 +14,7 @@ import {
   assign,
   createMachine,
   forwardTo,
-  interpret
+  createActor
 } from '../src/index.ts';
 import { fromCallback } from '../src/actors/callback.ts';
 import { trackEntries } from './utils.ts';
@@ -35,7 +35,7 @@ describe('entry/exit actions', () => {
         }
       });
       const flushTracked = trackEntries(machine);
-      interpret(machine).start();
+      createActor(machine).start();
 
       expect(flushTracked()).toEqual(['enter: __root__', 'enter: green']);
     });
@@ -61,7 +61,7 @@ describe('entry/exit actions', () => {
       });
 
       const flushTracked = trackEntries(machine);
-      interpret(machine).start();
+      createActor(machine).start();
 
       expect(flushTracked()).toEqual([
         'enter: __root__',
@@ -90,7 +90,7 @@ describe('entry/exit actions', () => {
       });
 
       const flushTracked = trackEntries(machine);
-      interpret(machine).start();
+      createActor(machine).start();
 
       expect(flushTracked()).toEqual([
         'enter: __root__',
@@ -116,7 +116,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'TIMER' });
@@ -144,7 +144,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'TIMER' });
@@ -176,7 +176,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'PED_COUNTDOWN' });
@@ -193,7 +193,7 @@ describe('entry/exit actions', () => {
       });
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'FAKE' });
@@ -218,7 +218,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'FAKE' });
@@ -243,7 +243,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'RESTART' });
@@ -273,7 +273,7 @@ describe('entry/exit actions', () => {
       });
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       flushTracked();
       actor.send({ type: 'RESTART' });
@@ -336,7 +336,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       actual.length = 0;
 
       actor.send({ type: 'CHANGE' });
@@ -374,7 +374,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       flushTracked();
       actor.send({ type: 'CHANGE' });
@@ -407,7 +407,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       flushTracked();
       actor.send({ type: 'NEXT' });
@@ -449,7 +449,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'NEXT_FN' });
@@ -498,7 +498,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       flushTracked();
       actor.send({ type: 'to-A' });
@@ -533,7 +533,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       flushTracked();
       actor.send({ type: 'UPDATE' });
@@ -566,7 +566,7 @@ describe('entry/exit actions', () => {
         }
       );
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       actor.send({ type: 'EV' });
 
       expect(spy).not.toHaveBeenCalled();
@@ -595,7 +595,7 @@ describe('entry/exit actions', () => {
         }
       );
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       actor.send({ type: 'EV' });
 
       expect(spy).not.toHaveBeenCalled();
@@ -625,7 +625,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       entrySpy.mockClear();
       exitSpy.mockClear();
@@ -657,7 +657,7 @@ describe('entry/exit actions', () => {
 
         const flushTracked = trackEntries(machine);
 
-        const actor = interpret(machine).start();
+        const actor = createActor(machine).start();
         flushTracked();
 
         actor.send({ type: 'TACK' });
@@ -687,7 +687,7 @@ describe('entry/exit actions', () => {
 
         const flushTracked = trackEntries(machine);
 
-        const actor = interpret(machine).start();
+        const actor = createActor(machine).start();
         flushTracked();
 
         actor.send({ type: 'ABSOLUTE_TACK' });
@@ -706,7 +706,7 @@ describe('entry/exit actions', () => {
         }
       });
       const flushTracked = trackEntries(machine);
-      interpret(machine).start();
+      createActor(machine).start();
 
       expect(flushTracked()).toEqual(['enter: __root__', 'enter: green']);
     });
@@ -726,7 +726,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'TIMER' });
@@ -753,7 +753,7 @@ describe('entry/exit actions', () => {
       });
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'TIMER' });
@@ -784,7 +784,7 @@ describe('entry/exit actions', () => {
       });
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'PED_COUNTDOWN' });
@@ -801,7 +801,7 @@ describe('entry/exit actions', () => {
       });
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'FAKE' });
@@ -823,7 +823,7 @@ describe('entry/exit actions', () => {
       });
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'FAKE' });
@@ -845,7 +845,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'RESTART' });
@@ -874,7 +874,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({ type: 'RESTART' });
@@ -913,7 +913,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       flushTracked();
       service.send({ type: 'NEXT' });
 
@@ -954,7 +954,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       service.send({ type: 'NEXT' });
 
       flushTracked();
@@ -996,7 +996,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       flushTracked();
       service.send({ type: 'NEXT' });
 
@@ -1032,7 +1032,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(m);
 
-      const service = interpret(m).start();
+      const service = createActor(m).start();
 
       flushTracked();
       service.send({ type: 'EV' });
@@ -1066,7 +1066,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(m);
 
-      const service = interpret(m).start();
+      const service = createActor(m).start();
 
       flushTracked();
       service.send({ type: 'EV' });
@@ -1099,7 +1099,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(m);
 
-      const service = interpret(m).start();
+      const service = createActor(m).start();
       service.send({ type: 'EV' });
 
       flushTracked();
@@ -1138,7 +1138,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(m);
 
-      const service = interpret(m).start();
+      const service = createActor(m).start();
       service.send({ type: 'EV' });
 
       flushTracked();
@@ -1177,7 +1177,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       flushTracked();
       actor.send({ type: 'ENTER_PARALLEL' });
@@ -1220,7 +1220,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       flushTracked();
       service.send({ type: 'FOO' });
@@ -1267,7 +1267,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       flushTracked();
       service.send({ type: 'FOO' });
@@ -1301,7 +1301,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(parent);
 
-      const service = interpret(parent).start();
+      const service = createActor(parent).start();
 
       flushTracked();
       service.send({ type: 'WHATEVER' });
@@ -1327,7 +1327,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      interpret(machine).start();
+      createActor(machine).start();
       flushTracked();
 
       setTimeout(() => {
@@ -1372,7 +1372,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const actor = interpret(parentMachine);
+      const actor = createActor(parentMachine);
       actor.subscribe({
         complete: () => {
           expect(exitCalled).toBeTruthy();
@@ -1403,7 +1403,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       service.stop();
 
       expect(exitCalled).toBeTruthy();
@@ -1425,7 +1425,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       flushTracked();
       service.stop();
@@ -1454,7 +1454,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       // it's important to send an event here that results in a transition that computes new `state.configuration`
       // and that could impact the order in which exit actions are called
@@ -1493,7 +1493,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       // it's important to send an event here that results in a transition as that computes new `state.configuration`
       // and that could impact the order in which exit actions are called
@@ -1538,7 +1538,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       // it's important to send an event here that results in a transition as that computes new `state.configuration`
       // and that could impact the order in which exit actions are called
@@ -1590,7 +1590,7 @@ describe('entry/exit actions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       // it's important to send an event here that results in a transition as that computes new `state.configuration`
       // and that could impact the order in which exit actions are called
       service.send({ type: 'EV' });
@@ -1614,7 +1614,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       service.stop();
 
       expect(receivedEvent).toEqual({ type: 'xstate.stop' });
@@ -1639,7 +1639,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       service.send({ type: 'NEXT' });
 
       expect(receivedEvent).toEqual({ type: 'NEXT' });
@@ -1664,7 +1664,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const interpreter = interpret(parent);
+      const interpreter = createActor(parent);
       interpreter.start();
 
       expect(() => interpreter.stop()).not.toThrow();
@@ -1701,7 +1701,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const interpreter = interpret(parent).start();
+      const interpreter = createActor(parent).start();
       interpreter.send({ type: 'STOP_CHILD' });
     });
 
@@ -1741,7 +1741,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const interpreter = interpret(parent).start();
+      const interpreter = createActor(parent).start();
       interpreter.send({ type: 'FINISH_CHILD' });
 
       expect(eventReceived).toBe(true);
@@ -1786,7 +1786,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const interpreter = interpret(parent).start();
+      const interpreter = createActor(parent).start();
       interpreter.send({ type: 'NEXT' });
 
       expect(eventReceived).toBe(true);
@@ -1839,7 +1839,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const interpreter = interpret(parent).start();
+      const interpreter = createActor(parent).start();
       interpreter.send({ type: 'NEXT' });
 
       expect(eventReceived).toBe(true);
@@ -1861,7 +1861,7 @@ describe('entry/exit actions', () => {
         })
       });
 
-      const interpreter = interpret(parent).start();
+      const interpreter = createActor(parent).start();
       interpreter.stop();
     });
 
@@ -1882,7 +1882,7 @@ describe('entry/exit actions', () => {
         }
       );
 
-      const interpreter = interpret(parent).start();
+      const interpreter = createActor(parent).start();
       interpreter.stop();
 
       expect(called).toBe(true);
@@ -1916,7 +1916,7 @@ describe('entry/exit actions', () => {
         }
       );
 
-      const interpreter = interpret(machine).start();
+      const interpreter = createActor(machine).start();
       interpreter.stop();
 
       expect(interpreter.getSnapshot().context.executedAssigns).toEqual([
@@ -1945,7 +1945,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       service.send({ type: 'INITIALIZE_SYNC_SEQUENCE' });
     });
@@ -1980,7 +1980,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       service.send({ type: 'INITIALIZE_SYNC_SEQUENCE' });
 
@@ -2019,7 +2019,7 @@ describe('entry/exit actions', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       service.send({ type: 'INITIALIZE_SYNC_SEQUENCE' });
 
@@ -2046,7 +2046,7 @@ describe('initial actions', () => {
         }
       }
     });
-    interpret(machine).start();
+    createActor(machine).start();
     expect(actual).toEqual(['initialA', 'entryA']);
   });
 
@@ -2075,7 +2075,7 @@ describe('initial actions', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'NEXT' });
 
@@ -2106,7 +2106,7 @@ describe('initial actions', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'NEXT' });
 
@@ -2131,7 +2131,7 @@ describe('actions on invalid transition', () => {
         stop: {}
       }
     });
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'STOP' });
     expect(spy).toHaveBeenCalledTimes(1);
@@ -2176,7 +2176,7 @@ describe('actions config', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({ type: 'EVENT' });
 
     expect(spy).toHaveBeenCalledTimes(2);
@@ -2195,7 +2195,7 @@ describe('actions config', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(spy).toHaveBeenCalledTimes(2);
   });
@@ -2231,7 +2231,7 @@ describe('actions config', () => {
         }
       }
     );
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
     const snapshot = actorRef.getSnapshot();
 
@@ -2271,7 +2271,7 @@ describe('actions config', () => {
       }
     });
 
-    const actor = interpret(anonMachine).start();
+    const actor = createActor(anonMachine).start();
 
     expect(entryCalled).toBe(true);
 
@@ -2310,7 +2310,7 @@ describe('action meta', () => {
       }
     );
 
-    interpret(testMachine).start();
+    createActor(testMachine).start();
 
     expect(spy).toHaveBeenCalledWith({
       type: 'entryAction',
@@ -2342,7 +2342,7 @@ describe('action meta', () => {
       }
     );
 
-    interpret(testMachine).start();
+    createActor(testMachine).start();
 
     expect(spy).toHaveBeenCalledWith({
       type: 'entryAction'
@@ -2372,7 +2372,7 @@ describe('purely defined actions', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(spy.mock.calls[0][0]).toEqual({ length: 3 });
   });
@@ -2392,7 +2392,7 @@ describe('purely defined actions', () => {
       })
     });
 
-    expect(() => interpret(machine).start()).not.toThrow();
+    expect(() => createActor(machine).start()).not.toThrow();
   });
 
   it('should allow for purely defined dynamic actions', () => {
@@ -2418,7 +2418,7 @@ describe('purely defined actions', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(spy.mock.calls[0][0]).toEqual({ item: { id: 1 }, index: 0 });
     expect(spy.mock.calls[1][0]).toEqual({ item: { id: 2 }, index: 1 });
@@ -2438,7 +2438,7 @@ describe('purely defined actions', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(spy).toBeCalled();
   });
@@ -2453,7 +2453,7 @@ describe('purely defined actions', () => {
       ])
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(called).toBeTruthy();
   });
@@ -2511,7 +2511,7 @@ describe('forwardTo()', () => {
       }
     });
 
-    const service = interpret(parent);
+    const service = createActor(parent);
     service.subscribe({ complete: () => done() });
     service.start();
 
@@ -2567,7 +2567,7 @@ describe('forwardTo()', () => {
       }
     });
 
-    const service = interpret(parent);
+    const service = createActor(parent);
     service.subscribe({ complete: () => done() });
     service.start();
 
@@ -2583,7 +2583,7 @@ describe('forwardTo()', () => {
 
     const errorSpy = jest.fn();
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: errorSpy
     });
@@ -2607,7 +2607,7 @@ describe('log()', () => {
     const machine = createMachine({
       entry: log('some string', 'string label')
     });
-    interpret(machine, { logger: consoleSpy }).start();
+    createActor(machine, { logger: consoleSpy }).start();
 
     expect(consoleSpy.mock.calls).toMatchInlineSnapshot(`
       [
@@ -2628,7 +2628,7 @@ describe('log()', () => {
       },
       entry: log(({ context }) => `expr ${context.count}`, 'expr label')
     });
-    interpret(machine, { logger: consoleSpy }).start();
+    createActor(machine, { logger: consoleSpy }).start();
 
     expect(consoleSpy.mock.calls).toMatchInlineSnapshot(`
       [
@@ -2659,7 +2659,7 @@ describe('choose', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().context).toEqual({ answer: 42 });
   });
@@ -2686,7 +2686,7 @@ describe('choose', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().context).toEqual({ answer: 42 });
     expect(executed).toBeTruthy();
@@ -2714,7 +2714,7 @@ describe('choose', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().context).toEqual({ answer: 42 });
   });
@@ -2741,7 +2741,7 @@ describe('choose', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().context).toEqual({ answer: 42 });
   });
@@ -2788,7 +2788,7 @@ describe('choose', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().context).toEqual({
       firstLevel: true,
@@ -2819,7 +2819,7 @@ describe('choose', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().context).toEqual({ counter: 101, answer: 42 });
   });
@@ -2854,7 +2854,7 @@ describe('choose', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT', counter: 101 });
     expect(service.getSnapshot().context).toEqual({ answer: 42 });
   });
@@ -2889,7 +2889,7 @@ describe('choose', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'GIVE_ANSWER' });
 
     expect(service.getSnapshot().context).toEqual({ counter: 101, answer: 42 });
@@ -2920,7 +2920,7 @@ describe('choose', () => {
       }
     );
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().context).toEqual({ answer: 42 });
   });
@@ -2953,7 +2953,7 @@ describe('choose', () => {
       }
     );
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().context).toEqual({ answer: 42 });
   });
@@ -3010,7 +3010,7 @@ describe('sendTo', () => {
       entry: sendTo(({ context }) => context.child, { type: 'EVENT' })
     });
 
-    interpret(parentMachine).start();
+    createActor(parentMachine).start();
   });
 
   it('should be able to send an event from expression to an actor', (done) => {
@@ -3043,7 +3043,7 @@ describe('sendTo', () => {
       )
     });
 
-    interpret(parentMachine).start();
+    createActor(parentMachine).start();
   });
 
   it('should report a type error for an invalid event', () => {
@@ -3101,7 +3101,7 @@ describe('sendTo', () => {
       entry: sendTo('child', { type: 'EVENT' })
     });
 
-    interpret(parentMachine).start();
+    createActor(parentMachine).start();
   });
 
   it('should be able to send an event directly to an ActorRef', (done) => {
@@ -3132,7 +3132,7 @@ describe('sendTo', () => {
       })
     });
 
-    interpret(parentMachine).start();
+    createActor(parentMachine).start();
   });
 
   it('should be able to read from event', () => {
@@ -3164,7 +3164,7 @@ describe('sendTo', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'EVENT', value: 'foo' });
   });
@@ -3179,7 +3179,7 @@ describe('sendTo', () => {
     });
 
     expect(() => {
-      interpret(machine).start();
+      createActor(machine).start();
     }).toThrowErrorMatchingInlineSnapshot(
       `"Only event objects may be used with sendTo; use sendTo({ type: "a string" }) instead"`
     );
@@ -3213,7 +3213,7 @@ describe('raise', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.subscribe({ complete: () => done() });
 
@@ -3240,7 +3240,7 @@ describe('raise', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     // The state should not be changed yet; `delay: 0` is equivalent to `setTimeout(..., 0)`
     expect(service.getSnapshot().value).toEqual('a');
@@ -3268,7 +3268,7 @@ describe('raise', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().value).toEqual('b');
   });
@@ -3294,7 +3294,7 @@ describe('raise', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.subscribe({ complete: () => done() });
 
@@ -3320,7 +3320,7 @@ describe('raise', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'NEXT' });
 
@@ -3358,7 +3358,7 @@ describe('raise', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'NEXT' });
 
@@ -3384,7 +3384,7 @@ describe('raise', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'CANCEL' });
 
@@ -3402,7 +3402,7 @@ describe('raise', () => {
     });
 
     expect(() => {
-      interpret(machine).start();
+      createActor(machine).start();
     }).toThrowErrorMatchingInlineSnapshot(
       `"Only event objects may be used with raise; use raise({ type: "a string" }) instead"`
     );
@@ -3431,7 +3431,7 @@ it('should call transition actions in document order for same-level parallel reg
       }
     }
   });
-  const service = interpret(machine).start();
+  const service = createActor(machine).start();
   service.send({ type: 'FOO' });
 
   expect(actual).toEqual(['a', 'b']);
@@ -3464,7 +3464,7 @@ it('should call transition actions in document order for states at different lev
       }
     }
   });
-  const service = interpret(machine).start();
+  const service = createActor(machine).start();
   service.send({ type: 'FOO' });
 
   expect(actual).toEqual(['a1', 'b']);
@@ -3485,7 +3485,7 @@ describe('assign action order', () => {
       ]
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(captured).toEqual([0, 1, 2]);
   });
@@ -3519,7 +3519,7 @@ describe('assign action order', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(captured).toEqual([0, 1, 2]);
   });
@@ -3541,7 +3541,7 @@ describe('assign action order', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'EV' });
     service.send({ type: 'EV' });
@@ -3672,7 +3672,7 @@ describe('action meta', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 });
 
@@ -3690,7 +3690,7 @@ it('should call an inline action responding to an initial raise with the raised 
     }
   });
 
-  interpret(machine).start();
+  createActor(machine).start();
 
   expect(spy).toHaveBeenCalledWith({ type: 'HELLO' });
 });
@@ -3716,7 +3716,7 @@ it('should call a referenced action responding to an initial raise with the rais
     }
   );
 
-  interpret(machine).start();
+  createActor(machine).start();
 
   expect(spy).toHaveBeenCalledWith({ type: 'HELLO' });
 });
@@ -3736,7 +3736,7 @@ it('should call an inline action responding to an initial raise with updated (no
     }
   });
 
-  interpret(machine).start();
+  createActor(machine).start();
 
   expect(spy).toHaveBeenCalledWith({ count: 42 });
 });
@@ -3763,7 +3763,7 @@ it('should call a referenced action responding to an initial raise with updated 
     }
   );
 
-  interpret(machine).start();
+  createActor(machine).start();
 
   expect(spy).toHaveBeenCalledWith({ count: 42 });
 });

--- a/packages/core/test/activities.test.ts
+++ b/packages/core/test/activities.test.ts
@@ -1,5 +1,5 @@
 import { fromCallback } from '../src/actors/index.ts';
-import { interpret, createMachine, assign } from '../src/index.ts';
+import { createActor, createMachine, assign } from '../src/index.ts';
 
 // TODO: remove this file but before doing that ensure that things tested here are covered by other tests
 
@@ -13,7 +13,7 @@ describe('invocations (activities)', () => {
         })
       }
     });
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(active).toBe(true);
   });
@@ -32,7 +32,7 @@ describe('invocations (activities)', () => {
         }
       }
     });
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(active).toBe(true);
   });
@@ -56,7 +56,7 @@ describe('invocations (activities)', () => {
         }
       }
     });
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(active).toBe(true);
   });
@@ -81,7 +81,7 @@ describe('invocations (activities)', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'TIMER' });
 
@@ -117,7 +117,7 @@ describe('invocations (activities)', () => {
         }
       }
     });
-    const service = interpret(machine);
+    const service = createActor(machine);
 
     service.start();
     service.send({ type: 'TIMER' });
@@ -160,7 +160,7 @@ describe('invocations (activities)', () => {
         }
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'TIMER' });
     service.send({ type: 'TIMER' });
@@ -205,7 +205,7 @@ describe('invocations (activities)', () => {
         }
       }
     });
-    const service = interpret(machine);
+    const service = createActor(machine);
 
     service.start();
     service.send({ type: 'TIMER' });
@@ -237,7 +237,7 @@ describe('invocations (activities)', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'E' });
 
@@ -268,7 +268,7 @@ describe('invocations (activities)', () => {
         }
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'E' });
     service.send({ type: 'IGNORE' });
@@ -305,7 +305,7 @@ describe('invocations (activities)', () => {
         }
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'E' });
 
@@ -359,7 +359,7 @@ describe('invocations (activities)', () => {
         }
       }
     );
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'NEXT' });
 
@@ -410,7 +410,7 @@ describe('invocations (activities)', () => {
         }
       }
     );
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'NEXT' });
 
@@ -447,7 +447,7 @@ describe('invocations (activities)', () => {
         b: {}
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(active).toBe(true);
 

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1,5 +1,5 @@
 import {
-  interpret,
+  createActor,
   createMachine,
   ActorRef,
   ActorRefFrom,
@@ -159,7 +159,7 @@ describe('spawning machines', () => {
         }
       }
     });
-    const service = interpret(todosMachine);
+    const service = createActor(todosMachine);
     service.subscribe({
       complete: () => {
         done();
@@ -203,13 +203,13 @@ describe('spawning machines', () => {
       }
     );
 
-    const actor = interpret(parentMachine);
+    const actor = createActor(parentMachine);
     actor.start();
     expect(actor.getSnapshot().value).toBe('success');
   });
 
   it('should allow bidirectional communication between parent/child actors', (done) => {
-    const actor = interpret(clientMachine);
+    const actor = createActor(clientMachine);
     actor.subscribe({
       complete: () => {
         done();
@@ -257,7 +257,7 @@ describe('spawning promises', () => {
       }
     });
 
-    const promiseService = interpret(promiseMachine);
+    const promiseService = createActor(promiseMachine);
     promiseService.subscribe({
       complete: () => {
         done();
@@ -305,7 +305,7 @@ describe('spawning promises', () => {
       }
     );
 
-    const promiseService = interpret(promiseMachine);
+    const promiseService = createActor(promiseMachine);
     promiseService.subscribe({
       complete: () => {
         done();
@@ -355,7 +355,7 @@ describe('spawning callbacks', () => {
       }
     });
 
-    const callbackService = interpret(callbackMachine);
+    const callbackService = createActor(callbackMachine);
     callbackService.subscribe({
       complete: () => {
         done();
@@ -398,7 +398,7 @@ describe('spawning observables', () => {
       }
     });
 
-    const observableService = interpret(observableMachine);
+    const observableService = createActor(observableMachine);
     observableService.subscribe({
       complete: () => {
         done();
@@ -440,7 +440,7 @@ describe('spawning observables', () => {
       }
     );
 
-    const observableService = interpret(observableMachine);
+    const observableService = createActor(observableMachine);
     observableService.subscribe({
       complete: () => {
         done();
@@ -484,7 +484,7 @@ describe('spawning observables', () => {
       }
     });
 
-    const observableService = interpret(observableMachine);
+    const observableService = createActor(observableMachine);
     observableService.subscribe({
       complete: () => {
         done();
@@ -528,7 +528,7 @@ describe('spawning event observables', () => {
       }
     });
 
-    const observableService = interpret(observableMachine);
+    const observableService = createActor(observableMachine);
     observableService.subscribe({
       complete: () => {
         done();
@@ -572,7 +572,7 @@ describe('spawning event observables', () => {
       }
     );
 
-    const observableService = interpret(observableMachine);
+    const observableService = createActor(observableMachine);
     observableService.subscribe({
       complete: () => {
         done();
@@ -603,7 +603,7 @@ describe('communicating with spawned actors', () => {
       }
     });
 
-    const existingService = interpret(existingMachine).start();
+    const existingService = createActor(existingMachine).start();
 
     const parentMachine = createMachine<{
       existingRef?: ActorRef<any>;
@@ -639,7 +639,7 @@ describe('communicating with spawned actors', () => {
       }
     });
 
-    const parentService = interpret(parentMachine);
+    const parentService = createActor(parentMachine);
     parentService.subscribe({
       complete: () => {
         done();
@@ -668,7 +668,7 @@ describe('communicating with spawned actors', () => {
       }
     });
 
-    const existingService = interpret(existingMachine).start();
+    const existingService = createActor(existingMachine).start();
 
     const parentMachine = createMachine<{
       existingRef: ActorRef<any> | undefined;
@@ -705,7 +705,7 @@ describe('communicating with spawned actors', () => {
       }
     });
 
-    const parentService = interpret(parentMachine);
+    const parentService = createActor(parentMachine);
     parentService.subscribe({
       complete: () => {
         done();
@@ -746,7 +746,7 @@ describe('actors', () => {
       }
     });
 
-    const actor = interpret(startMachine);
+    const actor = createActor(startMachine);
     actor.subscribe(() => {
       expect(count).toEqual(1);
     });
@@ -791,7 +791,7 @@ describe('actors', () => {
         end: { type: 'final' }
       }
     });
-    interpret(parent).start();
+    createActor(parent).start();
     expect(spawnCounter).toBe(1);
   });
 
@@ -829,7 +829,7 @@ describe('actors', () => {
       }
     });
 
-    const service = interpret(testMachine).start();
+    const service = createActor(testMachine).start();
     expect(service.getSnapshot().value).toEqual('done');
   });
 
@@ -846,9 +846,11 @@ describe('actors', () => {
       }
     });
 
-    // expect(interpret(nullActorMachine).getSnapshot().context.ref!.id).toBe('null'); // TODO: identify null actors
+    interpret;
+
+    // expect(createActor(nullActorMachine).getSnapshot().context.ref!.id).toBe('null'); // TODO: identify null actors
     expect(
-      interpret(nullActorMachine).getSnapshot().context.ref!.send
+      createActor(nullActorMachine).getSnapshot().context.ref!.send
     ).toBeDefined();
   });
 
@@ -862,7 +864,7 @@ describe('actors', () => {
         ref2: spawn(fromCallback(() => cleanup2))
       })
     });
-    const actorRef = interpret(parent).start();
+    const actorRef = createActor(parent).start();
 
     expect(Object.keys(actorRef.getSnapshot().children).length).toBe(2);
 
@@ -890,7 +892,7 @@ describe('actors', () => {
         }
       }
     );
-    const actorRef = interpret(parent).start();
+    const actorRef = createActor(parent).start();
 
     expect(Object.keys(actorRef.getSnapshot().children).length).toBe(2);
 
@@ -927,7 +929,7 @@ describe('actors', () => {
         }
       });
 
-      const countService = interpret(countMachine);
+      const countService = createActor(countMachine);
       countService.subscribe((state) => {
         if (state.context.count?.getSnapshot() === 2) {
           done();
@@ -974,7 +976,7 @@ describe('actors', () => {
         }
       });
 
-      const countService = interpret(countMachine);
+      const countService = createActor(countMachine);
       countService.subscribe({
         complete: () => {
           done();
@@ -1017,7 +1019,7 @@ describe('actors', () => {
         }
       });
 
-      const countService = interpret(countMachine);
+      const countService = createActor(countMachine);
       countService.subscribe({
         complete: () => {
           done();
@@ -1065,7 +1067,7 @@ describe('actors', () => {
         }
       });
 
-      const pingService = interpret(pingMachine);
+      const pingService = createActor(pingMachine);
       pingService.subscribe({
         complete: () => {
           done();
@@ -1095,7 +1097,7 @@ describe('actors', () => {
       }
     });
 
-    const actor = interpret(machine);
+    const actor = createActor(machine);
     actor.subscribe({
       complete: () => {
         done();
@@ -1124,7 +1126,7 @@ describe('actors', () => {
       }
     });
 
-    const actor = interpret(machine);
+    const actor = createActor(machine);
     actor.subscribe({
       complete: () => {
         done();
@@ -1168,7 +1170,7 @@ describe('actors', () => {
         }
       }
     );
-    const service = interpret(parentMachine);
+    const service = createActor(parentMachine);
     expect(() => {
       service.start();
     }).not.toThrow();
@@ -1186,7 +1188,7 @@ describe('actors', () => {
           spawn(fromPromise(() => ({ then: (fn: any) => fn(null) } as any)))
       })
     });
-    const service = interpret(parentMachine);
+    const service = createActor(parentMachine);
     expect(() => {
       service.start();
     }).not.toThrow();
@@ -1211,7 +1213,7 @@ describe('actors', () => {
         child: ({ spawn }) => spawn(fromObservable(createEmptyObservable))
       })
     });
-    const service = interpret(parentMachine);
+    const service = createActor(parentMachine);
     expect(() => {
       service.start();
     }).not.toThrow();
@@ -1242,7 +1244,7 @@ describe('actors', () => {
         done: {}
       }
     });
-    const service = interpret(parentMachine);
+    const service = createActor(parentMachine);
 
     service.start();
 
@@ -1261,10 +1263,10 @@ describe('actors', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     const persistedState = actor.getPersistedState();
 
-    interpret(machine, {
+    createActor(machine, {
       state: persistedState
     }).start();
 
@@ -1284,10 +1286,10 @@ describe('actors', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     const persistedState = actor.getPersistedState();
 
-    interpret(machine, {
+    createActor(machine, {
       state: persistedState
     }).start();
 

--- a/packages/core/test/actorLogic.test.ts
+++ b/packages/core/test/actorLogic.test.ts
@@ -1,6 +1,6 @@
 import { EMPTY, interval, of, throwError } from 'rxjs';
 import { take } from 'rxjs/operators';
-import { AnyActorRef, createMachine, interpret } from '../src/index.ts';
+import { AnyActorRef, createMachine, createActor } from '../src/index.ts';
 import {
   fromCallback,
   fromEventObservable,
@@ -20,14 +20,14 @@ describe('promise logic (fromPromise)', () => {
         })
     );
 
-    const actor = interpret(promiseLogic).start();
+    const actor = createActor(promiseLogic).start();
 
     const snapshot = await waitFor(actor, (s) => s === 'hello');
 
     expect(snapshot).toBe('hello');
   });
   it('should resolve', (done) => {
-    const actor = interpret(fromPromise(() => Promise.resolve(42)));
+    const actor = createActor(fromPromise(() => Promise.resolve(42)));
 
     actor.subscribe((state) => {
       if (state === 42) {
@@ -39,7 +39,7 @@ describe('promise logic (fromPromise)', () => {
   });
 
   it('should resolve (observer .next)', (done) => {
-    const actor = interpret(fromPromise(() => Promise.resolve(42)));
+    const actor = createActor(fromPromise(() => Promise.resolve(42)));
 
     actor.subscribe({
       next: (state) => {
@@ -53,7 +53,7 @@ describe('promise logic (fromPromise)', () => {
   });
 
   it('should reject (observer .error)', (done) => {
-    const actor = interpret(fromPromise(() => Promise.reject('Error')));
+    const actor = createActor(fromPromise(() => Promise.reject('Error')));
 
     actor.subscribe({
       error: (data) => {
@@ -66,7 +66,7 @@ describe('promise logic (fromPromise)', () => {
   });
 
   it('should complete (observer .complete)', async () => {
-    const actor = interpret(fromPromise(() => Promise.resolve(42)));
+    const actor = createActor(fromPromise(() => Promise.resolve(42)));
     actor.start();
 
     const snapshot = await waitFor(actor, (s) => s === 42);
@@ -81,7 +81,7 @@ describe('promise logic (fromPromise)', () => {
       return Promise.resolve(42);
     });
 
-    const actor = interpret(logic);
+    const actor = createActor(logic);
 
     actor.getSnapshot();
 
@@ -96,13 +96,13 @@ describe('promise logic (fromPromise)', () => {
         })
     );
 
-    const actor = interpret(promiseLogic);
+    const actor = createActor(promiseLogic);
     actor.start();
 
     const resolvedPersistedState = actor.getPersistedState();
     actor.stop();
 
-    const restoredActor = interpret(promiseLogic, {
+    const restoredActor = createActor(promiseLogic, {
       state: resolvedPersistedState
     }).start();
 
@@ -120,7 +120,7 @@ describe('promise logic (fromPromise)', () => {
         })
     );
 
-    const actor = interpret(promiseLogic);
+    const actor = createActor(promiseLogic);
     actor.start();
 
     setTimeout(() => {
@@ -132,7 +132,7 @@ describe('promise logic (fromPromise)', () => {
         })
       );
 
-      const restoredActor = interpret(promiseLogic, {
+      const restoredActor = createActor(promiseLogic, {
         state: resolvedPersistedState
       }).start();
       expect(restoredActor.getSnapshot()).toBe(42);
@@ -146,7 +146,7 @@ describe('promise logic (fromPromise)', () => {
       createdPromises++;
       return Promise.resolve(createdPromises);
     });
-    const actor = interpret(promiseLogic);
+    const actor = createActor(promiseLogic);
     actor.start();
 
     await new Promise((res) => setTimeout(res, 5));
@@ -159,7 +159,7 @@ describe('promise logic (fromPromise)', () => {
     );
     expect(createdPromises).toBe(1);
 
-    const restoredActor = interpret(promiseLogic, {
+    const restoredActor = createActor(promiseLogic, {
       state: resolvedPersistedState
     }).start();
 
@@ -173,7 +173,7 @@ describe('promise logic (fromPromise)', () => {
       createdPromises++;
       return Promise.reject(createdPromises);
     });
-    const actor = interpret(promiseLogic);
+    const actor = createActor(promiseLogic);
     actor.subscribe({ error: function preventUnhandledErrorListener() {} });
     actor.start();
 
@@ -187,7 +187,7 @@ describe('promise logic (fromPromise)', () => {
     );
     expect(createdPromises).toBe(1);
 
-    const restoredActor = interpret(promiseLogic, {
+    const restoredActor = createActor(promiseLogic, {
       state: rejectedPersistedState
     }).start();
 
@@ -202,7 +202,7 @@ describe('promise logic (fromPromise)', () => {
       return Promise.resolve(42);
     });
 
-    interpret(promiseLogic).start();
+    createActor(promiseLogic).start();
   });
 
   it('should have reference to self', () => {
@@ -213,7 +213,7 @@ describe('promise logic (fromPromise)', () => {
       return Promise.resolve(42);
     });
 
-    interpret(promiseLogic).start();
+    createActor(promiseLogic).start();
   });
 });
 
@@ -236,7 +236,7 @@ describe('transition function logic (fromTransition)', () => {
       { status: 'active' as 'inactive' | 'active' }
     );
 
-    const actor = interpret(transitionLogic).start();
+    const actor = createActor(transitionLogic).start();
 
     expect(actor.getSnapshot().status).toBe('active');
 
@@ -257,7 +257,7 @@ describe('transition function logic (fromTransition)', () => {
         status: 'inactive' as 'inactive' | 'active'
       }
     );
-    const actor = interpret(logic).start();
+    const actor = createActor(logic).start();
     actor.send({ type: 'activate' });
     const persistedState = actor.getPersistedState();
 
@@ -265,7 +265,7 @@ describe('transition function logic (fromTransition)', () => {
       status: 'active'
     });
 
-    const restoredActor = interpret(logic, { state: persistedState });
+    const restoredActor = createActor(logic, { state: persistedState });
 
     restoredActor.start();
 
@@ -279,7 +279,7 @@ describe('transition function logic (fromTransition)', () => {
       return 42;
     }, 0);
 
-    const actor = interpret(transitionLogic).start();
+    const actor = createActor(transitionLogic).start();
 
     actor.send({ type: 'a' });
   });
@@ -291,7 +291,7 @@ describe('transition function logic (fromTransition)', () => {
       return 42;
     }, 0);
 
-    const actor = interpret(transitionLogic).start();
+    const actor = createActor(transitionLogic).start();
 
     actor.send({ type: 'a' });
   });
@@ -301,7 +301,7 @@ describe('observable logic (fromObservable)', () => {
   it('should interpret an observable', async () => {
     const observableLogic = fromObservable(() => interval(10).pipe(take(4)));
 
-    const actor = interpret(observableLogic).start();
+    const actor = createActor(observableLogic).start();
 
     const snapshot = await waitFor(actor, (s) => s === 3);
 
@@ -309,7 +309,7 @@ describe('observable logic (fromObservable)', () => {
   });
 
   it('should resolve', () => {
-    const actor = interpret(fromObservable(() => of(42)));
+    const actor = createActor(fromObservable(() => of(42)));
     const spy = jest.fn();
 
     actor.subscribe(spy);
@@ -320,7 +320,7 @@ describe('observable logic (fromObservable)', () => {
   });
 
   it('should resolve (observer .next)', () => {
-    const actor = interpret(fromObservable(() => of(42)));
+    const actor = createActor(fromObservable(() => of(42)));
     const spy = jest.fn();
 
     actor.subscribe({
@@ -332,7 +332,7 @@ describe('observable logic (fromObservable)', () => {
   });
 
   it('should reject (observer .error)', () => {
-    const actor = interpret(fromObservable(() => throwError(() => 'Error')));
+    const actor = createActor(fromObservable(() => throwError(() => 'Error')));
     const spy = jest.fn();
 
     actor.subscribe({
@@ -344,7 +344,7 @@ describe('observable logic (fromObservable)', () => {
   });
 
   it('should complete (observer .complete)', () => {
-    const actor = interpret(fromObservable(() => EMPTY));
+    const actor = createActor(fromObservable(() => EMPTY));
     const spy = jest.fn();
 
     actor.subscribe({
@@ -363,7 +363,7 @@ describe('observable logic (fromObservable)', () => {
       return EMPTY;
     });
 
-    const actor = interpret(logic);
+    const actor = createActor(logic);
 
     actor.getSnapshot();
 
@@ -377,7 +377,7 @@ describe('observable logic (fromObservable)', () => {
       return of(42);
     });
 
-    interpret(observableLogic).start();
+    createActor(observableLogic).start();
   });
 
   it('should have reference to self', () => {
@@ -387,7 +387,7 @@ describe('observable logic (fromObservable)', () => {
       return of(42);
     });
 
-    interpret(observableLogic).start();
+    createActor(observableLogic).start();
   });
 });
 
@@ -399,7 +399,7 @@ describe('eventObservable logic (fromEventObservable)', () => {
       return of({ type: 'a' });
     });
 
-    interpret(observableLogic).start();
+    createActor(observableLogic).start();
   });
 
   it('should have reference to self', () => {
@@ -409,7 +409,7 @@ describe('eventObservable logic (fromEventObservable)', () => {
       return of({ type: 'a' });
     });
 
-    interpret(observableLogic).start();
+    createActor(observableLogic).start();
   });
 });
 
@@ -423,7 +423,7 @@ describe('callback logic (fromCallback)', () => {
       });
     });
 
-    const actor = interpret(callbackLogic).start();
+    const actor = createActor(callbackLogic).start();
 
     actor.send({ type: 'a' });
   });
@@ -434,7 +434,7 @@ describe('callback logic (fromCallback)', () => {
       expect(system).toBeDefined();
     });
 
-    interpret(callbackLogic).start();
+    createActor(callbackLogic).start();
   });
 
   it('should have reference to self', () => {
@@ -443,7 +443,7 @@ describe('callback logic (fromCallback)', () => {
       expect(self.send).toBeDefined();
     });
 
-    interpret(callbackLogic).start();
+    createActor(callbackLogic).start();
   });
 
   it('can send self reference in an event to parent', (done) => {
@@ -477,7 +477,7 @@ describe('callback logic (fromCallback)', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 });
 
@@ -524,7 +524,7 @@ describe('machine logic', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     await waitFor(actor, (s) => s.matches('success'));
 
@@ -597,7 +597,7 @@ describe('machine logic', () => {
       }
     });
 
-    const actor = interpret(parentMachine).start();
+    const actor = createActor(parentMachine).start();
 
     // parent is at 'idle'
     // ...
@@ -609,7 +609,7 @@ describe('machine logic', () => {
     // child is at 'b'
 
     const persistedState = actor.getPersistedState()!;
-    const newActor = interpret(parentMachine, {
+    const newActor = createActor(parentMachine, {
       state: persistedState
     }).start();
     const newSnapshot = newActor.getSnapshot();
@@ -632,7 +632,7 @@ describe('machine logic', () => {
       }
     });
 
-    const actor = interpret(machine);
+    const actor = createActor(machine);
 
     expect(actor.getPersistedState()).toEqual(
       expect.objectContaining({
@@ -652,7 +652,7 @@ describe('machine logic', () => {
       }
     });
 
-    const actor = interpret(machine);
+    const actor = createActor(machine);
 
     expect(actor.getPersistedState()?.children['child'].state).toEqual(
       expect.objectContaining({
@@ -672,13 +672,13 @@ describe('machine logic', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     const persisted = actor.getPersistedState();
 
     delete persisted?.children['child'];
 
-    const actor2 = interpret(machine, { state: persisted }).start();
+    const actor2 = createActor(machine, { state: persisted }).start();
 
     expect(actor2.getSnapshot().children.child.getSnapshot().value).toBe(
       'inner'
@@ -693,6 +693,6 @@ describe('machine logic', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 });

--- a/packages/core/test/after.test.ts
+++ b/packages/core/test/after.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index.ts';
+import { createMachine, createActor } from '../src/index.ts';
 import { after } from '../src/actions.ts';
 
 const lightMachine = createMachine({
@@ -32,7 +32,7 @@ describe('delayed transitions', () => {
   it('should transition after delay', () => {
     jest.useFakeTimers();
 
-    const actorRef = interpret(lightMachine).start();
+    const actorRef = createActor(lightMachine).start();
     expect(actorRef.getSnapshot().value).toBe('green');
 
     jest.advanceTimersByTime(500);
@@ -71,7 +71,7 @@ describe('delayed transitions', () => {
       }
     });
 
-    const actor = interpret(machine);
+    const actor = createActor(machine);
     actor.subscribe({
       complete: () => {
         done();
@@ -108,7 +108,7 @@ describe('delayed transitions', () => {
       }
     });
 
-    const actor = interpret(machine);
+    const actor = createActor(machine);
     actor.subscribe({
       complete: () => {
         expect(actual).toEqual(['entered one', 'entered two', 'entered three']);
@@ -148,7 +148,7 @@ describe('delayed transitions', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     jest.advanceTimersByTime(10);
     expect(spy).not.toHaveBeenCalled();
@@ -176,11 +176,11 @@ describe('delayed transitions', () => {
       }
     });
 
-    const actorRef1 = interpret(machine).start();
+    const actorRef1 = createActor(machine).start();
     actorRef1.send({ type: 'next' });
     const withAfterState = actorRef1.getPersistedState();
 
-    const actorRef2 = interpret(machine, { state: withAfterState });
+    const actorRef2 = createActor(machine, { state: withAfterState });
     actorRef2.subscribe({ complete: () => done() });
     actorRef2.start();
   });
@@ -206,11 +206,11 @@ describe('delayed transitions', () => {
         }
       });
 
-    let service = interpret(createMyMachine()).start();
+    let service = createActor(createMyMachine()).start();
 
     const persistedState = JSON.parse(JSON.stringify(service.getSnapshot()));
 
-    service = interpret(createMyMachine(), { state: persistedState }).start();
+    service = createActor(createMyMachine(), { state: persistedState }).start();
 
     service.send({ type: 'NEXT' });
 
@@ -243,7 +243,7 @@ describe('delayed transitions', () => {
         }
       });
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       expect(spy).toBeCalledWith(context);
       expect(actor.getSnapshot().value).toBe('inactive');
@@ -287,7 +287,7 @@ describe('delayed transitions', () => {
         }
       );
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       const event = {
         type: 'ACTIVATE',

--- a/packages/core/test/assign.test.ts
+++ b/packages/core/test/assign.test.ts
@@ -1,4 +1,4 @@
-import { assign, createMachine, interpret } from '../src/index.ts';
+import { assign, createMachine, createActor } from '../src/index.ts';
 
 interface CounterContext {
   count: number;
@@ -93,7 +93,7 @@ describe('assign', () => {
   it('applies the assignment to the external state (property assignment)', () => {
     const counterMachine = createCounterMachine();
 
-    const actorRef = interpret(counterMachine).start();
+    const actorRef = createActor(counterMachine).start();
     actorRef.send({
       type: 'DEC'
     });
@@ -112,7 +112,7 @@ describe('assign', () => {
   it('applies the assignment to the external state', () => {
     const counterMachine = createCounterMachine();
 
-    const actorRef = interpret(counterMachine).start();
+    const actorRef = createActor(counterMachine).start();
     actorRef.send({
       type: 'INC'
     });
@@ -130,7 +130,7 @@ describe('assign', () => {
 
   it('applies the assignment to multiple properties (property assignment)', () => {
     const counterMachine = createCounterMachine();
-    const actorRef = interpret(counterMachine).start();
+    const actorRef = createActor(counterMachine).start();
     actorRef.send({
       type: 'WIN_PROP'
     });
@@ -140,7 +140,7 @@ describe('assign', () => {
 
   it('applies the assignment to multiple properties (static)', () => {
     const counterMachine = createCounterMachine();
-    const actorRef = interpret(counterMachine).start();
+    const actorRef = createActor(counterMachine).start();
     actorRef.send({
       type: 'WIN_STATIC'
     });
@@ -150,7 +150,7 @@ describe('assign', () => {
 
   it('applies the assignment to multiple properties (static + prop assignment)', () => {
     const counterMachine = createCounterMachine();
-    const actorRef = interpret(counterMachine).start();
+    const actorRef = createActor(counterMachine).start();
     actorRef.send({
       type: 'WIN_MIX'
     });
@@ -160,7 +160,7 @@ describe('assign', () => {
 
   it('applies the assignment to multiple properties', () => {
     const counterMachine = createCounterMachine();
-    const actorRef = interpret(counterMachine).start();
+    const actorRef = createActor(counterMachine).start();
     actorRef.send({
       type: 'WIN'
     });
@@ -170,7 +170,7 @@ describe('assign', () => {
 
   it('applies the assignment to the explicit external state (property assignment)', () => {
     const machine = createCounterMachine({ count: 50, foo: 'bar' });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'DEC' });
     const oneState = actorRef.getSnapshot();
 
@@ -185,7 +185,7 @@ describe('assign', () => {
 
     const machine2 = createCounterMachine({ count: 100, foo: 'bar' });
 
-    const actorRef2 = interpret(machine2).start();
+    const actorRef2 = createActor(machine2).start();
     actorRef2.send({ type: 'DEC' });
     const threeState = actorRef2.getSnapshot();
 
@@ -195,7 +195,7 @@ describe('assign', () => {
 
   it('applies the assignment to the explicit external state', () => {
     const machine = createCounterMachine({ count: 50, foo: 'bar' });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'INC' });
     const oneState = actorRef.getSnapshot();
 
@@ -210,7 +210,7 @@ describe('assign', () => {
 
     const machine2 = createCounterMachine({ count: 102, foo: 'bar' });
 
-    const actorRef2 = interpret(machine2).start();
+    const actorRef2 = createActor(machine2).start();
     actorRef2.send({ type: 'INC' });
     const threeState = actorRef2.getSnapshot();
 
@@ -220,7 +220,7 @@ describe('assign', () => {
 
   it('should maintain state after unhandled event', () => {
     const counterMachine = createCounterMachine();
-    const actorRef = interpret(counterMachine).start();
+    const actorRef = createActor(counterMachine).start();
 
     actorRef.send({
       type: 'FAKE_EVENT'
@@ -233,7 +233,7 @@ describe('assign', () => {
 
   it('sets undefined properties', () => {
     const counterMachine = createCounterMachine();
-    const actorRef = interpret(counterMachine).start();
+    const actorRef = createActor(counterMachine).start();
 
     actorRef.send({
       type: 'SET_MAYBE'
@@ -271,7 +271,7 @@ describe('assign', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'INC', value: 30 });
 
     expect(actorRef.getSnapshot().context.count).toEqual(30);
@@ -297,7 +297,7 @@ describe('assign meta', () => {
       }
     );
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.getSnapshot().context.count).toEqual(11);
   });
@@ -320,7 +320,7 @@ describe('assign meta', () => {
       }
     );
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.getSnapshot().context.count).toEqual(11);
   });
@@ -348,7 +348,7 @@ describe('assign meta', () => {
       }
     );
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'EVENT' });
   });

--- a/packages/core/test/deep.test.ts
+++ b/packages/core/test/deep.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index.ts';
+import { createMachine, createActor } from '../src/index.ts';
 import { trackEntries } from './utils.ts';
 
 describe('deep transitions', () => {
@@ -34,7 +34,7 @@ describe('deep transitions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({
@@ -80,7 +80,7 @@ describe('deep transitions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({
@@ -126,7 +126,7 @@ describe('deep transitions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({
@@ -173,7 +173,7 @@ describe('deep transitions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({
@@ -219,7 +219,7 @@ describe('deep transitions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({
@@ -279,7 +279,7 @@ describe('deep transitions', () => {
       });
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({
@@ -344,7 +344,7 @@ describe('deep transitions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({
@@ -408,7 +408,7 @@ describe('deep transitions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({
@@ -473,7 +473,7 @@ describe('deep transitions', () => {
 
       const flushTracked = trackEntries(machine);
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
       flushTracked();
 
       actor.send({

--- a/packages/core/test/deterministic.test.ts
+++ b/packages/core/test/deterministic.test.ts
@@ -1,4 +1,4 @@
-import { fromCallback, interpret } from '../src/index.ts';
+import { fromCallback, createActor } from '../src/index.ts';
 import { createMachine } from '../src/Machine.ts';
 
 describe('deterministic machine', () => {
@@ -86,7 +86,7 @@ describe('deterministic machine', () => {
         }
       });
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       const previousSnapshot = actor.getSnapshot();
 
@@ -239,7 +239,7 @@ describe('deterministic machine', () => {
         }
       });
 
-      const actor = interpret(machine).start();
+      const actor = createActor(machine).start();
 
       const previousSnapshot = actor.getSnapshot();
 

--- a/packages/core/test/devTools.test.ts
+++ b/packages/core/test/devTools.test.ts
@@ -1,4 +1,4 @@
-import { interpret, DevToolsAdapter, createMachine } from '../src/index.ts';
+import { createActor, DevToolsAdapter, createMachine } from '../src/index.ts';
 
 describe('devTools', () => {
   it('should register services with a custom devTools adapter', (done) => {
@@ -22,7 +22,7 @@ describe('devTools', () => {
       }
     });
 
-    const service = interpret(machine, {
+    const service = createActor(machine, {
       devTools: customAdapter
     });
 

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, fromCallback, fromPromise, interpret } from '../src';
+import { createMachine, fromCallback, fromPromise, createActor } from '../src';
 import { ActorStatus } from '../src/interpreter';
 
 const cleanups: (() => void)[] = [];
@@ -33,7 +33,7 @@ describe('error handling', () => {
       throw new Error('no_infinite_loop_when_error_is_thrown_in_subscribe');
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.subscribe(spy);
     actor.send({ type: 'activate' });
@@ -68,7 +68,7 @@ describe('error handling', () => {
       throw new Error('doesnt_crash_actor_when_error_is_thrown_in_subscribe');
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.subscribe(spy);
     actor.send({ type: 'activate' });
@@ -107,7 +107,7 @@ describe('error handling', () => {
     });
     const errorSpy = jest.fn();
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.subscribe({
       next: nextSpy,
@@ -145,7 +145,7 @@ describe('error handling', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     installGlobalOnErrorHandler((ev) => {
       ev.preventDefault();
@@ -172,7 +172,7 @@ describe('error handling', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     installGlobalOnErrorHandler((ev) => {
       ev.preventDefault();
@@ -199,7 +199,7 @@ describe('error handling', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     installGlobalOnErrorHandler(() => {
       done.fail();
@@ -228,7 +228,7 @@ describe('error handling', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     const childActorRef = Object.values(actorRef.getSnapshot().children)[0];
     childActorRef.subscribe({
       error: () => {}
@@ -261,7 +261,7 @@ describe('error handling', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     const childActorRef = Object.values(actorRef.getSnapshot().children)[0];
     childActorRef.subscribe({
       error: () => {}
@@ -294,7 +294,7 @@ describe('error handling', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     const childActorRef = Object.values(actorRef.getSnapshot().children)[0];
     childActorRef.subscribe({
       error: () => {}
@@ -338,7 +338,7 @@ describe('error handling', () => {
 
     const errorSpy = jest.fn();
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: errorSpy
     });
@@ -369,7 +369,7 @@ describe('error handling', () => {
 
     const errorSpy = jest.fn();
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: errorSpy
     });
@@ -406,7 +406,7 @@ describe('error handling', () => {
 
     const errorSpy = jest.fn();
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: errorSpy
     });
@@ -439,7 +439,7 @@ describe('error handling', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.start();
 
     expect(actorRef.status).toBe(ActorStatus.Running);
@@ -459,7 +459,7 @@ describe('error handling', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.start();
 
     expect(actorRef.status).not.toBe(ActorStatus.Running);
@@ -485,7 +485,7 @@ describe('error handling', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: () => {
         throw new Error('error_thrown_by_error_listener');
@@ -516,7 +516,7 @@ describe('error handling', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: () => {}
     });
@@ -548,7 +548,7 @@ describe('error handling', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: () => {
         throw new Error('error_thrown_by_error_listener');

--- a/packages/core/test/event.test.ts
+++ b/packages/core/test/event.test.ts
@@ -1,4 +1,9 @@
-import { createMachine, interpret, assign, AnyActorRef } from '../src/index.ts';
+import {
+  createMachine,
+  createActor,
+  assign,
+  AnyActorRef
+} from '../src/index.ts';
 import { sendTo } from '../src/actions/send';
 
 describe('events', () => {
@@ -53,7 +58,7 @@ describe('events', () => {
       }
     });
 
-    const service = interpret(authClientMachine);
+    const service = createActor(authClientMachine);
     service.subscribe({ complete: () => done() });
     service.start();
 
@@ -118,7 +123,7 @@ describe('nested transitions', () => {
       }
     );
     const password = 'xstate123';
-    const actorRef = interpret(authMachine).start();
+    const actorRef = createActor(authMachine).start();
     actorRef.send({ type: 'changePassword', password });
 
     const snapshot = actorRef.getSnapshot();

--- a/packages/core/test/eventDescriptors.test.ts
+++ b/packages/core/test/eventDescriptors.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index';
+import { createMachine, createActor } from '../src/index';
 
 describe('event descriptors', () => {
   it('should fallback to using wildcard transition definition (if specified)', () => {
@@ -16,7 +16,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'BAR' });
     expect(service.getSnapshot().value).toBe('C');
   });
@@ -36,7 +36,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
     expect(service.getSnapshot().value).toBe('pass');
   });
@@ -56,7 +56,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'foo.bar' });
     expect(service.getSnapshot().value).toBe('pass');
   });
@@ -76,7 +76,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'foo.bar.baz' });
     expect(service.getSnapshot().value).toBe('pass');
   });
@@ -99,7 +99,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'foo.bar.baz' });
     expect(service.getSnapshot().value).toBe('pass');
   });
@@ -119,13 +119,13 @@ describe('event descriptors', () => {
       }
     });
 
-    const actorRef1 = interpret(machine).start();
+    const actorRef1 = createActor(machine).start();
 
     actorRef1.send({ type: 'event' });
 
     expect(actorRef1.getSnapshot().matches('success')).toBeFalsy();
 
-    const actorRef2 = interpret(machine).start();
+    const actorRef2 = createActor(machine).start();
 
     actorRef2.send({ type: 'eventually' });
 
@@ -147,13 +147,13 @@ describe('event descriptors', () => {
       }
     });
 
-    const actorRef1 = interpret(machine).start();
+    const actorRef1 = createActor(machine).start();
 
     actorRef1.send({ type: 'event' });
 
     expect(actorRef1.getSnapshot().matches('success')).toBeTruthy();
 
-    const actorRef2 = interpret(machine).start();
+    const actorRef2 = createActor(machine).start();
 
     actorRef2.send({ type: 'eventually' });
 
@@ -175,19 +175,19 @@ describe('event descriptors', () => {
       }
     });
 
-    const actorRef1 = interpret(machine).start();
+    const actorRef1 = createActor(machine).start();
 
     actorRef1.send({ type: 'event.whatever' });
 
     expect(actorRef1.getSnapshot().matches('success')).toBeTruthy();
 
-    const actorRef2 = interpret(machine).start();
+    const actorRef2 = createActor(machine).start();
 
     actorRef2.send({ type: 'eventually' });
 
     expect(actorRef2.getSnapshot().matches('success')).toBeFalsy();
 
-    const actorRef3 = interpret(machine).start();
+    const actorRef3 = createActor(machine).start();
 
     actorRef3.send({ type: 'eventually.event' });
 
@@ -209,7 +209,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'event.first.second' });
 
@@ -231,7 +231,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'event.foo.bar.first.second' });
 
@@ -254,7 +254,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const actorRef1 = interpret(machine).start();
+    const actorRef1 = createActor(machine).start();
 
     actorRef1.send({ type: 'event.foo.bar.first.second' });
 
@@ -277,7 +277,7 @@ describe('event descriptors', () => {
       ]
     `);
 
-    const actorRef2 = interpret(machine).start();
+    const actorRef2 = createActor(machine).start();
 
     actorRef2.send({ type: 'whatever.event' });
 
@@ -314,7 +314,7 @@ describe('event descriptors', () => {
       }
     });
 
-    const actorRef1 = interpret(machine).start();
+    const actorRef1 = createActor(machine).start();
 
     actorRef1.send({ type: 'eventually.bar.baz' });
 
@@ -331,7 +331,7 @@ describe('event descriptors', () => {
       ]
     `);
 
-    const actorRef2 = interpret(machine).start();
+    const actorRef2 = createActor(machine).start();
 
     actorRef2.send({ type: 'prevent.whatever' });
 

--- a/packages/core/test/examples/6.8.test.ts
+++ b/packages/core/test/examples/6.8.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../../src/index.ts';
+import { createMachine, createActor } from '../../src/index.ts';
 import { testAll } from '../utils.ts';
 
 describe('Example 6.8', () => {
@@ -68,7 +68,7 @@ describe('Example 6.8', () => {
   testAll(machine, expected);
 
   it('should respect the history mechanism', () => {
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: '1' });
     actorRef.send({ type: '6' });

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret, assign } from '../src/index.ts';
+import { createMachine, createActor, assign } from '../src/index.ts';
 
 describe('final states', () => {
   it('should emit the "done.state.*" event when all nested states are in their final states', () => {
@@ -45,7 +45,7 @@ describe('final states', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({
       type: 'NEXT_1'
@@ -86,7 +86,7 @@ describe('final states', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(actual).toEqual(['bazAction', 'barAction', 'fooAction']);
   });
@@ -132,7 +132,7 @@ describe('final states', () => {
       }
     });
 
-    const service = interpret(machine);
+    const service = createActor(machine);
     service.subscribe({
       complete: () => {
         expect(service.getSnapshot().context).toEqual({
@@ -163,7 +163,7 @@ describe('final states', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'FINISH', value: 1 });
     expect(spy).toBeCalledTimes(1);
   });
@@ -179,7 +179,7 @@ describe('final states', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     expect(actor.getSnapshot().output.selfRef.send).toBeDefined();
   });
 });

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -1,4 +1,4 @@
-import { interpret, createMachine, raise } from '../src/index.ts';
+import { createActor, createMachine, raise } from '../src/index.ts';
 import { and, not, or } from '../src/guards';
 import { trackEntries } from './utils.ts';
 
@@ -79,13 +79,13 @@ describe('guard conditions', () => {
   );
 
   it('should transition only if condition is met', () => {
-    const actorRef1 = interpret(lightMachine, {
+    const actorRef1 = createActor(lightMachine, {
       input: { elapsed: 50 }
     }).start();
     actorRef1.send({ type: 'TIMER' });
     expect(actorRef1.getSnapshot().value).toEqual('green');
 
-    const actorRef2 = interpret(lightMachine, {
+    const actorRef2 = createActor(lightMachine, {
       input: { elapsed: 120 }
     }).start();
     actorRef2.send({ type: 'TIMER' });
@@ -93,7 +93,7 @@ describe('guard conditions', () => {
   });
 
   it('should transition if condition based on event is met', () => {
-    const actorRef = interpret(lightMachine).start();
+    const actorRef = createActor(lightMachine).start();
     actorRef.send({
       type: 'EMERGENCY',
       isEmergency: true
@@ -102,7 +102,7 @@ describe('guard conditions', () => {
   });
 
   it('should not transition if condition based on event is not met', () => {
-    const actorRef = interpret(lightMachine).start();
+    const actorRef = createActor(lightMachine).start();
     actorRef.send({
       type: 'EMERGENCY'
     });
@@ -133,7 +133,7 @@ describe('guard conditions', () => {
     });
 
     const flushTracked = trackEntries(machine);
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     flushTracked();
 
     actor.send({ type: 'TIMER', elapsed: 10 });
@@ -143,7 +143,7 @@ describe('guard conditions', () => {
   });
 
   it('should work with defined string transitions', () => {
-    const actorRef = interpret(lightMachine, {
+    const actorRef = createActor(lightMachine, {
       input: { elapsed: 120 }
     }).start();
     actorRef.send({
@@ -157,7 +157,7 @@ describe('guard conditions', () => {
   });
 
   it('should work with guard objects', () => {
-    const actorRef = interpret(lightMachine, {
+    const actorRef = createActor(lightMachine, {
       input: { elapsed: 150 }
     }).start();
     actorRef.send({
@@ -216,7 +216,7 @@ describe('guard conditions', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({
       type: 'TIMER'
     });
@@ -240,7 +240,7 @@ describe('guard conditions', () => {
 
     const errorSpy = jest.fn();
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: errorSpy
     });
@@ -297,7 +297,7 @@ describe('guard conditions', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'T1' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -344,7 +344,7 @@ describe('guard conditions', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'T2' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -391,7 +391,7 @@ describe('guard conditions', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'A' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -423,7 +423,7 @@ describe('guard conditions', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'MACRO' });
 
     expect(service.getSnapshot().value).toBe('c');
@@ -477,13 +477,13 @@ describe('custom guards', () => {
       }
     );
 
-    const actorRef1 = interpret(machine).start();
+    const actorRef1 = createActor(machine).start();
     actorRef1.send({ type: 'EVENT', value: 4 });
     const passState = actorRef1.getSnapshot();
 
     expect(passState.value).toEqual('active');
 
-    const actorRef2 = interpret(machine).start();
+    const actorRef2 = createActor(machine).start();
     actorRef2.send({ type: 'EVENT', value: 3 });
     const failState = actorRef2.getSnapshot();
 
@@ -564,7 +564,7 @@ describe('referencing guards', () => {
 
     const errorSpy = jest.fn();
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     actorRef.subscribe({
       error: errorSpy
     });
@@ -604,7 +604,7 @@ describe('referencing guards', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -639,7 +639,7 @@ describe('referencing guards', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -661,7 +661,7 @@ describe('guards - other', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'EVENT' });
 
     expect(service.getSnapshot().value).toBe('c');
@@ -713,7 +713,7 @@ describe('guards with child guards', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -737,7 +737,7 @@ describe('not() guard', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'EVENT' });
 
@@ -767,7 +767,7 @@ describe('not() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -798,7 +798,7 @@ describe('not() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -828,7 +828,7 @@ describe('not() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -852,7 +852,7 @@ describe('and() guard', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -881,7 +881,7 @@ describe('and() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -915,7 +915,7 @@ describe('and() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -949,7 +949,7 @@ describe('and() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -973,7 +973,7 @@ describe('or() guard', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -1003,7 +1003,7 @@ describe('or() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -1037,7 +1037,7 @@ describe('or() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
@@ -1071,7 +1071,7 @@ describe('or() guard', () => {
       }
     );
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();

--- a/packages/core/test/history.test.ts
+++ b/packages/core/test/history.test.ts
@@ -1,4 +1,4 @@
-import { interpret, createMachine } from '../src/index';
+import { createActor, createMachine } from '../src/index';
 
 describe('history states', () => {
   it('should go to the most recently visited state (explicit shallow history type)', () => {
@@ -27,7 +27,7 @@ describe('history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'POWER' });
@@ -60,7 +60,7 @@ describe('history states', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'POWER' });
@@ -89,7 +89,7 @@ describe('history states', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'POWER' });
 
@@ -115,7 +115,7 @@ describe('history states', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'POWER' });
 
@@ -160,7 +160,7 @@ describe('history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'DEPLOY' });
     actorRef.send({ type: 'SUCCESS' });
@@ -204,7 +204,7 @@ describe('history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'NEXT' });
 
@@ -226,7 +226,7 @@ describe('history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     expect(actorRef.getSnapshot().value).toBe('bar');
   });
@@ -253,7 +253,7 @@ describe('history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'NEXT' });
 
@@ -302,7 +302,7 @@ describe('deep history states', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER' });
@@ -354,7 +354,7 @@ describe('deep history states', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER' });
@@ -410,7 +410,7 @@ describe('deep history states', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER' });
@@ -480,7 +480,7 @@ describe('parallel history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER_A' });
@@ -549,7 +549,7 @@ describe('parallel history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER_A' });
@@ -637,7 +637,7 @@ describe('parallel history states', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER_A' });
@@ -727,7 +727,7 @@ describe('parallel history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER_A' });
@@ -817,7 +817,7 @@ describe('parallel history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER_A' });
@@ -909,7 +909,7 @@ describe('parallel history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH' });
     actorRef.send({ type: 'INNER_A' });
@@ -929,7 +929,7 @@ describe('parallel history states', () => {
 });
 
 it('internal transition to a history state should enter default history state configuration if the containing state has never been exited yet', () => {
-  const service = interpret(
+  const service = createActor(
     createMachine({
       initial: 'first',
       states: {
@@ -996,7 +996,7 @@ describe('multistage history states', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'SWITCH_TURBO' });
     actorRef.send({ type: 'POWER' });

--- a/packages/core/test/id.test.ts
+++ b/packages/core/test/id.test.ts
@@ -1,5 +1,5 @@
 import { testAll } from './utils';
-import { createMachine, interpret } from '../src/index.ts';
+import { createMachine, createActor } from '../src/index.ts';
 
 const idMachine = createMachine({
   initial: 'A',
@@ -96,7 +96,7 @@ describe('State node IDs', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({
       type: 'ACTION'

--- a/packages/core/test/initial.test.ts
+++ b/packages/core/test/initial.test.ts
@@ -1,4 +1,4 @@
-import { interpret, createMachine } from '../src/index.ts';
+import { createActor, createMachine } from '../src/index.ts';
 
 describe('Initial states', () => {
   it('should return the correct initial state', () => {
@@ -19,7 +19,7 @@ describe('Initial states', () => {
         leaf: {}
       }
     });
-    expect(interpret(machine).getSnapshot().value).toEqual({
+    expect(createActor(machine).getSnapshot().value).toEqual({
       a: { b: 'c' }
     });
   });
@@ -64,7 +64,7 @@ describe('Initial states', () => {
         }
       }
     });
-    expect(interpret(machine).getSnapshot().value).toEqual({
+    expect(createActor(machine).getSnapshot().value).toEqual({
       foo: { a: { b: 'c' } },
       bar: { a: { b: 'c' } }
     });
@@ -154,7 +154,7 @@ describe('Initial states', () => {
         }
       }
     });
-    expect(interpret(machine).getSnapshot().value).toEqual({
+    expect(createActor(machine).getSnapshot().value).toEqual({
       one: {
         foo: { a: { b: 'c' } },
         bar: { a: { b: 'c' } }
@@ -177,7 +177,7 @@ describe('Initial states', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     expect(actorRef.getSnapshot().value).toEqual({ foo: 'deep' });
   });
 
@@ -210,7 +210,7 @@ describe('Initial states', () => {
         }
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     expect(service.getSnapshot().value).toEqual({
       root: {
         foo: 'foo_deep',
@@ -240,7 +240,7 @@ describe('Initial states', () => {
         }
       }
     });
-    interpret(machine).start();
+    createActor(machine).start();
     expect(called).toEqual(false);
   });
 });

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -4,7 +4,7 @@ import {
   AnyActorRef,
   AnyEventObject,
   assign,
-  interpret
+  createActor
 } from '../src';
 import { createMachine } from '../src/Machine';
 import {
@@ -31,7 +31,7 @@ describe('input', () => {
       }
     });
 
-    interpret(machine, { input: { startCount: 42 } }).start();
+    createActor(machine, { input: { startCount: 42 } }).start();
 
     expect(spy).toHaveBeenCalledWith(42);
   });
@@ -44,7 +44,7 @@ describe('input', () => {
       }
     });
 
-    interpret(machine, { input: { greeting: 'hello' } }).start();
+    createActor(machine, { input: { greeting: 'hello' } }).start();
   });
 
   it('should throw if input is expected but not provided', () => {
@@ -59,7 +59,7 @@ describe('input', () => {
     });
 
     expect(() => {
-      interpret(machine).start();
+      createActor(machine).start();
     }).toThrowError(/Cannot read properties of undefined/);
   });
 
@@ -71,7 +71,7 @@ describe('input', () => {
     });
 
     expect(() => {
-      interpret(machine).start();
+      createActor(machine).start();
     }).not.toThrowError();
   });
 
@@ -82,7 +82,7 @@ describe('input', () => {
 
     expect(() => {
       // TODO: add ts-expect-errpr
-      interpret(machine).start();
+      createActor(machine).start();
     }).not.toThrowError();
   });
 
@@ -107,7 +107,7 @@ describe('input', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 
   it('should provide input data to spawned machines', (done) => {
@@ -134,7 +134,7 @@ describe('input', () => {
       })
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 
   it('should create a promise with input', async () => {
@@ -142,7 +142,7 @@ describe('input', () => {
       ({ input }) => Promise.resolve(input)
     );
 
-    const promiseActor = interpret(promiseLogic, {
+    const promiseActor = createActor(promiseLogic, {
       input: { count: 42 }
     }).start();
 
@@ -157,7 +157,7 @@ describe('input', () => {
       ({ input }) => input
     );
 
-    const transitionActor = interpret(transitionLogic, {
+    const transitionActor = createActor(transitionLogic, {
       input: { count: 42 }
     }).start();
 
@@ -170,7 +170,7 @@ describe('input', () => {
       { count: number }
     >(({ input }) => of(input));
 
-    const observableActor = interpret(observableLogic, {
+    const observableActor = createActor(observableLogic, {
       input: { count: 42 }
     });
 
@@ -190,7 +190,7 @@ describe('input', () => {
       done();
     });
 
-    interpret(callbackLogic, {
+    createActor(callbackLogic, {
       input: { count: 42 }
     }).start();
   });
@@ -222,7 +222,7 @@ describe('input', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(spy).toHaveBeenCalledWith(42);
   });
@@ -266,7 +266,7 @@ describe('input', () => {
       }
     );
 
-    interpret(machine, { input: 42 }).start();
+    createActor(machine, { input: 42 }).start();
 
     expect(spy).toHaveBeenCalledWith(142);
   });
@@ -295,7 +295,7 @@ describe('input', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(spy).toHaveBeenCalledWith(42);
   });
@@ -333,7 +333,7 @@ describe('input', () => {
       }
     );
 
-    interpret(machine, { input: 42 }).start();
+    createActor(machine, { input: 42 }).start();
 
     expect(spy).toHaveBeenCalledWith(142);
   });
@@ -376,7 +376,7 @@ describe('input', () => {
       }
     );
 
-    interpret(machine, { input: 42 }).start();
+    createActor(machine, { input: 42 }).start();
 
     expect(spy).toHaveBeenCalledWith(142);
   });
@@ -406,7 +406,7 @@ describe('input', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(spy).toHaveBeenCalledWith(100);
   });
@@ -435,7 +435,7 @@ describe('input', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(spy).toHaveBeenCalledWith(100);
   });
@@ -450,7 +450,7 @@ describe('input', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(spy).toHaveBeenCalledWith(actor);
   });
@@ -474,7 +474,7 @@ describe('input', () => {
       }
     );
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(spy).toHaveBeenCalledWith(actor);
   });

--- a/packages/core/test/internalTransitions.test.ts
+++ b/packages/core/test/internalTransitions.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret, assign } from '../src/index';
+import { createMachine, createActor, assign } from '../src/index';
 import { trackEntries } from './utils';
 
 describe('internal transitions', () => {
@@ -20,7 +20,7 @@ describe('internal transitions', () => {
     });
 
     const flushTracked = trackEntries(machine);
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     flushTracked();
 
     actor.send({
@@ -52,7 +52,7 @@ describe('internal transitions', () => {
     });
 
     const flushTracked = trackEntries(machine);
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     flushTracked();
 
     actor.send({
@@ -93,7 +93,7 @@ describe('internal transitions', () => {
     });
 
     const flushTracked = trackEntries(machine);
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({
       type: 'NEXT'
     });
@@ -133,7 +133,7 @@ describe('internal transitions', () => {
     });
 
     const flushTracked = trackEntries(machine);
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     flushTracked();
 
     actor.send({
@@ -160,7 +160,7 @@ describe('internal transitions', () => {
         bar: {}
       }
     });
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({
       type: 'CLICKED'
     });
@@ -180,7 +180,7 @@ describe('internal transitions', () => {
         }
       }
     });
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({
       type: 'TARGETLESS_ARRAY'
     });
@@ -199,7 +199,7 @@ describe('internal transitions', () => {
         }
       }
     });
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({
       type: 'TARGETLESS_OBJECT'
     });
@@ -215,7 +215,7 @@ describe('internal transitions', () => {
       initial: 'foo',
       states: { foo: {} }
     });
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({
       type: 'TARGETLESS_ARRAY'
     });
@@ -231,7 +231,7 @@ describe('internal transitions', () => {
       initial: 'foo',
       states: { foo: {} }
     });
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({
       type: 'TARGETLESS_OBJECT'
     });
@@ -248,7 +248,7 @@ describe('internal transitions', () => {
         foo: {}
       }
     });
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({
       type: 'PARENT_EVENT'
     });
@@ -298,7 +298,7 @@ describe('internal transitions', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'REENTER' });
 
@@ -351,7 +351,7 @@ describe('internal transitions', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'REENTER' });
 

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -17,7 +17,7 @@ import {
   StateValue,
   assign,
   createMachine,
-  interpret,
+  createActor,
   sendParent,
   EventFrom
 } from '../src/index.ts';
@@ -160,7 +160,7 @@ describe('invoke', () => {
       }
     );
 
-    const actorRef = interpret(someParentMachine).start();
+    const actorRef = createActor(someParentMachine).start();
     actorRef.send({ type: 'FORWARD_DEC' });
 
     // 1. The 'parent' machine will not do anything (inert transition)
@@ -246,7 +246,7 @@ describe('invoke', () => {
       }
     });
 
-    const actor = interpret(machine);
+    const actor = createActor(machine);
     actor.subscribe({
       complete: () => {
         done();
@@ -257,7 +257,7 @@ describe('invoke', () => {
   });
 
   it('should start services (explicit machine, invoke = machine)', (done) => {
-    const actor = interpret(fetcherMachine);
+    const actor = createActor(fetcherMachine);
     actor.subscribe({
       complete: () => {
         done();
@@ -304,7 +304,7 @@ describe('invoke', () => {
         }
       }
     });
-    const actor = interpret(machineInvokeMachine);
+    const actor = createActor(machineInvokeMachine);
     actor.subscribe({ complete: () => done() });
     actor.start();
   });
@@ -352,7 +352,7 @@ describe('invoke', () => {
         }
       }
     });
-    const actor = interpret(machineInvokeMachine);
+    const actor = createActor(machineInvokeMachine);
     actor.subscribe({ complete: () => done() });
     actor.start();
   });
@@ -401,7 +401,7 @@ describe('invoke', () => {
       }
     );
 
-    const actor = interpret(
+    const actor = createActor(
       someParentMachine.provide({
         actors: {
           child: createMachine({
@@ -457,7 +457,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(mainMachine);
+      const actor = createActor(mainMachine);
       actor.subscribe({
         complete: () => {
           done();
@@ -485,7 +485,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(mainMachine);
+      const actor = createActor(mainMachine);
       actor.subscribe({
         complete: () => {
           done();
@@ -529,7 +529,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(mainMachine).start();
+      const actor = createActor(mainMachine).start();
 
       expect(actor.getSnapshot().value).toBe('two');
     });
@@ -571,7 +571,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(pingMachine);
+      const actor = createActor(pingMachine);
       actor.subscribe({
         complete: () => {
           done();
@@ -608,7 +608,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       expect(entryActionsCount).toEqual(1);
       expect(invokeCount).toEqual(1);
       expect(invokeDisposeCount).toEqual(0);
@@ -647,7 +647,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
 
       service.send({
         type: 'finished'
@@ -718,7 +718,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(parent);
+      const service = createActor(parent);
       service.subscribe({
         complete: () => {
           expect(invokeCount).toBe(1);
@@ -819,7 +819,7 @@ describe('invoke', () => {
             }
           }
         });
-        const service = interpret(machine);
+        const service = createActor(machine);
         service.subscribe({
           complete: () => {
             done();
@@ -829,7 +829,7 @@ describe('invoke', () => {
       });
 
       it('should be invoked with a promise factory and reject with ErrorExecution', (done) => {
-        const actor = interpret(invokePromiseMachine, {
+        const actor = createActor(invokePromiseMachine, {
           input: { id: 31, succeed: false }
         });
         actor.subscribe({ complete: () => done() });
@@ -857,7 +857,7 @@ describe('invoke', () => {
           }
         });
 
-        const service = interpret(promiseMachine);
+        const service = createActor(promiseMachine);
         service.subscribe({
           error(err) {
             expect(err.message).toEqual(expect.stringMatching(/test/));
@@ -891,7 +891,7 @@ describe('invoke', () => {
           }
         });
 
-        const actor = interpret(promiseMachine);
+        const actor = createActor(promiseMachine);
 
         actor.subscribe({
           error: (err) => {
@@ -932,7 +932,7 @@ describe('invoke', () => {
             }
           }
         });
-        const actor = interpret(promiseMachine);
+        const actor = createActor(promiseMachine);
         actor.subscribe({ complete: () => done() });
         actor.start();
       });
@@ -971,7 +971,7 @@ describe('invoke', () => {
             }
           }
         );
-        const actor = interpret(promiseMachine);
+        const actor = createActor(promiseMachine);
         actor.subscribe({ complete: () => done() });
         actor.start();
       });
@@ -1000,7 +1000,7 @@ describe('invoke', () => {
           }
         });
 
-        const actor = interpret(promiseMachine);
+        const actor = createActor(promiseMachine);
         actor.subscribe({
           complete: () => {
             expect(actor.getSnapshot().context.count).toEqual(1);
@@ -1042,7 +1042,7 @@ describe('invoke', () => {
           }
         );
 
-        const actor = interpret(promiseMachine);
+        const actor = createActor(promiseMachine);
         actor.subscribe({
           complete: () => {
             expect(actor.getSnapshot().context.count).toEqual(1);
@@ -1079,7 +1079,7 @@ describe('invoke', () => {
           }
         });
 
-        const actor = interpret(promiseMachine);
+        const actor = createActor(promiseMachine);
         actor.subscribe({
           complete: () => {
             expect(count).toEqual(1);
@@ -1122,7 +1122,7 @@ describe('invoke', () => {
           }
         );
 
-        const actor = interpret(promiseMachine);
+        const actor = createActor(promiseMachine);
         actor.subscribe({
           complete: () => {
             expect(count).toEqual(1);
@@ -1189,7 +1189,7 @@ describe('invoke', () => {
           }
         );
 
-        const actor = interpret(promiseMachine);
+        const actor = createActor(promiseMachine);
         actor.subscribe({ complete: () => done() });
         actor.start();
         actor.send({
@@ -1279,7 +1279,7 @@ describe('invoke', () => {
           }
         );
 
-        const service = interpret(machine);
+        const service = createActor(machine);
         service.subscribe({
           complete: () => {
             const snapshot = service.getSnapshot();
@@ -1378,7 +1378,7 @@ describe('invoke', () => {
         }
       );
 
-      const actor = interpret(callbackMachine);
+      const actor = createActor(callbackMachine);
       actor.subscribe({ complete: () => done() });
       actor.start();
       actor.send({
@@ -1422,7 +1422,7 @@ describe('invoke', () => {
 
       const expectedStateValues = ['pending', 'first', 'intermediate'];
       const stateValues: StateValue[] = [];
-      const actor = interpret(callbackMachine);
+      const actor = createActor(callbackMachine);
       actor.subscribe((current) => stateValues.push(current.value));
       actor.start().send({ type: 'BEGIN' });
       for (let i = 0; i < expectedStateValues.length; i++) {
@@ -1462,7 +1462,7 @@ describe('invoke', () => {
 
       const expectedStateValues = ['idle', 'intermediate'];
       const stateValues: StateValue[] = [];
-      const actor = interpret(callbackMachine);
+      const actor = createActor(callbackMachine);
       actor.subscribe((current) => stateValues.push(current.value));
       actor.start().send({ type: 'BEGIN' });
       for (let i = 0; i < expectedStateValues.length; i++) {
@@ -1509,7 +1509,7 @@ describe('invoke', () => {
 
       const expectedStateValues = ['pending', 'second', 'third'];
       const stateValues: StateValue[] = [];
-      const actor = interpret(callbackMachine);
+      const actor = createActor(callbackMachine);
       actor.subscribe((current) => {
         stateValues.push(current.value);
       });
@@ -1556,7 +1556,7 @@ describe('invoke', () => {
           }
         }
       });
-      const actor = interpret(intervalMachine);
+      const actor = createActor(intervalMachine);
       actor.subscribe({ complete: () => done() });
       actor.start();
     });
@@ -1579,7 +1579,7 @@ describe('invoke', () => {
           idle: {}
         }
       });
-      const actorRef = interpret(intervalMachine).start();
+      const actorRef = createActor(intervalMachine).start();
 
       actorRef.send({ type: 'NEXT' });
 
@@ -1612,7 +1612,7 @@ describe('invoke', () => {
           }
         }
       });
-      const actor = interpret(pingPongMachine);
+      const actor = createActor(pingPongMachine);
       actor.subscribe({ complete: () => done() });
       actor.start();
     });
@@ -1642,7 +1642,7 @@ describe('invoke', () => {
           }
         }
       });
-      const actor = interpret(errorMachine);
+      const actor = createActor(errorMachine);
       actor.subscribe({ complete: () => done() });
       actor.start();
     });
@@ -1667,7 +1667,7 @@ describe('invoke', () => {
       });
 
       const expectedStateValue = 'failed';
-      const service = interpret(errorMachine).start();
+      const service = createActor(errorMachine).start();
       expect(service.getSnapshot().value).toEqual(expectedStateValue);
     });
 
@@ -1697,7 +1697,7 @@ describe('invoke', () => {
           }
         }
       });
-      const actor = interpret(errorMachine);
+      const actor = createActor(errorMachine);
       actor.subscribe({ complete: () => done() });
       actor.start();
     });
@@ -1728,7 +1728,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(asyncWithDoneMachine);
+      const actor = createActor(asyncWithDoneMachine);
       actor.subscribe({
         complete: () => {
           expect(actor.getSnapshot().context.result).toEqual(42);
@@ -1788,7 +1788,7 @@ describe('invoke', () => {
         }
       });
 
-      interpret(errorMachine).start().send({ type: 'FETCH' });
+      createActor(errorMachine).start().send({ type: 'FETCH' });
 
       expect(errorHandlersCalled).toEqual(1);
     });
@@ -1809,7 +1809,7 @@ describe('invoke', () => {
           }
         }
       });
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({ type: 'GO_TO_WAITING' });
       const waitingState = actorRef.getSnapshot();
 
@@ -1836,7 +1836,7 @@ describe('invoke', () => {
       });
       const spy = jest.fn();
 
-      const actorRef = interpret(errorMachine);
+      const actorRef = createActor(errorMachine);
       actorRef.subscribe({
         error: spy
       });
@@ -1870,7 +1870,7 @@ describe('invoke', () => {
         }
       });
 
-      interpret(machine).start();
+      createActor(machine).start();
     });
 
     describe('sub invoke race condition ends on the completed state', () => {
@@ -1909,7 +1909,7 @@ describe('invoke', () => {
         }
       });
 
-      const actorRef = interpret(anotherParentMachine).start();
+      const actorRef = createActor(anotherParentMachine).start();
       actorRef.send({ type: 'STOPCHILD' });
 
       expect(actorRef.getSnapshot().value).toEqual('completed');
@@ -1945,7 +1945,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(obsMachine);
+      const service = createActor(obsMachine);
       service.subscribe({
         complete: () => {
           done();
@@ -1989,7 +1989,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(obsMachine);
+      const actor = createActor(obsMachine);
       actor.subscribe({
         complete: () => {
           done();
@@ -2044,7 +2044,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(obsMachine);
+      const actor = createActor(obsMachine);
       actor.subscribe({
         complete: () => {
           done();
@@ -2067,7 +2067,7 @@ describe('invoke', () => {
         }
       });
 
-      interpret(machine).start();
+      createActor(machine).start();
     });
   });
 
@@ -2104,7 +2104,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(obsMachine);
+      const service = createActor(obsMachine);
       service.subscribe({
         complete: () => {
           done();
@@ -2155,7 +2155,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(obsMachine);
+      const actor = createActor(obsMachine);
       actor.subscribe({
         complete: () => {
           done();
@@ -2212,7 +2212,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(obsMachine);
+      const actor = createActor(obsMachine);
       actor.subscribe({
         complete: () => {
           done();
@@ -2242,7 +2242,7 @@ describe('invoke', () => {
         }
       });
 
-      interpret(machine).start();
+      createActor(machine).start();
     });
   });
 
@@ -2272,7 +2272,7 @@ describe('invoke', () => {
         }
       });
 
-      const countService = interpret(countMachine);
+      const countService = createActor(countMachine);
       countService.subscribe((state) => {
         if (state.children['count']?.getSnapshot() === 2) {
           done();
@@ -2315,7 +2315,7 @@ describe('invoke', () => {
         }
       });
 
-      const pingService = interpret(pingMachine);
+      const pingService = createActor(pingMachine);
       pingService.subscribe({
         complete: () => {
           done();
@@ -2351,7 +2351,7 @@ describe('invoke', () => {
         }
       });
 
-      const countService = interpret(countMachine);
+      const countService = createActor(countMachine);
       countService.subscribe((state) => {
         if (state.children['count']?.getSnapshot() === 2) {
           done();
@@ -2394,7 +2394,7 @@ describe('invoke', () => {
         }
       });
 
-      const countService = interpret(countMachine);
+      const countService = createActor(countMachine);
       countService.subscribe((state) => {
         if (state.children['count']?.getSnapshot() === 2) {
           done();
@@ -2452,7 +2452,7 @@ describe('invoke', () => {
     });
 
     it('should create invocations from machines in nested states', (done) => {
-      const actor = interpret(pingMachine);
+      const actor = createActor(pingMachine);
       actor.subscribe({ complete: () => done() });
       actor.start();
     });
@@ -2505,7 +2505,7 @@ describe('invoke', () => {
     });
 
     it('should start all services at once', (done) => {
-      const service = interpret(multiple);
+      const service = createActor(multiple);
       service.subscribe({
         complete: () => {
           expect(service.getSnapshot().context).toEqual({
@@ -2579,7 +2579,7 @@ describe('invoke', () => {
     });
 
     it('should run services in parallel', (done) => {
-      const service = interpret(parallel);
+      const service = createActor(parallel);
       service.subscribe({
         complete: () => {
           expect(service.getSnapshot().context).toEqual({
@@ -2615,7 +2615,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(transientMachine);
+      const service = createActor(transientMachine);
 
       service.start();
 
@@ -2654,7 +2654,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(transientMachine);
+      const service = createActor(transientMachine);
 
       service.start();
 
@@ -2715,7 +2715,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(machine);
+      const service = createActor(machine);
       service.subscribe({ complete: () => done() });
       service.start();
 
@@ -2749,7 +2749,7 @@ describe('invoke', () => {
         }
       });
 
-      const service = interpret(transientMachine);
+      const service = createActor(transientMachine);
 
       service.start();
 
@@ -2789,7 +2789,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(parent);
+      const actor = createActor(parent);
       actor.subscribe({
         complete: () => {
           done();
@@ -2836,7 +2836,7 @@ describe('invoke', () => {
         }
       });
 
-      const actor = interpret(parent);
+      const actor = createActor(parent);
       actor.subscribe({
         complete: () => {
           done();
@@ -2886,7 +2886,7 @@ describe('invoke', () => {
         }
       }
     );
-    const actor = interpret(machine);
+    const actor = createActor(machine);
     actor.subscribe({ complete: () => done() });
     actor.start();
   });
@@ -2935,7 +2935,7 @@ describe('invoke', () => {
     );
 
     await new Promise<void>((res) => {
-      const actor = interpret(machine);
+      const actor = createActor(machine);
       actor.subscribe({ complete: () => res() });
       actor.start();
     });
@@ -2969,7 +2969,7 @@ describe('invoke', () => {
         }
       });
 
-      interpret(machine).start();
+      createActor(machine).start();
     });
   });
 
@@ -3004,7 +3004,7 @@ describe('invoke', () => {
       }
     );
 
-    const actor = interpret(machine);
+    const actor = createActor(machine);
     actor.subscribe({
       complete: () => {
         done();
@@ -3051,7 +3051,7 @@ describe('invoke', () => {
       );
 
       expect(
-        interpret(machine).getSnapshot().children['machine.a:invocation[0]']
+        createActor(machine).getSnapshot().children['machine.a:invocation[0]']
       ).toBeDefined();
     }
   );
@@ -3104,7 +3104,7 @@ describe('invoke', () => {
       }
     );
 
-    interpret(testMachine).start();
+    createActor(testMachine).start();
 
     // check within a macrotask so all promise-induced microtasks have a chance to resolve first
     setTimeout(() => {
@@ -3160,7 +3160,7 @@ describe('invoke', () => {
       }
     });
 
-    interpret(testMachine).start();
+    createActor(testMachine).start();
 
     // check within a macrotask so all promise-induced microtasks have a chance to resolve first
     setTimeout(() => {
@@ -3193,7 +3193,7 @@ describe('invoke', () => {
         }
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'GO_AWAY_AND_REENTER' });
 
@@ -3222,7 +3222,7 @@ describe('invoke', () => {
         }
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'FINISH' });
     expect(disposed).toBe(true);
@@ -3256,7 +3256,7 @@ describe('invoke', () => {
         }
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'FINISH' });
     expect(disposed).toBe(true);
@@ -3288,7 +3288,7 @@ describe('invoke', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'EVENT' });
 
@@ -3344,7 +3344,7 @@ describe('invoke input', () => {
       }
     );
 
-    const service = interpret(machine);
+    const service = createActor(machine);
     service.subscribe({
       complete: () => {
         done();
@@ -3367,6 +3367,6 @@ describe('invoke input', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 });

--- a/packages/core/test/machine.test.ts
+++ b/packages/core/test/machine.test.ts
@@ -1,4 +1,4 @@
-import { interpret, createMachine, assign } from '../src/index.ts';
+import { createActor, createMachine, assign } from '../src/index.ts';
 import { State } from '../src/State.ts';
 
 const pedestrianStates = {
@@ -139,16 +139,16 @@ describe('machine', () => {
         guards: { someCondition: () => true }
       });
 
-      expect(interpret(differentMachine).getSnapshot().context).toEqual({
+      expect(createActor(differentMachine).getSnapshot().context).toEqual({
         foo: 'bar'
       });
 
       expect(() => {
-        interpret(differentMachine).start();
+        createActor(differentMachine).start();
       }).toThrowErrorMatchingInlineSnapshot(`"new entry"`);
 
       shouldThrow = false;
-      const actorRef = interpret(differentMachine).start();
+      const actorRef = createActor(differentMachine).start();
       actorRef.send({ type: 'EVENT' });
 
       expect(actorRef.getSnapshot().value).toEqual('bar');
@@ -161,7 +161,7 @@ describe('machine', () => {
         }
       });
       const differentMachine = machine.provide({});
-      const actorRef = interpret(differentMachine).start();
+      const actorRef = createActor(differentMachine).start();
       expect(actorRef.getSnapshot().context).toEqual({ foo: 'bar' });
     });
 
@@ -193,7 +193,7 @@ describe('machine', () => {
     });
 
     it('machines defined without context should have a default empty object for context', () => {
-      expect(interpret(createMachine({})).getSnapshot().context).toEqual({});
+      expect(createActor(createMachine({})).getSnapshot().context).toEqual({});
     });
 
     it('should lazily create context for all interpreter instances created from the same machine template created by `provide`', () => {
@@ -205,8 +205,8 @@ describe('machine', () => {
 
       const copiedMachine = machine.provide({});
 
-      const a = interpret(copiedMachine).start();
-      const b = interpret(copiedMachine).start();
+      const a = createActor(copiedMachine).start();
+      const b = createActor(copiedMachine).start();
 
       expect(a.getSnapshot().context.foo).not.toBe(b.getSnapshot().context.foo);
     });
@@ -226,8 +226,8 @@ describe('machine', () => {
       const testMachine1 = createMachine(config);
       const testMachine2 = createMachine(config);
 
-      const initialState1 = interpret(testMachine1).getSnapshot();
-      const initialState2 = interpret(testMachine2).getSnapshot();
+      const initialState1 = createActor(testMachine1).getSnapshot();
+      const initialState2 = createActor(testMachine2).getSnapshot();
 
       expect(initialState1.context).not.toBe(initialState2.context);
 
@@ -331,7 +331,7 @@ describe('machine', () => {
         }
       });
 
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({ type: 'NEXT' });
       const barState = actorRef.getSnapshot();
 
@@ -353,12 +353,12 @@ describe('machine', () => {
         }
       });
 
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({ type: 'NEXT' });
       const persistedState = actorRef.getPersistedState();
 
       const spy = jest.fn();
-      const actorRef2 = interpret(machine, { state: persistedState });
+      const actorRef2 = createActor(machine, { state: persistedState });
       actorRef2.subscribe({
         complete: spy
       });
@@ -380,7 +380,7 @@ describe('machine', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().value).toBe('b');
+      expect(createActor(machine).getSnapshot().value).toBe('b');
     });
   });
 
@@ -443,7 +443,7 @@ describe('machine', () => {
         }
       });
 
-      const actorRef = interpret(testMachine);
+      const actorRef = createActor(testMachine);
       expect(actorRef.getSnapshot().value).toEqual({});
 
       actorRef.start();

--- a/packages/core/test/match.test.ts
+++ b/packages/core/test/match.test.ts
@@ -1,4 +1,4 @@
-import { matchesState, createMachine, interpret } from '../src/index.ts';
+import { matchesState, createMachine, createActor } from '../src/index.ts';
 
 describe('matchesState()', () => {
   it('should return true if two states are equivalent', () => {
@@ -113,7 +113,7 @@ describe('matches() method', () => {
       }
     });
 
-    const initialState = interpret(machine).getSnapshot();
+    const initialState = createActor(machine).getSnapshot();
 
     expect(initialState.matches('foo')).toBeTruthy();
     expect(initialState.matches({ foo: 'bar' })).toBeTruthy();

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index.ts';
+import { createMachine, createActor } from '../src/index.ts';
 
 describe('state meta data', () => {
   const pedestrianStates = {
@@ -73,7 +73,7 @@ describe('state meta data', () => {
   });
 
   it('states should aggregate meta data', () => {
-    const actorRef = interpret(lightMachine).start();
+    const actorRef = createActor(lightMachine).start();
     actorRef.send({ type: 'TIMER' });
     const yellowState = actorRef.getSnapshot();
 
@@ -87,7 +87,7 @@ describe('state meta data', () => {
   });
 
   it('states should aggregate meta data (deep)', () => {
-    const actorRef = interpret(lightMachine).start();
+    const actorRef = createActor(lightMachine).start();
     actorRef.send({ type: 'TIMER' });
     actorRef.send({ type: 'TIMER' });
     expect(actorRef.getSnapshot().meta).toEqual({
@@ -124,7 +124,7 @@ describe('state meta data', () => {
       }
     });
 
-    const actor = interpret(machine, {
+    const actor = createActor(machine, {
       state: machine.resolveStateValue('second')
     });
     actor.start();

--- a/packages/core/test/multiple.test.ts
+++ b/packages/core/test/multiple.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index';
+import { createMachine, createActor } from '../src/index';
 
 describe('multiple', () => {
   const machine = createMachine({
@@ -137,7 +137,7 @@ describe('multiple', () => {
 
   describe('transitions to parallel states', () => {
     it('should enter initial states of parallel states', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({ type: 'INITIAL' });
       expect(actorRef.getSnapshot().value).toEqual({
         para: { A: 'B', K: 'L', P: 'Q' }
@@ -145,7 +145,7 @@ describe('multiple', () => {
     });
 
     it('should enter specific states in one region', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({ type: 'DEEP_M' });
       expect(actorRef.getSnapshot().value).toEqual({
         para: { A: 'B', K: 'M', P: 'Q' }
@@ -153,7 +153,7 @@ describe('multiple', () => {
     });
 
     it('should enter specific states in all regions', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({ type: 'DEEP_CMR' });
       expect(actorRef.getSnapshot().value).toEqual({
         para: { A: 'C', K: 'M', P: 'R' }
@@ -161,7 +161,7 @@ describe('multiple', () => {
     });
 
     it('should enter specific states in some regions', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({ type: 'DEEP_MR' });
       expect(actorRef.getSnapshot().value).toEqual({
         para: { A: 'B', K: 'M', P: 'R' }
@@ -169,26 +169,26 @@ describe('multiple', () => {
     });
 
     it.skip('should reject two targets in the same region', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       expect(() => actorRef.send({ type: 'BROKEN_SAME_REGION' })).toThrow();
     });
 
     it.skip('should reject targets inside and outside a region', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       expect(() =>
         actorRef.send({ type: 'BROKEN_DIFFERENT_REGIONS' })
       ).toThrow();
     });
 
     it.skip('should reject two targets in different regions', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       expect(() =>
         actorRef.send({ type: 'BROKEN_DIFFERENT_REGIONS_2' })
       ).toThrow();
     });
 
     it.skip('should reject two targets in different regions at different levels', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       expect(() =>
         actorRef.send({ type: 'BROKEN_DIFFERENT_REGIONS_3' })
       ).toThrow();
@@ -196,14 +196,14 @@ describe('multiple', () => {
 
     it.skip('should reject two deep targets in different regions at top level', () => {
       // TODO: this test has the same body as the one before it, this doesn't look alright
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       expect(() =>
         actorRef.send({ type: 'BROKEN_DIFFERENT_REGIONS_3' })
       ).toThrow();
     });
 
     it.skip('should reject two deep targets in different regions at different levels', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       expect(() =>
         actorRef.send({ type: 'BROKEN_DIFFERENT_REGIONS_4' })
       ).toThrow();

--- a/packages/core/test/parallel.test.ts
+++ b/packages/core/test/parallel.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret, StateValue } from '../src/index.ts';
+import { createMachine, createActor, StateValue } from '../src/index.ts';
 import { assign } from '../src/actions/assign.ts';
 import { raise } from '../src/actions/raise.ts';
 import { testMultiTransition } from './utils.ts';
@@ -493,7 +493,7 @@ const deepFlatParallelMachine = createMachine({
 
 describe('parallel states', () => {
   it('should have initial parallel states', () => {
-    const initialState = interpret(wordMachine).getSnapshot();
+    const initialState = createActor(wordMachine).getSnapshot();
 
     expect(initialState.value).toEqual({
       bold: 'off',
@@ -560,7 +560,7 @@ describe('parallel states', () => {
   });
 
   it('should have all parallel states represented in the state value', () => {
-    const actorRef = interpret(wakMachine).start();
+    const actorRef = createActor(wakMachine).start();
     actorRef.send({ type: 'WAK1' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -570,7 +570,7 @@ describe('parallel states', () => {
   });
 
   it('should have all parallel states represented in the state value (2)', () => {
-    const actorRef = interpret(wakMachine).start();
+    const actorRef = createActor(wakMachine).start();
     actorRef.send({ type: 'WAK2' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -580,7 +580,7 @@ describe('parallel states', () => {
   });
 
   it('should work with regions without states', () => {
-    expect(interpret(flatParallelMachine).getSnapshot().value).toEqual({
+    expect(createActor(flatParallelMachine).getSnapshot().value).toEqual({
       foo: {},
       bar: {},
       baz: 'one'
@@ -588,7 +588,7 @@ describe('parallel states', () => {
   });
 
   it('should work with regions without states', () => {
-    const actorRef = interpret(flatParallelMachine).start();
+    const actorRef = createActor(flatParallelMachine).start();
     actorRef.send({ type: 'E' });
     expect(actorRef.getSnapshot().value).toEqual({
       foo: {},
@@ -598,7 +598,7 @@ describe('parallel states', () => {
   });
 
   it('should properly transition to relative substate', () => {
-    const actorRef = interpret(composerMachine).start();
+    const actorRef = createActor(composerMachine).start();
     actorRef.send({
       type: 'singleClickActivity'
     });
@@ -651,7 +651,7 @@ describe('parallel states', () => {
         }
       }
     });
-    expect(interpret(machine).getSnapshot().value).toEqual({
+    expect(createActor(machine).getSnapshot().value).toEqual({
       OUTER1: 'B',
       OUTER2: {
         INNER1: 'OFF',
@@ -661,7 +661,7 @@ describe('parallel states', () => {
   });
 
   it('should properly transition when raising events for a parallel state', () => {
-    const actorRef = interpret(raisingParallelMachine).start();
+    const actorRef = createActor(raisingParallelMachine).start();
     actorRef.send({
       type: 'EVENT_OUTER1_B'
     });
@@ -714,7 +714,7 @@ describe('parallel states', () => {
       }
     });
 
-    const actorRef = interpret(simultaneousMachine).start();
+    const actorRef = createActor(simultaneousMachine).start();
     actorRef.send({
       type: 'SAVE'
     });
@@ -735,7 +735,7 @@ describe('parallel states', () => {
 
   describe('transitions with nested parallel states', () => {
     it('should properly transition when in a simple nested state', () => {
-      const actorRef = interpret(nestedParallelState).start();
+      const actorRef = createActor(nestedParallelState).start();
       actorRef.send({
         type: 'EVENT_SIMPLE'
       });
@@ -755,7 +755,7 @@ describe('parallel states', () => {
     });
 
     it('should properly transition when in a complex nested state', () => {
-      const actorRef = interpret(nestedParallelState).start();
+      const actorRef = createActor(nestedParallelState).start();
       actorRef.send({
         type: 'EVENT_COMPLEX'
       });
@@ -804,7 +804,7 @@ describe('parallel states', () => {
     });
 
     it('should represent the flat nested parallel states in the state value', () => {
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({
         type: 'to-B'
       });
@@ -820,7 +820,7 @@ describe('parallel states', () => {
 
   describe('deep flat parallel states', () => {
     it('should properly evaluate deep flat parallel states', () => {
-      const actorRef = interpret(deepFlatParallelMachine).start();
+      const actorRef = createActor(deepFlatParallelMachine).start();
 
       actorRef.send({ type: 'a' });
       actorRef.send({ type: 'c' });
@@ -866,7 +866,7 @@ describe('parallel states', () => {
         }
       });
 
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       expect(() => {
         actorRef.send({
           type: 'UPDATE'
@@ -925,7 +925,7 @@ describe('parallel states', () => {
         }
       });
 
-      const actorRef = interpret(testMachine).start();
+      const actorRef = createActor(testMachine).start();
 
       actorRef.send({ type: 'toggle' });
       actorRef.send({ type: 'go to dashboard' });
@@ -964,7 +964,7 @@ describe('parallel states', () => {
         }
       });
 
-      const actorRef = interpret(testMachine).start();
+      const actorRef = createActor(testMachine).start();
 
       actorRef.send({
         type: 'GOTO_FOOBAZ'
@@ -1033,7 +1033,7 @@ describe('parallel states', () => {
       }
     });
 
-    const service = interpret(machine);
+    const service = createActor(machine);
     service.subscribe({
       complete: () => {
         done();
@@ -1091,7 +1091,7 @@ describe('parallel states', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'finish_one' });
     service.send({ type: 'finish_two' });

--- a/packages/core/test/predictableExec.test.ts
+++ b/packages/core/test/predictableExec.test.ts
@@ -2,7 +2,7 @@ import {
   AnyInterpreter,
   assign,
   createMachine,
-  interpret,
+  createActor,
   sendTo
 } from '../src/index.ts';
 import { raise, sendParent, stop } from '../src/actions.ts';
@@ -34,7 +34,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     expect(actual).toEqual(['custom', 'assign']);
@@ -50,7 +50,7 @@ describe('predictableExec', () => {
 
     expect(called).toBe(false);
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(called).toBe(true);
   });
@@ -67,7 +67,7 @@ describe('predictableExec', () => {
       ]
     });
 
-    expect(interpret(machine).getSnapshot().context.called).toBe(true);
+    expect(createActor(machine).getSnapshot().context.called).toBe(true);
   });
 
   it('should call raised transition custom actions with raised event', () => {
@@ -93,7 +93,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     expect(eventArg.type).toBe('RAISED');
@@ -126,7 +126,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     expect(eventArg.type).toBe('RAISED');
@@ -160,7 +160,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     expect(eventArg.type).toBe('RAISED');
@@ -185,7 +185,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     expect(service.getSnapshot().children.myChild).toBeDefined();
@@ -214,7 +214,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
     service.send({ type: 'NEXT' });
 
@@ -244,7 +244,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     expect(calledWith).toBe(1);
@@ -301,7 +301,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     actual.length = 0;
 
@@ -361,7 +361,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     actual.length = 0;
 
@@ -421,7 +421,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     actual.length = 0;
 
@@ -481,7 +481,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     actual.length = 0;
 
@@ -522,7 +522,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({
       type: 'ACTIVATE'
@@ -551,7 +551,7 @@ describe('predictableExec', () => {
       ]
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
 
     expect(actual).toEqual([0, 1, 2]);
   });
@@ -608,7 +608,7 @@ describe('predictableExec', () => {
       }
     });
 
-    service = interpret(machine);
+    service = createActor(machine);
     service.subscribe({
       complete: () => {
         expect(service.getSnapshot().value).toBe('success');
@@ -646,7 +646,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().value).toBe('done');
   });
@@ -689,7 +689,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
   });
 
@@ -722,7 +722,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     expect(received).toEqual({ type: 'KNOCK_KNOCK' });
@@ -777,7 +777,7 @@ describe('predictableExec', () => {
       }
     });
 
-    service = interpret(machine);
+    service = createActor(machine);
     service.subscribe({
       complete: () => {
         expect(service.getSnapshot().value).toBe('success');
@@ -815,7 +815,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(service.getSnapshot().value).toBe('done');
   });
@@ -845,7 +845,7 @@ describe('predictableExec', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'TOGGLE' });
   });

--- a/packages/core/test/rehydration.test.ts
+++ b/packages/core/test/rehydration.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index.ts';
+import { createMachine, createActor } from '../src/index.ts';
 
 describe('rehydration', () => {
   describe('using persisted state', () => {
@@ -12,12 +12,12 @@ describe('rehydration', () => {
         }
       });
 
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       const persistedState = JSON.stringify(actorRef.getPersistedState());
       actorRef.stop();
       const restoredState = machine.createState(JSON.parse(persistedState));
 
-      const service = interpret(machine, { state: restoredState }).start();
+      const service = createActor(machine, { state: restoredState }).start();
 
       expect(service.getSnapshot().hasTag('foo')).toBe(true);
     });
@@ -34,13 +34,13 @@ describe('rehydration', () => {
         }
       });
 
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       const persistedState = JSON.stringify(actorRef.getPersistedState());
       actorRef.stop();
       const restoredState = machine.createState(JSON.parse(persistedState));
 
       actual.length = 0;
-      interpret(machine, { state: restoredState }).start().stop();
+      createActor(machine, { state: restoredState }).start().stop();
 
       expect(actual).toEqual(['a', 'root']);
     });
@@ -55,10 +55,10 @@ describe('rehydration', () => {
       });
 
       const persistedState = JSON.stringify(
-        interpret(machine).start().getSnapshot()
+        createActor(machine).start().getSnapshot()
       );
       const restoredState = JSON.parse(persistedState);
-      const service = interpret(machine, { state: restoredState }).start();
+      const service = createActor(machine, { state: restoredState }).start();
 
       expect(service.getSnapshot().can({ type: 'FOO' })).toBe(true);
     });
@@ -79,7 +79,7 @@ describe('rehydration', () => {
       });
 
       const activeState = machine.resolveStateValue('active');
-      const service = interpret(machine, { state: activeState });
+      const service = createActor(machine, { state: activeState });
 
       service.start();
 
@@ -103,7 +103,7 @@ describe('rehydration', () => {
 
       const activeState = machine.resolveStateValue('active');
 
-      interpret(machine, { state: activeState }).start().stop();
+      createActor(machine, { state: activeState }).start().stop();
 
       expect(actual).toEqual(['active', 'root']);
     });
@@ -115,7 +115,7 @@ describe('rehydration', () => {
       entry: entrySpy
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(entrySpy).toHaveBeenCalledTimes(1);
 
@@ -123,7 +123,7 @@ describe('rehydration', () => {
 
     actor.stop();
 
-    interpret(machine, { state: persistedState }).start();
+    createActor(machine, { state: persistedState }).start();
 
     expect(entrySpy).toHaveBeenCalledTimes(1);
   });

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as pkgUp from 'pkg-up';
 import { SimulatedClock } from '../src/SimulatedClock';
-import { AnyState, AnyStateMachine, interpret } from '../src/index.ts';
+import { AnyState, AnyStateMachine, createActor } from '../src/index.ts';
 import { toMachine, sanitizeStateId } from '../src/scxml';
 import { getStateNodes } from '../src/stateUtils';
 
@@ -354,7 +354,7 @@ async function runW3TestToCompletion(machine: AnyStateMachine): Promise<void> {
     let nextState: AnyState;
     let prevState: AnyState;
 
-    const actor = interpret(machine, {
+    const actor = createActor(machine, {
       logger: () => void 0
     });
     actor.subscribe({
@@ -391,7 +391,7 @@ async function runTestToCompletion(
   }
 
   let done = false;
-  const service = interpret(machine, {
+  const service = createActor(machine, {
     clock: new SimulatedClock()
   });
 

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index';
+import { createMachine, createActor } from '../src/index';
 import { assign } from '../src/actions/assign';
 import { fromCallback } from '../src/actors/callback';
 
@@ -108,7 +108,7 @@ const exampleMachine = createMachine({
 describe('State', () => {
   describe('.nextEvents', () => {
     it('returns the next possible events for the current state', () => {
-      const actorRef = interpret(exampleMachine);
+      const actorRef = createActor(exampleMachine);
 
       expect(actorRef.getSnapshot().nextEvents.sort()).toEqual(
         [
@@ -134,7 +134,7 @@ describe('State', () => {
         'MACHINE_EVENT'
       ]);
 
-      const actorRef2 = interpret(exampleMachine).start();
+      const actorRef2 = createActor(exampleMachine).start();
       actorRef2.send({ type: 'TO_THREE' });
 
       expect(actorRef2.getSnapshot().nextEvents.sort()).toEqual([
@@ -146,7 +146,7 @@ describe('State', () => {
     });
 
     it('returns events when transitioned from StateValue', () => {
-      const actorRef = interpret(exampleMachine).start();
+      const actorRef = createActor(exampleMachine).start();
 
       actorRef.send({
         type: 'TO_THREE'
@@ -172,18 +172,18 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(noEventsMachine).getSnapshot().nextEvents).toEqual([]);
+      expect(createActor(noEventsMachine).getSnapshot().nextEvents).toEqual([]);
     });
   });
 
   describe('machine.createState()', () => {
     it('should be able to create a state from a JSON config', () => {
-      const initialState = interpret(exampleMachine).getSnapshot();
+      const initialState = createActor(exampleMachine).getSnapshot();
       const jsonInitialState = JSON.parse(JSON.stringify(initialState));
 
       const stateFromConfig = exampleMachine.createState(jsonInitialState);
 
-      const actorRef = interpret(exampleMachine, {
+      const actorRef = createActor(exampleMachine, {
         state: stateFromConfig
       }).start();
 
@@ -198,7 +198,7 @@ describe('State', () => {
     });
 
     it('should preserve state.nextEvents using machine.resolveState', () => {
-      const actorRef = interpret(exampleMachine);
+      const actorRef = createActor(exampleMachine);
       const initialState = actorRef.getSnapshot();
       const { nextEvents } = initialState;
       const jsonInitialState = JSON.parse(JSON.stringify(initialState));
@@ -213,7 +213,7 @@ describe('State', () => {
 
   describe('State.prototype.matches', () => {
     it('should keep reference to state instance after destructuring', () => {
-      const { matches } = interpret(exampleMachine).getSnapshot();
+      const { matches } = createActor(exampleMachine).getSnapshot();
 
       expect(matches('one')).toBe(true);
     });
@@ -221,7 +221,7 @@ describe('State', () => {
 
   describe('State.prototype.toStrings', () => {
     it('should return all state paths as strings', () => {
-      const actorRef = interpret(exampleMachine).start();
+      const actorRef = createActor(exampleMachine).start();
       actorRef.send({
         type: 'TO_TWO',
         foo: 'test'
@@ -235,7 +235,7 @@ describe('State', () => {
     });
 
     it('should keep reference to state instance after destructuring', () => {
-      expect(interpret(exampleMachine).getSnapshot().toStrings()).toEqual([
+      expect(createActor(exampleMachine).getSnapshot().toStrings()).toEqual([
         'one'
       ]);
     });
@@ -243,11 +243,11 @@ describe('State', () => {
 
   describe('.done', () => {
     it('should show that a machine has not reached its final state', () => {
-      expect(interpret(exampleMachine).getSnapshot().done).toBe(false);
+      expect(createActor(exampleMachine).getSnapshot().done).toBe(false);
     });
 
     it('should show that a machine has reached its final state', () => {
-      const actorRef = interpret(exampleMachine).start();
+      const actorRef = createActor(exampleMachine).start();
       actorRef.send({ type: 'TO_FINAL' });
       expect(actorRef.getSnapshot().done).toBe(true);
     });
@@ -267,7 +267,9 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'NEXT' })).toBe(true);
+      expect(createActor(machine).getSnapshot().can({ type: 'NEXT' })).toBe(
+        true
+      );
     });
 
     it('should return true for an event object that results in a transition to a different state', () => {
@@ -283,7 +285,9 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'NEXT' })).toBe(true);
+      expect(createActor(machine).getSnapshot().can({ type: 'NEXT' })).toBe(
+        true
+      );
     });
 
     it('should return true for an event object that results in a new action', () => {
@@ -300,7 +304,9 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'NEXT' })).toBe(true);
+      expect(createActor(machine).getSnapshot().can({ type: 'NEXT' })).toBe(
+        true
+      );
     });
 
     it('should return true for an event object that results in a context change', () => {
@@ -318,7 +324,9 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'NEXT' })).toBe(true);
+      expect(createActor(machine).getSnapshot().can({ type: 'NEXT' })).toBe(
+        true
+      );
     });
 
     it('should return true for a reentering self-transition without actions', () => {
@@ -333,7 +341,7 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'EV' })).toBe(true);
+      expect(createActor(machine).getSnapshot().can({ type: 'EV' })).toBe(true);
     });
 
     it('should return true for a reentering self-transition with reentry action', () => {
@@ -349,7 +357,7 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'EV' })).toBe(true);
+      expect(createActor(machine).getSnapshot().can({ type: 'EV' })).toBe(true);
     });
 
     it('should return true for a reentering self-transition with transition action', () => {
@@ -367,7 +375,7 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'EV' })).toBe(true);
+      expect(createActor(machine).getSnapshot().can({ type: 'EV' })).toBe(true);
     });
 
     it('should return true for a targetless transition with actions', () => {
@@ -384,7 +392,7 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'EV' })).toBe(true);
+      expect(createActor(machine).getSnapshot().can({ type: 'EV' })).toBe(true);
     });
 
     it('should return false for a forbidden transition', () => {
@@ -399,7 +407,9 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'EV' })).toBe(false);
+      expect(createActor(machine).getSnapshot().can({ type: 'EV' })).toBe(
+        false
+      );
     });
 
     it('should return false for an unknown event', () => {
@@ -415,7 +425,7 @@ describe('State', () => {
         }
       });
 
-      expect(interpret(machine).getSnapshot().can({ type: 'UNKNOWN' })).toBe(
+      expect(createActor(machine).getSnapshot().can({ type: 'UNKNOWN' })).toBe(
         false
       );
     });
@@ -437,7 +447,7 @@ describe('State', () => {
       });
 
       expect(
-        interpret(machine).getSnapshot().can({
+        createActor(machine).getSnapshot().can({
           type: 'CHECK'
         })
       ).toBe(true);
@@ -460,7 +470,7 @@ describe('State', () => {
       });
 
       expect(
-        interpret(machine).getSnapshot().can({
+        createActor(machine).getSnapshot().can({
           type: 'CHECK'
         })
       ).toBe(false);
@@ -489,7 +499,7 @@ describe('State', () => {
         }
       });
 
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       service.getSnapshot().can({ type: 'SPAWN' });
       expect(spawned).toBe(false);
     });
@@ -509,7 +519,7 @@ describe('State', () => {
         }
       });
 
-      const actorRef = interpret(machine);
+      const actorRef = createActor(machine);
 
       expect(actorRef.getSnapshot().can({ type: 'EVENT' })).toBeTruthy();
 
@@ -531,7 +541,7 @@ describe('State', () => {
         }
       });
 
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
 
       expect(actorRef.getSnapshot().can({ type: 'EVENT' })).toBeTruthy();
 
@@ -567,7 +577,7 @@ describe('State', () => {
       });
 
       expect(
-        interpret(machine).getSnapshot().can({ type: 'EVENT' })
+        createActor(machine).getSnapshot().can({ type: 'EVENT' })
       ).toBeTruthy();
     });
 
@@ -594,7 +604,7 @@ describe('State', () => {
         }
       });
 
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       actorRef.send({ type: 'NEXT' });
 
       expect(actorRef.getSnapshot().can({ type: 'NEXT' })).toBeTruthy();
@@ -612,7 +622,7 @@ describe('State', () => {
         }
       });
 
-      const actorRef = interpret(machine).start();
+      const actorRef = createActor(machine).start();
       const persistedState = JSON.stringify(actorRef.getPersistedState());
       actorRef.stop();
       const restoredState = machine.createState(JSON.parse(persistedState));

--- a/packages/core/test/stateIn.test.ts
+++ b/packages/core/test/stateIn.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index.ts';
+import { createMachine, createActor } from '../src/index.ts';
 import { stateIn } from '../src/guards.ts';
 
 describe('transition "in" check', () => {
@@ -59,7 +59,7 @@ describe('transition "in" check', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT2' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -123,7 +123,7 @@ describe('transition "in" check', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT3' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -187,7 +187,7 @@ describe('transition "in" check', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT1' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -246,7 +246,7 @@ describe('transition "in" check', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT2' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -307,7 +307,7 @@ describe('transition "in" check', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT_DEEP' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -368,7 +368,7 @@ describe('transition "in" check', () => {
         }
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT_DEEP' });
 
     expect(actorRef.getSnapshot().value).toEqual({
@@ -411,7 +411,7 @@ describe('transition "in" check', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     actorRef.send({ type: 'TIMER' });
     actorRef.send({ type: 'TIMER' });
@@ -455,7 +455,7 @@ describe('transition "in" check', () => {
       }
     );
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
     actor.send({
       type: 'NEXT'
     });

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -9,7 +9,7 @@ import {
   fromObservable,
   fromPromise,
   fromTransition,
-  interpret,
+  createActor,
   sendTo,
   stop
 } from '../src/index.ts';
@@ -54,7 +54,7 @@ describe('system', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 
   it('should register a spawned actor', (done) => {
@@ -101,7 +101,7 @@ describe('system', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'toggle' });
   });
@@ -115,14 +115,14 @@ describe('system', () => {
     });
 
     // no .start() here is important for the test
-    const actor = interpret(machine);
+    const actor = createActor(machine);
 
     expect(actor.system.get('someChild')).toBeDefined();
   });
 
   it('root actor can be given the systemId', () => {
     const machine = createMachine({});
-    const actor = interpret(machine, { systemId: 'test' });
+    const actor = createActor(machine, { systemId: 'test' });
     expect(actor.system.get('test')).toBe(actor);
   });
 
@@ -143,7 +143,7 @@ describe('system', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.system.get('test')).toBeDefined();
 
@@ -166,7 +166,7 @@ describe('system', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.system.get('test')).toBeDefined();
 
@@ -201,7 +201,7 @@ describe('system', () => {
 
     const errorSpy = jest.fn();
 
-    const actorRef = interpret(machine, { systemId: 'test' });
+    const actorRef = createActor(machine, { systemId: 'test' });
     actorRef.subscribe({
       error: errorSpy
     });
@@ -228,7 +228,7 @@ describe('system', () => {
       }
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 
   it('should be accessible in referenced custom actions', () => {
@@ -249,7 +249,7 @@ describe('system', () => {
       }
     );
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 
   it('should be accessible in assign actions', () => {
@@ -263,7 +263,7 @@ describe('system', () => {
       })
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 
   it('should be accessible in sendTo actions', () => {
@@ -281,7 +281,7 @@ describe('system', () => {
       )
     });
 
-    interpret(machine).start();
+    createActor(machine).start();
   });
 
   it('should be accessible in promise logic', () => {
@@ -301,7 +301,7 @@ describe('system', () => {
       ]
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.system.get('test')).toBeDefined();
   });
@@ -325,7 +325,7 @@ describe('system', () => {
       ]
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.system.get('test')).toBeDefined();
 
@@ -351,7 +351,7 @@ describe('system', () => {
       ]
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.system.get('test')).toBeDefined();
   });
@@ -374,7 +374,7 @@ describe('system', () => {
       ]
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.system.get('test')).toBeDefined();
   });
@@ -395,7 +395,7 @@ describe('system', () => {
       ]
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     expect(actor.system.get('test')).toBeDefined();
   });

--- a/packages/core/test/tags.test.ts
+++ b/packages/core/test/tags.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index.ts';
+import { createMachine, createActor } from '../src/index.ts';
 
 describe('tags', () => {
   it('supports tagging states', () => {
@@ -23,7 +23,7 @@ describe('tags', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     expect(actorRef.getSnapshot().hasTag('go')).toBeTruthy();
     actorRef.send({ type: 'TIMER' });
     expect(actorRef.getSnapshot().hasTag('go')).toBeTruthy();
@@ -54,7 +54,7 @@ describe('tags', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     const initialState = actorRef.getSnapshot();
 
     expect(initialState.hasTag('go')).toBeFalsy();
@@ -94,7 +94,7 @@ describe('tags', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     expect(actorRef.getSnapshot().tags).toEqual(new Set(['yes']));
     actorRef.send({ type: 'DEACTIVATE' });
@@ -111,7 +111,7 @@ describe('tags', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({
       type: 'UNMATCHED'
     });
@@ -128,7 +128,7 @@ describe('tags', () => {
       }
     });
 
-    expect(interpret(machine).getSnapshot().hasTag('go')).toBeTruthy();
+    expect(createActor(machine).getSnapshot().hasTag('go')).toBeTruthy();
   });
 
   it('stringifies to an array', () => {
@@ -141,7 +141,7 @@ describe('tags', () => {
       }
     });
 
-    const jsonState = interpret(machine).getSnapshot().toJSON();
+    const jsonState = createActor(machine).getSnapshot().toJSON();
 
     expect(jsonState.tags).toEqual(['go', 'light']);
   });

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from '../src/index';
+import { createMachine, createActor } from '../src/index';
 import { raise } from '../src/actions/raise';
 import { assign } from '../src/actions/assign';
 import { stateIn } from '../src/guards';
@@ -46,7 +46,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'UPDATE_BUTTON_CLICKED' });
 
     expect(actorRef.getSnapshot().value).toEqual('D');
@@ -71,7 +71,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'UPDATE_BUTTON_CLICKED' });
 
     expect(actorRef.getSnapshot().value).toEqual('D');
@@ -95,7 +95,7 @@ describe('transient states (eventless transitions)', () => {
         F: {}
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'UPDATE_BUTTON_CLICKED' });
 
     expect(actorRef.getSnapshot().value).toEqual('F');
@@ -124,7 +124,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actor = interpret(machine).start();
+    const actor = createActor(machine).start();
 
     actor.send({ type: 'TIMER' });
 
@@ -188,7 +188,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'E' });
 
     expect(actorRef.getSnapshot().value).toEqual({ A: 'A2', B: 'B2', C: 'C4' });
@@ -245,7 +245,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'E' });
 
     expect(actorRef.getSnapshot().value).toEqual({ A: 'A4', B: 'B4' });
@@ -302,7 +302,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'E' });
 
     expect(actorRef.getSnapshot().value).toEqual({ A: 'A4', B: 'B4' });
@@ -350,7 +350,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'A' });
 
     expect(actorRef.getSnapshot().value).toEqual({ A: 'A2', B: 'B2', C: 'C2' });
@@ -398,18 +398,18 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'A' });
 
     expect(actorRef.getSnapshot().value).toEqual({ A: 'A2', B: 'B2', C: 'C2' });
   });
 
   it('should determine the resolved initial state from the transient state', () => {
-    expect(interpret(greetingMachine).getSnapshot().value).toEqual('morning');
+    expect(createActor(greetingMachine).getSnapshot().value).toEqual('morning');
   });
 
   it('should determine the resolved state from an initial transient state', () => {
-    const actorRef = interpret(greetingMachine).start();
+    const actorRef = createActor(greetingMachine).start();
 
     actorRef.send({ type: 'CHANGE' });
     expect(actorRef.getSnapshot().value).toEqual('morning');
@@ -444,7 +444,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'FOO' });
 
     expect(actorRef.getSnapshot().value).toBe('e');
@@ -464,7 +464,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'FOO' });
 
     expect(actorRef.getSnapshot().value).toBe('b');
@@ -488,7 +488,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'FOO' });
 
     expect(actorRef.getSnapshot().value).toBe('pass');
@@ -521,7 +521,7 @@ describe('transient states (eventless transitions)', () => {
       ]
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'ADD' });
 
     expect(actorRef.getSnapshot().done).toBe(true);
@@ -555,7 +555,7 @@ describe('transient states (eventless transitions)', () => {
       ]
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'ADD' });
 
     expect(actorRef.getSnapshot().done).toBe(true);
@@ -604,7 +604,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine);
+    const actorRef = createActor(machine);
     expect(() => actorRef.start()).not.toThrow();
   });
 
@@ -625,7 +625,7 @@ describe('transient states (eventless transitions)', () => {
         b: {}
       }
     });
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     shouldMatch = true;
     actorRef.send({ type: 'WHATEVER' });
@@ -657,7 +657,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
 
     shouldMatch = true;
     actorRef.send({ type: 'WHATEVER' });
@@ -690,7 +690,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     actorRef.send({ type: 'EVENT' });
 
     expect(actorRef.getSnapshot().done).toBe(true);
@@ -726,7 +726,7 @@ describe('transient states (eventless transitions)', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'EVENT', value: 42 });
   });
 });

--- a/packages/core/test/typeHelpers.test.ts
+++ b/packages/core/test/typeHelpers.test.ts
@@ -4,7 +4,7 @@ import {
   createMachine,
   SnapshotFrom,
   EventFrom,
-  interpret,
+  createActor,
   MachineImplementationsFrom,
   StateValueFrom,
   ActorLogic,
@@ -124,7 +124,7 @@ describe('EventFrom', () => {
       }
     });
 
-    const service = interpret(machine);
+    const service = createActor(machine);
 
     type InterpreterEvent = EventFrom<typeof service>;
 
@@ -314,7 +314,7 @@ describe('StateValueFrom', () => {
 
 describe('SnapshotFrom', () => {
   it('should return state type from a service that has concrete event type', () => {
-    const service = interpret(
+    const service = createActor(
       createMachine({
         types: {
           events: {} as { type: 'FOO' }
@@ -334,7 +334,7 @@ describe('SnapshotFrom', () => {
 
     function acceptState(_state: SnapshotFrom<typeof machine>) {}
 
-    acceptState(interpret(machine).getSnapshot());
+    acceptState(createActor(machine).getSnapshot());
     // @ts-expect-error
     acceptState("isn't any");
   });
@@ -348,7 +348,7 @@ describe('SnapshotFrom', () => {
 
     function acceptState(_state: SnapshotFrom<typeof machine>) {}
 
-    acceptState(interpret(machine).getSnapshot());
+    acceptState(createActor(machine).getSnapshot());
     // @ts-expect-error
     acceptState("isn't any");
   });
@@ -365,7 +365,7 @@ describe('ActorRefFrom', () => {
       actorRef.send({ type: 'TEST' });
     }
 
-    acceptActorRef(interpret(logic).start());
+    acceptActorRef(createActor(logic).start());
   });
 });
 

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -1,7 +1,7 @@
 import {
   ActorLogic,
   assign,
-  interpret,
+  createActor,
   MachineContext,
   StateMachine
 } from '../src/index.ts';
@@ -307,7 +307,7 @@ describe('typegen types', () => {
       }
     });
 
-    interpret(machine).getSnapshot().matches('a');
+    createActor(machine).getSnapshot().matches('a');
   });
 
   it('should allow valid object `matches`', () => {
@@ -324,7 +324,7 @@ describe('typegen types', () => {
       }
     });
 
-    interpret(machine).getSnapshot().matches({ a: 'c' });
+    createActor(machine).getSnapshot().matches({ a: 'c' });
   });
 
   it('should not allow invalid string `matches`', () => {
@@ -345,7 +345,7 @@ describe('typegen types', () => {
     });
 
     // @ts-expect-error
-    interpret(machine).getSnapshot().matches('d');
+    createActor(machine).getSnapshot().matches('d');
   });
 
   it('should not allow invalid object `matches`', () => {
@@ -363,7 +363,7 @@ describe('typegen types', () => {
     });
 
     // @ts-expect-error
-    interpret(machine).getSnapshot().matches({ a: 'd' });
+    createActor(machine).getSnapshot().matches({ a: 'd' });
   });
 
   it('should allow a valid tag with `hasTag`', () => {
@@ -383,7 +383,7 @@ describe('typegen types', () => {
       }
     });
 
-    interpret(machine).getSnapshot().hasTag('a');
+    createActor(machine).getSnapshot().hasTag('a');
   });
 
   it('should not allow an invalid tag with `hasTag`', () => {
@@ -404,7 +404,7 @@ describe('typegen types', () => {
     });
 
     // @ts-expect-error
-    interpret(machine).getSnapshot().hasTag('d');
+    createActor(machine).getSnapshot().hasTag('d');
   });
 
   it('`withConfig` should require all missing implementations ', () => {
@@ -464,7 +464,7 @@ describe('typegen types', () => {
       types: { typegen: {} as TypesMeta }
     });
 
-    interpret(machine);
+    createActor(machine);
   });
 
   it('should not allow to create an actor out of a machine with missing implementations', () => {
@@ -489,7 +489,7 @@ describe('typegen types', () => {
 
     // TODO: rethink this; should probably be done as a linter rule instead
     // @x-ts-expect-error
-    interpret(machine);
+    createActor(machine);
   });
 
   it('should allow to create an actor out of a machine with implementations provided through `withConfig`', () => {
@@ -512,7 +512,7 @@ describe('typegen types', () => {
       }
     });
 
-    interpret(
+    createActor(
       machine.provide({
         actions: {
           myAction: () => {}
@@ -1049,7 +1049,7 @@ describe('typegen types', () => {
       }
     });
 
-    const state = interpret(machine).getSnapshot();
+    const state = createActor(machine).getSnapshot();
 
     if (state.matches('a')) {
       // @ts-expect-error
@@ -1074,7 +1074,7 @@ describe('typegen types', () => {
       }
     });
 
-    const state = interpret(machine).getSnapshot();
+    const state = createActor(machine).getSnapshot();
 
     if (state.matches('a') && state.matches('a.b')) {
       ((_accept: string) => {})(state.context.foo);

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -7,7 +7,7 @@ import {
   ActorRefFrom,
   assign,
   createMachine,
-  interpret,
+  createActor,
   MachineContext,
   Spawner,
   StateMachine
@@ -267,7 +267,7 @@ describe('events', () => {
       entry: raise<any, any, any>({ type: 'FOO' })
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'FOO' });
     // @ts-expect-error
@@ -284,7 +284,7 @@ describe('events', () => {
       entry: () => {}
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     service.send({ type: 'FOO' });
     // @ts-expect-error
@@ -420,7 +420,7 @@ describe('events', () => {
 
 describe('interpreter', () => {
   it('should be convertable to Rx observable', () => {
-    const s = interpret(
+    const s = createActor(
       createMachine({
         types: {
           context: {} as { count: number }
@@ -1114,7 +1114,7 @@ describe('actor types', () => {
       }
     );
 
-    const snapshot = interpret(machine).getSnapshot();
+    const snapshot = createActor(machine).getSnapshot();
     const childSnapshot = snapshot.children.someChild!.getSnapshot();
 
     ((_accept: string | undefined) => {})(childSnapshot.context.foo);
@@ -1264,7 +1264,7 @@ describe('actor types', () => {
       }
     });
 
-    const childActor = interpret(machine).getSnapshot().children.myChild;
+    const childActor = createActor(machine).getSnapshot().children.myChild;
 
     ((_accept: ActorRefFrom<typeof child> | undefined) => {})(childActor);
     // @ts-expect-error
@@ -1287,7 +1287,7 @@ describe('actor types', () => {
       }
     });
 
-    const childActor = interpret(machine).getSnapshot().children.someChild;
+    const childActor = createActor(machine).getSnapshot().children.someChild;
 
     ((_accept: ActorRefFrom<typeof child> | undefined) => {})(childActor);
     // @ts-expect-error
@@ -1323,10 +1323,10 @@ describe('actor types', () => {
       }
     });
 
-    interpret(machine).getSnapshot().children.counter;
-    interpret(machine).getSnapshot().children.quiz;
+    createActor(machine).getSnapshot().children.counter;
+    createActor(machine).getSnapshot().children.quiz;
     // @ts-expect-error
-    interpret(machine).getSnapshot().children.someChild;
+    createActor(machine).getSnapshot().children.someChild;
   });
 
   it('when some provided actors have specified ids index signature should be allowed', () => {
@@ -1357,10 +1357,10 @@ describe('actor types', () => {
       }
     });
 
-    const counterActor = interpret(machine).getSnapshot().children.counter;
+    const counterActor = createActor(machine).getSnapshot().children.counter;
     ((_accept: ActorRefFrom<typeof child1> | undefined) => {})(counterActor);
 
-    const someActor = interpret(machine).getSnapshot().children.someChild;
+    const someActor = createActor(machine).getSnapshot().children.someChild;
     // @ts-expect-error
     ((_accept: ActorRefFrom<typeof child2> | undefined) => {})(someActor);
     ((
@@ -1686,7 +1686,7 @@ describe('input', () => {
       }
     });
 
-    interpret(machine, { input: { count: 100 } });
+    createActor(machine, { input: { count: 100 } });
   });
 
   it('should reject invalid input type when interpreting an actor', () => {
@@ -1698,7 +1698,7 @@ describe('input', () => {
       }
     });
 
-    interpret(machine, {
+    createActor(machine, {
       input: {
         // @ts-expect-error
         count: ''

--- a/packages/core/test/waitFor.test.ts
+++ b/packages/core/test/waitFor.test.ts
@@ -1,4 +1,4 @@
-import { interpret, waitFor } from '../src/index.ts';
+import { createActor, waitFor } from '../src/index.ts';
 import { createMachine } from '../src/index.ts';
 
 describe('waitFor', () => {
@@ -13,7 +13,7 @@ describe('waitFor', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     setTimeout(() => service.send({ type: 'NEXT' }), 10);
 
@@ -36,7 +36,7 @@ describe('waitFor', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     try {
       await waitFor(service, (state) => state.matches('c'), { timeout: 10 });
@@ -58,7 +58,7 @@ describe('waitFor', () => {
         c: {}
       }
     });
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     const result = await Promise.race([
       waitFor(service, (state) => state.matches('c'), {
         timeout: Infinity
@@ -83,7 +83,7 @@ describe('waitFor', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     setTimeout(() => {
       service.send({ type: 'NEXT' });
@@ -104,7 +104,7 @@ describe('waitFor', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     await expect(
       waitFor(service, (state) => state.matches('a'))
@@ -114,7 +114,7 @@ describe('waitFor', () => {
   it('should not subscribe when the predicate immediately matches', () => {
     const machine = createMachine({});
 
-    const actorRef = interpret(machine).start();
+    const actorRef = createActor(machine).start();
     const spy = jest.fn();
     actorRef.subscribe = spy;
 
@@ -137,7 +137,7 @@ describe('waitFor', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     await waitFor(service, (state) => {
       count++;
@@ -164,7 +164,7 @@ describe('waitFor', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     await expect(
@@ -187,7 +187,7 @@ describe('waitFor', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     service.send({ type: 'NEXT' });
 
     await expect(

--- a/packages/xstate-analytics/test/analytics.test.ts
+++ b/packages/xstate-analytics/test/analytics.test.ts
@@ -1,5 +1,5 @@
 import { createAnalyzer } from '../src/index.ts';
-import { createMachine, interpret } from 'xstate';
+import { createMachine, createActor } from 'xstate';
 
 const pedestrianStates = {
   initial: 'walk',
@@ -63,7 +63,7 @@ describe('@xstate/analytics', () => {
   it.skip('analyzes transition counts', () => {
     let analysis: any = {};
 
-    const service = interpret(lightMachine);
+    const service = createActor(lightMachine);
 
     service.subscribe(
       createAnalyzer((a) => {

--- a/packages/xstate-immer/test/immer.test.ts
+++ b/packages/xstate-immer/test/immer.test.ts
@@ -1,4 +1,4 @@
-import { createMachine, interpret } from 'xstate';
+import { createMachine, createActor } from 'xstate';
 import { assign, createUpdater, ImmerUpdateEvent } from '../src/index.ts';
 
 describe('@xstate/immer', () => {
@@ -21,7 +21,7 @@ describe('@xstate/immer', () => {
       }
     });
 
-    const actorRef = interpret(countMachine).start();
+    const actorRef = createActor(countMachine).start();
     expect(actorRef.getSnapshot().context).toEqual({ count: 0 });
 
     actorRef.send({ type: 'INC' });
@@ -57,7 +57,7 @@ describe('@xstate/immer', () => {
       }
     );
 
-    const actorRef = interpret(countMachine).start();
+    const actorRef = createActor(countMachine).start();
     expect(actorRef.getSnapshot().context).toEqual({ count: 0 });
 
     actorRef.send({ type: 'INC_TWICE' });
@@ -96,7 +96,7 @@ describe('@xstate/immer', () => {
       }
     );
 
-    const actorRef = interpret(countMachine).start();
+    const actorRef = createActor(countMachine).start();
     expect(actorRef.getSnapshot().context.foo.bar.baz).toEqual([1, 2, 3]);
 
     actorRef.send({ type: 'INC_TWICE' });
@@ -147,7 +147,7 @@ describe('@xstate/immer', () => {
       }
     });
 
-    const actorRef = interpret(countMachine).start();
+    const actorRef = createActor(countMachine).start();
     expect(actorRef.getSnapshot().context.foo.bar.baz).toEqual([1, 2, 3]);
 
     actorRef.send(bazUpdater.update(4));
@@ -212,7 +212,7 @@ describe('@xstate/immer', () => {
       }
     });
 
-    const service = interpret(formMachine);
+    const service = createActor(formMachine);
     service.subscribe({
       complete: () => {
         done();

--- a/packages/xstate-inspect/examples/server.ts
+++ b/packages/xstate-inspect/examples/server.ts
@@ -1,6 +1,6 @@
 import { inspect } from '@xstate/inspect/server';
 import WebSocket = require('ws');
-import { createMachine, interpret, sendTo } from 'xstate';
+import { createMachine, createActor, sendTo } from 'xstate';
 import { fromCallback } from 'xstate/actors';
 
 inspect({
@@ -39,6 +39,6 @@ const machine = createMachine({
   }
 });
 
-const actor = interpret(machine, { devTools: true });
+const actor = createActor(machine, { devTools: true });
 actor.subscribe((s) => console.log(s.value));
 actor.start();

--- a/packages/xstate-inspect/src/browser.ts
+++ b/packages/xstate-inspect/src/browser.ts
@@ -2,7 +2,7 @@ import {
   ActorRef,
   AnyInterpreter,
   EventObject,
-  interpret,
+  createActor,
   Observer,
   toObserver
 } from 'xstate';
@@ -106,7 +106,7 @@ export function inspect(options?: InspectorOptions): Inspector | undefined {
   }
 
   const inspectMachine = createInspectMachine(devTools, options);
-  const inspectService = interpret(inspectMachine).start();
+  const inspectService = createActor(inspectMachine).start();
   const listeners = new Set<Observer<any>>();
 
   const sub = inspectService.subscribe((state) => {

--- a/packages/xstate-inspect/src/server.ts
+++ b/packages/xstate-inspect/src/server.ts
@@ -1,5 +1,5 @@
 import { WebSocketServer } from 'ws';
-import { ActorRef, EventObject, interpret, Interpreter } from 'xstate';
+import { ActorRef, EventObject, createActor, Interpreter } from 'xstate';
 import { toActorRef } from 'xstate/actors';
 import { createInspectMachine, InspectMachineEvent } from './inspectMachine.ts';
 import { Inspector, Replacer } from './types.ts';
@@ -51,7 +51,7 @@ interface ServerInspectorOptions {
 export function inspect(options: ServerInspectorOptions): Inspector {
   const { server } = options;
   const devTools = createDevTools();
-  const inspectService = interpret(
+  const inspectService = createActor(
     createInspectMachine(devTools, options)
   ).start();
   let client: ActorRef<any, undefined> = toActorRef({

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -1,4 +1,4 @@
-import { assign, createMachine, interpret } from 'xstate';
+import { assign, createMachine, createActor } from 'xstate';
 import { createDevTools, inspect } from '../src/index.ts';
 
 // mute the warning about this not being implemented by jsdom
@@ -80,7 +80,7 @@ describe('@xstate/inspect', () => {
 
     iframeMock.initConnection();
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     // The devTools will notify the listeners:
     // 1. the built-in service listener
@@ -128,7 +128,7 @@ describe('@xstate/inspect', () => {
 
     iframeMock.initConnection();
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     expect(() => devTools.register(service)).not.toThrow();
 
@@ -186,7 +186,7 @@ describe('@xstate/inspect', () => {
 
     iframeMock.initConnection();
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     devTools.register(service);
 
@@ -256,7 +256,7 @@ describe('@xstate/inspect', () => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     devTools.onRegister(() => {
       done();
@@ -299,7 +299,7 @@ describe('@xstate/inspect', () => {
 
     iframeMock.initConnection();
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     devTools.register(service);
 
     iframeMock.flushMessages();
@@ -366,7 +366,7 @@ describe('@xstate/inspect', () => {
 
     iframeMock.initConnection();
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
     devTools.register(service);
 
     service.stop();

--- a/packages/xstate-react/src/useActorRef.ts
+++ b/packages/xstate-react/src/useActorRef.ts
@@ -6,7 +6,7 @@ import {
   AnyStateMachine,
   AreAllImplementationsAssumedToBeProvided,
   InternalMachineImplementations,
-  interpret,
+  createActor,
   ActorRefFrom,
   InterpreterOptions,
   InterpreterStatus,
@@ -34,7 +34,7 @@ export function useIdleInterpreter(
   }
 
   const actorRef = useConstant(() => {
-    return interpret(machine as AnyStateMachine, options);
+    return createActor(machine as AnyStateMachine, options);
   });
 
   // TODO: consider using `useAsapEffect` that would do this in `useInsertionEffect` is that's available

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -9,7 +9,7 @@ import {
   createMachine,
   DoneEventObject,
   doneInvoke,
-  interpret,
+  createActor,
   Interpreter,
   PersistedMachineState,
   raise,
@@ -64,7 +64,7 @@ describeEachReactMode('useActor (%s)', ({ suiteKey, render }) => {
     }
   });
 
-  const actorRef = interpret(
+  const actorRef = createActor(
     fetchMachine.provide({
       actors: {
         fetchData: fromCallback(({ sendBack }) => {
@@ -896,7 +896,7 @@ describeEachReactMode('useActor (%s)', ({ suiteKey, render }) => {
       }
     });
 
-    const actorRef = interpret(testMachine).start();
+    const actorRef = createActor(testMachine).start();
     const persistedState = JSON.stringify(actorRef.getPersistedState());
     actorRef.stop();
 

--- a/packages/xstate-react/test/useSelector.test.tsx
+++ b/packages/xstate-react/test/useSelector.test.tsx
@@ -7,7 +7,7 @@ import {
   assign,
   createMachine,
   fromTransition,
-  interpret,
+  createActor,
   StateFrom
 } from 'xstate';
 import {
@@ -329,8 +329,8 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
   });
 
   it('should immediately render snapshot of initially spawned custom actor', () => {
-    const createActor = (latestValue: string) =>
-      interpret({
+    const createCustomActor = (latestValue: string) =>
+      createActor({
         transition: (s) => s,
         subscribe: () => {
           return { unsubscribe: () => {} };
@@ -342,11 +342,11 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
     const parentMachine = createMachine({
       types: {
         context: {} as {
-          childActor: ReturnType<typeof createActor>;
+          childActor: ReturnType<typeof createCustomActor>;
         }
       },
       context: () => ({
-        childActor: createActor('foo')
+        childActor: createCustomActor('foo')
       })
     });
 
@@ -469,8 +469,8 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
   });
 
   it("should render snapshot value when actor doesn't emit anything", () => {
-    const createActor = (latestValue: string) =>
-      interpret({
+    const createCustomActor = (latestValue: string) =>
+      createActor({
         transition: (s) => s,
         subscribe: () => {
           return { unsubscribe: () => {} };
@@ -486,7 +486,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
         }
       },
       context: () => ({
-        childActor: createActor('foo')
+        childActor: createCustomActor('foo')
       })
     });
 
@@ -506,8 +506,8 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
   });
 
   it('should render snapshot state when actor changes', () => {
-    const createActor = (latestValue: string) =>
-      interpret({
+    const createCustomActor = (latestValue: string) =>
+      createActor({
         transition: (s) => s,
         subscribe: () => {
           return { unsubscribe: () => {} };
@@ -516,8 +516,8 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
         getInitialState: () => latestValue
       });
 
-    const actor1 = createActor('foo');
-    const actor2 = createActor('bar');
+    const actor1 = createCustomActor('foo');
+    const actor2 = createCustomActor('bar');
 
     const identitySelector = (value: any) => value;
 
@@ -538,7 +538,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
   });
 
   it("should keep rendering a new selected value after selector change when the actor doesn't emit", async () => {
-    const actor = interpret({
+    const actor = createActor({
       transition: (s) => s,
       subscribe: () => {
         return { unsubscribe: () => {} };
@@ -588,7 +588,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
       }
     });
 
-    const service = interpret(machine).start();
+    const service = createActor(machine).start();
 
     let renders = 0;
 
@@ -752,7 +752,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
           <button
             data-testid="button"
             onClick={() =>
-              setActor(interpret(fromTransition((s) => s, { count: 42 })))
+              setActor(createActor(fromTransition((s) => s, { count: 42 })))
             }
           >
             Set actor

--- a/packages/xstate-scxml/test/scxml.test.ts
+++ b/packages/xstate-scxml/test/scxml.test.ts
@@ -5,7 +5,7 @@ import {
   AnyStateMachine,
   createMachine,
   getStateNodes,
-  interpret,
+  createActor,
   SimulatedClock
 } from 'xstate';
 import { toMachine } from '../src/scxml';
@@ -26,7 +26,7 @@ async function runTestToCompletion(
 ): Promise<void> {
   let done = false;
 
-  const service = interpret(machine, {
+  const service = createActor(machine, {
     clock: new SimulatedClock()
   });
   let nextState: AnyState = service.getSnapshot();

--- a/packages/xstate-solid/src/createService.ts
+++ b/packages/xstate-solid/src/createService.ts
@@ -1,5 +1,5 @@
 import type { AnyStateMachine, InterpreterFrom } from 'xstate';
-import { interpret } from 'xstate';
+import { createActor } from 'xstate';
 import type { RestParams } from './types.ts';
 import { onCleanup } from 'solid-js';
 import { isServer } from 'solid-js/web';
@@ -19,7 +19,7 @@ export function createService<TMachine extends AnyStateMachine>(
 
   const machineWithConfig = machine.provide(machineConfig as any);
 
-  const service = interpret(machineWithConfig, interpreterOptions);
+  const service = createActor(machineWithConfig, interpreterOptions);
 
   if (!isServer) {
     service.start();

--- a/packages/xstate-solid/src/createSpawn.ts
+++ b/packages/xstate-solid/src/createSpawn.ts
@@ -1,11 +1,11 @@
 import { onCleanup } from 'solid-js';
 import { isServer } from 'solid-js/web';
-import { ActorRef, ActorLogic, EventObject, interpret } from 'xstate';
+import { ActorRef, ActorLogic, EventObject, createActor } from 'xstate';
 
 export function createSpawn<TState, TEvent extends EventObject>(
   logic: ActorLogic<TEvent, TState>
 ): ActorRef<TEvent, TState> {
-  const actorRef = interpret(logic);
+  const actorRef = createActor(logic);
 
   if (!isServer) {
     actorRef.start?.();

--- a/packages/xstate-solid/test/from._test.tsx
+++ b/packages/xstate-solid/test/from._test.tsx
@@ -1,5 +1,5 @@
 /* @jsxImportSource solid-js */
-import { assign, createMachine, interpret } from 'xstate';
+import { assign, createMachine, createActor } from 'xstate';
 import { render, fireEvent, screen } from 'solid-testing-library';
 import { createEffect, from } from 'solid-js';
 
@@ -18,7 +18,7 @@ describe("usage of interpret from core with Solid's from", () => {
     });
 
     const App = () => {
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       const serviceState = from(service);
 
       createEffect(() => {
@@ -46,7 +46,7 @@ describe("usage of interpret from core with Solid's from", () => {
     });
 
     const App = () => {
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       const serviceState = from(service);
       createEffect(() => {
         if (serviceState()!.matches('active')) {
@@ -84,7 +84,7 @@ describe("usage of interpret from core with Solid's from", () => {
     });
 
     const App = () => {
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       const serviceState = from(service);
 
       createEffect(() => {
@@ -137,8 +137,8 @@ describe("usage of interpret from core with Solid's from", () => {
     });
 
     const Test = () => {
-      const service1 = interpret(machine).start();
-      const service2 = interpret(machine).start();
+      const service1 = createActor(machine).start();
+      const service2 = createActor(machine).start();
       const state1 = from(service1);
       const state2 = from(service2);
       return (

--- a/packages/xstate-solid/test/useActor.test.tsx
+++ b/packages/xstate-solid/test/useActor.test.tsx
@@ -6,7 +6,7 @@ import {
   assign,
   ActorRef,
   ActorRefFrom,
-  interpret
+  createActor
 } from 'xstate';
 import { fireEvent, screen, render, waitFor } from 'solid-testing-library';
 import {
@@ -22,7 +22,7 @@ import {
 import { createStore, reconcile } from 'solid-js/store';
 
 const createSimpleActor = <T extends unknown>(value: T) =>
-  interpret({
+  createActor({
     transition: (s) => s,
     getSnapshot: () => value,
     getInitialState: () => value
@@ -144,7 +144,7 @@ describe('useActor', () => {
     });
 
     const Spawner = () => {
-      const [service] = createSignal(interpret(machine).start());
+      const [service] = createSignal(createActor(machine).start());
       const [current, send] = useActor(service);
 
       onMount(() => {
@@ -352,7 +352,7 @@ describe('useActor', () => {
     });
 
     const App = () => {
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       const [state, send] = useActor(service);
       const [toStrings, setToStrings] = createSignal(state().toStrings());
       createEffect(
@@ -417,7 +417,7 @@ describe('useActor', () => {
     });
 
     const App = () => {
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       const [state, send] = useActor(service);
       const [toJson, setToJson] = createSignal(state().toJSON());
       createEffect(
@@ -485,7 +485,7 @@ describe('useActor', () => {
     });
 
     const App = () => {
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       const [state, send] = useActor(service);
       const [canGo, setCanGo] = createSignal(state().hasTag('go'));
       createEffect(() => {
@@ -546,7 +546,7 @@ describe('useActor', () => {
     });
 
     const App = () => {
-      const service = interpret(machine).start();
+      const service = createActor(machine).start();
       const [state, send] = useActor(service);
       const [canToggle, setCanToggle] = createSignal(
         state().can({ type: 'TOGGLE' })
@@ -638,7 +638,7 @@ describe('useActor', () => {
   });
 
   it('should provide value from `actor.getSnapshot()` immediately', () => {
-    const simpleActor = interpret({
+    const simpleActor = createActor({
       transition: (s) => s,
       getSnapshot: () => 42,
       getInitialState: () => 42
@@ -903,7 +903,7 @@ describe('useActor', () => {
     });
 
     const Test = () => {
-      const [state, send] = useActor(interpret(actorMachine).start());
+      const [state, send] = useActor(createActor(actorMachine).start());
       const [changeIndex0, setChangeIndex0] = createSignal(0);
       const [changeIndex1, setChangeIndex1] = createSignal(0);
       const [changeRoot, setChangeRoot] = createSignal(0);
@@ -1188,7 +1188,7 @@ describe('useActor', () => {
         }
       }
     );
-    const counterService = interpret(counterMachine).start();
+    const counterService = createActor(counterMachine).start();
 
     const Counter = () => {
       const [state, send] = useActor(counterService);
@@ -1254,7 +1254,7 @@ describe('useActor', () => {
       }
     });
 
-    const counterService = interpret(machine).start();
+    const counterService = createActor(machine).start();
 
     const Comp = () => {
       let calls = 0;
@@ -1305,8 +1305,8 @@ describe('useActor', () => {
       }
     });
 
-    const counterService1 = interpret(counterMachine).start();
-    const counterService2 = interpret(counterMachine).start();
+    const counterService1 = createActor(counterMachine).start();
+    const counterService2 = createActor(counterMachine).start();
 
     const Counter = (props: {
       counterRef: Accessor<ActorRefFrom<typeof counterMachine>>;
@@ -1376,8 +1376,8 @@ describe('useActor', () => {
         }
       }
     });
-    const counterService1 = interpret(counterMachine2).start();
-    const counterService2 = interpret(counterMachine2).start();
+    const counterService1 = createActor(counterMachine2).start();
+    const counterService2 = createActor(counterMachine2).start();
 
     const Counter = (props: {
       counterRef: Accessor<ActorRefFrom<typeof counterMachine2>>;
@@ -1453,7 +1453,7 @@ describe('useActor', () => {
     });
 
     const Counter = () => {
-      const counterService = interpret(counterMachine2).start();
+      const counterService = createActor(counterMachine2).start();
       const [state, send] = useActor(counterService);
       const [effectCount, setEffectCount] = createSignal(0);
       createEffect(
@@ -1521,8 +1521,8 @@ describe('useActor', () => {
     });
 
     const Test = () => {
-      const service1 = interpret(machine).start();
-      const service2 = interpret(machine).start();
+      const service1 = createActor(machine).start();
+      const service2 = createActor(machine).start();
       const [state1, send1] = useActor(service1);
       const [state2, send2] = useActor(service2);
 

--- a/packages/xstate-solid/test/useMachine.test.tsx
+++ b/packages/xstate-solid/test/useMachine.test.tsx
@@ -8,7 +8,7 @@ import {
   InterpreterStatus,
   PersistedMachineState,
   raise,
-  interpret,
+  createActor,
   ActorLogicFrom
 } from 'xstate';
 import { render, screen, waitFor, fireEvent } from 'solid-testing-library';
@@ -69,7 +69,7 @@ describe('useMachine hook', () => {
     }
   });
 
-  const actorRef = interpret(
+  const actorRef = createActor(
     fetchMachine.provide({
       actors: {
         fetchData: fromCallback(({ sendBack }) => {
@@ -1700,7 +1700,7 @@ describe('useMachine (strict mode)', () => {
         }
       });
 
-      const actorRef = interpret(testMachine).start();
+      const actorRef = createActor(testMachine).start();
       const persistedState = JSON.stringify(actorRef.getPersistedState());
       actorRef.stop();
 

--- a/packages/xstate-svelte/src/useMachine.ts
+++ b/packages/xstate-svelte/src/useMachine.ts
@@ -4,7 +4,7 @@ import {
   AnyStateMachine,
   AreAllImplementationsAssumedToBeProvided,
   InternalMachineImplementations,
-  interpret,
+  createActor,
   InterpreterFrom,
   InterpreterOptions,
   StateFrom,
@@ -63,7 +63,7 @@ export function useMachine<TMachine extends AnyStateMachine>(
 
   const resolvedMachine = machine.provide(machineConfig as any);
 
-  const service = interpret(resolvedMachine, interpreterOptions).start();
+  const service = createActor(resolvedMachine, interpreterOptions).start();
 
   onDestroy(() => service.stop());
 

--- a/packages/xstate-svelte/test/UseSelector.svelte
+++ b/packages/xstate-svelte/test/UseSelector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { interpret, createMachine, assign } from 'xstate';
+  import { createActor, createMachine, assign } from 'xstate';
   import { useSelector } from '../src/index.ts';
 
   const machine = createMachine({
@@ -30,7 +30,7 @@
     }
   });
 
-  const service = interpret(machine).start();
+  const service = createActor(machine).start();
 
   const state = useSelector(service, (state) => state);
   const count = useSelector(service, (state) => state.context.count);

--- a/packages/xstate-svelte/test/UseSelectorCustomFn.svelte
+++ b/packages/xstate-svelte/test/UseSelectorCustomFn.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { interpret, createMachine, assign } from 'xstate';
+  import { createActor, createMachine, assign } from 'xstate';
   import { useSelector } from '../src/index.ts';
 
   const machine = createMachine<{ name: string }>({
@@ -17,7 +17,7 @@
     }
   });
 
-  const service = interpret(machine).start();
+  const service = createActor(machine).start();
 
   const name = useSelector(
     service,

--- a/packages/xstate-svelte/test/UseSelectorDeferredSubscription.svelte
+++ b/packages/xstate-svelte/test/UseSelectorDeferredSubscription.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { interpret, createMachine, assign } from 'xstate';
+  import { createActor, createMachine, assign } from 'xstate';
   import { get } from 'svelte/store';
   import { useSelector } from '../src/index.ts';
 
@@ -24,7 +24,7 @@
     }
   });
 
-  const service = interpret(machine).start();
+  const service = createActor(machine).start();
 
   const state = useSelector(service, (state) => state);
   const count = useSelector(service, (state) => state.context.count);

--- a/packages/xstate-svelte/test/interpreterAsReadable.svelte
+++ b/packages/xstate-svelte/test/interpreterAsReadable.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
   // this file acts as a type test
-  import { createMachine, interpret } from 'xstate';
+  import { createMachine, createActor } from 'xstate';
 
-  const service = interpret(
+  const service = createActor(
     createMachine({
       types: {
         context: {} as { count: number }

--- a/packages/xstate-svelte/test/useMachine.test.ts
+++ b/packages/xstate-svelte/test/useMachine.test.ts
@@ -2,9 +2,9 @@ import { render, fireEvent } from '@testing-library/svelte';
 import UseMachine from './UseMachine.svelte';
 import UseMachineNonPersistentSubcription from './UseMachineNonPersistentSubcription.svelte';
 import { fetchMachine } from './fetchMachine';
-import { doneInvoke, fromCallback, interpret } from 'xstate';
+import { doneInvoke, fromCallback, createActor } from 'xstate';
 
-const actorRef = interpret(
+const actorRef = createActor(
   fetchMachine.provide({
     actors: {
       fetchData: fromCallback(({ sendBack }) => {

--- a/packages/xstate-vue/src/useInterpret.ts
+++ b/packages/xstate-vue/src/useInterpret.ts
@@ -3,7 +3,7 @@ import {
   AnyStateMachine,
   AreAllImplementationsAssumedToBeProvided,
   InternalMachineImplementations,
-  interpret,
+  createActor,
   InterpreterFrom,
   InterpreterOptions,
   Observer,
@@ -63,7 +63,7 @@ export function useInterpret<TMachine extends AnyStateMachine>(
 
   const machineWithConfig = machine.provide(machineConfig as any);
 
-  const service = interpret(machineWithConfig, interpreterOptions).start();
+  const service = createActor(machineWithConfig, interpreterOptions).start();
 
   let sub: Subscription | undefined;
   onMounted(() => {

--- a/packages/xstate-vue/src/useSpawn.ts
+++ b/packages/xstate-vue/src/useSpawn.ts
@@ -1,4 +1,4 @@
-import { ActorRef, ActorLogic, EventObject, interpret } from 'xstate';
+import { ActorRef, ActorLogic, EventObject, createActor } from 'xstate';
 import { onBeforeUnmount } from 'vue';
 
 /**
@@ -11,7 +11,7 @@ import { onBeforeUnmount } from 'vue';
 export function useSpawn<TState, TEvent extends EventObject>(
   logic: ActorLogic<TEvent, TState>
 ): ActorRef<TEvent, TState> {
-  const actorRef = interpret(logic);
+  const actorRef = createActor(logic);
 
   actorRef.start?.();
   onBeforeUnmount(() => {

--- a/packages/xstate-vue/test/UseActorCreateSimple.vue
+++ b/packages/xstate-vue/test/UseActorCreateSimple.vue
@@ -13,10 +13,10 @@ import { ActorRef } from 'xstate';
 import { defineComponent, shallowRef } from 'vue';
 
 import { useActor } from '../src/index.ts';
-import { interpret } from 'xstate/src';
+import { createActor } from 'xstate/src';
 
 const createSimpleActor = (value: number): ActorRef<any, number> =>
-  interpret({
+  createActor({
     transition: (s) => s,
     getSnapshot: () => value,
     getInitialState: () => value,

--- a/packages/xstate-vue/test/UseActorSimple.vue
+++ b/packages/xstate-vue/test/UseActorSimple.vue
@@ -4,9 +4,9 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { interpret, ActorRef } from 'xstate';
+import { createActor, ActorRef } from 'xstate';
 import { useActor } from '../src/index.ts';
-const simpleActor: ActorRef<any, number> = interpret({
+const simpleActor: ActorRef<any, number> = createActor({
   transition: (s) => s,
   getSnapshot: () => 42,
   getInitialState: () => 42,

--- a/packages/xstate-vue/test/useActor.test.ts
+++ b/packages/xstate-vue/test/useActor.test.ts
@@ -4,7 +4,7 @@ import UseActorSimple from './UseActorSimple.vue';
 import UseActorCreateSimple from './UseActorCreateSimple.vue';
 import UseActorComponentProp from './UseActorComponentProp.vue';
 
-import { createMachine, interpret, sendParent } from 'xstate';
+import { createMachine, createActor, sendParent } from 'xstate';
 
 describe('useActor composable function', () => {
   it('initial invoked actor should be immediately available', async () => {
@@ -43,7 +43,7 @@ describe('useActor composable function', () => {
       }
     });
 
-    const serviceMachine = interpret(machine).start();
+    const serviceMachine = createActor(machine).start();
 
     const { getByTestId } = render(UseActorComponentProp, {
       props: { actor: serviceMachine.getSnapshot().children.child }

--- a/packages/xstate-vue/test/useMachine.test.ts
+++ b/packages/xstate-vue/test/useMachine.test.ts
@@ -5,7 +5,7 @@ import {
   createMachine,
   assign,
   doneInvoke,
-  interpret,
+  createActor,
   fromCallback
 } from 'xstate';
 import { CallbackActorLogic } from 'xstate/actors';
@@ -47,7 +47,7 @@ describe('useMachine composition function', () => {
     }
   });
 
-  const actorRef = interpret(
+  const actorRef = createActor(
     fetchMachine.provide({
       actors: {
         fetchData: fromCallback(({ sendBack }) => {


### PR DESCRIPTION
The `interpret(...)` function has been deprecated and renamed to `createActor(...)`:

```diff
-import { interpret } from 'xstate';
+import { createActor } from 'xstate';

-const actor = interpret(machine);
+const actor = createActor(machine);
```
