### PR TITLE
Update the Transloadit's sponsorship link and logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,8 +417,6 @@ Special thanks to the sponsors who support this open-source project:
     <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
     <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
   </picture>
-  <br />
-  Transloadit
 </a>
 
 ## SemVer Policy

--- a/README.md
+++ b/README.md
@@ -411,7 +411,15 @@ const previousState = paymentMachine.transition(reviewState, {
 
 Special thanks to the sponsors who support this open-source project:
 
-<a href="https://transloadit.com/"><img src="https://assets.transloadit.com/assets/images/logo-v2.svg" alt="Transloadit logo" width="200" /><br />Transloadit</a>
+<a href="https://transloadit.com/?utm_source=xstate&utm_medium=referral&utm_campaign=sponsorship&utm_content=github">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
+    <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
+  </picture>
+  <br />
+  Transloadit
+</a>
 
 ## SemVer Policy
 


### PR DESCRIPTION
Hi there,

I'm Alexander, a designer from Transloadit. I'd like to fix our logo appearance in XState's README, and add some UTM tags to the link to our website.

## Changes

- Fixed the Transloadit logo wasn't visible when GitHub is used with light theme
- Added UTM tags to the link to Transloadit's website

## Preview

**Before:**

> <img width="567" alt="Screenshot 2023-09-18 at 11 19 55@2x" src="https://github.com/statelyai/xstate/assets/375537/17ba60f2-eed5-4c7e-a400-c807e6b5f8b3">

**After:**

> <img width="564" alt="Screenshot 2023-09-18 at 11 20 04@2x" src="https://github.com/statelyai/xstate/assets/375537/27f6dc46-f15a-4bdd-8a7c-b13364962bb9">

**Dark/light mode preview:**

> ![Screenshot 2023-09-18 at 11 21 44](https://github.com/statelyai/xstate/assets/375537/6e9e580b-3d20-44d6-bc64-8724e70402d0)

/cc @kvz
