### PR TITLE
[v5] Alias `useMachine` in `@xstate/react`

### DIFF
--- a/.changeset/big-avocados-raise.md
+++ b/.changeset/big-avocados-raise.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': minor
+---
+
+The `useMachine` function is aliased to `useActor` and not shown as visually deprecated.

--- a/packages/xstate-react/src/useMachine.ts
+++ b/packages/xstate-react/src/useMachine.ts
@@ -9,8 +9,7 @@ import {
 import { useActor } from './useActor.ts';
 
 /**
- *
- * @deprecated Use `useActor(...)` instead.
+ * @alias useActor
  */
 export function useMachine<TMachine extends AnyStateMachine>(
   machine: AreAllImplementationsAssumedToBeProvided<


### PR DESCRIPTION
This PR makes it so that `useMachine` (very commonly used hook) doesn't appear as strikethrough in code (technically aliased, not deprecated)