### PR TITLE
Remove leftovers of `invoke.meta`

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -303,11 +303,6 @@ export type AnyTransitionConfig = TransitionConfig<
   any
 >;
 
-export interface InvokeMeta {
-  src: string;
-  meta: MetaObject | undefined;
-}
-
 export interface InvokeDefinition<
   TContext extends MachineContext,
   TEvent extends EventObject,
@@ -372,7 +367,6 @@ export interface InvokeDefinition<
     InvokeDefinition<TContext, TEvent, TAction, TGuard, TDelay>,
     'onDone' | 'onError' | 'toJSON'
   >;
-  meta: MetaObject | undefined;
 }
 
 type Delay<TDelay extends string> = TDelay | number;
@@ -564,10 +558,6 @@ type DistributeActors<
                 TDelay
               >
             >;
-        /**
-         * Meta data related to this invocation
-         */
-        meta?: MetaObject;
       } & (TActor['id'] extends string
         ? {
             /**
@@ -654,10 +644,6 @@ export type InvokeConfig<
               TDelay
             >
           >;
-      /**
-       * Meta data related to this invocation
-       */
-      meta?: MetaObject;
     };
 
 export type AnyInvokeConfig = InvokeConfig<any, any, any, any, any, any>;

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -2941,38 +2941,6 @@ describe('invoke', () => {
     });
   });
 
-  describe('meta data', () => {
-    it('should show meta data', () => {
-      const machine = createMachine({
-        invoke: {
-          src: 'someSource',
-          meta: {
-            url: 'stately.ai'
-          }
-        }
-      });
-
-      expect(machine.root.invoke[0].meta).toEqual({ url: 'stately.ai' });
-    });
-
-    it('meta data should be available in the invoke source function', () => {
-      expect.assertions(1);
-      const machine = createMachine({
-        invoke: {
-          src: fromPromise(({ input }) => {
-            expect(input).toEqual({ url: 'stately.ai' });
-            return Promise.resolve();
-          }),
-          input: {
-            url: 'stately.ai'
-          }
-        }
-      });
-
-      createActor(machine).start();
-    });
-  });
-
   it('invoke generated ID should be predictable based on the state node where it is defined', (done) => {
     const machine = createMachine(
       {


### PR DESCRIPTION
This feature~ was replaced in v5 by `invoke.input` so we don't need it since it's actually not used by the runtime anyhow.