### PR TITLE
[@xstate/graph] Mock `actorContext`

### DIFF
--- a/.changeset/angry-seals-sin.md
+++ b/.changeset/angry-seals-sin.md
@@ -1,0 +1,21 @@
+---
+'@xstate/graph': patch
+---
+
+Traversing state machines that have delayed transitions will now work as expected:
+
+```ts
+const machine = createMachine({
+  initial: 'a',
+  states: {
+    a: {
+      after: {
+        1000: 'b'
+      }
+    },
+    b: {}
+  }
+});
+
+const paths = getShortestPaths(machine); // works
+```

--- a/packages/xstate-graph/src/actorContext.ts
+++ b/packages/xstate-graph/src/actorContext.ts
@@ -1,0 +1,14 @@
+import { AnyActorContext, createEmptyActor } from 'xstate';
+
+export function createMockActorContext(): AnyActorContext {
+  const emptyActor = createEmptyActor();
+  return {
+    self: emptyActor,
+    logger: console.log,
+    id: '',
+    sessionId: Math.random().toString(32).slice(2),
+    defer: () => {},
+    system: emptyActor,
+    stopChild: () => {}
+  };
+}

--- a/packages/xstate-graph/src/adjacency.ts
+++ b/packages/xstate-graph/src/adjacency.ts
@@ -1,6 +1,7 @@
 import { ActorLogic, ActorSystem, EventObject, Snapshot } from 'xstate';
 import { SerializedEvent, SerializedState, TraversalOptions } from './types';
 import { AdjacencyMap, resolveTraversalOptions } from './graph';
+import { createMockActorContext } from './actorContext';
 
 export function getAdjacencyMap<
   TSnapshot extends Snapshot<unknown>,
@@ -21,7 +22,7 @@ export function getAdjacencyMap<
     fromState: customFromState,
     stopCondition
   } = resolveTraversalOptions(logic, options);
-  const actorContext = { self: {} } as any; // TODO: figure out the simulation API
+  const actorContext = createMockActorContext();
   const fromState =
     customFromState ??
     logic.getInitialState(

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -20,6 +20,7 @@ import type {
   AnyStateNode,
   TraversalConfig
 } from './types.ts';
+import { createMockActorContext } from './actorContext.ts';
 
 function flatten<T>(array: Array<T | T[]>): T[] {
   return ([] as T[]).concat(...array);
@@ -101,9 +102,9 @@ export function createDefaultMachineOptions<TMachine extends AnyStateMachine>(
         })
       ) as any[];
     },
-    fromState: machine.getInitialState(
-      {} as any // TODO: figure out the simulation API
-    ) as ReturnType<TMachine['transition']>,
+    fromState: machine.getInitialState(createMockActorContext()) as ReturnType<
+      TMachine['transition']
+    >,
     ...otherOptions
   };
 

--- a/packages/xstate-graph/src/pathFromEvents.ts
+++ b/packages/xstate-graph/src/pathFromEvents.ts
@@ -19,6 +19,7 @@ import {
   createDefaultLogicOptions
 } from './graph';
 import { alterPath } from './alterPath';
+import { createMockActorContext } from './actorContext';
 
 function isMachine(value: any): value is AnyStateMachine {
   return !!value && '__xstatenode' in value;
@@ -45,7 +46,7 @@ export function getPathsFromEvents<
       ? createDefaultMachineOptions(logic)
       : createDefaultLogicOptions()) as TraversalOptions<TSnapshot, TEvent>
   );
