### PR TITLE
Update docs url on xstate.js.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
         <a href="https://github.com/statelyai/xstate">GitHub</a>
       </li>
       <li class="link" style="--i: 1">
-        <a href="/docs">Docs</a>
+        <a href="https://stately.ai/docs/xstate">Docs</a>
       </li>
       <li class="link" style="--i: 2">
         <a href="https://stately.ai/viz">Visualizer</a>


### PR DESCRIPTION
This PR updates the docs URL on xstate.js.org so it points to the new XState docs.