### PR TITLE
[@xstate/react] Add deprecation notice for `machine` in Provider prop types

### DIFF
--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -54,6 +54,10 @@ export function createActorContext<TLogic extends AnyActorLogic>(
     props: {
       children: React.ReactNode;
       options?: ActorOptions<TLogic>;
+      /**
+       * @deprecated Use `logic` instead.
+       */
+      machine?: never;
     } & (TLogic extends AnyStateMachine
       ? AreAllImplementationsAssumedToBeProvided<
           TLogic['__TResolvedTypesMeta']


### PR DESCRIPTION
<img width="462" alt="CleanShot 2023-10-29 at 07 15 48@2x" src="https://github.com/statelyai/xstate/assets/1093738/1a640a64-6e29-4d02-9efd-a56f9e455ad2">
