### PR TITLE
[v5] ActorContext -> ActorScope

### DIFF
--- a/.changeset/five-queens-behave.md
+++ b/.changeset/five-queens-behave.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Internal: changed the actor context type from `ActorContext` to `ActorScope` to mitigate confusion.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -24,7 +24,7 @@ import type {
   TypegenDisabled
 } from './typegenTypes.ts';
 import type {
-  ActorContext,
+  ActorScope,
   ActorLogic,
   EventObject,
   InternalMachineImplementations,
@@ -38,7 +38,7 @@ import type {
   StateValue,
   TransitionDefinition,
   ParameterizedObject,
-  AnyActorContext,
+  AnyActorScope,
   AnyEventObject,
   ProvidedActor,
   AnyActorRef,
@@ -316,7 +316,7 @@ export class StateMachine<
       TResolvedTypesMeta
     >,
     event: TEvent,
-    actorCtx: ActorContext<typeof state, TEvent>
+    actorScope: ActorScope<typeof state, TEvent>
   ): MachineSnapshot<
     TContext,
     TEvent,
@@ -336,7 +336,7 @@ export class StateMachine<
       });
     }
 
-    const { state: nextState } = macrostep(state, event, actorCtx);
+    const { state: nextState } = macrostep(state, event, actorScope);
 
     return nextState as typeof state;
   }
@@ -358,11 +358,11 @@ export class StateMachine<
       TResolvedTypesMeta
     >,
     event: TEvent,
-    actorCtx: AnyActorContext
+    actorScope: AnyActorScope
   ): Array<
     MachineSnapshot<TContext, TEvent, TActor, TTag, TOutput, TResolvedTypesMeta>
   > {
-    return macrostep(state, event, actorCtx).microstates as (typeof state)[];
+    return macrostep(state, event, actorScope).microstates as (typeof state)[];
   }
 
   public getTransitionData(
@@ -384,7 +384,7 @@ export class StateMachine<
    * This "pre-initial" state is provided to initial actions executed in the initial state.
    */
   private getPreInitialState(
-    actorCtx: AnyActorContext,
+    actorScope: AnyActorScope,
     initEvent: any,
     internalQueue: AnyEventObject[]
   ): MachineSnapshot<
@@ -415,7 +415,7 @@ export class StateMachine<
       return resolveActionsAndContext(
         preInitial,
         initEvent,
-        actorCtx,
+        actorScope,
         [assign(assignment)],
         internalQueue
       ) as SnapshotFrom<this>;
@@ -428,7 +428,7 @@ export class StateMachine<
    * Returns the initial `State` instance, with reference to `self` as an `ActorRef`.
    */
   public getInitialState(
-    actorCtx: ActorContext<
+    actorScope: ActorScope<
       MachineSnapshot<
         TContext,
         TEvent,
@@ -451,7 +451,7 @@ export class StateMachine<
     const initEvent = createInitEvent(input) as unknown as TEvent; // TODO: fix;
     const internalQueue: AnyEventObject[] = [];
     const preInitialState = this.getPreInitialState(
-      actorCtx,
+      actorScope,
       initEvent,
       internalQueue
     );
@@ -467,7 +467,7 @@ export class StateMachine<
         }
       ],
       preInitialState,
-      actorCtx,
+      actorScope,
       initEvent,
       true,
       internalQueue
@@ -476,7 +476,7 @@ export class StateMachine<
     const { state: macroState } = macrostep(
       nextState,
       initEvent as AnyEventObject,
-      actorCtx,
+      actorScope,
       internalQueue
     );
 
@@ -563,7 +563,7 @@ export class StateMachine<
 
   public restoreState(
     snapshot: Snapshot<unknown>,
-    _actorCtx: ActorContext<
+    _actorScope: ActorScope<
       MachineSnapshot<
         TContext,
         TEvent,
@@ -600,11 +600,11 @@ export class StateMachine<
         return;
       }
 
-      const actorState = logic.restoreState?.(childState, _actorCtx);
+      const actorState = logic.restoreState?.(childState, _actorScope);
 
       const actorRef = createActor(logic, {
         id: actorId,
-        parent: _actorCtx?.self,
+        parent: _actorScope?.self,
         state: actorState,
         systemId: actorData.systemId
       });

