### PR TITLE
[v5] Consistent `actorRef` property for inspection events

### DIFF
--- a/.changeset/clever-jars-fly.md
+++ b/.changeset/clever-jars-fly.md
@@ -1,0 +1,23 @@
+---
+'xstate': minor
+---
+
+All inspector events (snapshot, event, actor) now have a common `actorRef` property. This makes it easier to discern which inspection event is for which actor:
+
+```ts
+const actor = createActor(someMachine, {
+  inspect: (event) => {
+    // Was previously a type error
+    if (event.actorRef === actor) {
+      // This event is for the root actor
+    }
+
+    if (event.type === '@xstate.event') {
+      // previously event.targetRef
+      event.actorRef;
+    }
+  }
+});
+```
+
+In the `'xstate.event'` event, the `actorRef` property is now the target actor (recipient of the event). Previously, this was the `event.targetRef` property (which is now removed).

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -313,7 +313,7 @@ export class Actor<TLogic extends AnyActorLogic>
     this.system._sendInspectionEvent({
       type: '@xstate.event',
       sourceRef: this._parent,
-      targetRef: this,
+      actorRef: this,
       event: initEvent
     });
 

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -59,7 +59,7 @@ export function createSystem<T extends ActorSystemInfo>(
       system._sendInspectionEvent({
         type: '@xstate.event',
         sourceRef: source,
-        targetRef: target,
+        actorRef: target,
         event
       });
 
@@ -71,11 +71,17 @@ export function createSystem<T extends ActorSystemInfo>(
 }
 export interface BaseInspectionEventProperties {
   rootId: string; // the session ID of the root
+  /**
+   * The relevant actorRef for the inspection event.
+   * - For snapshot events, this is the `actorRef` of the snapshot.
+   * - For event events, this is the target `actorRef` (recipient of event).
+   * - For actor events, this is the `actorRef` of the registered actor.
+   */
+  actorRef: AnyActorRef;
 }
 
 export interface InspectedSnapshotEvent extends BaseInspectionEventProperties {
   type: '@xstate.snapshot';
-  actorRef: AnyActorRef; // Only available locally
   event: AnyEventObject; // { type: string, ... }
   snapshot: Snapshot<unknown>;
 }
@@ -86,13 +92,11 @@ export interface InspectedEventEvent extends BaseInspectionEventProperties {
   // - root init events
   // - events sent from external (non-actor) sources
   sourceRef: AnyActorRef | undefined;
-  targetRef: AnyActorRef; // Session ID, required
   event: AnyEventObject; // { type: string, ... }
 }
 
 export interface InspectedActorEvent extends BaseInspectionEventProperties {
   type: '@xstate.actor';
-  actorRef: AnyActorRef;
 }
 
 export type InspectionEvent =

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -13,7 +13,7 @@ function simplifyEvent(inspectionEvent: InspectionEvent) {
     return {
       type: inspectionEvent.type,
       sourceId: inspectionEvent.sourceRef?.sessionId,
-      targetId: inspectionEvent.targetRef.sessionId,
+      targetId: inspectionEvent.actorRef.sessionId,
       event: inspectionEvent.event
     };
   }


### PR DESCRIPTION
All inspector events (snapshot, event, actor) now have a common `actorRef` property. This makes it easier to discern which inspection event is for which actor:

```ts
const actor = createActor(someMachine, {
  inspect: (event) => {
    // Was previously a type error
    if (event.actorRef === actor) {
      // This event is for the root actor
    }

    if (event.type === '@xstate.event') {
      // previously event.targetRef
      event.actorRef;
    }
  }
});
```

In the `'xstate.event'` event, the `actorRef` property is now the target actor (recipient of the event). Previously, this was the `event.targetRef` property (which is now removed).