-  const actorContext = { self: {} } as any; // TODO: figure out the simulation API
+  const actorContext = createMockActorContext();
   const fromState =
     resolvedOptions.fromState ??
     logic.getInitialState(

--- a/packages/xstate-graph/src/shortestPaths.ts
+++ b/packages/xstate-graph/src/shortestPaths.ts
@@ -9,6 +9,7 @@ import {
   StatePlanMap,
   TraversalOptions
 } from './types';
+import { createMockActorContext } from './actorContext';
 
 export function getShortestPaths<TLogic extends AnyActorLogic>(
   logic: TLogic,
@@ -26,10 +27,7 @@ export function getShortestPaths<TLogic extends AnyActorLogic>(
   ) => SerializedState;
   const fromState =
     resolvedOptions.fromState ??
-    logic.getInitialState(
-      {} as any, // TODO: figure out the simulation API
-      undefined
-    );
+    logic.getInitialState(createMockActorContext(), undefined);
   const adjacency = getAdjacencyMap(logic, resolvedOptions);
 
   // weight, state, event

--- a/packages/xstate-graph/src/simplePaths.ts
+++ b/packages/xstate-graph/src/simplePaths.ts
@@ -19,6 +19,7 @@ import {
 import { resolveTraversalOptions, createDefaultMachineOptions } from './graph';
 import { getAdjacencyMap } from './adjacency';
 import { alterPath } from './alterPath';
+import { createMockActorContext } from './actorContext';
 
 export function getSimplePaths<TLogic extends AnyActorLogic>(
   logic: TLogic,
@@ -31,7 +32,7 @@ export function getSimplePaths<TLogic extends AnyActorLogic>(
   type TEvent = EventFromLogic<TLogic>;
 
   const resolvedOptions = resolveTraversalOptions(logic, options);
-  const actorContext = { self: {} } as any; // TODO: figure out the simulation API
+  const actorContext = createMockActorContext();
   const fromState =
     resolvedOptions.fromState ?? logic.getInitialState(actorContext, undefined);
   const serializeState = resolvedOptions.serializeState as (

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -16,6 +16,7 @@ import {
   getSimplePaths
 } from '../src';
 import { joinPaths } from '../src/graph';
+import { createMockActorContext } from '../src/actorContext';
 
 function getPathsSnapshot(
   paths: Array<StatePath<Snapshot<unknown>, EventObject>>
@@ -216,9 +217,7 @@ describe('@xstate/graph', () => {
       expect(
         shortestPaths.find((path) =>
           path.state.matches(
-            lightMachine.getInitialState(
-              {} as any // TODO: figure out the simulation API
-            ).value
+            lightMachine.getInitialState(createMockActorContext()).value
           )
         )!.steps
       ).toHaveLength(1);
@@ -377,36 +376,28 @@ describe('@xstate/graph', () => {
       expect(
         getSimplePaths(lightMachine).find((p) =>
           p.state.matches(
-            lightMachine.getInitialState(
-              {} as any // TODO: figure out the simulation API
-            ).value
+            lightMachine.getInitialState(createMockActorContext()).value
           )
         )
       ).toBeDefined();
       expect(
         getSimplePaths(lightMachine).find((p) =>
           p.state.matches(
-            lightMachine.getInitialState(
-              {} as any // TODO: figure out the simulation API
-            ).value
+            lightMachine.getInitialState(createMockActorContext()).value
           )
         )!.steps
       ).toHaveLength(1);
       expect(
         getSimplePaths(equivMachine).find((p) =>
           p.state.matches(
-            equivMachine.getInitialState(
-              {} as any // TODO: figure out the simulation API
-            ).value
+            equivMachine.getInitialState(createMockActorContext()).value
           )
         )!
       ).toBeDefined();
       expect(
         getSimplePaths(equivMachine).find((p) =>
           p.state.matches(
-            equivMachine.getInitialState(
-              {} as any // TODO: figure out the simulation API
-            ).value
+            equivMachine.getInitialState(createMockActorContext()).value
           )
         )!.steps
       ).toHaveLength(1);

--- a/packages/xstate-graph/test/shortestPaths.test.ts
+++ b/packages/xstate-graph/test/shortestPaths.test.ts
@@ -143,7 +143,7 @@ describe('getShortestPaths', () => {
     expect(pathWithTwoTodos).toBeDefined();
   });
 
-  it('should not throw for machines with delays', () => {
+  it('should work for machines with delays', () => {
     const machine = createMachine({
       initial: 'a',
       states: {
@@ -156,8 +156,11 @@ describe('getShortestPaths', () => {
       }
     });
 
-    expect(() => {
-      getShortestPaths(machine);
-    }).not.toThrowError();
+    const shortestPaths = getShortestPaths(machine);
+
+    expect(shortestPaths.map((p) => p.steps.map((s) => s.event.type))).toEqual([
+      ['xstate.init'],
+      ['xstate.init', 'xstate.after(1000)#(machine).a']
+    ]);
   });
 });

--- a/packages/xstate-graph/test/shortestPaths.test.ts
+++ b/packages/xstate-graph/test/shortestPaths.test.ts
@@ -142,4 +142,22 @@ describe('getShortestPaths', () => {
 
     expect(pathWithTwoTodos).toBeDefined();
   });
+
+  it('should not throw for machines with delays', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          after: {
+            1000: 'b'
+          }
+        },
+        b: {}
+      }
+    });
+
+    expect(() => {
+      getShortestPaths(machine);
+    }).not.toThrowError();
+  });
 });


### PR DESCRIPTION
This PR makes machines like this work, that would previously error. The problem was we didn't have a `actorCtx.defer(...)` function.

```ts
    const machine = createMachine({
      initial: 'a',
      states: {
        a: {
          after: {
            1000: 'b'
          }
        },
        b: {}
      }
    });
```