### PR TITLE
[v5] Routable states

### DIFF
--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -453,6 +453,18 @@ export function formatTransitions<
     }
     existing.push(delayedTransition);
   }
+  Object.values(stateNode.states).forEach((sn) => {
+    if (sn.config.route) {
+      const eventType = `xstate.route.${sn.path.join('.')}`;
+      const transition: TransitionConfig<TContext, TEvent> = {
+        target: `.${sn.key}`
+      };
+
+      transitions.set(eventType, [
+        formatTransition(stateNode, eventType, transition)
+      ]);
+    }
+  });
   return transitions as Map<string, TransitionDefinition<TContext, any>[]>;
 }
 

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -457,6 +457,7 @@ export function formatTransitions<
     if (sn.config.route) {
       const eventType = `xstate.route.${sn.path.join('.')}`;
       const transition: TransitionConfig<TContext, TEvent> = {
+        ...sn.config.route,
         target: `.${sn.key}`
       };
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -669,7 +669,19 @@ export interface StateNodeConfig<
    * A default target for a history state
    */
   target?: string;
-  route?: boolean;
+  route?: RouteTransitionConfig<TContext, TEvent>;
+}
+
+export interface RouteTransitionConfig<
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> {
+  guard?: GuardConfig<TContext, TEvent>;
+  actions?: Actions<TContext, TEvent>;
+  reenter?: boolean;
+  meta?: Record<string, any>;
+  description?: string;
+  // no target because target is self
 }
 
 export interface StateNodeDefinition<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -669,6 +669,7 @@ export interface StateNodeConfig<
    * A default target for a history state
    */
   target?: string;
+  route?: boolean;
 }
 
 export interface StateNodeDefinition<

--- a/packages/core/test/route.test.ts
+++ b/packages/core/test/route.test.ts
@@ -1,0 +1,31 @@
+import { createActor, createMachine } from '../src';
+
+describe('route', () => {
+  it('should transition directly to a route if route: true', () => {
+    const machine = createMachine({
+      id: 'routeTest',
+      initial: 'a',
+      states: {
+        a: {},
+        b: {
+          route: true
+        },
+        c: {}
+      }
+    });
+
+    const actor = createActor(machine).start();
+
+    actor.send({
+      type: 'xstate.route.b'
+    });
+
+    expect(actor.getSnapshot().value).toEqual('b');
+
+    actor.send({
+      type: 'xstate.route.c'
+    });
+
+    expect(actor.getSnapshot().value).toEqual('b');
+  });
+});

--- a/packages/core/test/route.test.ts
+++ b/packages/core/test/route.test.ts
@@ -1,14 +1,14 @@
 import { createActor, createMachine } from '../src';
 
 describe('route', () => {
-  it('should transition directly to a route if route: true', () => {
+  it('should transition directly to a route if route is an empty transition config', () => {
     const machine = createMachine({
       id: 'routeTest',
       initial: 'a',
       states: {
         a: {},
         b: {
-          route: true
+          route: {}
         },
         c: {}
       }
@@ -27,5 +27,86 @@ describe('route', () => {
     });
 
     expect(actor.getSnapshot().value).toEqual('b');
+  });
+
+  it('should transition directly to a route if guard passes', () => {
+    const machine = createMachine({
+      id: 'routeTest',
+      initial: 'a',
+      states: {
+        a: {},
+        b: {
+          route: {
+            guard: () => false
+          }
+        },
+        c: {
+          route: {
+            guard: () => true
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+
+    expect(actor.getSnapshot().value).toEqual('a');
+
+    actor.send({
+      type: 'xstate.route.b'
+    });
+
+    expect(actor.getSnapshot().value).toEqual('a');
+
+    actor.send({
+      type: 'xstate.route.c'
+    });
+
+    expect(actor.getSnapshot().value).toEqual('c');
+  });
+
+  it('should work with parallel states', () => {
+    const todoMachine = createMachine({
+      type: 'parallel',
+      states: {
+        todo: {
+          initial: 'new',
+          states: {
+            new: {},
+            editing: {}
+          }
+        },
+        filter: {
+          initial: 'all',
+          states: {
+            all: {
+              route: {}
+            },
+            active: {
+              route: {}
+            },
+            completed: {
+              route: {}
+            }
+          }
+        }
+      }
+    });
+
+    const todoActor = createActor(todoMachine).start();
+
+    expect(todoActor.getSnapshot().value).toEqual({
+      todo: 'new',
+      filter: 'all'
+    });
+
+    todoActor.send({
+      type: 'xstate.route.filter.active'
+    });
+
+    expect(todoActor.getSnapshot().value).toEqual({
+      todo: 'new',
+      filter: 'active'
+    });
   });
 });


### PR DESCRIPTION
This PR enables developers to mark states as "routes" by providing a `route` config, which is just a normal transition config without the target:

```ts
const todoMachine = createMachine({
  type: 'parallel',
  states: {
    todo: {
      initial: 'new',
      states: {
        new: {},
        editing: {}
      }
    },
    filter: {
      initial: 'all',
      states: {
        all: {
          route: {}
        },
        active: {
          route: {}
        },
        completed: {
          route: {}
        }
      }
    }
  }
});

const todoActor = createActor(todoMachine).start();

todoActor.send({ type: 'xstate.route.filter.active' });
// => transitions directly to { todo: 'new', filter: 'active' }
```

The motivation for this is that there are many use-cases for wanting to transition directly to a state, such as in modeling page routes or steps in a multi-step form. Previously, you needed to manually hard-code transitions for these, which resulted in an unnatural and verbose state machine definition.