### PR TITLE
Persist callback input

### DIFF
--- a/.changeset/wise-eggs-train.md
+++ b/.changeset/wise-eggs-train.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The `input` of a callback actor created with `fromCallback(...)` will now be properly restored when the actor is persisted.

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -117,6 +117,11 @@ export function fromCallback<TEvent extends EventObject, TInput>(
         _dispose: undefined
       };
     },
-    getPersistedState: ({ _dispose, _receivers, ...rest }) => rest
+    getPersistedState: ({ _dispose, _receivers, ...rest }) => rest,
+    restoreState: (state) => ({
+      _receivers: new Set(),
+      _dispose: undefined,
+      ...state
+    })
   };
 }

--- a/packages/core/test/actorLogic.test.ts
+++ b/packages/core/test/actorLogic.test.ts
@@ -489,6 +489,44 @@ describe('callback logic (fromCallback)', () => {
 
     createActor(machine).start();
   });
+
+  it('should persist the input of a callback', () => {
+    let seenInput = undefined;
+    const machine = createMachine(
+      {
+        context: {
+          data: 42
+        },
+        invoke: {
+          src: 'cb',
+          input: ({ context }) => context.data
+        }
+      },
+      {
+        actors: {
+          cb: fromCallback(({ input }) => {
+            seenInput = input;
+          })
+        }
+      }
+    );
+
+    const actor = createActor(machine);
+
+    actor.start();
+
+    const state = actor.getPersistedState();
+
+    actor.stop();
+
+    seenInput = undefined;
+
+    const restoredActor = createActor(machine, { state });
+
+    restoredActor.start();
+
+    expect(seenInput).toBe(42);
+  });
 });
 
 describe('machine logic', () => {


### PR DESCRIPTION
This PR persists the `input` of callback, which was coming back as `undefined` when restoring callback state.