### PR TITLE
Remove getMachineShortestPaths and getMachineSimplePaths

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,6 @@
   "baseBranch": "main",
   "ignore": [
     "@xstate/analytics",
-    "@xstate/graph",
     "@xstate/immer",
     "@xstate/inspect",
     "@xstate/solid",

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,6 +7,7 @@
   "baseBranch": "main",
   "ignore": [
     "@xstate/analytics",
+    "@xstate/graph",
     "@xstate/immer",
     "@xstate/inspect",
     "@xstate/solid",

--- a/.changeset/grumpy-planes-protect.md
+++ b/.changeset/grumpy-planes-protect.md
@@ -1,0 +1,20 @@
+---
+'@xstate/graph': major
+---
+
+Remove `getMachineShortestPaths` and `getMachineSimplePaths`
+
+```diff
+import {
+- getMachineShortestPaths,
++ getShortestPaths,
+- getMachineSimplePaths,
++ getSimplePaths
+} from '@xstate/graph';
+
+-const paths = getMachineShortestPaths(machine);
++const paths = getShortestPaths(machine);
+
+-const paths = getMachineSimplePaths(machine);
++const paths = getSimplePaths(machine);
+```

--- a/packages/xstate-graph/src/adjacency.ts
+++ b/packages/xstate-graph/src/adjacency.ts
@@ -20,7 +20,7 @@ export function getAdjacencyMap<
     traversalLimit: limit,
     fromState: customFromState,
     stopCondition
-  } = resolveTraversalOptions(options);
+  } = resolveTraversalOptions(logic, options);
   const actorContext = { self: {} } as any; // TODO: figure out the simulation API
   const fromState =
     customFromState ?? logic.getInitialState(actorContext, undefined);

--- a/packages/xstate-graph/src/index.ts
+++ b/packages/xstate-graph/src/index.ts
@@ -6,8 +6,8 @@ export {
   toDirectedGraph,
   joinPaths
 } from './graph.ts';
-export { getMachineSimplePaths, getSimplePaths } from './simplePaths.ts';
-export { getShortestPaths, getMachineShortestPaths } from './shortestPaths.ts';
+export { getSimplePaths } from './simplePaths.ts';
+export { getShortestPaths } from './shortestPaths.ts';
 export { getPathsFromEvents } from './pathFromEvents.ts';
 export { getAdjacencyMap } from './adjacency.ts';
 

