### PR TITLE
[v5] Export actor logic types

### DIFF
--- a/.changeset/beige-pianos-give.md
+++ b/.changeset/beige-pianos-give.md
@@ -1,0 +1,14 @@
+---
+'xstate': minor
+---
+
+Actor types are now exported from `xstate`:
+
+```ts
+import {
+  type CallbackActorLogic,
+  type ObservableActorLogic,
+  type PromiseActorLogic,
+  type TransitionActorLogic
+} from 'xstate';
+```

--- a/packages/core/src/actors/index.ts
+++ b/packages/core/src/actors/index.ts
@@ -8,9 +8,13 @@ import type {
 } from '../types.ts';
 import { fromTransition } from './transition.ts';
 export { fromCallback, type CallbackActorLogic } from './callback.ts';
-export { fromEventObservable, fromObservable } from './observable.ts';
+export {
+  fromEventObservable,
+  fromObservable,
+  type ObservableActorLogic
+} from './observable.ts';
 export { fromPromise, type PromiseActorLogic } from './promise.ts';
-export { fromTransition } from './transition.ts';
+export { fromTransition, type TransitionActorLogic } from './transition.ts';
 
 export function isActorRef(item: any): item is ActorRef<any> {
   return !!item && typeof item === 'object' && typeof item.send === 'function';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,15 +1,5 @@
 export * from './actions.ts';
-export {
-  fromCallback,
-  fromEventObservable,
-  fromObservable,
-  fromPromise,
-  fromTransition,
-  type CallbackActorLogic,
-  type ObservableActorLogic,
-  type PromiseActorLogic,
-  type TransitionActorLogic
-} from './actors/index.ts';
+export * from './actors/index.ts';
 export { SimulatedClock } from './SimulatedClock.ts';
 export { type Spawner } from './spawn.ts';
 export { StateMachine } from './StateMachine.ts';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,11 @@ export {
   fromEventObservable,
   fromObservable,
   fromPromise,
-  fromTransition
+  fromTransition,
+  type CallbackActorLogic,
+  type ObservableActorLogic,
+  type PromiseActorLogic,
+  type TransitionActorLogic
 } from './actors/index.ts';
 export { SimulatedClock } from './SimulatedClock.ts';
 export { type Spawner } from './spawn.ts';


### PR DESCRIPTION

Actor types are now exported from `xstate`:

```ts
import {
  type CallbackActorLogic,
  type ObservableActorLogic,
  type PromiseActorLogic,
  type TransitionActorLogic
} from 'xstate';
```