--- a/packages/core/src/actions/assign.ts
+++ b/packages/core/src/actions/assign.ts
@@ -3,7 +3,7 @@ import { cloneState } from '../State.ts';
 import { Spawner, createSpawner } from '../spawn.ts';
 import type {
   ActionArgs,
-  AnyActorContext,
+  AnyActorScope,
   AnyActorRef,
   AnyEventObject,
   AnyState,
@@ -26,7 +26,7 @@ export interface AssignArgs<
 }
 
 function resolveAssign(
-  actorContext: AnyActorContext,
+  actorScope: AnyActorScope,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any>,
   actionParams: ParameterizedObject['params'] | undefined,
@@ -48,14 +48,9 @@ function resolveAssign(
   const assignArgs: AssignArgs<any, any, any, any> = {
     context: state.context,
     event: actionArgs.event,
-    spawn: createSpawner(
-      actorContext,
-      state,
-      actionArgs.event,
-      spawnedChildren
-    ),
-    self: actorContext?.self,
-    system: actorContext?.system
+    spawn: createSpawner(actorScope, state, actionArgs.event, spawnedChildren),
+    self: actorScope?.self,
+    system: actorScope?.system
   };
   let partialUpdate: Record<string, unknown> = {};
   if (typeof assignment === 'function') {

--- a/packages/core/src/actions/cancel.ts
+++ b/packages/core/src/actions/cancel.ts
@@ -1,6 +1,6 @@
 import isDevelopment from '#is-development';
 import {
-  AnyActorContext,
+  AnyActorScope,
   AnyActor,
   AnyState,
   EventObject,
@@ -22,7 +22,7 @@ type ResolvableSendId<
     ) => string);
 
 function resolveCancel(
-  _: AnyActorContext,
+  _: AnyActorScope,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any>,
   actionParams: ParameterizedObject['params'] | undefined,
@@ -33,8 +33,8 @@ function resolveCancel(
   return [state, resolvedSendId];
 }
 
-function executeCancel(actorContext: AnyActorContext, resolvedSendId: string) {
-  (actorContext.self as AnyActor).cancel(resolvedSendId);
+function executeCancel(actorScope: AnyActorScope, resolvedSendId: string) {
+  (actorScope.self as AnyActor).cancel(resolvedSendId);
 }
 
 export interface CancelAction<

--- a/packages/core/src/actions/choose.ts
+++ b/packages/core/src/actions/choose.ts
@@ -3,7 +3,7 @@ import {
   EventObject,
   ChooseBranch,
   MachineContext,
-  AnyActorContext,
+  AnyActorScope,
   AnyState,
   ActionArgs,
   ParameterizedObject,
@@ -14,7 +14,7 @@ import { evaluateGuard } from '../guards.ts';
 import { toArray } from '../utils.ts';
 
 function resolveChoose(
-  _: AnyActorContext,
+  _: AnyActorScope,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any>,
   _actionParams: ParameterizedObject['params'] | undefined,

--- a/packages/core/src/actions/log.ts
+++ b/packages/core/src/actions/log.ts
@@ -1,7 +1,7 @@
 import isDevelopment from '#is-development';
 import {
   ActionArgs,
-  AnyActorContext,
+  AnyActorScope,
   AnyState,
   EventObject,
   LogExpr,
@@ -17,7 +17,7 @@ type ResolvableLogValue<
 > = string | LogExpr<TContext, TExpressionEvent, TParams, TEvent>;
 
 function resolveLog(
-  _: AnyActorContext,
+  _: AnyActorScope,
   state: AnyState,
   actionArgs: ActionArgs<any, any, any>,
   actionParams: ParameterizedObject['params'] | undefined,
@@ -40,7 +40,7 @@ function resolveLog(
 }
 
 function executeLog(
-  { logger }: AnyActorContext,
+  { logger }: AnyActorScope,
   { value, label }: { value: unknown; label: string | undefined }
 ) {
   if (label) {

--- a/packages/core/src/actions/pure.ts
+++ b/packages/core/src/actions/pure.ts
@@ -3,7 +3,7 @@ import {
   Actions,
   ActionArgs,
   UnknownAction,
-  AnyActorContext,
+  AnyActorScope,
   AnyState,
   EventObject,
   MachineContext,
@@ -15,7 +15,7 @@ import {
 import { toArray } from '../utils.ts';
 
 function resolvePure(
-  _: AnyActorContext,
+  _: AnyActorScope,
   state: AnyState,
   args: ActionArgs<any, any, any>,
   _actionParams: ParameterizedObject['params'] | undefined,

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -1,7 +1,7 @@
 import isDevelopment from '#is-development';
 import {
   ActionArgs,
-  AnyActorContext,
+  AnyActorScope,
   AnyActor,
   AnyState,
   DelayExpr,
@@ -15,7 +15,7 @@ import {
 } from '../types.ts';
 
 function resolveRaise(
-  _: AnyActorContext,
+  _: AnyActorScope,
   state: AnyState,
   args: ActionArgs<any, any, any>,
   actionParams: ParameterizedObject['params'] | undefined,
@@ -77,7 +77,7 @@ function resolveRaise(
 }
 
 function executeRaise(
-  actorContext: AnyActorContext,
+  actorScope: AnyActorScope,
   params: {
     event: EventObject;
     id: string | undefined;
@@ -85,7 +85,7 @@ function executeRaise(
   }
 ) {
   if (typeof params.delay === 'number') {
-    (actorContext.self as AnyActor).delaySend(
+    (actorScope.self as AnyActor).delaySend(
       params as typeof params & { delay: number }
     );
     return;

--- a/packages/core/src/actions/stop.ts
+++ b/packages/core/src/actions/stop.ts
@@ -4,7 +4,7 @@ import { ActorStatus } from '../interpreter.ts';
 import {
   ActionArgs,
   ActorRef,
-  AnyActorContext,
+  AnyActorScope,
   AnyState,
   EventObject,
   MachineContext,
@@ -25,7 +25,7 @@ type ResolvableActorRef<
     ) => ActorRef<any, any> | string);
 
 function resolveStop(
-  _: AnyActorContext,
+  _: AnyActorScope,
   state: AnyState,
   args: ActionArgs<any, any, any>,
   actionParams: ParameterizedObject['params'] | undefined,
@@ -51,7 +51,7 @@ function resolveStop(
   ];
 }
 function executeStop(
-  actorContext: AnyActorContext,
+  actorScope: AnyActorScope,
   actorRef: ActorRef<any, any> | undefined
 ) {
   if (!actorRef) {
@@ -61,20 +61,20 @@ function executeStop(
   // we need to eagerly unregister it here so a new actor with the same systemId can be registered immediately
   // since we defer actual stopping of the actor but we don't defer actor creations (and we can't do that)
   // this could throw on `systemId` collision, for example, when dealing with reentering transitions
-  actorContext.system._unregister(actorRef);
+  actorScope.system._unregister(actorRef);
 
   // this allows us to prevent an actor from being started if it gets stopped within the same macrostep
   // this can happen, for example, when the invoking state is being exited immediately by an always transition
   if (actorRef.status !== ActorStatus.Running) {
-    actorContext.stopChild(actorRef);
+    actorScope.stopChild(actorRef);
     return;
   }
   // stopping a child enqueues a stop event in the child actor's mailbox
   // we need for all of the already enqueued events to be processed before we stop the child
   // the parent itself might want to send some events to a child (for example from exit actions on the invoking state)
   // and we don't want to ignore those events
-  actorContext.defer(() => {
-    actorContext.stopChild(actorRef);
+  actorScope.defer(() => {
+    actorScope.stopChild(actorRef);
   });
 }
 

--- a/packages/core/src/actors/transition.ts
+++ b/packages/core/src/actors/transition.ts
@@ -1,6 +1,6 @@
 import {
   ActorLogic,
-  ActorContext,
+  ActorScope,
   ActorSystem,
   EventObject,
   ActorRefFrom,
@@ -43,7 +43,7 @@ export function fromTransition<
   transition: (
     state: TContext,
     event: TEvent,
-    actorContext: ActorContext<TransitionSnapshot<TContext>, TEvent, TSystem>
+    actorScope: ActorScope<TransitionSnapshot<TContext>, TEvent, TSystem>
   ) => TContext,
   initialContext:
     | TContext
@@ -57,10 +57,10 @@ export function fromTransition<
 ): TransitionActorLogic<TContext, TEvent, TInput> {
   return {
     config: transition,
-    transition: (state, event, actorContext) => {
+    transition: (state, event, actorScope) => {
       return {
         ...state,
-        context: transition(state.context, event as TEvent, actorContext as any)
+        context: transition(state.context, event as TEvent, actorScope as any)
       };
     },
     getInitialState: (_, input) => {

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -15,7 +15,7 @@ import {
   MissingImplementationsError
 } from './typegenTypes.ts';
 import type {
-  ActorContext,
+  ActorScope,
   ActorSystem,
   AnyActorLogic,
   AnyStateMachine,
@@ -112,7 +112,7 @@ export class Actor<TLogic extends AnyActorLogic>
   public _parent?: ActorRef<any, any>;
   public ref: ActorRef<EventFromLogic<TLogic>, SnapshotFrom<TLogic>>;
   // TODO: add typings for system
-  private _actorContext: ActorContext<
+  private _actorScope: ActorScope<
     SnapshotFrom<TLogic>,
     EventFromLogic<TLogic>,
     any
@@ -164,7 +164,7 @@ export class Actor<TLogic extends AnyActorLogic>
     this.options = resolvedOptions;
     this.src = resolvedOptions.src;
     this.ref = this;
-    this._actorContext = {
+    this._actorScope = {
       self: this,
       id: this.id,
       sessionId: this.sessionId,
@@ -196,9 +196,9 @@ export class Actor<TLogic extends AnyActorLogic>
   private _initState() {
     this._state = this.options.state
       ? this.logic.restoreState
-        ? this.logic.restoreState(this.options.state, this._actorContext)
+        ? this.logic.restoreState(this.options.state, this._actorScope)
         : this.options.state
-      : this.logic.getInitialState(this._actorContext, this.options?.input);
+      : this.logic.getInitialState(this._actorScope, this.options?.input);
   }
 
   // array of functions to defer
@@ -335,7 +335,7 @@ export class Actor<TLogic extends AnyActorLogic>
 
     if (this.logic.start) {
       try {
-        this.logic.start(this._state, this._actorContext);
+        this.logic.start(this._state, this._actorScope);
       } catch (err) {
         this._stopProcedure();
         this._error(err);
@@ -363,7 +363,7 @@ export class Actor<TLogic extends AnyActorLogic>
     let nextState;
     let caughtError;
     try {
-      nextState = this.logic.transition(this._state, event, this._actorContext);
+      nextState = this.logic.transition(this._state, event, this._actorScope);
     } catch (err) {
       // we wrap it in a box so we can rethrow it later even if falsy value gets caught here
       caughtError = { err };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1922,7 +1922,7 @@ export type __ResolvedTypesMetaFrom<T> = T extends StateMachine<
   ? TResolvedTypesMeta
   : never;
 
-export interface ActorContext<
+export interface ActorScope<
   TSnapshot extends Snapshot<unknown>,
   TEvent extends EventObject,
   TSystem extends ActorSystem<any> = ActorSystem<any>
@@ -1936,7 +1936,7 @@ export interface ActorContext<
   stopChild: (child: AnyActorRef) => void;
 }
 
-export type AnyActorContext = ActorContext<any, any, AnyActorSystem>;
+export type AnyActorScope = ActorScope<any, any, AnyActorSystem>;
 
 export type Snapshot<TOutput> =
   | {
@@ -1970,17 +1970,17 @@ export interface ActorLogic<
   transition: (
     state: TSnapshot,
     message: TEvent,
-    ctx: ActorContext<TSnapshot, TEvent, TSystem>
+    ctx: ActorScope<TSnapshot, TEvent, TSystem>
   ) => TSnapshot;
   getInitialState: (
-    actorCtx: ActorContext<TSnapshot, TEvent, TSystem>,
+    actorScope: ActorScope<TSnapshot, TEvent, TSystem>,
     input: TInput
   ) => TSnapshot;
   restoreState?: (
     persistedState: Snapshot<unknown>,
-    actorCtx: ActorContext<TSnapshot, TEvent>
+    actorScope: ActorScope<TSnapshot, TEvent>
   ) => TSnapshot;
-  start?: (state: TSnapshot, actorCtx: ActorContext<TSnapshot, TEvent>) => void;
+  start?: (state: TSnapshot, actorScope: ActorScope<TSnapshot, TEvent>) => void;
   /**
    * @returns Persisted state
    */
@@ -2014,7 +2014,7 @@ export type SnapshotFrom<T> = ReturnTypeOrValue<T> extends infer R
     ? StateFrom<R>
     : R extends ActorLogic<any, any, any, any>
     ? ReturnType<R['transition']>
-    : R extends ActorContext<infer TSnapshot, infer _, infer __>
+    : R extends ActorScope<infer TSnapshot, infer _, infer __>
     ? TSnapshot
     : never
   : never;

--- a/packages/core/test/actorLogic.test.ts
+++ b/packages/core/test/actorLogic.test.ts
@@ -859,10 +859,10 @@ describe('composable actor logic', () => {
     function withLogs<T extends AnyActorLogic>(actorLogic: T): T {
       return {
         ...actorLogic,
-        transition: (state, event, actorCtx) => {
+        transition: (state, event, actorScope) => {
           logs.push(event.type);
 
-          return actorLogic.transition(state, event, actorCtx);
+          return actorLogic.transition(state, event, actorScope);
         }
       };
     }
@@ -897,8 +897,8 @@ describe('composable actor logic', () => {
     function withLogs<T extends AnyActorLogic>(actorLogic: T): T {
       return {
         ...actorLogic,
-        transition: (state: Snapshot<unknown>, event, actorCtx) => {
-          const s = actorLogic.transition(state, event, actorCtx);
+        transition: (state: Snapshot<unknown>, event, actorScope) => {
+          const s = actorLogic.transition(state, event, actorScope);
           logs.push(s.output);
 
           return s;
@@ -921,8 +921,8 @@ describe('composable actor logic', () => {
     function withLogs<T extends AnyActorLogic>(actorLogic: T): T {
       return {
         ...actorLogic,
-        transition: (state: Snapshot<unknown>, event, actorCtx) => {
-          const s = actorLogic.transition(state, event, actorCtx);
+        transition: (state: Snapshot<unknown>, event, actorScope) => {
+          const s = actorLogic.transition(state, event, actorScope);
           logs.push(s.context);
 
           return s;
@@ -948,8 +948,8 @@ describe('composable actor logic', () => {
     function withLogs<T extends AnyActorLogic>(actorLogic: T): T {
       return {
         ...actorLogic,
-        transition: (state: Snapshot<unknown>, event, actorCtx) => {
-          const s = actorLogic.transition(state, event, actorCtx);
+        transition: (state: Snapshot<unknown>, event, actorScope) => {
+          const s = actorLogic.transition(state, event, actorScope);
 
           if (s.status === 'active') {
             logs.push(s.context);

--- a/packages/core/test/deterministic.test.ts
+++ b/packages/core/test/deterministic.test.ts
@@ -63,14 +63,14 @@ describe('deterministic machine', () => {
 
   describe('machine.transition()', () => {
     it('should properly transition states based on event-like object', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue('green'),
           {
             type: 'TIMER'
           },
-          actorContext
+          actorScope
         ).value
       ).toEqual('yellow');
     });
@@ -99,23 +99,23 @@ describe('deterministic machine', () => {
     });
 
     it('should throw an error if not given an event', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(() =>
         lightMachine.transition(
           testMachine.resolveStateValue('red'),
           undefined as any,
-          actorContext
+          actorScope
         )
       ).toThrow();
     });
 
     it('should transition to nested states as target', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         testMachine.transition(
           testMachine.resolveStateValue('a'),
           { type: 'T' },
-          actorContext
+          actorScope
         ).value
       ).toEqual({
         b: 'b1'
@@ -123,47 +123,47 @@ describe('deterministic machine', () => {
     });
 
     it('should throw an error for transitions from invalid states', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(() =>
         testMachine.transition(
           testMachine.resolveStateValue('fake'),
           { type: 'T' },
-          actorContext
+          actorScope
         )
       ).toThrow();
     });
 
     it('should throw an error for transitions from invalid substates', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(() =>
         testMachine.transition(
           testMachine.resolveStateValue('a.fake'),
           {
             type: 'T'
           },
-          actorContext
+          actorScope
         )
       ).toThrow();
     });
 
     it('should use the machine.initialState when an undefined state is given', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
-          lightMachine.getInitialState(actorContext),
+          lightMachine.getInitialState(actorScope),
           { type: 'TIMER' },
-          actorContext
+          actorScope
         ).value
       ).toEqual('yellow');
     });
 
     it('should use the machine.initialState when an undefined state is given (unhandled event)', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
-          lightMachine.getInitialState(actorContext),
+          lightMachine.getInitialState(actorScope),
           { type: 'TIMER' },
-          actorContext
+          actorScope
         ).value
       ).toEqual('yellow');
     });
@@ -172,25 +172,25 @@ describe('deterministic machine', () => {
   // TODO: figure out the simulation API
   describe('machine.transition() with nested states', () => {
     it('should properly transition a nested state', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue({ red: 'walk' }),
           { type: 'PED_COUNTDOWN' },
-          actorContext
+          actorScope
         ).value
       ).toEqual({ red: 'wait' });
     });
 
     it('should transition from initial nested states', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue('red'),
           {
             type: 'PED_COUNTDOWN'
           },
-          actorContext
+          actorScope
         ).value
       ).toEqual({
         red: 'wait'
@@ -198,14 +198,14 @@ describe('deterministic machine', () => {
     });
 
     it('should transition from deep initial nested states', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue('red'),
           {
             type: 'PED_COUNTDOWN'
           },
-          actorContext
+          actorScope
         ).value
       ).toEqual({
         red: 'wait'
@@ -213,12 +213,12 @@ describe('deterministic machine', () => {
     });
 
     it('should bubble up events that nested states cannot handle', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue({ red: 'stop' }),
           { type: 'TIMER' },
-          actorContext
+          actorScope
         ).value
       ).toEqual('green');
     });
@@ -252,14 +252,14 @@ describe('deterministic machine', () => {
     });
 
     it('should transition to the deepest initial state', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         lightMachine.transition(
           lightMachine.resolveStateValue('yellow'),
           {
             type: 'TIMER'
           },
-          actorContext
+          actorScope
         ).value
       ).toEqual({
         red: 'walk'
@@ -267,20 +267,20 @@ describe('deterministic machine', () => {
     });
 
     it('should return the same state if no transition occurs', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       const initialState = lightMachine.transition(
-        lightMachine.getInitialState(actorContext),
+        lightMachine.getInitialState(actorScope),
         {
           type: 'NOTHING'
         },
-        actorContext
+        actorScope
       );
       const nextState = lightMachine.transition(
         initialState,
         {
           type: 'NOTHING'
         },
-        actorContext
+        actorScope
       );
 
       expect(initialState.value).toEqual(nextState.value);
@@ -311,12 +311,12 @@ describe('deterministic machine', () => {
     );
 
     it('should work with substate nodes that have the same key', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
       expect(
         machine.transition(
-          machine.getInitialState(actorContext),
+          machine.getInitialState(actorScope),
           { type: 'NEXT' },
-          actorContext
+          actorScope
         ).value
       ).toEqual('test');
     });
@@ -324,12 +324,12 @@ describe('deterministic machine', () => {
 
   describe('forbidden events', () => {
     it('undefined transitions should forbid events', () => {
-      const actorContext = null as any; // TODO: figure out the simulation API
+      const actorScope = null as any; // TODO: figure out the simulation API
 
       const walkState = lightMachine.transition(
         lightMachine.resolveStateValue({ red: 'walk' }),
         { type: 'TIMER' },
-        actorContext
+        actorScope
       );
 
       expect(walkState.value).toEqual({ red: 'walk' });

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../src/actors/index.ts';
 import {
   ActorLogic,
-  ActorContext,
+  ActorScope,
   EventObject,
   SpecialTargets,
   StateValue,
@@ -2386,7 +2386,7 @@ describe('invoke', () => {
       const countReducer = (
         count: number,
         event: CountEvents,
-        { self }: ActorContext<any, CountEvents>
+        { self }: ActorScope<any, CountEvents>
       ): number => {
         if (event.type === 'INC') {
           self.send({ type: 'DOUBLE' });

--- a/packages/core/test/microstep.test.ts
+++ b/packages/core/test/microstep.test.ts
@@ -30,11 +30,11 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = null as any; // TODO: figure out the simulation API
+    const actorScope = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
-      machine.getInitialState(actorContext),
+      machine.getInitialState(actorScope),
       { type: 'GO' },
-      actorContext
+      actorScope
     );
 
     expect(states.map((s) => s.value)).toEqual(['a', 'b', 'c', 'd']);
@@ -56,11 +56,11 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = null as any; // TODO: figure out the simulation API
+    const actorScope = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.resolveStateValue('first'),
       { type: 'TRIGGER' },
-      actorContext
+      actorScope
     );
 
     expect(states.map((s) => s.value)).toEqual(['second', 'third']);
@@ -87,11 +87,11 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = null as any; // TODO: figure out the simulation API
+    const actorScope = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
       machine.resolveStateValue('first'),
       { type: 'TRIGGER' },
-      actorContext
+      actorScope
     );
 
     expect(states.map((s) => s.value)).toEqual(['second', 'third']);
@@ -110,11 +110,11 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = null as any; // TODO: figure out the simulation API
+    const actorScope = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
-      machine.getInitialState(actorContext),
+      machine.getInitialState(actorScope),
       { type: 'TRIGGER' },
-      actorContext
+      actorScope
     );
 
     expect(states.map((s) => s.value)).toEqual(['second']);
@@ -153,11 +153,11 @@ describe('machine.microstep()', () => {
       }
     });
 
-    const actorContext = null as any; // TODO: figure out the simulation API
+    const actorScope = null as any; // TODO: figure out the simulation API
     const states = machine.microstep(
-      machine.getInitialState(actorContext),
+      machine.getInitialState(actorScope),
       { type: 'TRIGGER' },
-      actorContext
+      actorScope
     );
 
     expect(states.map((s) => s.value)).toEqual([

--- a/packages/xstate-graph/src/actorScope.ts
+++ b/packages/xstate-graph/src/actorScope.ts
@@ -1,6 +1,6 @@
-import { AnyActorContext, createEmptyActor } from 'xstate';
+import { AnyActorScope, createEmptyActor } from 'xstate';
 
-export function createMockActorContext(): AnyActorContext {
+export function createMockActorScope(): AnyActorScope {
   const emptyActor = createEmptyActor();
   return {
     self: emptyActor,

--- a/packages/xstate-graph/src/adjacency.ts
+++ b/packages/xstate-graph/src/adjacency.ts
@@ -1,5 +1,5 @@
 import {
-  ActorContext,
+  ActorScope,
   ActorLogic,
   ActorSystem,
   EventObject,
@@ -7,7 +7,7 @@ import {
 } from 'xstate';
 import { SerializedEvent, SerializedState, TraversalOptions } from './types';
 import { AdjacencyMap, resolveTraversalOptions } from './graph';
-import { createMockActorContext } from './actorContext';
+import { createMockActorScope } from './actorScope';
 
 export function getAdjacencyMap<
   TSnapshot extends Snapshot<unknown>,
@@ -27,7 +27,7 @@ export function getAdjacencyMap<
     fromState: customFromState,
     stopCondition
   } = resolveTraversalOptions(logic, options);
-  const actorContext = createMockActorContext() as ActorContext<
+  const actorScope = createMockActorScope() as ActorScope<
     TSnapshot,
     TEvent,
     TSystem
@@ -35,7 +35,7 @@ export function getAdjacencyMap<
   const fromState =
     customFromState ??
     logic.getInitialState(
-      actorContext,
+      actorScope,
       // TODO: fix this
       undefined as TInput
     );
@@ -79,7 +79,7 @@ export function getAdjacencyMap<
       typeof getEvents === 'function' ? getEvents(state) : getEvents;
 
     for (const nextEvent of events) {
-      const nextState = transition(state, nextEvent, actorContext);
+      const nextState = transition(state, nextEvent, actorScope);
 
       if (!options.filter || options.filter(nextState, nextEvent)) {
         adj[serializedState].transitions[

--- a/packages/xstate-graph/src/graph.ts
+++ b/packages/xstate-graph/src/graph.ts
@@ -20,7 +20,7 @@ import type {
   AnyStateNode,
   TraversalConfig
 } from './types.ts';
-import { createMockActorContext } from './actorContext.ts';
+import { createMockActorScope } from './actorScope.ts';
 
 function flatten<T>(array: Array<T | T[]>): T[] {
   return ([] as T[]).concat(...array);
@@ -102,7 +102,7 @@ export function createDefaultMachineOptions<TMachine extends AnyStateMachine>(
         })
       ) as any[];
     },
-    fromState: machine.getInitialState(createMockActorContext()) as ReturnType<
+    fromState: machine.getInitialState(createMockActorScope()) as ReturnType<
       TMachine['transition']
     >,
     ...otherOptions

--- a/packages/xstate-graph/src/pathFromEvents.ts
+++ b/packages/xstate-graph/src/pathFromEvents.ts
@@ -1,5 +1,5 @@
 import {
-  ActorContext,
+  ActorScope,
   ActorLogic,
   ActorSystem,
   AnyStateMachine,
@@ -20,7 +20,7 @@ import {
   createDefaultLogicOptions
 } from './graph';
 import { alterPath } from './alterPath';
-import { createMockActorContext } from './actorContext';
+import { createMockActorScope } from './actorScope';
 
 function isMachine(value: any): value is AnyStateMachine {
   return !!value && '__xstatenode' in value;
@@ -46,7 +46,7 @@ export function getPathsFromEvents<
       ? createDefaultMachineOptions(logic)
       : createDefaultLogicOptions()) as TraversalOptions<TSnapshot, TEvent>
   );
-  const actorContext = createMockActorContext() as ActorContext<
+  const actorScope = createMockActorScope() as ActorScope<
     TSnapshot,
     TEvent,
     TSystem
@@ -54,7 +54,7 @@ export function getPathsFromEvents<
   const fromState =
     resolvedOptions.fromState ??
     logic.getInitialState(
-      actorContext,
+      actorScope,
       // TODO: fix this
       undefined as TInput
     );

--- a/packages/xstate-graph/src/shortestPaths.ts
+++ b/packages/xstate-graph/src/shortestPaths.ts
@@ -9,7 +9,7 @@ import {
   StatePlanMap,
   TraversalOptions
 } from './types';
-import { createMockActorContext } from './actorContext';
+import { createMockActorScope } from './actorScope';
 
 export function getShortestPaths<TLogic extends AnyActorLogic>(
   logic: TLogic,
@@ -27,7 +27,7 @@ export function getShortestPaths<TLogic extends AnyActorLogic>(
   ) => SerializedState;
   const fromState =
     resolvedOptions.fromState ??
-    logic.getInitialState(createMockActorContext(), undefined);
+    logic.getInitialState(createMockActorScope(), undefined);
   const adjacency = getAdjacencyMap(logic, resolvedOptions);
 
   // weight, state, event

--- a/packages/xstate-graph/src/simplePaths.ts
+++ b/packages/xstate-graph/src/simplePaths.ts
@@ -19,7 +19,7 @@ import {
 import { resolveTraversalOptions, createDefaultMachineOptions } from './graph';
 import { getAdjacencyMap } from './adjacency';
 import { alterPath } from './alterPath';
-import { createMockActorContext } from './actorContext';
+import { createMockActorScope } from './actorScope';
 
 export function getSimplePaths<TLogic extends AnyActorLogic>(
   logic: TLogic,
@@ -32,9 +32,9 @@ export function getSimplePaths<TLogic extends AnyActorLogic>(
   type TEvent = EventFromLogic<TLogic>;
 
   const resolvedOptions = resolveTraversalOptions(logic, options);
-  const actorContext = createMockActorContext();
+  const actorScope = createMockActorScope();
   const fromState =
-    resolvedOptions.fromState ?? logic.getInitialState(actorContext, undefined);
+    resolvedOptions.fromState ?? logic.getInitialState(actorScope, undefined);
   const serializeState = resolvedOptions.serializeState as (
     ...args: Parameters<typeof resolvedOptions.serializeState>
   ) => SerializedState;

--- a/packages/xstate-graph/test/graph.test.ts
+++ b/packages/xstate-graph/test/graph.test.ts
@@ -16,7 +16,7 @@ import {
   getSimplePaths
 } from '../src';
 import { joinPaths } from '../src/graph';
-import { createMockActorContext } from '../src/actorContext';
+import { createMockActorScope } from '../src/actorScope';
 
 function getPathsSnapshot(
   paths: Array<StatePath<Snapshot<unknown>, EventObject>>
@@ -217,7 +217,7 @@ describe('@xstate/graph', () => {
       expect(
         shortestPaths.find((path) =>
           path.state.matches(
-            lightMachine.getInitialState(createMockActorContext()).value
+            lightMachine.getInitialState(createMockActorScope()).value
           )
         )!.steps
       ).toHaveLength(1);
@@ -376,28 +376,28 @@ describe('@xstate/graph', () => {
       expect(
         getSimplePaths(lightMachine).find((p) =>
           p.state.matches(
-            lightMachine.getInitialState(createMockActorContext()).value
+            lightMachine.getInitialState(createMockActorScope()).value
           )
         )
       ).toBeDefined();
       expect(
         getSimplePaths(lightMachine).find((p) =>
           p.state.matches(
-            lightMachine.getInitialState(createMockActorContext()).value
+            lightMachine.getInitialState(createMockActorScope()).value
           )
         )!.steps
       ).toHaveLength(1);
       expect(
         getSimplePaths(equivMachine).find((p) =>
           p.state.matches(
-            equivMachine.getInitialState(createMockActorContext()).value
+            equivMachine.getInitialState(createMockActorScope()).value
           )
         )!
       ).toBeDefined();
       expect(
         getSimplePaths(equivMachine).find((p) =>
           p.state.matches(
-            equivMachine.getInitialState(createMockActorContext()).value
+            equivMachine.getInitialState(createMockActorScope()).value
           )
         )!.steps
       ).toHaveLength(1);


### PR DESCRIPTION
Changed the actor context type from `ActorContext` to `ActorScope` to mitigate confusion.