--- a/packages/xstate-graph/src/pathFromEvents.ts
+++ b/packages/xstate-graph/src/pathFromEvents.ts
@@ -28,7 +28,8 @@ export function getPathsFromEvents<
   events: TEvent[],
   options?: TraversalOptions<TInternalState, TEvent>
 ): Array<StatePath<TInternalState, TEvent>> {
-  const resolvedOptions = resolveTraversalOptions<TInternalState, TEvent>(
+  const resolvedOptions = resolveTraversalOptions(
+    logic,
     {
       events,
       ...options

--- a/packages/xstate-graph/src/shortestPaths.ts
+++ b/packages/xstate-graph/src/shortestPaths.ts
@@ -3,7 +3,10 @@ import {
   AnyStateMachine,
   StateFrom,
   EventFrom,
-  ActorLogic
+  ActorLogic,
+  AnyActorLogic,
+  SnapshotFrom,
+  EventFromLogic
 } from 'xstate';
 import {
   SerializedEvent,
@@ -15,11 +18,15 @@ import {
 import { resolveTraversalOptions, createDefaultMachineOptions } from './graph';
 import { getAdjacencyMap } from './adjacency';
 
-export function getShortestPaths<TState, TEvent extends EventObject>(
-  logic: ActorLogic<TEvent, TState>,
+export function getShortestPaths<
+  TLogic extends AnyActorLogic,
+  TState extends SnapshotFrom<TLogic>,
+  TEvent extends EventFromLogic<TLogic>
+>(
+  logic: TLogic,
   options?: TraversalOptions<TState, TEvent>
 ): Array<StatePath<TState, TEvent>> {
-  const resolvedOptions = resolveTraversalOptions(options);
+  const resolvedOptions = resolveTraversalOptions(logic, options);
   const serializeState = resolvedOptions.serializeState as (
     ...args: Parameters<typeof resolvedOptions.serializeState>
   ) => SerializedState;
@@ -130,16 +137,4 @@ export function getShortestPaths<TState, TEvent extends EventObject>(
   }
 
   return paths;
-}
-
-export function getMachineShortestPaths<TMachine extends AnyStateMachine>(
-  machine: TMachine,
-  options?: TraversalOptions<StateFrom<TMachine>, EventFrom<TMachine>>
-): Array<StatePath<StateFrom<TMachine>, EventFrom<TMachine>>> {
-  const resolvedOptions = resolveTraversalOptions(
-    options,
-    createDefaultMachineOptions(machine, options)
-  );
-
-  return getShortestPaths(machine as any, resolvedOptions);
 }

--- a/packages/xstate-graph/src/simplePaths.ts
+++ b/packages/xstate-graph/src/simplePaths.ts
@@ -3,7 +3,10 @@ import {
   AnyStateMachine,
   StateFrom,
   EventFrom,
-  ActorLogic
+  ActorLogic,
+  AnyActorLogic,
+  EventFromLogic,
+  SnapshotFrom
 } from 'xstate';
 import {
   SerializedEvent,
@@ -15,23 +18,15 @@ import {
 import { resolveTraversalOptions, createDefaultMachineOptions } from './graph';
 import { getAdjacencyMap } from './adjacency';
 
-export function getMachineSimplePaths<TMachine extends AnyStateMachine>(
-  machine: TMachine,
-  options?: TraversalOptions<StateFrom<TMachine>, EventFrom<TMachine>>
-): Array<StatePath<StateFrom<TMachine>, EventFrom<TMachine>>> {
-  const resolvedOptions = resolveTraversalOptions(
-    options,
-    createDefaultMachineOptions(machine)
-  );
-
-  return getSimplePaths(machine as any, resolvedOptions);
-}
-
-export function getSimplePaths<TState, TEvent extends EventObject>(
-  logic: ActorLogic<TEvent, TState>,
-  options: TraversalOptions<TState, TEvent>
+export function getSimplePaths<
+  TLogic extends AnyActorLogic,
+  TState extends SnapshotFrom<TLogic>,
+  TEvent extends EventFromLogic<TLogic>
+>(
+  logic: TLogic,
+  options?: TraversalOptions<TState, TEvent>
 ): Array<StatePath<TState, TEvent>> {
-  const resolvedOptions = resolveTraversalOptions(options);
+  const resolvedOptions = resolveTraversalOptions(logic, options);
   const actorContext = { self: {} } as any; // TODO: figure out the simulation API
   const fromState =
     resolvedOptions.fromState ?? logic.getInitialState(actorContext, undefined);

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -10,12 +10,10 @@ import {
 import {
   getStateNodes,
   getPathsFromEvents,
-  getMachineSimplePaths,
-  getMachineShortestPaths,
+  getShortestPaths,
   toDirectedGraph,
   StatePath,
   joinPaths,
-  getShortestPaths,
   getSimplePaths
 } from '../src';
 
@@ -189,20 +187,20 @@ describe('@xstate/graph', () => {
 
   describe('getShortestPaths()', () => {
     it('should return a mapping of shortest paths to all states', () => {
-      const paths = getMachineShortestPaths(lightMachine);
+      const paths = getShortestPaths(lightMachine);
 
       expect(getPathsSnapshot(paths)).toMatchSnapshot('shortest paths');
     });
 
     it('should return a mapping of shortest paths to all states (parallel)', () => {
-      const paths = getMachineShortestPaths(parallelMachine);
+      const paths = getShortestPaths(parallelMachine);
       expect(getPathsSnapshot(paths)).toMatchSnapshot(
         'shortest paths parallel'
       );
     });
 
     it('the initial state should have a zero-length path', () => {
-      const shortestPaths = getMachineShortestPaths(lightMachine);
+      const shortestPaths = getShortestPaths(lightMachine);
 
       expect(
         shortestPaths.find((path) =>
@@ -216,7 +214,7 @@ describe('@xstate/graph', () => {
     });
 
     xit('should not throw when a condition is present', () => {
-      expect(() => getMachineShortestPaths(condMachine)).not.toThrow();
+      expect(() => getShortestPaths(condMachine)).not.toThrow();
     });
 
     it.skip('should represent conditional paths based on context', () => {
@@ -249,7 +247,7 @@ describe('@xstate/graph', () => {
         }
       });
 
-      const paths = getMachineShortestPaths(machine, {
+      const paths = getShortestPaths(machine, {
         events: [
           {
             type: 'EVENT',
@@ -269,7 +267,7 @@ describe('@xstate/graph', () => {
 
   describe('getSimplePaths()', () => {
     it('should return a mapping of arrays of simple paths to all states', () => {
-      const paths = getMachineSimplePaths(lightMachine);
+      const paths = getSimplePaths(lightMachine);
 
       // Multiple different ways to get to flashing (from any other state)
       expect(paths.map((path) => path.state.value)).toMatchInlineSnapshot(`
@@ -315,7 +313,7 @@ describe('@xstate/graph', () => {
     });
 
     it('should return a mapping of simple paths to all states (parallel)', () => {
-      const paths = getMachineSimplePaths(parallelMachine);
+      const paths = getSimplePaths(parallelMachine);
 
       expect(paths.map((p) => p.state.value)).toMatchInlineSnapshot(`
         [
@@ -349,7 +347,7 @@ describe('@xstate/graph', () => {
         }
       });
 
-      const paths = getMachineSimplePaths(machine);
+      const paths = getSimplePaths(machine);
 
       expect(paths.map((p) => p.state.value)).toMatchInlineSnapshot(`
         [
@@ -365,7 +363,7 @@ describe('@xstate/graph', () => {
 
     it('should return a single empty path for the initial state', () => {
       expect(
-        getMachineSimplePaths(lightMachine).find((p) =>
+        getSimplePaths(lightMachine).find((p) =>
           p.state.matches(
             lightMachine.getInitialState(
               {} as any // TODO: figure out the simulation API
@@ -374,7 +372,7 @@ describe('@xstate/graph', () => {
         )
       ).toBeDefined();
       expect(
-        getMachineSimplePaths(lightMachine).find((p) =>
+        getSimplePaths(lightMachine).find((p) =>
           p.state.matches(
             lightMachine.getInitialState(
               {} as any // TODO: figure out the simulation API
@@ -383,7 +381,7 @@ describe('@xstate/graph', () => {
         )!.steps
       ).toHaveLength(0);
       expect(
-        getMachineSimplePaths(equivMachine).find((p) =>
+        getSimplePaths(equivMachine).find((p) =>
           p.state.matches(
             equivMachine.getInitialState(
               {} as any // TODO: figure out the simulation API
@@ -392,7 +390,7 @@ describe('@xstate/graph', () => {
         )!
       ).toBeDefined();
       expect(
-        getMachineSimplePaths(equivMachine).find((p) =>
+        getSimplePaths(equivMachine).find((p) =>
           p.state.matches(
             equivMachine.getInitialState(
               {} as any // TODO: figure out the simulation API
@@ -434,7 +432,7 @@ describe('@xstate/graph', () => {
         }
       });
 
-      const paths = getMachineSimplePaths(countMachine, {
+      const paths = getSimplePaths(countMachine, {
         events: [{ type: 'INC', value: 1 } as const]
       });
 
@@ -586,7 +584,7 @@ describe('filtering', () => {
       }
     });
 
-    const sp = getMachineShortestPaths(machine, {
+    const sp = getShortestPaths(machine, {
       events: [{ type: 'INC' }],
       filter: (s) => s.context.count < 5
     });
@@ -629,7 +627,7 @@ it('should provide previous state for serializeState()', () => {
     }
   });
 
-  const shortestPaths = getMachineShortestPaths(machine, {
+  const shortestPaths = getShortestPaths(machine, {
     serializeState: (state, event, prevState) => {
       return `${JSON.stringify(state.value)} via ${event?.type}${
         prevState ? ` via ${JSON.stringify(prevState.value)}` : ''
@@ -647,7 +645,7 @@ it('should provide previous state for serializeState()', () => {
   ).toEqual([0, 3]);
 });
 
-it.each([getMachineShortestPaths, getMachineSimplePaths])(
+it.each([getShortestPaths, getSimplePaths])(
   'from-state can be specified',
   (pathGetter) => {
     const machine = createMachine({

--- a/packages/xstate-graph/test/shortestPaths.test.ts
+++ b/packages/xstate-graph/test/shortestPaths.test.ts
@@ -1,8 +1,8 @@
 import { assign, createMachine } from 'xstate';
 import { joinPaths } from '../src/graph';
-import { getMachineShortestPaths } from '../src/shortestPaths';
+import { getShortestPaths } from '../src/shortestPaths';
 
-describe('getMachineShortestPaths', () => {
+describe('getShortestPaths', () => {
   it('finds the shortest paths to a state without continuing traversal from that state', () => {
     const m = createMachine<{ count: number }>({
       initial: 'a',
@@ -38,7 +38,7 @@ describe('getMachineShortestPaths', () => {
       }
     });
 
-    const p = getMachineShortestPaths(m, {
+    const p = getShortestPaths(m, {
       toState: (state) => state.matches('c')
     });
 
@@ -74,11 +74,11 @@ describe('getMachineShortestPaths', () => {
       }
     });
 
-    const pathsToB = getMachineShortestPaths(m, {
+    const pathsToB = getShortestPaths(m, {
       toState: (state) => state.matches('b')
     });
     const paths = pathsToB.flatMap((path) => {
-      const pathsToY = getMachineShortestPaths(m, {
+      const pathsToY = getShortestPaths(m, {
         fromState: path.state,
         toState: (state) => state.matches('y')
       });
@@ -118,7 +118,7 @@ describe('getMachineShortestPaths', () => {
       }
     });
 
-    const shortestPaths = getMachineShortestPaths(machine, {
+    const shortestPaths = getShortestPaths(machine, {
       events: [
         {
           type: 'todo.add',

--- a/packages/xstate-graph/test/types.test.ts
+++ b/packages/xstate-graph/test/types.test.ts
@@ -1,5 +1,5 @@
 import { createMachine } from 'xstate';
-import { getMachineShortestPaths } from '../src/index.ts';
+import { getShortestPaths } from '../src/index.ts';
 
 describe('types', () => {
   it('`getEvents` should be allowed to return a mutable array', () => {
@@ -9,7 +9,7 @@ describe('types', () => {
       }
     });
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       events: [
         {
           type: 'FOO'
@@ -25,7 +25,7 @@ describe('types', () => {
       }
     });
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       events: [
         {
           type: 'FOO'
@@ -41,7 +41,7 @@ describe('types', () => {
       }
     });
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       events: [
         {
           type: 'FOO',
@@ -58,7 +58,7 @@ describe('types', () => {
       }
     });
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       events: [{ type: 'FOO', value: 100 }]
     });
   });
@@ -72,7 +72,7 @@ describe('types', () => {
 
     const events = [{ type: 'FOO', value: 100 }] as const;
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       events
     });
   });
@@ -84,7 +84,7 @@ describe('types', () => {
       }
     });
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       events: () => [{ type: 'FOO', value: 100 }] as const
     });
   });
@@ -94,7 +94,7 @@ describe('types', () => {
       types: { events: {} as { type: 'FOO'; value: number } }
     });
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       events: [
         {
           // @ts-expect-error
@@ -112,7 +112,7 @@ describe('types', () => {
       }
     });
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       events: [
         {
           type: 'FOO',
@@ -126,7 +126,7 @@ describe('types', () => {
   it('`serializeEvent` should be allowed to return plain string', () => {
     const machine = createMachine({});
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       serializeEvent: () => ''
     });
   });
@@ -134,7 +134,7 @@ describe('types', () => {
   it('`serializeState` should be allowed to return plain string', () => {
     const machine = createMachine({});
 
-    getMachineShortestPaths(machine, {
+    getShortestPaths(machine, {
       serializeState: () => ''
     });
   });


### PR DESCRIPTION
Remove `getMachineShortestPaths` and `getMachineSimplePaths`

```diff
import {
- getMachineShortestPaths,
+ getShortestPaths,
- getMachineSimplePaths,
+ getSimplePaths
} from '@xstate/graph';

-const paths = getMachineShortestPaths(machine);
+const paths = getShortestPaths(machine);

-const paths = getMachineSimplePaths(machine);
+const paths = getSimplePaths(machine);
```
