### PR TITLE
Fixed an issue with `exit` actions sometimes being called twice when machine reached its final state

### DIFF
--- a/.changeset/small-lobsters-tie.md
+++ b/.changeset/small-lobsters-tie.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with `exit` actions sometimes being called twice when a machine reaches its final state and leads its parent to stopping it at the same time.

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -636,6 +636,9 @@ export class Interpreter<
 
     // let what is currently processed to be finished
     scheduler.schedule(() => {
+      if (this._state?.done) {
+        return;
+      }
       // it feels weird to handle this here but we need to handle this even slightly "out of band"
       const _event = toSCXMLEvent({ type: 'xstate.stop' }) as any;
 

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1418,15 +1418,13 @@ describe('entry/exit actions', () => {
     });
 
     it('sent events from exit handlers of a done child should be received by its children ', () => {
-      let eventReceived = false;
+      const spy = jest.fn();
 
       const grandchild = createMachine({
         id: 'grandchild',
         on: {
           STOPPED: {
-            actions: () => {
-              eventReceived = true;
-            }
+            actions: spy
           }
         }
       });
@@ -1467,7 +1465,7 @@ describe('entry/exit actions', () => {
       const interpreter = interpret(parent).start();
       interpreter.send({ type: 'NEXT' });
 
-      expect(eventReceived).toBe(true);
+      expect(spy).toHaveBeenCalledTimes(1);
     });
 
     it('actors spawned in exit handlers of a stopped child should not be started', () => {


### PR DESCRIPTION
fixes https://github.com/statelyai/xstate/issues/4167