### PR TITLE
[v5] Add `.stateNode` for actions and guards

### DIFF
--- a/.changeset/shiny-laws-juggle.md
+++ b/.changeset/shiny-laws-juggle.md
@@ -1,0 +1,28 @@
+---
+'xstate': minor
+---
+
+The `stateNode` where an action or guard originates can now be read in the action or guard's provided implementation, or inline:
+
+```ts
+const machine = createMachine({
+  initial: 'idle',
+  states: {
+    idle: {
+      meta: { message: 'I am idle', enabled: true },
+
+      entry: ({ stateNode }) => {
+        stateNode.message; // 'I am idle'
+      },
+
+      on: {
+        someEvent: {
+          guard: ({ stateNode }) => {
+            return stateNode.enabled; // true
+          }
+        }
+      }
+    }
+  }
+});
+```

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -293,7 +293,7 @@ export class StateMachine<
       const assignment = ({ spawn, event }: any) =>
         context({ spawn, input: event.input });
       return resolveActionsAndContext(
-        [assign(assignment)],
+        [[assign(assignment), this.root]],
         initEvent as TEvent,
         preInitial,
         actorCtx

--- a/packages/core/src/actions/assign.ts
+++ b/packages/core/src/actions/assign.ts
@@ -43,7 +43,8 @@ function resolve(
       spawnedChildren
     ),
     self: actorContext?.self,
-    system: actorContext?.system
+    system: actorContext?.system,
+    stateNode: actionArgs.stateNode
   };
   let partialUpdate: Record<string, unknown> = {};
   if (typeof assignment === 'function') {

--- a/packages/core/src/actions/choose.ts
+++ b/packages/core/src/actions/choose.ts
@@ -25,7 +25,13 @@ function resolve(
   const matchedActions = branches.find((condition) => {
     return (
       !condition.guard ||
-      evaluateGuard(condition.guard, state.context, actionArgs.event, state)
+      evaluateGuard(
+        condition.guard,
+        state.context,
+        actionArgs.event,
+        state,
+        actionArgs.stateNode
+      )
     );
   })?.actions;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,6 +83,7 @@ export interface UnifiedArg<
   event: TExpressionEvent;
   self: ActorRef<TExpressionEvent>; // TODO: this should refer to `TEvent`
   system: ActorSystem<any>;
+  stateNode: AnyStateNode;
 }
 
 export type MachineContext = Record<string, any>;

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2475,7 +2475,7 @@ describe('forwardTo()', () => {
           on: {
             EVENT: {
               actions: sendParent({ type: 'SUCCESS' }),
-              guard: ({ event }) => event.value === 42
+              guard: ({ event, stateNode }) => event.value === 42
             }
           }
         }
@@ -4019,5 +4019,38 @@ describe('actions', () => {
     expect(spy).toHaveBeenCalledWith({
       type: 'myAction'
     });
+  });
+
+  it('should have stateNode available in object', () => {
+    const machine = createMachine({
+      id: 'root',
+      entry: ({ stateNode }) => {
+        expect(stateNode.id).toBe('root');
+      },
+      initial: 'foo',
+      states: {
+        foo: {
+          meta: { foo: 'bar' },
+          entry: ({ stateNode }) => {
+            expect(stateNode.id).toBe('root.foo');
+
+            // Real-life use-case test
+            expect(stateNode.meta).toEqual({ foo: 'bar' });
+          },
+          on: {
+            event: {
+              actions: ({ stateNode }) => {
+                expect(stateNode.id).toBe('root.foo');
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect.assertions(4);
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'event' });
   });
 });

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -1028,4 +1028,27 @@ describe('or() guard', () => {
 
     expect(actorRef.getSnapshot().matches('b')).toBeTruthy();
   });
+
+  it('should have stateNode available in object', () => {
+    const machine = createMachine({
+      id: 'root',
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            event: {
+              guard: ({ stateNode }) => stateNode.id === 'root.a',
+              target: 'success'
+            }
+          }
+        },
+        success: {}
+      }
+    });
+
+    const actorRef = createActor(machine).start();
+    actorRef.send({ type: 'event' });
+
+    expect(actorRef.getSnapshot().matches('success')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
The `stateNode` where an action or guard originates can now be read in the action or guard's provided implementation, or inline:

```ts
const machine = createMachine({
  initial: 'idle',
  states: {
    idle: {
      meta: { message: 'I am idle', enabled: true },

      entry: ({ stateNode }) => {
        stateNode.message; // 'I am idle'
      },

      on: {
        someEvent: {
          guard: ({ stateNode }) => {
            return stateNode.enabled; // true
          }
        }
      }
    }
  }
});
```