### PR TITLE
Modify useMachine config instance warning

### DIFF
--- a/.changeset/ninety-apes-watch.md
+++ b/.changeset/ninety-apes-watch.md
@@ -1,0 +1,5 @@
+---
+'@xstate/react': minor
+---
+
+machine reference warning will trigger only when instance of the config changes

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -296,11 +296,11 @@ const machine = createMachine(config);
 
 const Component = () => {
   const doStuff = useSomeHook();
-  const [state, send] = useMachine(machine, React.useMemo(() => {
+  const [state, send] = useMachine(machine, React.useMemo(() => ({
     actions: {
       someHookAction: (ctx) => doStuff(ctx);
     }
-  }, [doStuff]));
+  }), [doStuff]));
   return <></>
 }
 ```

--- a/packages/xstate-react/src/fsm.ts
+++ b/packages/xstate-react/src/fsm.ts
@@ -43,10 +43,10 @@ export function useMachine<TMachine extends StateMachine.AnyMachine>(
   if (process.env.NODE_ENV !== 'production') {
     const [initialMachine] = useState(stateMachine);
 
-    if (stateMachine !== initialMachine) {
+    if (stateMachine.config !== initialMachine.config) {
       console.warn(
         'Machine given to `useMachine` has changed between renders. This is not supported and might lead to unexpected results.\n' +
-          'Please make sure that you pass the same Machine as argument each time.'
+          'Please make sure that you pass the same instance of the config argument to createMachine(...) each time. The options argument can change between renders'
       );
     }
   }

--- a/packages/xstate-react/src/useInterpret.ts
+++ b/packages/xstate-react/src/useInterpret.ts
@@ -35,10 +35,10 @@ export function useIdleInterpreter(
   ) {
     const [initialMachine] = useState(machine);
 
-    if (getMachine !== initialMachine) {
+    if (getMachine.config !== initialMachine.config) {
       console.warn(
         'Machine given to `useMachine` has changed between renders. This is not supported and might lead to unexpected results.\n' +
-          'Please make sure that you pass the same Machine as argument each time.'
+          'Please make sure that you pass the same instance of the config argument to createMachine(...) each time. The options argument can change between renders'
       );
     }
   }


### PR DESCRIPTION
This change will address the 2nd edge case covered in the documentation I updated. currently there is no way to modify a reference of an action without triggering the useMachine warning. 