### PR TITLE
Removed `Interpreter['status']` from publicly available properties

### DIFF
--- a/.changeset/flat-jokes-breathe.md
+++ b/.changeset/flat-jokes-breathe.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+Removed `Interpreter['status']` from publicly available properties.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -493,11 +493,13 @@ export class StateMachine<
       TResolvedTypesMeta
     >
   ): void {
-    Object.values(state.children).forEach((child: any) => {
-      if (child.getSnapshot().status === 'active') {
-        child.start();
+    Object.values(state.children as Record<string, AnyActorRef>).forEach(
+      (child: any) => {
+        if (child.getSnapshot().status === 'active') {
+          child.start();
+        }
       }
-    });
+    );
   }
 
   public getStateNodeById(stateId: string): StateNode<TContext, TEvent> {

--- a/packages/core/src/actions/spawn.ts
+++ b/packages/core/src/actions/spawn.ts
@@ -1,7 +1,7 @@
 import isDevelopment from '#is-development';
 import { cloneState } from '../State.ts';
 import { createErrorActorEvent } from '../eventUtils.ts';
-import { ActorStatus, createActor } from '../interpreter.ts';
+import { ProcessingStatus, createActor } from '../interpreter.ts';
 import {
   ActionArgs,
   AnyActorScope,
@@ -115,7 +115,7 @@ function executeSpawn(
   }
 
   actorScope.defer(() => {
-    if (actorRef.status === ActorStatus.Stopped) {
+    if (actorRef._processingStatus === ProcessingStatus.Stopped) {
       return;
     }
     try {

--- a/packages/core/src/actions/stop.ts
+++ b/packages/core/src/actions/stop.ts
@@ -1,6 +1,6 @@
 import isDevelopment from '#is-development';
 import { cloneState } from '../State.ts';
-import { ActorStatus } from '../interpreter.ts';
+import { ProcessingStatus } from '../interpreter.ts';
 import {
   ActionArgs,
   ActorRef,
@@ -65,7 +65,7 @@ function executeStop(
 
   // this allows us to prevent an actor from being started if it gets stopped within the same macrostep
   // this can happen, for example, when the invoking state is being exited immediately by an always transition
-  if (actorRef.status !== ActorStatus.Running) {
+  if (actorRef._processingStatus !== ProcessingStatus.Running) {
     actorScope.stopChild(actorRef);
     return;
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,14 +7,7 @@ export { getStateNodes } from './stateUtils.ts';
 export * from './typegenTypes.ts';
 export * from './types.ts';
 export { waitFor } from './waitFor.ts';
-import {
-  Actor,
-  ActorStatus,
-  createActor,
-  interpret,
-  Interpreter,
-  InterpreterStatus
-} from './interpreter.ts';
+import { Actor, createActor, interpret, Interpreter } from './interpreter.ts';
 import { createMachine } from './Machine.ts';
 import { mapState } from './mapState.ts';
 import { State } from './State.ts';
@@ -23,11 +16,9 @@ import { StateNode } from './StateNode.ts';
 export { matchesState, pathToStateValue, toObserver } from './utils.ts';
 export {
   Actor,
-  ActorStatus,
   createActor,
   createMachine,
   interpret,
-  InterpreterStatus,
   mapState,
   State,
   StateNode,

--- a/packages/core/src/spawn.ts
+++ b/packages/core/src/spawn.ts
@@ -1,5 +1,5 @@
 import { createErrorActorEvent } from './eventUtils.ts';
-import { ActorStatus, createActor } from './interpreter.ts';
+import { ProcessingStatus, createActor } from './interpreter.ts';
 import {
   ActorRefFrom,
   AnyActorScope,
@@ -140,7 +140,7 @@ export function createSpawner(
     const actorRef = spawn(src, options) as TODO; // TODO: fix types
     spawnedChildren[actorRef.id] = actorRef;
     actorScope.defer(() => {
-      if (actorRef.status === ActorStatus.Stopped) {
+      if (actorRef._processingStatus === ProcessingStatus.Stopped) {
         return;
       }
       try {

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -15,7 +15,6 @@ import {
   WILDCARD
 } from './constants.ts';
 import { evaluateGuard } from './guards.ts';
-import { ActorStatus } from './interpreter.ts';
 import {
   ActionArgs,
   AnyEventObject,
@@ -50,6 +49,7 @@ import {
   toStateValue,
   toTransitionConfigArray
 } from './utils.ts';
+import { ProcessingStatus } from './interpreter.ts';
 
 type Configuration<
   TContext extends MachineContext,
@@ -1541,7 +1541,7 @@ function resolveActionsAndContextWorker(
         : undefined;
 
     if (!('resolve' in resolvedAction)) {
-      if (actorScope?.self.status === ActorStatus.Running) {
+      if (actorScope?.self._processingStatus === ProcessingStatus.Running) {
         resolvedAction(actionArgs, actionParams);
       } else {
         actorScope?.defer(() => {
@@ -1568,7 +1568,7 @@ function resolveActionsAndContextWorker(
     }
 
     if ('execute' in builtinAction) {
-      if (actorScope?.self.status === ActorStatus.Running) {
+      if (actorScope?.self._processingStatus === ProcessingStatus.Running) {
         builtinAction.execute(actorScope!, params);
       } else {
         actorScope?.defer(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,6 @@
 import type { StateNode } from './StateNode.ts';
 import type { State } from './State.ts';
-import type { ActorStatus, Clock, Actor } from './interpreter.ts';
+import type { Clock, Actor, ProcessingStatus } from './interpreter.ts';
 import type { MachineSnapshot, StateMachine } from './StateMachine.ts';
 import {
   TypegenDisabled,
@@ -1792,7 +1792,8 @@ export interface ActorRef<
   // TODO: figure out how to hide this externally as `sendTo(ctx => ctx.actorRef._parent._parent._parent._parent)` shouldn't be allowed
   _parent?: ActorRef<any, any>;
   system?: ActorSystem<any>;
-  status: ActorStatus;
+  /** @internal */
+  _processingStatus: ProcessingStatus;
   src?: string;
 }
 

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -71,7 +71,7 @@ describe('error handling', () => {
       }
     });
 
-    const subscriber = jest.fn().mockImplementation(() => {
+    const subscriber = jest.fn().mockImplementationOnce(() => {
       throw new Error('doesnt_crash_actor_when_error_is_thrown_in_subscribe');
     });
 

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -1,5 +1,4 @@
 import { createMachine, fromCallback, fromPromise, createActor } from '../src';
-import { ActorStatus } from '../src/interpreter';
 
 const cleanups: (() => void)[] = [];
 function installGlobalOnErrorHandler(handler: (ev: ErrorEvent) => void) {
@@ -50,6 +49,8 @@ describe('error handling', () => {
   });
 
   it(`doesn't crash the actor when an error is thrown in subscribe`, (done) => {
+    const spy = jest.fn();
+
     const machine = createMachine({
       id: 'machine',
       initial: 'initial',
@@ -60,27 +61,37 @@ describe('error handling', () => {
         initial: {
           on: { activate: 'active' }
         },
-        active: {}
+        active: {
+          on: {
+            do: {
+              actions: spy
+            }
+          }
+        }
       }
     });
 
-    const spy = jest.fn().mockImplementation(() => {
+    const subscriber = jest.fn().mockImplementation(() => {
       throw new Error('doesnt_crash_actor_when_error_is_thrown_in_subscribe');
     });
 
     const actor = createActor(machine).start();
 
-    actor.subscribe(spy);
+    actor.subscribe(subscriber);
     actor.send({ type: 'activate' });
 
-    expect(spy).toHaveBeenCalledTimes(1);
-    expect(actor.status).toEqual(ActorStatus.Running);
+    expect(subscriber).toHaveBeenCalledTimes(1);
+    expect(actor.getSnapshot().status).toEqual('active');
 
     installGlobalOnErrorHandler((ev) => {
       ev.preventDefault();
       expect(ev.error.message).toEqual(
         'doesnt_crash_actor_when_error_is_thrown_in_subscribe'
       );
+
+      actor.send({ type: 'do' });
+      expect(spy).toHaveBeenCalledTimes(1);
+
       done();
     });
   });
@@ -424,6 +435,8 @@ describe('error handling', () => {
   });
 
   it(`handled sync errors thrown when starting an actor shouldn't crash the parent`, () => {
+    const spy = jest.fn();
+
     const machine = createMachine({
       initial: 'pending',
       states: {
@@ -435,14 +448,23 @@ describe('error handling', () => {
             onError: 'failed'
           }
         },
-        failed: {}
+        failed: {
+          on: {
+            do: {
+              actions: spy
+            }
+          }
+        }
       }
     });
 
     const actorRef = createActor(machine);
     actorRef.start();
 
-    expect(actorRef.status).toBe(ActorStatus.Running);
+    expect(actorRef.getSnapshot().status).toBe('active');
+
+    actorRef.send({ type: 'do' });
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   it(`unhandled sync errors thrown when starting an actor should crash the parent`, (done) => {
@@ -452,7 +474,7 @@ describe('error handling', () => {
         pending: {
           invoke: {
             src: fromCallback(() => {
-              throw new Error('handled_sync_error_in_actor_start');
+              throw new Error('unhandled_sync_error_in_actor_start');
             })
           }
         }
@@ -462,11 +484,11 @@ describe('error handling', () => {
     const actorRef = createActor(machine);
     actorRef.start();
 
-    expect(actorRef.status).not.toBe(ActorStatus.Running);
+    expect(actorRef.getSnapshot().status).toBe('error');
 
     installGlobalOnErrorHandler((ev) => {
       ev.preventDefault();
-      expect(ev.error.message).toEqual('handled_sync_error_in_actor_start');
+      expect(ev.error.message).toEqual('unhandled_sync_error_in_actor_start');
       done();
     });
   });

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -5,7 +5,6 @@ import {
   sendParent,
   StateValue,
   createMachine,
-  ActorStatus,
   ActorRefFrom,
   ActorRef,
   cancel,
@@ -1793,7 +1792,8 @@ describe('interpreter', () => {
 
     const service = createActor(machine).start();
 
-    expect(service.status).toBe(ActorStatus.Stopped);
+    expect(service.getSnapshot().status).toBe('done');
+
     service.subscribe({
       complete: () => {
         done();

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -5,7 +5,6 @@ import {
   ActorRefFrom,
   AnyActorLogic,
   ActorOptions,
-  ActorStatus,
   SnapshotFrom
 } from 'xstate';
 import { useIdleInterpreter } from './useActorRef.ts';
@@ -50,7 +49,7 @@ export function useActor<TLogic extends AnyActorLogic>(
 
     return () => {
       actorRef.stop();
-      actorRef.status = ActorStatus.NotStarted;
+      (actorRef as any)._processingStatus = 0;
       (actorRef as any)._initState();
     };
   }, [actorRef]);

--- a/packages/xstate-react/src/useActorRef.ts
+++ b/packages/xstate-react/src/useActorRef.ts
@@ -13,8 +13,7 @@ import {
   StateFrom,
   toObserver,
   SnapshotFrom,
-  TODO,
-  ActorStatus
+  TODO
 } from 'xstate';
 import useConstant from './useConstant.ts';
 import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
@@ -108,7 +107,7 @@ export function useActorRef<TLogic extends AnyActorLogic>(
 
     return () => {
       actorRef.stop();
-      actorRef.status = ActorStatus.NotStarted;
+      (actorRef as any)._processingStatus = 0;
       (actorRef as any)._initState();
     };
   }, []);

--- a/packages/xstate-solid/test/useMachine.test.tsx
+++ b/packages/xstate-solid/test/useMachine.test.tsx
@@ -15,7 +15,6 @@ import { fireEvent, render, screen, waitFor } from 'solid-testing-library';
 import {
   Actor,
   ActorLogicFrom,
-  ActorStatus,
   assign,
   createActor,
   createMachine,
@@ -1484,7 +1483,7 @@ describe('useMachine hook', () => {
     });
     const Display = () => {
       onCleanup(() => {
-        expect(service.status).toBe(ActorStatus.Stopped);
+        expect(service.getSnapshot().status).toBe('stopped');
         done();
       });
       const [state, , service] = useMachine(machine);


### PR DESCRIPTION
I think that perhaps it would even be cool to move this to the mailbox. However, I bumped into small issues while trying to do so and I don't want to spend more time on this right now.