### PR TITLE
Update machine snapshots with the stopped status when the actor gets stopped

### DIFF
--- a/.changeset/honest-swans-complain.md
+++ b/.changeset/honest-swans-complain.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed the issue with stopped state machines not updating their snapshots with that information.

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1610,7 +1610,9 @@ export function macrostep(
 
   // Handle stop event
   if (event.type === XSTATE_STOP) {
-    nextState = stopChildren(nextState, event, actorCtx);
+    nextState = cloneState(stopChildren(nextState, event, actorCtx), {
+      status: 'stopped'
+    });
     states.push(nextState);
 
     return {

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -630,4 +630,14 @@ describe('State', () => {
       expect(restoredSnapshot.hasTag('foo')).toBe(true);
     });
   });
+
+  describe('.status', () => {
+    it("should be 'stopped' after a running actor gets stopped", () => {
+      const snapshot = createActor(createMachine({}))
+        .start()
+        .stop()
+        .getSnapshot();
+      expect(snapshot.status).toBe('stopped');
+    });
+  });
 });


### PR DESCRIPTION
Perhaps this should become the actor's responsibility but currently each actor logic does this on its own.