### PR TITLE
[v5] provide AbortSignal to fromPromise

### DIFF
--- a/packages/core/test/actorLogic.test.ts
+++ b/packages/core/test/actorLogic.test.ts
@@ -215,6 +215,33 @@ describe('promise logic (fromPromise)', () => {
 
     createActor(promiseLogic).start();
   });
+
+  it('should have reference to not aborted abort signal', () => {
+    let signal: AbortSignal | undefined = undefined;
+    const promiseLogic = fromPromise(({ signal: s }) => {
+      signal = s;
+      return Promise.resolve(42);
+    });
+
+    createActor(promiseLogic).start();
+
+    expect(signal).toBeDefined();
+    expect(signal!.aborted).toEqual(false);
+  });
+
+  it('should abort the abort signal upon stop()', () => {
+    let signal: AbortSignal | undefined = undefined;
+    const promiseLogic = fromPromise(({ signal: s }) => {
+      signal = s;
+      return new Promise((res) => setTimeout(() => res(42), 100));
+    });
+
+    createActor(promiseLogic).start().stop();
+
+    expect(signal).toBeDefined();
+    expect(signal!.aborted).toEqual(true);
+    expect(signal!.reason).toEqual('Actor recieved stop signal');
+  });
 });
 
 describe('transition function logic (fromTransition)', () => {


### PR DESCRIPTION
This PR allows fromPromise actors to consume an AbortSignal which is aborted once the actor receives the `stop` event.
A consumer can then cancel (long) running promises. Example:

```js
const logic = fromPromise(({event, signal}) => {
  const response = await fetch(`https://example.com/users/${event.userId}`, {signal});
  return response.json();
})
```

 