### PR TITLE
Stop calling exit actions on stop

### DIFF
--- a/.changeset/wild-apes-play.md
+++ b/.changeset/wild-apes-play.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+`exit` actions of all states are no longer called when the machine gets stopped externally. Note that they are still called when the machine reaches its final state.

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -138,9 +138,6 @@ function executeSendTo(
     delay: number | undefined;
   }
 ) {
-  if (params.event.type === 'STOPPED') {
-    debugger;
-  }
   if (typeof params.delay === 'number') {
     (actorContext.self as AnyActor).delaySend(
       params as typeof params & { delay: number }

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -138,6 +138,9 @@ function executeSendTo(
     delay: number | undefined;
   }
 ) {
+  if (params.event.type === 'STOPPED') {
+    debugger;
+  }
   if (typeof params.delay === 'number') {
     (actorContext.self as AnyActor).delaySend(
       params as typeof params & { delay: number }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1577,7 +1577,7 @@ export function macrostep(
 
   // Handle stop event
   if (event.type === XSTATE_STOP) {
-    nextState = stopStep(nextState, event, actorCtx);
+    nextState = stopChildren(nextState, event, actorCtx);
     states.push(nextState);
 
     return {
@@ -1647,26 +1647,6 @@ function stopChildren(
     Object.values(nextState.children).map((child) => stop(child)),
     []
   );
-}
-
-function stopStep(
-  nextState: AnyState,
-  event: AnyEventObject,
-  actorCtx: AnyActorContext
-) {
-  const exitActions = nextState.configuration
-    .sort((a, b) => b.order - a.order)
-    .flatMap((stateNode) => stateNode.exit);
-
-  nextState = resolveActionsAndContext(
-    nextState,
-    event,
-    actorCtx,
-    exitActions,
-    []
-  );
-
-  return stopChildren(nextState, event, actorCtx);
 }
 
 function selectTransitions(

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -4,6 +4,7 @@ import {
   assign,
   AnyActorRef
 } from '../src/index.ts';
+import { trackEntries } from './utils.ts';
 
 describe('final states', () => {
   it('status of a machine with a root state being final should be done', () => {
@@ -824,5 +825,206 @@ describe('final states', () => {
     createActor(machine).start();
 
     expect(spy).toBeCalledTimes(1);
+  });
+
+  it('should call exit actions in reversed document order when the machines reaches its final state', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          on: {
+            EV: 'b'
+          }
+        },
+        b: {
+          type: 'final'
+        }
+      }
+    });
+
+    const flushTracked = trackEntries(machine);
+
+    const actorRef = createActor(machine).start();
+    flushTracked();
+
+    // it's important to send an event here that results in a transition that computes new `state.configuration`
+    // and that could impact the order in which exit actions are called
+    actorRef.send({ type: 'EV' });
+
+    expect(flushTracked()).toEqual([
+      // result of the transition
+      'exit: a',
+      'enter: b',
+      // result of reaching final states
+      'exit: b',
+      'exit: __root__'
+    ]);
+  });
+
+  it('should call exit actions of parallel states in reversed document order when the machines reaches its final state after earlier region transition', () => {
+    const machine = createMachine({
+      type: 'parallel',
+      states: {
+        a: {
+          initial: 'child_a1',
+          states: {
+            child_a1: {
+              on: {
+                EV2: 'child_a2'
+              }
+            },
+            child_a2: {
+              type: 'final'
+            }
+          }
+        },
+        b: {
+          initial: 'child_b1',
+          states: {
+            child_b1: {
+              on: {
+                EV1: 'child_b2'
+              }
+            },
+            child_b2: {
+              type: 'final'
+            }
+          }
+        }
+      }
+    });
+
+    const flushTracked = trackEntries(machine);
+
+    const actorRef = createActor(machine).start();
+
+    // it's important to send an event here that results in a transition as that computes new `state.configuration`
+    // and that could impact the order in which exit actions are called
+    actorRef.send({ type: 'EV1' });
+    flushTracked();
+    actorRef.send({ type: 'EV2' });
+
+    expect(flushTracked()).toEqual([
+      // result of the transition
+      'exit: a.child_a1',
+      'enter: a.child_a2',
+      // result of reaching final states
+      'exit: b.child_b2',
+      'exit: b',
+      'exit: a.child_a2',
+      'exit: a',
+      'exit: __root__'
+    ]);
+  });
+
+  it('should call exit actions of parallel states in reversed document order when the machines reaches its final state after later region transition', () => {
+    const machine = createMachine({
+      type: 'parallel',
+      states: {
+        a: {
+          initial: 'child_a1',
+          states: {
+            child_a1: {
+              on: {
+                EV2: 'child_a2'
+              }
+            },
+            child_a2: {
+              type: 'final'
+            }
+          }
+        },
+        b: {
+          initial: 'child_b1',
+          states: {
+            child_b1: {
+              on: {
+                EV1: 'child_b2'
+              }
+            },
+            child_b2: {
+              type: 'final'
+            }
+          }
+        }
+      }
+    });
+
+    const flushTracked = trackEntries(machine);
+
+    const actorRef = createActor(machine).start();
+    // it's important to send an event here that results in a transition as that computes new `state.configuration`
+    // and that could impact the order in which exit actions are called
+    actorRef.send({ type: 'EV1' });
+    flushTracked();
+    actorRef.send({ type: 'EV2' });
+
+    expect(flushTracked()).toEqual([
+      // result of the transition
+      'exit: a.child_a1',
+      'enter: a.child_a2',
+      // result of reaching final states
+      'exit: b.child_b2',
+      'exit: b',
+      'exit: a.child_a2',
+      'exit: a',
+      'exit: __root__'
+    ]);
+  });
+
+  it('should call exit actions of parallel states in reversed document order when the machines reaches its final state after multiple regions transition', () => {
+    const machine = createMachine({
+      type: 'parallel',
+      states: {
+        a: {
+          initial: 'child_a1',
+          states: {
+            child_a1: {
+              on: {
+                EV: 'child_a2'
+              }
+            },
+            child_a2: {
+              type: 'final'
+            }
+          }
+        },
+        b: {
+          initial: 'child_b1',
+          states: {
+            child_b1: {
+              on: {
+                EV: 'child_b2'
+              }
+            },
+            child_b2: {
+              type: 'final'
+            }
+          }
+        }
+      }
+    });
+
+    const flushTracked = trackEntries(machine);
+
+    const actorRef = createActor(machine).start();
+    flushTracked();
+    // it's important to send an event here that results in a transition as that computes new `state.configuration`
+    // and that could impact the order in which exit actions are called
+    actorRef.send({ type: 'EV' });
+
+    expect(flushTracked()).toEqual([
+      // result of the transition
+      'exit: b.child_b1',
+      'exit: a.child_a1',
+      'enter: a.child_a2',
+      'enter: b.child_b2',
+      // result of reaching final states
+      'exit: b.child_b2',
+      'exit: b',
+      'exit: a.child_a2',
+      'exit: a',
+      'exit: __root__'
+    ]);
   });
 });

--- a/packages/core/test/rehydration.test.ts
+++ b/packages/core/test/rehydration.test.ts
@@ -23,7 +23,7 @@ describe('rehydration', () => {
       expect(service.getSnapshot().hasTag('foo')).toBe(true);
     });
 
-    it('should call exit actions when machine gets stopped immediately', () => {
+    it('should not call exit actions when machine gets stopped immediately', () => {
       const actual: string[] = [];
       const machine = createMachine({
         exit: () => actual.push('root'),
@@ -39,12 +39,11 @@ describe('rehydration', () => {
       const persistedState = JSON.stringify(actorRef.getPersistedState());
       actorRef.stop();
 
-      actual.length = 0;
       createActor(machine, { state: JSON.parse(persistedState) })
         .start()
         .stop();
 
-      expect(actual).toEqual(['a', 'root']);
+      expect(actual).toEqual([]);
     });
 
     it('should get correct result back from `can` immediately', () => {
@@ -92,7 +91,7 @@ describe('rehydration', () => {
       expect(service.getSnapshot().hasTag('foo')).toBe(true);
     });
 
-    it('should call exit actions when machine gets stopped immediately', () => {
+    it('should not call exit actions when machine gets stopped immediately', () => {
       const actual: string[] = [];
       const machine = createMachine({
         exit: () => actual.push('root'),
@@ -113,7 +112,7 @@ describe('rehydration', () => {
         .start()
         .stop();
 
-      expect(actual).toEqual(['active', 'root']);
+      expect(actual).toEqual([]);
     });
   });
 


### PR DESCRIPTION
It's important for rehydration. A stopped aka persisted machine can't call its exit actions if we don't call entry actions later on when rehydrating that state. And we can't call those entry actions because we have no sensible `event` to call them with. In addition to that - the whole persisting/rehydrating cycle should be mostly transparent to the user and if we call those actions it's no longer transparent.

Originally, we only started to call those actions in this situation because it was what SCXML mandated. It didn't come from a user request.