### PR TITLE
Remove unused `Mailbox#prepend`

### DIFF
--- a/packages/core/src/Mailbox.ts
+++ b/packages/core/src/Mailbox.ts
@@ -24,22 +24,6 @@ export class Mailbox<T> {
     }
   }
 
-  // TODO: rethink this design
-  public prepend(event: T): void {
-    if (!this._current) {
-      this.enqueue(event);
-      return;
-    }
-
-    // we know that something is already queued up
-    // so the mailbox is already flushing or it's inactive
-    // therefore the only thing that we need to do is to reassign `this._current`
-    this._current = {
-      value: event,
-      next: this._current
-    };
-  }
-
   public enqueue(event: T): void {
     const enqueued = {
       value: event,
@@ -66,11 +50,7 @@ export class Mailbox<T> {
       // we assume here that this won't throw in a way that can affect this mailbox
       const consumed = this._current;
       this._process(consumed.value);
-      // something could have been prepended in the meantime
-      // so we need to be defensive here to avoid skipping over a prepended item
-      if (consumed === this._current) {
-        this._current = this._current.next;
-      }
+      this._current = consumed.next;
     }
     this._last = null;
   }


### PR DESCRIPTION
This was needed when we were prepending `xstate.init` to the mailbox but currently, this is not quite an explicit mailbox event - but rather it's handled "out of band". I wonder if we could refine this but, for the time being, this code is redundant. Even if we manage to rethink this design I think it should be possible to just `enqueue` the `xstate.init` event immediately rather than having to "prepend" it.