### PR TITLE
Improved type safety of `spawn`ed inline actors when the actor types are not provided explicitly

### DIFF
--- a/.changeset/polite-experts-wash.md
+++ b/.changeset/polite-experts-wash.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Improved type safety of `spawn`ed inline actors when the actor types are not provided explicitly. It fixes an issue with an incompatible actor being assignable to a location accepting a different actor type (like a context property).

--- a/packages/core/src/spawn.ts
+++ b/packages/core/src/spawn.ts
@@ -45,14 +45,14 @@ export type Spawner<TActor extends ProvidedActor> = IsLiteralString<
       ...[options = {} as any]: SpawnOptions<TActor, TSrc>
     ) => ActorRefFrom<(TActor & { src: TSrc })['logic']>
   : // TODO: do not accept machines without all implementations
-    (
-      src: AnyActorLogic | string,
+    <TLogic extends AnyActorLogic | string>(
+      src: TLogic,
       options?: {
         id?: string;
         systemId?: string;
         input?: unknown;
       }
-    ) => AnyActorRef;
+    ) => TLogic extends string ? AnyActorRef : ActorRefFrom<TLogic>;
 
 export function createSpawner(
   actorContext: AnyActorContext,

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1052,6 +1052,72 @@ describe('spawn', () => {
       })
     });
   });
+
+  it(`should return a concrete actor ref type based on actor logic argument, one that is assignable to a location expecting that concrete actor ref type`, () => {
+    const child = createMachine({
+      types: {} as {
+        context: {
+          counter: number;
+        };
+      },
+      context: {
+        counter: 100
+      }
+    });
+
+    createMachine({
+      types: {} as {
+        context: {
+          myChild?: ActorRefFrom<typeof child>;
+        };
+      },
+      context: {},
+      entry: assign({
+        myChild: ({ spawn }) => {
+          return spawn(child);
+        }
+      })
+    });
+  });
+
+  it(`should return a concrete actor ref type based on actor logic argument, one that isn't assignable to a location expecting a different concrete actor ref type`, () => {
+    const child = createMachine({
+      types: {} as {
+        context: {
+          counter: number;
+        };
+      },
+      context: {
+        counter: 100
+      }
+    });
+
+    const otherChild = createMachine({
+      types: {} as {
+        context: {
+          title: string;
+        };
+      },
+      context: {
+        title: 'The Answer'
+      }
+    });
+
+    createMachine({
+      types: {} as {
+        context: {
+          myChild?: ActorRefFrom<typeof child>;
+        };
+      },
+      context: {},
+      entry: assign({
+        // @ts-expect-error
+        myChild: ({ spawn }) => {
+          return spawn(otherChild);
+        }
+      })
+    });
+  });
 });
 
 describe('invoke', () => {


### PR DESCRIPTION
this PR redoes https://github.com/statelyai/xstate/pull/3136