### PR TITLE
Change `State['nextEvents']` return type to `string[]`

### DIFF
--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -244,7 +244,7 @@ export class State<
   /**
    * The next events that will cause a transition from the current state.
    */
-  public get nextEvents(): Array<TEvent['type']> {
+  public get nextEvents(): Array<string> {
     return memo(this, 'nextEvents', () => {
       return [
         ...new Set(flatten([...this.configuration.map((sn) => sn.ownEvents)]))


### PR DESCRIPTION
Currently, the returned values are **event descriptors**. Usually, they match `TEvent["type"]` but they don't have to. Values like this `foo.*` can be returned from this method.