### PR TITLE
Export inspection event types

### DIFF
--- a/.changeset/stale-crews-cry.md
+++ b/.changeset/stale-crews-cry.md
@@ -1,0 +1,14 @@
+---
+'xstate': patch
+---
+
+Inspection events are now exported:
+
+```ts
+import type {
+  InspectedActorEvent,
+  InspectedEventEvent,
+  InspectedSnapshotEvent,
+  InspectionEvent
+} from 'xstate';
+```

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,12 @@ export {
   StateNode,
   type Interpreter
 };
+export type {
+  InspectedActorEvent,
+  InspectedEventEvent,
+  InspectedSnapshotEvent,
+  InspectionEvent
+} from './system.ts';
 
 export { and, not, or, stateIn } from './guards.ts';
 

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -4,9 +4,9 @@ import {
   fromPromise,
   sendParent,
   sendTo,
-  waitFor
+  waitFor,
+  InspectionEvent
 } from '../src';
-import { InspectionEvent } from '../src/system';
 
 function simplifyEvent(inspectionEvent: InspectionEvent) {
   if (inspectionEvent.type === '@xstate.event') {


### PR DESCRIPTION

Inspection events are now exported:

```ts
import type {
  InspectedActorEvent,
  InspectedEventEvent,
  InspectedSnapshotEvent,
  InspectionEvent
} from 'xstate';
```