### PR TITLE
Do not resolve `output` of final states directly nested in parallel states

### DIFF
--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1178,16 +1178,13 @@ function enterStates(
       }
       while (
         ancestorMarker?.type === 'parallel' &&
+        !completedNodes.has(ancestorMarker) &&
         isInFinalState(mutConfiguration, ancestorMarker)
       ) {
-        const completedNode: typeof ancestorMarker = ancestorMarker;
-        if (completedNodes.has(completedNode)) {
-          break;
-        }
-        ancestorMarker = completedNode.parent;
-        rootCompletionNode = completedNode;
-        completedNodes.add(completedNode);
-        internalQueue.push(createDoneStateEvent(completedNode.id));
+        completedNodes.add(ancestorMarker);
+        internalQueue.push(createDoneStateEvent(ancestorMarker.id));
+        rootCompletionNode = ancestorMarker;
+        ancestorMarker = ancestorMarker.parent;
       }
       if (ancestorMarker) {
         continue;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1157,16 +1157,11 @@ function enterStates(
     if (stateNodeToEnter.type === 'final') {
       const parent = stateNodeToEnter.parent;
 
-      if (completedNodes.has(parent)) {
-        continue;
-      }
-      completedNodes.add(parent);
-
       let ancestorMarker =
         parent?.type === 'parallel' ? parent : parent?.parent;
       let rootCompletionNode = ancestorMarker || stateNodeToEnter;
 
-      if (ancestorMarker) {
+      if (parent?.type === 'compound') {
         internalQueue.push(
           createDoneStateEvent(
             parent!.id,
@@ -1180,21 +1175,19 @@ function enterStates(
               : undefined
           )
         );
-        while (
-          ancestorMarker?.type === 'parallel' &&
-          isInFinalState(mutConfiguration, ancestorMarker)
-        ) {
-          const completedNode: typeof ancestorMarker = ancestorMarker;
-
-          ancestorMarker = completedNode.parent;
-          rootCompletionNode = completedNode;
-
-          if (completedNodes.has(completedNode)) {
-            break;
-          }
-          completedNodes.add(completedNode);
-          internalQueue.push(createDoneStateEvent(completedNode.id));
+      }
+      while (
+        ancestorMarker?.type === 'parallel' &&
+        isInFinalState(mutConfiguration, ancestorMarker)
+      ) {
+        const completedNode: typeof ancestorMarker = ancestorMarker;
+        if (completedNodes.has(completedNode)) {
+          break;
         }
+        ancestorMarker = completedNode.parent;
+        rootCompletionNode = completedNode;
+        completedNodes.add(completedNode);
+        internalQueue.push(createDoneStateEvent(completedNode.id));
       }
       if (ancestorMarker) {
         continue;

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -1085,16 +1085,21 @@ describe('final states', () => {
     const spy = jest.fn();
 
     const machine = createMachine({
-      type: 'parallel',
+      initial: 'A',
       states: {
         A: {
-          type: 'final',
-          output: spy
-        },
-        B: {
-          initial: 'B1',
+          type: 'parallel',
           states: {
-            B1: {}
+            B: {
+              type: 'final',
+              output: spy
+            },
+            C: {
+              initial: 'C1',
+              states: {
+                C1: {}
+              }
+            }
           }
         }
       }

--- a/packages/core/test/final.test.ts
+++ b/packages/core/test/final.test.ts
@@ -1080,4 +1080,28 @@ describe('final states', () => {
 
     expect(actorRef.getSnapshot().status).toBe('active');
   });
+
+  it('should not resolve output of a final state if its parent is a parallel state', () => {
+    const spy = jest.fn();
+
+    const machine = createMachine({
+      type: 'parallel',
+      states: {
+        A: {
+          type: 'final',
+          output: spy
+        },
+        B: {
+          initial: 'B1',
+          states: {
+            B1: {}
+          }
+        }
+      }
+    });
+
+    createActor(machine).start();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
`xstate.done.state.*` events are dispatched for **parent** states and not for final states themselves. As parallel states are completed when all of their child regions are complete we can't dispatch this event in this situation as a completion of a single region would complete the whole parallel state.