### PR TITLE
[v5] Output types

### DIFF
--- a/.changeset/swift-stingrays-notice.md
+++ b/.changeset/swift-stingrays-notice.md
@@ -1,0 +1,30 @@
+---
+'xstate': minor
+---
+
+Output types can now be specified in the machine:
+
+```ts
+const machine = createMachine({
+  types: {} as {
+    output: {
+      result: 'pass' | 'fail';
+      score: number;
+    };
+  }
+  // ...
+});
+
+const actor = createActor(machine);
+
+// ...
+
+const snapshot = actor.getSnapshot();
+
+if (snapshot.output) {
+  snapshot.output.result;
+  // strongly typed as 'pass' | 'fail'
+  snapshot.output.score;
+  // strongly typed as number
+}
+```

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -19,6 +19,7 @@ export function createMachine<
   TEvent extends EventObject = AnyEventObject,
   TActor extends ProvidedActor = ProvidedActor,
   TInput = any,
+  TOutput = any,
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 >(
   config: MachineConfig<
@@ -27,6 +28,7 @@ export function createMachine<
     ParameterizedObject,
     TActor,
     TInput,
+    TOutput,
     TTypesMeta
   >,
   implementations?: InternalMachineImplementations<
@@ -42,9 +44,10 @@ export function createMachine<
   ParameterizedObject,
   TActor,
   TInput,
+  TOutput,
   ResolveTypegenMeta<TTypesMeta, TEvent, ParameterizedObject, TActor>
 > {
-  return new StateMachine<any, any, any, any, any, any>(
+  return new StateMachine<any, any, any, any, any, any, any>(
     config as any,
     implementations as any
   );

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -19,7 +19,7 @@ export function createMachine<
   TEvent extends EventObject = AnyEventObject,
   TActor extends ProvidedActor = ProvidedActor,
   TInput = any,
-  TOutput = any,
+  TOutput = unknown,
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 >(
   config: MachineConfig<

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -5,7 +5,8 @@ import {
   InternalMachineImplementations,
   ParameterizedObject,
   ProvidedActor,
-  AnyEventObject
+  AnyEventObject,
+  NonReducibleUnknown
 } from './types.ts';
 import {
   TypegenConstraint,
@@ -19,7 +20,7 @@ export function createMachine<
   TEvent extends EventObject = AnyEventObject,
   TActor extends ProvidedActor = ProvidedActor,
   TInput = any,
-  TOutput = unknown,
+  TOutput = NonReducibleUnknown,
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 >(
   config: MachineConfig<

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -70,6 +70,7 @@ export class State<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TActor extends ProvidedActor,
+  TOutput,
   TResolvedTypesMeta = TypegenDisabled
 > {
   public tags: Set<string>;
@@ -82,7 +83,7 @@ export class State<
   /**
    * The done data of the top-level finite state.
    */
-  public output: any; // TODO: add an explicit type for `output`
+  public output: TOutput | undefined;
   public error: unknown;
   public context: TContext;
   public historyValue: Readonly<HistoryValue<TContext, TEvent>> = {};
@@ -105,10 +106,10 @@ export class State<
     TContext extends MachineContext,
     TEvent extends EventObject = EventObject
   >(
-    stateValue: State<TContext, TEvent, TODO, any> | StateValue,
+    stateValue: State<TContext, TEvent, TODO, any, any> | StateValue,
     context: TContext = {} as TContext,
     machine: AnyStateMachine
-  ): State<TContext, TEvent, TODO, any> {
+  ): State<TContext, TEvent, TODO, any, any> {
     if (stateValue instanceof State) {
       if (stateValue.context !== context) {
         return new State<TContext, TEvent, TODO, any>(

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -81,7 +81,7 @@ export class State<
    */
   public done: boolean;
   /**
-   * The done data of the top-level finite state.
+   * The output data of the top-level finite state.
    */
   public output: TOutput | undefined;
   public error: unknown;

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -84,7 +84,7 @@ export class StateMachine<
 
   public implementations: MachineImplementationsSimplified<TContext, TEvent>;
 
-  public types: MachineTypes<TContext, TEvent, TActor, TInput>;
+  public types: MachineTypes<TContext, TEvent, TActor, TInput, TOutput>;
 
   public __xstatenode: true = true;
 

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -101,7 +101,7 @@ export class StateMachine<
     /**
      * The raw config used to create the machine.
      */
-    public config: MachineConfig<TContext, TEvent, any, any, any>,
+    public config: MachineConfig<TContext, TEvent, any, any, any, TOutput, any>,
     implementations?: MachineImplementationsSimplified<TContext, TEvent>
   ) {
     this.id = config.id || '(machine)';

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -74,7 +74,7 @@ export class StateMachine<
       >,
       TODO,
       TInput,
-      TODO
+      TOutput
     >
 {
   /**

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -62,7 +62,7 @@ interface StateNodeOptions<
 > {
   _key: string;
   _parent?: StateNode<TContext, TEvent>;
-  _machine: StateMachine<TContext, TEvent, any, any, any>;
+  _machine: StateMachine<TContext, TEvent, any, any, any, any>;
 }
 
 export class StateNode<
@@ -142,7 +142,7 @@ export class StateNode<
     /**
      * The raw config used to create the machine.
      */
-    public config: StateNodeConfig<TContext, TEvent, TODO, TODO>,
+    public config: StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
     options: StateNodeOptions<TContext, TEvent>
   ) {
     this.parent = options._parent;
@@ -168,7 +168,7 @@ export class StateNode<
         ? mapValues(
             this.config.states,
             (
-              stateConfig: StateNodeConfig<TContext, TEvent, TODO, TODO>,
+              stateConfig: StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
               key
             ) => {
               const stateNode = new StateNode(stateConfig, {
@@ -343,7 +343,7 @@ export class StateNode<
   }
 
   public next(
-    state: State<TContext, TEvent, TODO>,
+    state: State<TContext, TEvent, TODO, TODO>,
     event: TEvent
   ): TransitionDefinition<TContext, TEvent>[] | undefined {
     const eventType = event.type;

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -334,7 +334,7 @@ type HistoryAttributeValue = 'shallow' | 'deep' | undefined;
 function toConfig(
   nodeJson: XMLElement,
   id: string
-): StateNodeConfig<any, any, any, any> {
+): StateNodeConfig<any, any, any, any, any> {
   const parallel = nodeJson.name === 'parallel';
   let initial = parallel ? undefined : nodeJson.attributes!.initial;
   const { elements } = nodeJson;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -674,7 +674,7 @@ export function getStateNodes<
   TEvent extends EventObject
 >(
   stateNode: AnyStateNode,
-  state: StateValue | State<TContext, TEvent, TODO>
+  state: StateValue | State<TContext, TEvent, TODO, TODO>
 ): Array<AnyStateNode> {
   const stateValue = state instanceof State ? state.value : toStateValue(state);
 
@@ -710,7 +710,7 @@ export function transitionAtomicNode<
 >(
   stateNode: AnyStateNode,
   stateValue: string,
-  state: State<TContext, TEvent, TODO>,
+  state: State<TContext, TEvent, TODO, TODO>,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   const childStateNode = getStateNode(stateNode, stateValue);
@@ -729,7 +729,7 @@ export function transitionCompoundNode<
 >(
   stateNode: AnyStateNode,
   stateValue: StateValueMap,
-  state: State<TContext, TEvent, TODO>,
+  state: State<TContext, TEvent, TODO, TODO>,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   const subStateKeys = Object.keys(stateValue);
@@ -755,7 +755,7 @@ export function transitionParallelNode<
 >(
   stateNode: AnyStateNode,
   stateValue: StateValueMap,
-  state: State<TContext, TEvent, TODO>,
+  state: State<TContext, TEvent, TODO, TODO>,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   const allInnerTransitions: Array<TransitionDefinition<TContext, TEvent>> = [];
@@ -791,7 +791,7 @@ export function transitionNode<
 >(
   stateNode: AnyStateNode,
   stateValue: StateValue,
-  state: State<TContext, TEvent, TODO, any>,
+  state: State<TContext, TEvent, TODO, TODO, TODO>,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   // leaf node
@@ -1003,11 +1003,11 @@ export function microstep<
   TEvent extends EventObject
 >(
   transitions: Array<TransitionDefinition<TContext, TEvent>>,
-  currentState: State<TContext, TEvent, TODO, any>,
+  currentState: AnyState,
   actorCtx: AnyActorContext,
   event: TEvent,
   isInitial: boolean
-): State<TContext, TEvent, TODO, any> {
+): AnyState {
   const mutConfiguration = new Set(currentState.configuration);
 
   if (!transitions.length) {
@@ -1399,7 +1399,7 @@ export function resolveActionsAndContext<
 >(
   actions: Action<any, any, any>[],
   event: TEvent,
-  currentState: State<TContext, TEvent, TODO, any>,
+  currentState: AnyState,
   actorCtx: AnyActorContext
 ): AnyState {
   const { machine } = currentState;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -413,9 +413,10 @@ export type StatesConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TAction extends ParameterizedObject,
-  TActor extends ProvidedActor
+  TActor extends ProvidedActor,
+  TOutput
 > = {
-  [K in string]: StateNodeConfig<TContext, TEvent, TAction, TActor, TODO>;
+  [K in string]: StateNodeConfig<TContext, TEvent, TAction, TActor, TOutput>;
 };
 
 export type StatesDefinition<
@@ -594,7 +595,7 @@ export interface StateNodeConfig<
   /**
    * The mapping of state node keys to their state node configurations (recursive).
    */
-  states?: StatesConfig<TContext, TEvent, TAction, TActor> | undefined;
+  states?: StatesConfig<TContext, TEvent, TAction, TActor, unknown> | undefined;
   /**
    * The services to invoke upon entering this state node. These services will be stopped upon exiting this state node.
    */
@@ -1041,6 +1042,7 @@ export type MachineConfig<
    */
   version?: string;
   types?: MachineTypes<TContext, TEvent, TActor, TInput, TOutput, TTypesMeta>;
+  states?: StatesConfig<TContext, TEvent, TAction, TActor, TOutput> | undefined;
 }) &
   (Equals<TContext, MachineContext> extends true
     ? { context?: InitialContext<LowInfer<TContext>, TInput> }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1021,6 +1021,19 @@ export type ContextFactory<TContext extends MachineContext, TInput> = ({
   input: TInput;
 }) => TContext;
 
+type RootStateNodeConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  TAction extends ParameterizedObject,
+  TActor extends ProvidedActor,
+  TOutput
+> = Omit<
+  StateNodeConfig<TContext, TEvent, TAction, TActor, TOutput>,
+  'states'
+> & {
+  states?: StatesConfig<TContext, TEvent, TAction, TActor, TOutput> | undefined;
+};
+
 export type MachineConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
@@ -1029,15 +1042,12 @@ export type MachineConfig<
   TInput = any,
   TOutput = unknown,
   TTypesMeta = TypegenDisabled
-> = (Omit<
-  StateNodeConfig<
-    NoInfer<TContext>,
-    NoInfer<TEvent>,
-    NoInfer<TAction>,
-    NoInfer<TActor>,
-    NoInfer<TOutput>
-  >,
-  'states'
+> = (RootStateNodeConfig<
+  NoInfer<TContext>,
+  NoInfer<TEvent>,
+  NoInfer<TAction>,
+  NoInfer<TActor>,
+  NoInfer<TOutput>
 > & {
   /**
    * The initial context (extended state)
@@ -1047,7 +1057,6 @@ export type MachineConfig<
    */
   version?: string;
   types?: MachineTypes<TContext, TEvent, TActor, TInput, TOutput, TTypesMeta>;
-  states?: StatesConfig<TContext, TEvent, TAction, TActor, TOutput> | undefined;
 }) &
   (Equals<TContext, MachineContext> extends true
     ? { context?: InitialContext<LowInfer<TContext>, TInput> }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1024,7 +1024,7 @@ export type MachineConfig<
   TAction extends ParameterizedObject = ParameterizedObject,
   TActor extends ProvidedActor = ProvidedActor,
   TInput = any,
-  TOutput = any,
+  TOutput = unknown,
   TTypesMeta = TypegenDisabled
 > = (StateNodeConfig<
   NoInfer<TContext>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -595,7 +595,9 @@ export interface StateNodeConfig<
   /**
    * The mapping of state node keys to their state node configurations (recursive).
    */
-  states?: StatesConfig<TContext, TEvent, TAction, TActor, unknown> | undefined;
+  states?:
+    | StatesConfig<TContext, TEvent, TAction, TActor, NonReducibleUnknown>
+    | undefined;
   /**
    * The services to invoke upon entering this state node. These services will be stopped upon exiting this state node.
    */
@@ -1027,12 +1029,15 @@ export type MachineConfig<
   TInput = any,
   TOutput = unknown,
   TTypesMeta = TypegenDisabled
-> = (StateNodeConfig<
-  NoInfer<TContext>,
-  NoInfer<TEvent>,
-  NoInfer<TAction>,
-  NoInfer<TActor>,
-  NoInfer<TOutput>
+> = (Omit<
+  StateNodeConfig<
+    NoInfer<TContext>,
+    NoInfer<TEvent>,
+    NoInfer<TAction>,
+    NoInfer<TActor>,
+    NoInfer<TOutput>
+  >,
+  'states'
 > & {
   /**
    * The initial context (extended state)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1480,9 +1480,10 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
   ? R extends StateMachine<
       infer TContext,
       infer TEvent,
-      any,
-      any,
-      any,
+      infer _TAction,
+      infer TActor,
+      infer _Tinput,
+      infer TOutput,
       infer TResolvedTypesMeta
     >
     ? ActorRef<
@@ -1490,8 +1491,8 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
         State<
           TContext,
           TEvent,
-          TODO, // TActor
-          TODO, // TOutput
+          TActor,
+          TOutput,
           AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
             ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
             : TResolvedTypesMeta
@@ -1654,7 +1655,8 @@ export type SnapshotFrom<T> = ReturnTypeOrValue<T> extends infer R
         infer ___,
         infer ____,
         infer _____,
-        infer ______
+        infer ______,
+        infer _______
       >
     ? StateFrom<R>
     : R extends ActorLogic<
@@ -1715,8 +1717,9 @@ type ResolveEventType<T> = ReturnTypeOrValue<T> extends infer R
     : R extends State<
         infer _TContext,
         infer TEvent,
-        infer _TAction,
-        infer _TActor
+        infer _TActor,
+        infer _TOutput,
+        infer _TResolvedTypesMeta
       >
     ? TEvent
     : R extends ActorRef<infer TEvent, infer _>
@@ -1744,17 +1747,19 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
     : R extends State<
         infer TContext,
         infer _TEvent,
-        infer _TAction,
-        infer _TActor
+        infer _TActor,
+        infer _TOutput,
+        infer _TResolvedTypesMeta
       >
     ? TContext
     : R extends Actor<infer TActorLogic>
     ? TActorLogic extends StateMachine<
         infer TContext,
         infer _TEvent,
-        infer _TActions,
-        infer _TActors,
+        infer _TAction,
+        infer _TActor,
         infer _TInput,
+        infer _TOutput,
         infer _TTypesMeta
       >
       ? TContext

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -646,7 +646,7 @@ export interface StateNodeConfig<
    * The output data will be evaluated with the current `context` and placed on the `.data` property
    * of the event.
    */
-  output?: Mapper<TContext, TEvent, TOutput> | NonReducibleUnknown;
+  output?: Mapper<TContext, TEvent, TOutput> | TOutput;
   /**
    * The unique ID of the state node, which can be referenced as a transition target via the
    * `#id` syntax.

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -1,4 +1,9 @@
-import { createMachine, createActor, assign } from '../src/index.ts';
+import {
+  createMachine,
+  createActor,
+  assign,
+  AnyActorRef
+} from '../src/index.ts';
 
 describe('final states', () => {
   it('should emit the "done.state.*" event when all nested states are in their final states', () => {
@@ -170,6 +175,11 @@ describe('final states', () => {
 
   it('output mapper should receive self', () => {
     const machine = createMachine({
+      types: {
+        output: {} as {
+          selfRef: AnyActorRef;
+        }
+      },
       initial: 'done',
       states: {
         done: {
@@ -180,6 +190,6 @@ describe('final states', () => {
     });
 
     const actor = createActor(machine).start();
-    expect(actor.getSnapshot().output.selfRef.send).toBeDefined();
+    expect(actor.getSnapshot().output!.selfRef.send).toBeDefined();
   });
 });

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -1,11 +1,5 @@
 import { of } from 'rxjs';
-import {
-  AnyActorLogic,
-  AnyActorRef,
-  AnyEventObject,
-  assign,
-  createActor
-} from '../src';
+import { AnyActorLogic, AnyActorRef, assign, createActor } from '../src';
 import { createMachine } from '../src/Machine';
 import {
   fromCallback,

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -188,6 +188,20 @@ describe('context', () => {
   });
 });
 
+describe('output', () => {
+  it('output type should be represented in state', () => {
+    const machine = createMachine({
+      types: {} as {
+        output: number;
+      }
+    });
+
+    const state = machine.getInitialState(null as any);
+
+    ((_accept: number | undefined) => {})(state.output);
+  });
+});
+
 it('should infer context type from `config.context` when there is no `schema.context`', () => {
   createMachine(
     {
@@ -235,7 +249,7 @@ it('should not use actions as possible inference sites', () => {
 it('should work with generic context', () => {
   function createMachineWithExtras<TContext extends MachineContext>(
     context: TContext
-  ): StateMachine<TContext, any, any, any, any> {
+  ): StateMachine<TContext, any, any, any, any, any> {
     return createMachine({ context });
   }
 
@@ -309,7 +323,7 @@ describe('events', () => {
     function acceptMachine<
       TContext extends {},
       TEvent extends { type: string }
-    >(_machine: StateMachine<TContext, TEvent, any, any, any>) {}
+    >(_machine: StateMachine<TContext, TEvent, any, any, any, any>) {}
 
     acceptMachine(toggleMachine);
   });

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -200,6 +200,29 @@ describe('output', () => {
 
     ((_accept: number | undefined) => {})(state.output);
   });
+
+  it('output on top level state should be typechecked', () => {
+    const machine = createMachine({
+      types: {} as {
+        output: number;
+      },
+      states: {
+        done: {
+          type: 'final',
+          // @ts-expect-error
+          output: 'a string'
+        },
+        doneCorrect: {
+          type: 'final',
+          output: 42
+        }
+      }
+    });
+
+    const state = machine.getInitialState(null as any);
+
+    ((_accept: number | undefined) => {})(state.output);
+  });
 });
 
 it('should infer context type from `config.context` when there is no `schema.context`', () => {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -210,6 +210,7 @@ describe('output', () => {
       types: {} as {
         output: number;
       },
+      initial: 'done',
       states: {
         done: {
           type: 'final',
@@ -224,6 +225,7 @@ describe('output', () => {
       types: {} as {
         output: number;
       },
+      initial: 'done',
       states: {
         done: {
           type: 'final',
@@ -239,6 +241,7 @@ describe('output', () => {
       types: {} as {
         output: number;
       },
+      initial: 'done',
       states: {
         done: {
           type: 'final',
@@ -253,6 +256,7 @@ describe('output', () => {
       types: {} as {
         output: number;
       },
+      initial: 'done',
       states: {
         done: {
           type: 'final',
@@ -272,6 +276,7 @@ describe('output', () => {
         };
       },
       context: { password: 'okoń' },
+      initial: 'done',
       states: {
         done: {
           type: 'final',
@@ -297,6 +302,7 @@ describe('output', () => {
         };
       },
       context: { password: 'okoń' },
+      initial: 'secret',
       states: {
         secret: {
           initial: 'reveal',

--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -19,6 +19,7 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
     infer TAction,
     infer TActorMap,
     infer TInput,
+    infer TOutput,
     infer TResolvedTypesMeta
   >
     ? StateMachine<
@@ -27,6 +28,7 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
         TAction,
         TActorMap,
         TInput,
+        TOutput,
         AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
           ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
           : TResolvedTypesMeta

--- a/packages/xstate-scxml/src/scxml.ts
+++ b/packages/xstate-scxml/src/scxml.ts
@@ -350,7 +350,7 @@ type HistoryAttributeValue = 'shallow' | 'deep' | undefined;
 function toConfig(
   nodeJson: XMLElement,
   id: string
-): StateNodeConfig<any, any, any, any> {
+): StateNodeConfig<any, any, any, any, any> {
   const parallel = nodeJson.name === 'parallel';
   let initial = parallel ? undefined : nodeJson.attributes!.initial;
   const { elements } = nodeJson;

--- a/packages/xstate-solid/src/types.ts
+++ b/packages/xstate-solid/src/types.ts
@@ -15,9 +15,10 @@ type StateObject<
   TContext extends MachineContext,
   TEvent extends EventObject = EventObject,
   TActor extends ProvidedActor = ProvidedActor,
+  TOutput = unknown,
   TResolvedTypesMeta = TypegenDisabled
 > = Pick<
-  State<TContext, TEvent, TActor, any, TResolvedTypesMeta>,
+  State<TContext, TEvent, TActor, TOutput, TResolvedTypesMeta>,
   keyof AnyState
 >;
 
@@ -27,9 +28,10 @@ export type CheckSnapshot<Snapshot> = Snapshot extends State<
   infer TContext,
   infer TEvents,
   infer TActor,
+  infer TOutput,
   infer TResolvedTypesMeta
 >
-  ? StateObject<TContext, TEvents, TActor, TResolvedTypesMeta>
+  ? StateObject<TContext, TEvents, TActor, TOutput, TResolvedTypesMeta>
   : Snapshot;
 
 type InternalMachineOpts<

--- a/packages/xstate-solid/src/types.ts
+++ b/packages/xstate-solid/src/types.ts
@@ -16,7 +16,10 @@ type StateObject<
   TEvent extends EventObject = EventObject,
   TActor extends ProvidedActor = ProvidedActor,
   TResolvedTypesMeta = TypegenDisabled
-> = Pick<State<TContext, TEvent, TActor, TResolvedTypesMeta>, keyof AnyState>;
+> = Pick<
+  State<TContext, TEvent, TActor, any, TResolvedTypesMeta>,
+  keyof AnyState
+>;
 
 // Converts a State class type to a POJO State type. This reflects that the state
 // is being spread into a new object for reactive tracking in SolidJS

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -36,7 +36,7 @@ export interface TestStateNodeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject
 > extends Pick<
-    StateNodeConfig<TContext, TEvent, TODO, TODO>,
+    StateNodeConfig<TContext, TEvent, TODO, TODO, TODO>,
     | 'type'
     | 'history'
     | 'on'
@@ -74,9 +74,9 @@ export type TestMachineOptions<
 export interface TestMeta<T, TContext extends MachineContext> {
   test?: (
     testContext: T,
-    state: State<TContext, any, any>
+    state: State<TContext, any, any, any>
   ) => Promise<void> | void;
-  description?: string | ((state: State<TContext, any, any>) => string);
+  description?: string | ((state: State<TContext, any, any, any>) => string);
   skip?: boolean;
 }
 interface TestStateResult {
@@ -146,7 +146,7 @@ export interface TestTransitionConfig<
   TTestContext
 > extends TransitionConfig<TContext, TEvent> {
   test?: (
-    state: State<TContext, TEvent, any>,
+    state: State<TContext, TEvent, any, any>,
     testContext: TTestContext
   ) => void;
 }

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -29,7 +29,7 @@ export interface TestMachineConfig<
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 > extends TestStateNodeConfig<TContext, TEvent> {
   context?: MachineConfig<TContext, TEvent>['context'];
-  types?: MachineTypes<TContext, TEvent, TODO, TTypesMeta>;
+  types?: MachineTypes<TContext, TEvent, TODO, TODO, TTypesMeta>;
 }
 
 export interface TestStateNodeConfig<


### PR DESCRIPTION
Output types can now be specified in the machine:

```ts
const machine = createMachine({
  types: {} as {
    output: {
      result: 'pass' | 'fail';
      score: number;
    };
  }
  // ...
});

const actor = createActor(machine);

// ...

const snapshot = actor.getSnapshot();

if (snapshot.output) {
  snapshot.output.result;
  // strongly typed as 'pass' | 'fail'
  snapshot.output.score;
  // strongly typed as number
}
```
