### PR TITLE
[v5] Resumable promise logic

### DIFF
--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -50,7 +50,7 @@ export function fromPromise<T, TInput>(
     input: TInput;
     system: AnyActorSystem;
     self: PromiseActorRef<T>;
-    step: <T>(name: string, promise: Promise<T>) => Promise<T>;
+    step: <T>(name: string, promiseCreator: () => Promise<T>) => Promise<T>;
   }) => PromiseLike<T>
 ): PromiseActorLogic<T, TInput> {
   // TODO: add event types
@@ -101,7 +101,12 @@ export function fromPromise<T, TInput>(
         return;
       }
 
-      function step(name: string, promise: Promise<any>) {
+      function step(name: string, promiseCreator: () => Promise<any>) {
+        if (state.steps?.[name]) {
+          return state.steps[name][1];
+        }
+
+        const promise = promiseCreator();
         return promise.then(
           (result) => {
             self.send({


### PR DESCRIPTION
This PR introduces a `step(...)` wrapper to persist intermediate state in promises.

The `step(name, promiseFn)` function executes the promise created by the `promiseFn` the first time, and persists its result to the actor's internal state.

The promise actor's state can then be persisted (`actor.getPersistedState()`) and restored normally (`createActor(logic, { state })`) and the logic will essentially "resume" at the latest incomplete `step(...)`. The way this works is by using persisted values for previous steps; if there is a persisted value, no need to run the promise again.

```ts
const flow = fromPromise(async ({ step }) => {
  const user = await step('user', () => fetchUser());

  const friends = await step('friends', () => fetchFriends(user.id));

  if (friends.length > 0) {
    const party = await step('plan party', () => createEvent(user, friends));
    return party;
  }

  return null;
});
```

**Motivation**

This would be _completely opt-in_ - you can create promise logic as normal. Calling async functions in a named `step(name, promiseFn)` gives you a couple benefits:

- **Simple visualization** - we can show a basic partial state machine for previously executed steps
- **Persistence** - we can persist the results of each step (make sure they're uniquely named!) so that when we restore a promise, it can fast-forward to where you left off
- **Observability** - when hooked up to Stately in the future, you can see the status/result of each step visualized on a sequence diagram