### PR TITLE
Use `never` for contravariant parameters of `UnknownAction`

### DIFF
--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -279,7 +279,7 @@ export class StateMachine<
       const assignment = ({ spawn, event }: any) =>
         context({ spawn, input: event.input });
       return resolveActionsAndContext(
-        [assign(assignment)],
+        [assign(assignment as never)],
         initEvent as TEvent,
         preInitial,
         actorCtx

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -302,7 +302,9 @@ export function getDelayedTransitions(
     const delayRef =
       typeof delay === 'function' ? `${stateNode.id}:delay[${i}]` : delay;
     const eventType = after(delayRef, stateNode.id);
-    stateNode.entry.push(raise({ type: eventType }, { id: eventType, delay }));
+    stateNode.entry.push(
+      raise({ type: eventType }, { id: eventType, delay }) as never
+    );
     stateNode.exit.push(cancel(eventType));
     return eventType;
   };
@@ -1395,12 +1397,9 @@ interface BuiltinAction {
   execute: (actorContext: AnyActorContext, params: unknown) => void;
 }
 
-export function resolveActionsAndContext<
-  TContext extends MachineContext,
-  TEvent extends EventObject
->(
+export function resolveActionsAndContext(
   actions: UnknownAction[],
-  event: TEvent,
+  event: EventObject,
   currentState: AnyState,
   actorCtx: AnyActorContext
 ): AnyState {
@@ -1419,13 +1418,13 @@ export function resolveActionsAndContext<
         // it's fine to cast this here to get a common type and lack of errors in the rest of the code
         // our logic below makes sure that we call those 2 "variants" correctly
         (
-          machine.implementations.actions as Record<
+          machine.implementations.actions as any as Record<
             string,
             ActionFunction<
               MachineContext,
+              never,
               EventObject,
-              EventObject,
-              ParameterizedObject | undefined,
+              never,
               ParameterizedObject
             >
           >
@@ -1436,15 +1435,15 @@ export function resolveActionsAndContext<
     }
 
     const args = {
-      context: intermediateState.context,
-      event,
+      context: intermediateState.context as never,
+      event: event as never,
       self: actorCtx?.self,
       system: actorCtx?.system,
-      action: isInline
+      action: (isInline
         ? undefined
         : typeof action === 'string'
         ? { type: action }
-        : action
+        : action) as never
     };
 
     if (!('resolve' in resolved)) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -192,10 +192,10 @@ export type Action<
     >;
 
 export type UnknownAction = Action<
-  MachineContext,
+  never,
+  never,
   EventObject,
-  EventObject,
-  ParameterizedObject | undefined,
+  never,
   ParameterizedObject
 >;
 


### PR DESCRIPTION
This is kinda more correct because right now this is OK and t shouldn't ([TS playground](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgYygUwIYzQWQ8gC2ADs04BfOAMyghDgCIAPAZxizQYG44B6XuDACeYNCwBccAKwA6AAzyAtACM07GQCYAzACgdyCMTZx6AXhToOeQiTQAKBDriCRYyQkoYWiOGgBuaMQwEj7CopIMAGIA8tEMFBQANDrkAJRcegZG8ADa+DDAhgC6cOYgMrQQMDKBMFBCGTrAVHB2YWgQLfmFxKWm5gxUAK7EyAWGDKmITnDdhg4zzlnYTDDu5MnOzv617i7hjABCAIIASvEbi7NjPZIjACZoVLb3yVcsaAA2VOuz3hjEISbLYsIRsNAgX5eWaA4FpDLkHRAA)):
```ts
import { createMachine } from "xstate"; // types: 5.0.0-beta.23

const m = createMachine({
  types: {} as { events: { type: "FOO" } },
});

const [action] = m.root.entry;

if (typeof action === "function") {
  action({
    context: {},
    event: { type: "BAR" },
    action: undefined,

    self: {} as any,
    system: {} as any,
  });
}
```

I think that ideally, we'd just hide `.actions` as much as possible and disallow their public consumption. We might need to do some introspection at runtime ourselves but that can be achieved through private APIs.

It might be easier to expose those things publicly but then what this PR does is a safety improvement. One can try to introspect actions but they should be treated as opaque objects. If somebody wants to check if an action is a function then that can be done, its `.name` can be read, etc. However, the action function obtained this way shouldn't be callable - and that's what this PR does in a way.

As we might see here - I had to introduce some extra casts internally to satisfy this type. So there are some usability concerns for ourselves here. I think that perhaps the real issue might be that we are reusing this type internally and publicly. Internally we could likely avoid casts like this if we'd refactor most of our stuff to a public+private signature combos, something like:
```ts
function acceptEvent<TEvent extends { type: string }>(ev: TEvent): void; // public signature
function acceptEvent(ev: { type: string }) {} // private signature aka implementation
```

This way we'd lose some type-safety internally but usually it's rather unlikely that we'd mix those types somehow. To mitigate those risks we could use branded types though:
```ts
const tEvent = Symbol();
type TEvent = { type: string; [tEvent]?: 1 };

function acceptEvent<TEvent extends { type: string }>(ev: TEvent): void;
function acceptEvent(ev: TEvent) {}
``` 

This wouldn't help us to avoid passing one `TEvent` to another `TEvent` (when for example sending an event to another actor) but to mitigate this we could introduce more brands and type specific places with different branded event types (so we could have branded `TEvent` and `TForeignEvent`).

We can also continue using generics and propagate them through all layers. It's quite tedious to do so and we end up casting things at times to our generics or `any`.

Overall, casting internally is kinda inevitable - separating internal and public signatures is also a form of casting since TS allows implementation signatures to differ from their public signatures quite significantly. It's a tradeoff for sure - one way or another. Non-generic types would be easier to work with internally though.

Circling back to this `never` thing...  as I mentioned, part of the problem right now is that we reuse `UnknownAction` between internal and public sites. We could also consider using the current `UnknownAction` internally but type `StateNode['actions']` using a different type that would include `(arg: never) => void`. Actually, we could even just "taint" it with this type like this:
```ts
  public entry: (UnknownAction | ((arg: never) => void))[];
```

Either way... I don't really intend to land this PR right now. It's just my brain dump that I wanted to share with you.