### PR TITLE
[v5] Strongly type state and transition `meta`

### DIFF
--- a/.changeset/ten-rats-worry.md
+++ b/.changeset/ten-rats-worry.md
@@ -1,0 +1,30 @@
+---
+'xstate': minor
+---
+
+You can now strongly type `meta` on state nodes and transitions via `stateMeta` and `transitionMeta` respectively:
+
+```ts
+import { createMachine } from 'xstate';
+
+const machine = createMachine({
+  types: {
+    stateMeta: {} as { title: string },
+    transitionMeta: {} as { button: 'primary' | 'secondary' }
+  },
+  initial: 'idle',
+  states: {
+    idle: {
+      // Strongly typed from `stateMeta`
+      meta: { title: 'Idle' },
+      on: {
+        CLICK: {
+          target: 'loading',
+          // Strongly typed from `transitionMeta`
+          meta: { button: 'primary' }
+        }
+      }
+    }
+  }
+});
+```

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -28,7 +28,7 @@ export function createMachine<
   TInput = any,
   TOutput = NonReducibleUnknown,
   TStateMeta extends MetaObject = MetaObject,
-  TEventMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = MetaObject,
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 >(
   config: MachineConfig<
@@ -42,7 +42,7 @@ export function createMachine<
     TInput,
     TOutput,
     TStateMeta,
-    TEventMeta,
+    TTransitionMeta,
     TTypesMeta
   >,
   implementations?: InternalMachineImplementations<
@@ -84,7 +84,7 @@ export function createMachine<
   TInput,
   TOutput,
   TStateMeta,
-  TEventMeta,
+  TTransitionMeta,
   ResolveTypegenMeta<TTypesMeta, TEvent, TActor, TAction, TGuard, TDelay, TTag>
 > {
   return new StateMachine<
@@ -99,6 +99,6 @@ export function createMachine<
     any,
     any,
     any, // TStateMeta
-    any // TEventMeta
+    any // TTransitionMeta
   >(config as any, implementations as any);
 }

--- a/packages/core/src/Machine.ts
+++ b/packages/core/src/Machine.ts
@@ -7,7 +7,8 @@ import {
   ProvidedActor,
   AnyEventObject,
   NonReducibleUnknown,
-  Prop
+  Prop,
+  MetaObject
 } from './types.ts';
 import {
   TypegenConstraint,
@@ -26,6 +27,8 @@ export function createMachine<
   TTag extends string = string,
   TInput = any,
   TOutput = NonReducibleUnknown,
+  TStateMeta extends MetaObject = MetaObject,
+  TEventMeta extends MetaObject = MetaObject,
   TTypesMeta extends TypegenConstraint = TypegenDisabled
 >(
   config: MachineConfig<
@@ -38,6 +41,8 @@ export function createMachine<
     TTag,
     TInput,
     TOutput,
+    TStateMeta,
+    TEventMeta,
     TTypesMeta
   >,
   implementations?: InternalMachineImplementations<
@@ -78,10 +83,22 @@ export function createMachine<
     string,
   TInput,
   TOutput,
+  TStateMeta,
+  TEventMeta,
   ResolveTypegenMeta<TTypesMeta, TEvent, TActor, TAction, TGuard, TDelay, TTag>
 > {
-  return new StateMachine<any, any, any, any, any, any, any, any, any, any>(
-    config as any,
-    implementations as any
-  );
+  return new StateMachine<
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any, // TStateMeta
+    any // TEventMeta
+  >(config as any, implementations as any);
 }

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -44,7 +44,8 @@ import type {
   ProvidedActor,
   AnyActorRef,
   Equals,
-  TODO
+  TODO,
+  MetaObject
 } from './types.ts';
 import { isErrorEvent, resolveReferencedActor } from './utils.ts';
 
@@ -61,6 +62,8 @@ export class StateMachine<
   TTag extends string,
   TInput,
   TOutput,
+  TStateMeta extends MetaObject,
+  TEventMeta extends MetaObject,
   TResolvedTypesMeta = ResolveTypegenMeta<
     TypegenDisabled,
     NoInfer<TEvent>,
@@ -100,6 +103,8 @@ export class StateMachine<
     TTag,
     TInput,
     TOutput,
+    TStateMeta,
+    TEventMeta,
     TResolvedTypesMeta
   >;
 
@@ -128,7 +133,9 @@ export class StateMachine<
       any,
       any,
       TOutput,
-      any
+      any, // state meta
+      any, // event meta
+      any // typegen meta
     >,
     implementations?: MachineImplementationsSimplified<TContext, TEvent>
   ) {
@@ -183,6 +190,8 @@ export class StateMachine<
     TTag,
     TInput,
     TOutput,
+    TStateMeta,
+    TEventMeta,
     AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
       ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
       : TResolvedTypesMeta

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -63,7 +63,7 @@ export class StateMachine<
   TInput,
   TOutput,
   TStateMeta extends MetaObject,
-  TEventMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TResolvedTypesMeta = ResolveTypegenMeta<
     TypegenDisabled,
     NoInfer<TEvent>,
@@ -104,7 +104,7 @@ export class StateMachine<
     TInput,
     TOutput,
     TStateMeta,
-    TEventMeta,
+    TTransitionMeta,
     TResolvedTypesMeta
   >;
 
@@ -191,7 +191,7 @@ export class StateMachine<
     TInput,
     TOutput,
     TStateMeta,
-    TEventMeta,
+    TTransitionMeta,
     AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
       ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
       : TResolvedTypesMeta

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -128,6 +128,8 @@ export class StateNode<
     TODO, // guards
     TODO, // delays
     TODO, // tags
+    TODO, // state meta
+    TODO, // event meta
     TODO // types meta
   >;
   /**
@@ -162,7 +164,9 @@ export class StateNode<
       TODO, // output
       TODO, // guards
       TODO, // delays
-      TODO // tags
+      TODO, // tags,
+      TODO, // state meta
+      TODO // event meta
     >,
     options: StateNodeOptions<TContext, TEvent>
   ) {
@@ -295,7 +299,8 @@ export class StateNode<
       TEvent,
       ParameterizedObject,
       ParameterizedObject,
-      string
+      string,
+      TODO
     >
   > {
     return memo(this, 'invoke', () =>
@@ -341,7 +346,8 @@ export class StateNode<
           TEvent,
           ParameterizedObject,
           ParameterizedObject,
-          string
+          string,
+          TODO
         >;
       })
     );

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -457,7 +457,7 @@ export function formatInitialTransition<
   stateNode: AnyStateNode,
   _target:
     | SingleOrArray<string>
-    | InitialTransitionConfig<TContext, TEvent, TODO, TODO, TODO>
+    | InitialTransitionConfig<TContext, TEvent, TODO, TODO, TODO, TODO>
 ): InitialTransitionDefinition<TContext, TEvent> {
   if (typeof _target === 'string' || isArray(_target)) {
     const targets = toArray(_target).map((t) => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -106,7 +106,7 @@ export type InputFrom<T extends AnyActorLogic> = T extends StateMachine<
   infer TInput,
   infer _TOutput,
   infer _TStateMeta,
-  infer _TEventMeta,
+  infer _TTransitionMeta,
   infer _TResolvedTypesMeta
 >
   ? TInput
@@ -269,7 +269,7 @@ export interface TransitionConfig<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > {
   guard?: Guard<TContext, TExpressionEvent, undefined, TGuard>;
   actions?: Actions<
@@ -283,7 +283,7 @@ export interface TransitionConfig<
   >;
   reenter?: boolean;
   target?: TransitionTarget | undefined;
-  meta?: TEventMeta;
+  meta?: TTransitionMeta;
   description?: string;
 }
 
@@ -293,7 +293,7 @@ export interface InitialTransitionConfig<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > extends TransitionConfig<
     TContext,
     TEvent,
@@ -301,7 +301,7 @@ export interface InitialTransitionConfig<
     TAction,
     TGuard,
     TDelay,
-    TEventMeta
+    TTransitionMeta
   > {
   target: TransitionTarget;
 }
@@ -327,7 +327,7 @@ export interface InvokeDefinition<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > {
   id: string;
 
@@ -351,7 +351,7 @@ export interface InvokeDefinition<
           TAction,
           TGuard,
           TDelay,
-          TEventMeta
+          TTransitionMeta
         >
       >;
   /**
@@ -367,7 +367,7 @@ export interface InvokeDefinition<
           TAction,
           TGuard,
           TDelay,
-          TEventMeta
+          TTransitionMeta
         >
       >;
 
@@ -381,12 +381,19 @@ export interface InvokeDefinition<
           TAction,
           TGuard,
           TDelay,
-          TEventMeta
+          TTransitionMeta
         >
       >;
 
   toJSON: () => Omit<
-    InvokeDefinition<TContext, TEvent, TAction, TGuard, TDelay, TEventMeta>,
+    InvokeDefinition<
+      TContext,
+      TEvent,
+      TAction,
+      TGuard,
+      TDelay,
+      TTransitionMeta
+    >,
     'onDone' | 'onError' | 'toJSON'
   >;
   meta: MetaObject | undefined;
@@ -400,7 +407,7 @@ export type DelayedTransitions<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > =
   | {
       [K in Delay<TDelay>]?:
@@ -413,7 +420,7 @@ export type DelayedTransitions<
               TAction,
               TGuard,
               TDelay,
-              TEventMeta
+              TTransitionMeta
             >
           >;
     }
@@ -425,7 +432,7 @@ export type DelayedTransitions<
         TAction,
         TGuard,
         TDelay,
-        TEventMeta
+        TTransitionMeta
       > & {
         delay:
           | Delay<TDelay>
@@ -460,7 +467,7 @@ export type StatesConfig<
   TTag extends string,
   TOutput,
   TStateMeta extends MetaObject,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > = {
   [K in string]: StateNodeConfig<
     TContext,
@@ -472,7 +479,7 @@ export type StatesConfig<
     TTag,
     TOutput,
     TStateMeta,
-    TEventMeta
+    TTransitionMeta
   >;
 };
 
@@ -492,7 +499,7 @@ export type TransitionConfigOrTarget<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > = SingleOrArray<
   | TransitionConfigTarget
   | TransitionConfig<
@@ -502,7 +509,7 @@ export type TransitionConfigOrTarget<
       TAction,
       TGuard,
       TDelay,
-      TEventMeta
+      TTransitionMeta
     >
 >;
 
@@ -512,7 +519,7 @@ export type TransitionsConfig<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > =
   | {
       [K in EventDescriptor<TEvent>]?: TransitionConfigOrTarget<
@@ -522,7 +529,7 @@ export type TransitionsConfig<
         TAction,
         TGuard,
         TDelay,
-        TEventMeta
+        TTransitionMeta
       >;
     };
 
@@ -551,7 +558,7 @@ type DistributeActors<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > = TActor extends { src: infer TSrc }
   ? Compute<
       {
@@ -577,7 +584,7 @@ type DistributeActors<
                 TAction,
                 TGuard,
                 TDelay,
-                TEventMeta
+                TTransitionMeta
               >
             >;
         /**
@@ -593,7 +600,7 @@ type DistributeActors<
                 TAction,
                 TGuard,
                 TDelay,
-                TEventMeta
+                TTransitionMeta
               >
             >;
 
@@ -607,7 +614,7 @@ type DistributeActors<
                 TAction,
                 TGuard,
                 TDelay,
-                [TEventMeta]
+                [TTransitionMeta]
               >
             >;
         /**
@@ -639,7 +646,7 @@ export type InvokeConfig<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > = IsLiteralString<TActor['src']> extends true
   ? DistributeActors<
       TContext,
@@ -648,7 +655,7 @@ export type InvokeConfig<
       TAction,
       TGuard,
       TDelay,
-      TEventMeta
+      TTransitionMeta
     >
   : {
       /**
@@ -679,7 +686,7 @@ export type InvokeConfig<
               TAction,
               TGuard,
               TDelay,
-              TEventMeta
+              TTransitionMeta
             >
           >;
       /**
@@ -695,7 +702,7 @@ export type InvokeConfig<
               TAction,
               TGuard,
               TDelay,
-              TEventMeta
+              TTransitionMeta
             >
           >;
 
@@ -709,7 +716,7 @@ export type InvokeConfig<
               TAction,
               TGuard,
               TDelay,
-              TEventMeta
+              TTransitionMeta
             >
           >;
       /**
@@ -730,7 +737,7 @@ export interface StateNodeConfig<
   TTag extends string,
   TOutput,
   TStateMeta extends MetaObject,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > {
   /**
    * The initial state transition.
@@ -742,7 +749,7 @@ export interface StateNodeConfig<
         TAction,
         TGuard,
         TDelay,
-        TEventMeta
+        TTransitionMeta
       >
     | SingleOrArray<string>
     | undefined;
@@ -776,7 +783,7 @@ export interface StateNodeConfig<
         TTag,
         NonReducibleUnknown,
         TStateMeta,
-        TEventMeta
+        TTransitionMeta
       >
     | undefined;
   /**
@@ -791,13 +798,20 @@ export interface StateNodeConfig<
         TAction,
         TGuard,
         TDelay,
-        TEventMeta
+        TTransitionMeta
       >
   >;
   /**
    * The mapping of event types to their potential transition(s).
    */
-  on?: TransitionsConfig<TContext, TEvent, TAction, TGuard, TDelay, TEventMeta>;
+  on?: TransitionsConfig<
+    TContext,
+    TEvent,
+    TAction,
+    TGuard,
+    TDelay,
+    TTransitionMeta
+  >;
   /**
    * The action(s) to be executed upon entering the state node.
    */
@@ -821,7 +835,7 @@ export interface StateNodeConfig<
           TAction,
           TGuard,
           TDelay,
-          TEventMeta
+          TTransitionMeta
         >
       >
     | undefined;
@@ -835,7 +849,7 @@ export interface StateNodeConfig<
     TAction,
     TGuard,
     TDelay,
-    TEventMeta
+    TTransitionMeta
   >;
 
   /**
@@ -848,7 +862,7 @@ export interface StateNodeConfig<
     TAction,
     TGuard,
     TDelay,
-    TEventMeta
+    TTransitionMeta
   >;
   /**
    * @private
@@ -1349,7 +1363,7 @@ type RootStateNodeConfig<
   TTag extends string,
   TOutput,
   TStateMeta extends MetaObject,
-  TEventMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > = Omit<
   StateNodeConfig<
     TContext,
@@ -1361,7 +1375,7 @@ type RootStateNodeConfig<
     TTag,
     TOutput,
     TStateMeta,
-    TEventMeta
+    TTransitionMeta
   >,
   'states'
 > & {
@@ -1376,7 +1390,7 @@ type RootStateNodeConfig<
         TTag,
         TOutput,
         TStateMeta,
-        TEventMeta
+        TTransitionMeta
       >
     | undefined;
 };
@@ -1392,7 +1406,7 @@ export type MachineConfig<
   TInput = any,
   TOutput = unknown,
   TStateMeta extends MetaObject = MetaObject,
-  TEventMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = MetaObject,
   TTypesMeta = TypegenDisabled
 > = (RootStateNodeConfig<
   NoInfer<TContext>,
@@ -1404,7 +1418,7 @@ export type MachineConfig<
   NoInfer<TTag>,
   NoInfer<TOutput>,
   NoInfer<TStateMeta>,
-  NoInfer<TEventMeta>
+  NoInfer<TTransitionMeta>
 > & {
   /**
    * The initial context (extended state)
@@ -1424,7 +1438,7 @@ export type MachineConfig<
     TInput,
     TOutput,
     TStateMeta,
-    TEventMeta,
+    TTransitionMeta,
     TTypesMeta
   >;
 }) &
@@ -1449,7 +1463,7 @@ export interface MachineTypes<
   TInput,
   TOutput,
   TStateMeta extends MetaObject,
-  TEventMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TTypesMeta = TypegenDisabled
 > {
   context?: TContext;
@@ -1463,7 +1477,7 @@ export interface MachineTypes<
   output?: TOutput;
   typegen?: TTypesMeta;
   stateMeta?: TStateMeta;
-  eventMeta?: TEventMeta;
+  transitionMeta?: TTransitionMeta;
 }
 
 export interface HistoryStateNode<TContext extends MachineContext>
@@ -1917,7 +1931,7 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer TOutput,
       infer TStateMeta,
-      infer TEventMeta,
+      infer TTransitionMeta,
       infer TResolvedTypesMeta
     >
     ? ActorRef<
@@ -1966,7 +1980,7 @@ export type InterpreterFrom<
   infer TInput,
   infer TOutput,
   infer TStateMeta,
-  infer TEventMeta,
+  infer TTransitionMeta,
   infer TResolvedTypesMeta
 >
   ? Actor<
@@ -1997,7 +2011,7 @@ export type MachineImplementationsFrom<
   infer _TInput,
   infer _TOutput,
   infer TStateMeta,
-  infer TEventMeta,
+  infer TTransitionMeta,
   infer TResolvedTypesMeta
 >
   ? InternalMachineImplementations<
@@ -2110,7 +2124,7 @@ export type SnapshotFrom<T> = ReturnTypeOrValue<T> extends infer R
         infer _TInput,
         infer _TOutput,
         infer _TStateMeta,
-        infer _TEventMeta,
+        infer _TTransitionMeta,
         infer _TResolvedTypesMeta
       >
     ? StateFrom<R>
@@ -2170,7 +2184,7 @@ type ResolveEventType<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer _TOutput,
       infer _TStateMeta,
-      infer _TEventMeta,
+      infer _TTransitionMeta,
       infer _TResolvedTypesMeta
     >
     ? TEvent
@@ -2205,7 +2219,7 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer _TOutput,
       infer _TStateMeta,
-      infer _TEventMeta,
+      infer _TTransitionMeta,
       infer _TTypesMeta
     >
     ? TContext
@@ -2229,7 +2243,7 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
         infer _TInput,
         infer _TOutput,
         infer _TStateMeta,
-        infer _TEventMeta,
+        infer _TTransitionMeta,
         infer _TTypesMeta
       >
       ? TContext

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -1088,7 +1088,19 @@ describe('typegen types', () => {
       TContext extends MachineContext,
       TEvent extends { type: string }
     >(
-      machine: StateMachine<TContext, TEvent, any, any, any, any, any, any, any>
+      machine: StateMachine<
+        TContext,
+        TEvent,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any,
+        any, // state meta
+        any // event meta
+      >
     ) {
       return machine;
     }

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -3345,7 +3345,7 @@ describe('meta', () => {
   it('event meta', () => {
     createMachine({
       types: {
-        eventMeta: {} as { title: string }
+        transitionMeta: {} as { title: string }
       },
       initial: 'a',
       on: {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -380,7 +380,7 @@ it('should not use actions as possible inference sites', () => {
 it('should work with generic context', () => {
   function createMachineWithExtras<TContext extends MachineContext>(
     context: TContext
-  ): StateMachine<TContext, any, any, any, any, any, any, any, any> {
+  ): StateMachine<TContext, any, any, any, any, any, any, any, any, any, any> {
     return createMachine({ context });
   }
 
@@ -458,6 +458,8 @@ describe('events', () => {
       _machine: StateMachine<
         TContext,
         TEvent,
+        any,
+        any,
         any,
         any,
         any,
@@ -3314,5 +3316,51 @@ describe('tags', () => {
 
     // @ts-expect-error
     actor.getSnapshot().hasTag('other');
+  });
+});
+
+describe('meta', () => {
+  it('state meta', () => {
+    createMachine({
+      types: {
+        stateMeta: {} as { title: string }
+      },
+      initial: 'a',
+      states: {
+        a: {
+          meta: {
+            title: 'string'
+          }
+        },
+        b: {
+          meta: {
+            // @ts-expect-error
+            title: 1234
+          }
+        }
+      }
+    });
+  });
+
+  it('event meta', () => {
+    createMachine({
+      types: {
+        eventMeta: {} as { title: string }
+      },
+      initial: 'a',
+      on: {
+        event: {
+          meta: {
+            title: 'string'
+          }
+        },
+        // @ts-expect-error (wish it was at `title` though)
+        wrong: {
+          meta: {
+            title: 1234
+          }
+        }
+      }
+    });
   });
 });

--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -23,6 +23,8 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
     infer TTag,
     infer TInput,
     infer TOutput,
+    infer TStateMeta,
+    infer TEventMeta,
     infer TResolvedTypesMeta
   >
     ? StateMachine<
@@ -35,6 +37,8 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
         TTag,
         TInput,
         TOutput,
+        TStateMeta,
+        TEventMeta,
         AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
           ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
           : TResolvedTypesMeta

--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -24,7 +24,7 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
     infer TInput,
     infer TOutput,
     infer TStateMeta,
-    infer TEventMeta,
+    infer TTransitionMeta,
     infer TResolvedTypesMeta
   >
     ? StateMachine<
@@ -38,7 +38,7 @@ type ToMachinesWithProvidedImplementations<TMachine extends AnyStateMachine> =
         TInput,
         TOutput,
         TStateMeta,
-        TEventMeta,
+        TTransitionMeta,
         AreAllImplementationsAssumedToBeProvided<TResolvedTypesMeta> extends false
           ? MarkAllImplementationsAsProvided<TResolvedTypesMeta>
           : TResolvedTypesMeta

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -37,8 +37,10 @@ export interface TestMachineConfig<
     TODO,
     TODO,
     TODO,
-    TODO, // delays
-    TODO, // tags
+    TODO, // input
+    TODO, // output
+    TODO, // state meta
+    TODO, // event meta
     TTypesMeta
   >;
 }
@@ -53,6 +55,8 @@ export interface TestStateNodeConfig<
       TODO,
       TODO,
       ParameterizedObject,
+      TODO,
+      TODO,
       TODO,
       TODO,
       TODO
@@ -169,7 +173,7 @@ export interface TestTransitionConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TTestContext
-> extends TransitionConfig<TContext, TEvent, TEvent, TODO, TODO, string> {
+> extends TransitionConfig<TContext, TEvent, TEvent, TODO, TODO, string, TODO> {
   test?: (
     state: State<TContext, TEvent, any, any, any, any>,
     testContext: TTestContext


### PR DESCRIPTION
You can now strongly type `meta` on state nodes and transitions via `stateMeta` and `transitionMeta` respectively:

```ts
import { createMachine } from 'xstate';

const machine = createMachine({
  types: {
    stateMeta: {} as { title: string },
    transitionMeta: {} as { button: 'primary' | 'secondary' }
  },
  initial: 'idle',
  states: {
    idle: {
      // Strongly typed from `stateMeta`
      meta: { title: 'Idle' },
      on: {
        CLICK: {
          target: 'loading',
          // Strongly typed from `transitionMeta`
          meta: { button: 'primary' }
        }
      }
    }
  }
});
```

Fixes https://github.com/statelyai/xstate/issues/809

---

Motivation: strongly-typing things like this: https://github.com/statelyai/xstate/pull/4239/files#diff-a43cf6af3000f32addb10c6176a04f8a5066bc04358b4805726165c65d8565d3R64