### PR TITLE
Removed `StateNode['stateIds']` getter

### DIFF
--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -430,18 +430,6 @@ export class StateNode<
   }
 
   /**
-   * All the state node IDs of this state node and its descendant state nodes.
-   */
-  public get stateIds(): string[] {
-    const childStateIds = flatten(
-      Object.keys(this.states).map((stateKey) => {
-        return this.states[stateKey].stateIds;
-      })
-    );
-    return [this.id].concat(childStateIds);
-  }
-
-  /**
    * All the event types accepted by this state node and its descendants.
    */
   public get events(): Array<TEvent['type']> {

--- a/packages/xstate-test/src/validateMachine.ts
+++ b/packages/xstate-test/src/validateMachine.ts
@@ -1,33 +1,35 @@
-import { AnyStateMachine } from 'xstate';
+import { AnyStateMachine, AnyStateNode } from 'xstate';
+
+const validateState = (state: AnyStateNode) => {
+  if (state.invoke.length > 0) {
+    throw new Error('Invocations on test machines are not supported');
+  }
+  if (state.after.length > 0) {
+    throw new Error('After events on test machines are not supported');
+  }
+  // TODO: this doesn't account for always transitions
+  [
+    ...state.entry,
+    ...state.exit,
+    ...[...state.transitions.values()].flatMap((t) =>
+      t.flatMap((t) => t.actions)
+    )
+  ].forEach((action) => {
+    // TODO: this doesn't check referenced actions, only the inline ones
+    if (
+      typeof action === 'function' &&
+      'resolve' in action &&
+      typeof (action as any).delay === 'number'
+    ) {
+      throw new Error('Delayed actions on test machines are not supported');
+    }
+  });
+
+  for (const child of Object.values(state.states)) {
+    validateState(child);
+  }
+};
 
 export const validateMachine = (machine: AnyStateMachine) => {
-  const states = machine.root.stateIds.map((stateId) =>
-    machine.getStateNodeById(stateId)
-  );
-
-  states.forEach((state) => {
-    if (state.invoke.length > 0) {
-      throw new Error('Invocations on test machines are not supported');
-    }
-    if (state.after.length > 0) {
-      throw new Error('After events on test machines are not supported');
-    }
-    // TODO: this doesn't account for always transitions
-    [
-      ...state.entry,
-      ...state.exit,
-      ...[...state.transitions.values()].flatMap((t) =>
-        t.flatMap((t) => t.actions)
-      )
-    ].forEach((action) => {
-      // TODO: this doesn't check referenced actions, only the inline ones
-      if (
-        typeof action === 'function' &&
-        'resolve' in action &&
-        typeof (action as any).delay === 'number'
-      ) {
-        throw new Error('Delayed actions on test machines are not supported');
-      }
-    });
-  });
+  validateState(machine.root);
 };


### PR DESCRIPTION
I only found this to be used in a single place so it's an easy win for the bundlesize