### PR TITLE
Add a type-level test related to states composition

### DIFF
--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -401,6 +401,60 @@ it('should not widen literal types defined in `schema.context` based on `config.
   });
 });
 
+describe('states', () => {
+  it('should accept a state handling subset of events as part of the whole config handling superset of those events', () => {
+    const italicState = {
+      on: {
+        TOGGLE_BOLD: {
+          actions: () => {}
+        }
+      }
+    };
+
+    const boldState = {
+      on: {
+        TOGGLE_BOLD: {
+          actions: () => {}
+        }
+      }
+    };
+
+    createMachine({
+      types: {} as {
+        events: { type: 'TOGGLE_ITALIC' } | { type: 'TOGGLE_BOLD' };
+      },
+      type: 'parallel',
+      states: {
+        italic: italicState,
+        bold: boldState
+      }
+    });
+  });
+
+  // technically it wouldn't be a big problem accepting this, such transitions would just never be selected
+  // it's not worth complicating our types to support this though unless a strong argument is made in favor for this
+  it('should not accept a state handling an event type outside of the events accepted by the machine', () => {
+    const underlineState = {
+      on: {
+        TOGGLE_UNDERLINE: {
+          actions: () => {}
+        }
+      }
+    };
+
+    createMachine({
+      types: {} as {
+        events: { type: 'TOGGLE_ITALIC' } | { type: 'TOGGLE_BOLD' };
+      },
+      type: 'parallel',
+      states: {
+        // @ts-expect-error
+        underline: underlineState
+      }
+    });
+  });
+});
+
 describe('events', () => {
   it('should not use actions as possible inference sites 1', () => {
     const machine = createMachine({


### PR DESCRIPTION
this is a spiritual successor to https://github.com/statelyai/xstate/pull/1604

We don't fully support state composition done this way, typing builtin actions within the "state slice" is currently quite challenging and this pattern limits our current capabilities related to static analysis etc. From the types PoV though this simple example is OK and we can continue to support it.