### PR TITLE
Fixes to support Generating API Documentation

### DIFF
--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -982,11 +982,6 @@ function areConfigurationsEqual(
 
 /**
  * https://www.w3.org/TR/scxml/#microstepProcedure
- *
- * @internal
- * @param transitions
- * @param currentState
- * @param mutConfiguration
  */
 export function microstep<
   TContext extends MachineContext,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -983,7 +983,7 @@ function areConfigurationsEqual(
 /**
  * https://www.w3.org/TR/scxml/#microstepProcedure
  *
- * @private
+ * @internal
  * @param transitions
  * @param currentState
  * @param mutConfiguration

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -290,6 +290,7 @@ export interface StateValueMap {
  * @remarks
  *
  * - For a child atomic state node, this is a string, e.g., `"pending"`.
+ *
  * - For complex state nodes, this is an object, e.g., `{ success: "someChildState" }`.
  */
 export type StateValue = string | StateValueMap;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,6 +23,9 @@ export type HomomorphicOmit<T, K extends keyof any> = {
 };
 
 /**
+ *
+ * @remarks
+ *
  * `T | unknown` reduces to `unknown` and that can be problematic when it comes to contextual typing.
  * It especially is a problem when the union has a function member, like here:
  *

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -284,6 +284,8 @@ export interface StateValueMap {
 /**
  * The string or object representing the state value relative to the parent state node.
  *
+ * @remarks
+ *
  * - For a child atomic state node, this is a string, e.g., `"pending"`.
  * - For complex state nodes, this is an object, e.g., `{ success: "someChildState" }`.
  */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -837,7 +837,7 @@ export interface StateNodeConfig<
     TDelay
   >;
   /**
-   * @private
+   * @internal
    */
   parent?: StateNode<TContext, TEvent>;
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -840,9 +840,6 @@ export interface StateNodeConfig<
     TGuard,
     TDelay
   >;
-  /**
-   * @internal
-   */
   parent?: StateNode<TContext, TEvent>;
   /**
    * The meta data associated with this state node, which will be returned in State instances.


### PR DESCRIPTION
Companion PR for https://github.com/statelyai/docs/pull/237, which now uses `xstate` as a submodule, and requires these changes in order to build API docs.

This PR fixes issues that prevented the XState API docs index page from rendering properly, and fixes two warnings that occurred when API Documenter ran.

Includes and closes https://github.com/statelyai/xstate/pull/4374
