### PR TITLE
API Docs: createActor

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -559,7 +559,33 @@ export class Actor<TLogic extends AnyActorLogic>
 /**
  * Creates a new actor instance for the given actor logic with the provided options, if any.
  *
- * @param logic - The actor logic to create an actor from
+ * @remarks
+ * When you create an actor from actor logic via `createActor(logic)`, you implicitly create an actor system where the created actor is the root actor.
+ * Any actors spawned from this root actor and its descendants are part of that actor system.
+ *
+ * @example
+ * ```ts
+ * import { createActor } from 'xstate';
+ * import { someActorLogic } from './someActorLogic.ts';
+ *
+ * // Creating the actor, which implicitly creates an actor system with itself as the root actor
+ * const actor = createActor(someActorLogic);
+ *
+ * actor.subscribe((snapshot) => {
+ *   console.log(snapshot);
+ * });
+ *
+ * // Actors must be started by calling `actor.start()`, which will also start the actor system.
+ * actor.start();
+ *
+ * // Actors can receive events
+ * actor.send({ type: 'someEvent' });
+ *
+ * // You can stop root actors by calling `actor.stop()`, which will also stop the actor system and all actors in that system.
+ * actor.stop();
+ * ```
+ *
+ * @param logic - The actor logic to create an actor from. For a state machine actor logic creator, see {@link createMachine}. Other actor logic creators include {@link fromCallback}, {@link fromEventObservable}, {@link fromObservable}, {@link fromPromise}, and {@link fromTransition}.
  * @param options - Actor options
  */
 export function createActor<TLogic extends AnyActorLogic>(

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -557,10 +557,20 @@ export class Actor<TLogic extends AnyActorLogic>
 }
 
 /**
- * Creates a new `ActorRef` instance for the given machine with the provided options, if any.
+ * Creates a new actor instance for the given actor logic with the provided options, if any.
  *
- * @param machine The machine to create an actor from
- * @param options `ActorRef` options
+ * @param logic - The actor logic to create an actor from
+ * @param options - Actor options
+ */
+export function createActor<TLogic extends AnyActorLogic>(
+  logic: TLogic,
+  options?: ActorOptions<TLogic>
+): Actor<TLogic>;
+/**
+ * Creates a new actor instance for the given state machine actor logic with the provided options, if any.
+ *
+ * @param machine - The state machine actor logic to create an actor from
+ * @param options - Actor options
  */
 export function createActor<TMachine extends AnyStateMachine>(
   machine: AreAllImplementationsAssumedToBeProvided<
@@ -570,10 +580,6 @@ export function createActor<TMachine extends AnyStateMachine>(
     : MissingImplementationsError<TMachine['__TResolvedTypesMeta']>,
   options?: ActorOptions<TMachine>
 ): Actor<TMachine>;
-export function createActor<TLogic extends AnyActorLogic>(
-  logic: TLogic,
-  options?: ActorOptions<TLogic>
-): Actor<TLogic>;
 export function createActor(logic: any, options?: ActorOptions<any>): any {
   const interpreter = new Actor(logic, options);
 

--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -592,12 +592,6 @@ export function createActor<TLogic extends AnyActorLogic>(
   logic: TLogic,
   options?: ActorOptions<TLogic>
 ): Actor<TLogic>;
-/**
- * Creates a new actor instance for the given state machine actor logic with the provided options, if any.
- *
- * @param machine - The state machine actor logic to create an actor from
- * @param options - Actor options
- */
 export function createActor<TMachine extends AnyStateMachine>(
   machine: AreAllImplementationsAssumedToBeProvided<
     TMachine['__TResolvedTypesMeta']


### PR DESCRIPTION
Adds documentation for createActor with two overloaded signatures.

Moved the most common signature (logic) to the top, so VS Code IntelliSense will suggest it first.