### PR TITLE
fix: exit actions not running before transition (#1)

### DIFF
--- a/.changeset/twelve-hounds-warn.md
+++ b/.changeset/twelve-hounds-warn.md
@@ -1,0 +1,5 @@
+---
+'@xstate/fsm': patch
+---
+
+Fix an issue in @xstate/fsm where exit actions run after transition and not before

--- a/packages/xstate-fsm/src/types.ts
+++ b/packages/xstate-fsm/src/types.ts
@@ -103,6 +103,8 @@ export namespace StateMachine {
     TState extends Typestate<TContext>
   > {
     value: TState['value'];
+    exitContext: TContext;
+    exitActions: Array<ActionObject<TContext, TEvent>>;
     context: TContext;
     actions: Array<ActionObject<TContext, TEvent>>;
     changed?: boolean | undefined;

--- a/packages/xstate-fsm/test/fsm.test.ts
+++ b/packages/xstate-fsm/test/fsm.test.ts
@@ -113,8 +113,15 @@ describe('@xstate/fsm', () => {
   it('should transition correctly', () => {
     const nextState = lightFSM.transition('green', 'TIMER');
     expect(nextState.value).toEqual('yellow');
+    expect(nextState.exitActions.map((action) => action.type)).toEqual([
+      'exitGreen'
+    ]);
+    expect(nextState.exitContext).toEqual({
+      count: 2,
+      foo: 'static++',
+      go: true
+    });
     expect(nextState.actions.map((action) => action.type)).toEqual([
-      'exitGreen',
       'g-y 1',
       'g-y 2'
     ]);
@@ -355,6 +362,30 @@ describe('interpreter', () => {
     });
 
     interpret(machine).start();
+    expect(executed).toBe(true);
+  });
+
+  it('should execute exit action', () => {
+    let executed = false;
+    let service;
+    const machine = createMachine({
+      initial: 'foo',
+      states: {
+        foo: {
+          exit: () => {
+            executed = service.state.value === 'foo';
+          },
+          on: {
+            BAR: 'bar'
+          }
+        },
+        bar: {}
+      }
+    });
+
+    service = interpret(machine);
+    service.start();
+    service.send('BAR');
     expect(executed).toBe(true);
   });
 


### PR DESCRIPTION
This PR:

- Fixes an issue in `@xstate/fsm` where exit actions run after transition and not before