### PR TITLE
Added support to `stateIn` guard for checking a combination of an ID and a path

### DIFF
--- a/.changeset/eight-radios-battle.md
+++ b/.changeset/eight-radios-battle.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Added support to `stateIn` guard for checking a combination of an ID and a path, eg. `stateIn('#b.B1')`.

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -72,7 +72,8 @@ function checkStateIn(
   { stateValue }: { stateValue: StateValue }
 ) {
   if (typeof stateValue === 'string' && isStateId(stateValue)) {
-    return state.configuration.some((sn) => sn.id === stateValue.slice(1));
+    const target = state.machine.getStateNodeById(stateValue);
+    return state.configuration.some((sn) => sn === target);
   }
 
   return state.matches(stateValue);

--- a/packages/core/test/stateIn.test.ts
+++ b/packages/core/test/stateIn.test.ts
@@ -464,4 +464,39 @@ describe('transition "in" check', () => {
       location: 'success'
     });
   });
+
+  it('should be possible to check an ID with a path', () => {
+    const spy = jest.fn();
+    const machine = createMachine({
+      type: 'parallel',
+      states: {
+        A: {
+          initial: 'A1',
+          states: {
+            A1: {
+              on: {
+                MY_EVENT: {
+                  guard: stateIn('#b.B1'),
+                  actions: spy
+                }
+              }
+            }
+          }
+        },
+        B: {
+          id: 'b',
+          initial: 'B1',
+          states: {
+            B1: {}
+          }
+        }
+      }
+    });
+
+    createActor(machine).start().send({
+      type: 'MY_EVENT'
+    });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
closes https://github.com/statelyai/xstate/issues/4383