### PR TITLE
Switch from JSDoc to TSDoc

### DIFF
--- a/packages/core/src/typegenTypes.ts
+++ b/packages/core/src/typegenTypes.ts
@@ -41,12 +41,14 @@ export interface TypegenMeta extends TypegenEnabled {
   /**
    * A map for the internal events of the machine.
    *
+   * ```js
    * key: 'xstate.done.actor.myActor'
    * value: {
    *   type: 'xstate.done.actor.myActor';
    *   data: unknown;
    *   __tip: 'Declare the type in event types!';
    * }
+   * ```
    */
   internalEvents: {};
   /**

--- a/packages/core/src/waitFor.ts
+++ b/packages/core/src/waitFor.ts
@@ -6,7 +6,7 @@ interface WaitForOptions {
    * How long to wait before rejecting, if no emitted
    * state satisfies the predicate.
    *
-   * @default 10_000 (10 seconds)
+   * @defaultValue 10_000 (10 seconds)
    */
   timeout: number;
 }


### PR DESCRIPTION
I linted with `eslint-plugin-tsdoc` to identify cases where the JSDoc syntax used is not compatible with TSDoc. Found a couple cases and fixed them.

There is one remaining issue with `@param`, but I'm ignoring that for now. In JSDoc [`@param` can be name-only](https://jsdoc.app/tags-param.html#examples). But in TSDoc, `@param` is expected to always have a hyphen after the name (even if description is missing). We could avoid that linter warning by simply appending a hyphen after every `@param` name. But because it’s just a linter warning, and doesn’t make a difference to API Extractor, I didn’t bother.