### PR TITLE
Give unique names to `resolve` in `execute` helpers used by builtin actions

### DIFF
--- a/packages/core/src/actions/assign.ts
+++ b/packages/core/src/actions/assign.ts
@@ -26,7 +26,7 @@ export interface AssignArgs<
   spawn: Spawner<TActor>;
 }
 
-function resolve(
+function resolveAssign(
   actorContext: AnyActorContext,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any, any>,
@@ -138,7 +138,7 @@ export function assign<
   assign.type = 'xstate.assign';
   assign.assignment = assignment;
 
-  assign.resolve = resolve;
+  assign.resolve = resolveAssign;
 
   return assign;
 }

--- a/packages/core/src/actions/cancel.ts
+++ b/packages/core/src/actions/cancel.ts
@@ -20,7 +20,7 @@ type ResolvableSendId<
       args: ActionArgs<TContext, TExpressionEvent, TExpressionAction, TEvent>
     ) => string);
 
-function resolve(
+function resolveCancel(
   _: AnyActorContext,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any, any>,
@@ -31,7 +31,7 @@ function resolve(
   return [state, resolvedSendId];
 }
 
-function execute(actorContext: AnyActorContext, resolvedSendId: string) {
+function executeCancel(actorContext: AnyActorContext, resolvedSendId: string) {
   (actorContext.self as AnyActor).cancel(resolvedSendId);
 }
 
@@ -75,8 +75,8 @@ export function cancel<
   cancel.type = 'xstate.cancel';
   cancel.sendId = sendId;
 
-  cancel.resolve = resolve;
-  cancel.execute = execute;
+  cancel.resolve = resolveCancel;
+  cancel.execute = executeCancel;
 
   return cancel;
 }

--- a/packages/core/src/actions/choose.ts
+++ b/packages/core/src/actions/choose.ts
@@ -13,7 +13,7 @@ import {
 import { evaluateGuard } from '../guards.ts';
 import { toArray } from '../utils.ts';
 
-function resolve(
+function resolveChoose(
   _: AnyActorContext,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any, any>,
@@ -102,7 +102,7 @@ export function choose<
   choose.type = 'xstate.choose';
   choose.branches = branches;
 
-  choose.resolve = resolve;
+  choose.resolve = resolveChoose;
 
   return choose;
 }

--- a/packages/core/src/actions/invoke.ts
+++ b/packages/core/src/actions/invoke.ts
@@ -14,7 +14,7 @@ import {
 } from '../types.ts';
 import { resolveReferencedActor } from '../utils.ts';
 
-function resolve(
+function resolveInvoke(
   actorContext: AnyActorContext,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any, any>,
@@ -74,7 +74,7 @@ function resolve(
   ];
 }
 
-function execute(
+function executeInvoke(
   actorContext: AnyActorContext,
   { id, actorRef }: { id: string; actorRef: AnyActorRef }
 ) {
@@ -135,8 +135,8 @@ export function invoke<
   invoke.src = src;
   invoke.input = input;
 
-  invoke.resolve = resolve;
-  invoke.execute = execute;
+  invoke.resolve = resolveInvoke;
+  invoke.execute = executeInvoke;
 
   return invoke;
 }

--- a/packages/core/src/actions/log.ts
+++ b/packages/core/src/actions/log.ts
@@ -16,7 +16,7 @@ type ResolvableLogValue<
   TEvent extends EventObject
 > = string | LogExpr<TContext, TExpressionEvent, TExpressionAction, TEvent>;
 
-function resolve(
+function resolveLog(
   _: AnyActorContext,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any, any>,
@@ -37,7 +37,7 @@ function resolve(
   ];
 }
 
-function execute(
+function executeLog(
   { logger }: AnyActorContext,
   { value, label }: { value: unknown; label: string | undefined }
 ) {
@@ -91,8 +91,8 @@ export function log<
   log.value = value;
   log.label = label;
 
-  log.resolve = resolve;
-  log.execute = execute;
+  log.resolve = resolveLog;
+  log.execute = executeLog;
 
   return log;
 }

--- a/packages/core/src/actions/pure.ts
+++ b/packages/core/src/actions/pure.ts
@@ -14,7 +14,7 @@ import {
 } from '../types.ts';
 import { toArray } from '../utils.ts';
 
-function resolve(
+function resolvePure(
   _: AnyActorContext,
   state: AnyState,
   args: ActionArgs<any, any, any, any>,
@@ -105,7 +105,8 @@ export function pure<
 
   pure.type = 'xstate.pure';
   pure.get = getActions;
-  pure.resolve = resolve;
+
+  pure.resolve = resolvePure;
 
   return pure;
 }

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -14,7 +14,7 @@ import {
   ParameterizedObject
 } from '../types.ts';
 
-function resolve(
+function resolveRaise(
   _: AnyActorContext,
   state: AnyState,
   args: ActionArgs<any, any, any, any>,
@@ -73,7 +73,7 @@ function resolve(
   ];
 }
 
-function execute(
+function executeRaise(
   actorContext: AnyActorContext,
   params: {
     event: EventObject;
@@ -146,8 +146,8 @@ export function raise<
   raise.id = options?.id;
   raise.delay = options?.delay;
 
-  raise.resolve = resolve;
-  raise.execute = execute;
+  raise.resolve = resolveRaise;
+  raise.execute = executeRaise;
 
   return raise;
 }

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -24,7 +24,7 @@ import {
 } from '../types.ts';
 import { XSTATE_ERROR } from '../constants.ts';
 
-function resolve(
+function resolveSendTo(
   actorContext: AnyActorContext,
   state: AnyState,
   args: ActionArgs<any, any, any, any>,
@@ -110,7 +110,7 @@ function resolve(
     { to: targetActorRef, event: resolvedEvent, id, delay: resolvedDelay }
   ];
 }
-function execute(
+function executeSendTo(
   actorContext: AnyActorContext,
   params: {
     to: AnyActorRef;
@@ -202,8 +202,8 @@ export function sendTo<
   sendTo.id = options?.id;
   sendTo.delay = options?.delay;
 
-  sendTo.resolve = resolve;
-  sendTo.execute = execute;
+  sendTo.resolve = resolveSendTo;
+  sendTo.execute = executeSendTo;
 
   return sendTo;
 }

--- a/packages/core/src/actions/stop.ts
+++ b/packages/core/src/actions/stop.ts
@@ -23,7 +23,7 @@ type ResolvableActorRef<
       args: ActionArgs<TContext, TExpressionEvent, TExpressionAction, TEvent>
     ) => ActorRef<any, any> | string);
 
-function resolve(
+function resolveStop(
   _: AnyActorContext,
   state: AnyState,
   args: ActionArgs<any, any, any, any>,
@@ -48,7 +48,7 @@ function resolve(
     resolvedActorRef
   ];
 }
-function execute(
+function executeStop(
   actorContext: AnyActorContext,
   actorRef: ActorRef<any, any> | undefined
 ) {
@@ -103,8 +103,8 @@ export function stop<
   stop.type = 'xstate.stop';
   stop.actorRef = actorRef;
 
-  stop.resolve = resolve;
-  stop.execute = execute;
+  stop.resolve = resolveStop;
+  stop.execute = executeStop;
 
   return stop;
 }


### PR DESCRIPTION
It's just an internal change to make it more clear in the call stack what is being executed.