### PR TITLE
setup function may lead to unexpected behavior

### DIFF
--- a/packages/xstate-vue/test/typegenTypes.test.tsx
+++ b/packages/xstate-vue/test/typegenTypes.test.tsx
@@ -48,7 +48,7 @@ describe('useMachine', () => {
       setup() {
         // @ts-expect-error
         useMachine(machine);
-        return null;
+        return undefined;
       }
     });
   });


### PR DESCRIPTION
In Vue , returning null from the setup function may lead to unexpected behavior, so it's best to follow the recommendation to return undefined. This change should resolve the warning message mentioned.