### PR TITLE
Add a brand to `Function` to help distinguish resolved values from resolvers in the types

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -197,6 +197,14 @@ type ConditionalRequired<T, Condition extends boolean> = Condition extends true
   ? Required<T>
   : T;
 
+declare const functionBrand: unique symbol;
+type NotAFunction<T> = T & { [functionBrand]?: never };
+declare global {
+  interface Function {
+    [functionBrand]?: true;
+  }
+}
+
 export type WithDynamicParams<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
@@ -206,7 +214,7 @@ export type WithDynamicParams<
       {
         type: T['type'];
         params?:
-          | T['params']
+          | NotAFunction<T['params']>
           | (({
               context,
               event

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -2225,6 +2225,30 @@ describe('actions', () => {
     });
   });
 
+  it('should disallow dynamic params that return invalid params type when properties overlap with the function type', () => {
+    createMachine({
+      types: {} as {
+        actions:
+          | {
+              type: 'greet';
+              params: {
+                // (() => {}).name // string
+                // const a: { name: string } = () => {}; // #thisisfine
+                name: string;
+              };
+            }
+          | { type: 'poke' };
+      },
+      entry: {
+        type: 'greet',
+        // @ts-expect-error
+        params: () => ({
+          name: 100
+        })
+      }
+    });
+  });
+
   it('should provide context type to dynamic params', () => {
     createMachine({
       types: {} as {


### PR DESCRIPTION
I'm honestly not sure if I want to land this. It feels gross but helps to avoid legitimate errors 🤷‍♂️ 