### PR TITLE
[v5] `createAction()` (replaces `pure()` and `choose()`)

### DIFF
--- a/packages/core/src/actions/pure.ts
+++ b/packages/core/src/actions/pure.ts
@@ -1,4 +1,5 @@
 import isDevelopment from '#is-development';
+import { evaluateGuard } from '../guards.ts';
 import {
   Actions,
   ActionArgs,
@@ -143,11 +144,13 @@ function resolveCreateAction(
     get: ({
       context,
       event,
-      exec
+      exec,
+      guard
     }: {
       context: MachineContext;
       event: EventObject;
       exec: CreateActionExec;
+      guard: (guard: any) => boolean;
     }) => SingleOrArray<UnknownAction> | undefined;
   }
 ) {
@@ -166,7 +169,10 @@ function resolveCreateAction(
       actions.push(action);
     }
   };
-  get({ context: args.context, event: args.event, exec });
+  const guard = (guard: any) => {
+    return evaluateGuard(guard, state.context, args.event, state);
+  };
+  get({ context: args.context, event: args.event, exec, guard });
   return [state, undefined, actions];
 }
 
@@ -189,6 +195,7 @@ export function createAction<
   }: {
     context: TContext;
     event: TExpressionEvent;
+    guard: (guard: TGuard) => boolean;
     exec: {
       assign: (
         ...args: Parameters<

--- a/packages/core/src/actions/pure.ts
+++ b/packages/core/src/actions/pure.ts
@@ -1,5 +1,5 @@
 import isDevelopment from '#is-development';
-import { evaluateGuard } from '../guards.ts';
+import { GuardPredicate, evaluateGuard } from '../guards.ts';
 import {
   Actions,
   ActionArgs,
@@ -195,7 +195,11 @@ export function createAction<
   }: {
     context: TContext;
     event: TExpressionEvent;
-    guard: (guard: TGuard) => boolean;
+    guard: (
+      guard:
+        | TGuard
+        | GuardPredicate<TContext, TExpressionEvent, undefined, TGuard>
+    ) => boolean;
     exec: {
       assign: (
         ...args: Parameters<

--- a/packages/core/src/actions/pure.ts
+++ b/packages/core/src/actions/pure.ts
@@ -10,9 +10,13 @@ import {
   ParameterizedObject,
   SingleOrArray,
   NoInfer,
-  ProvidedActor
+  ProvidedActor,
+  ActionFunction
 } from '../types.ts';
 import { toArray } from '../utils.ts';
+import { assign } from './assign.ts';
+import { raise } from './raise.ts';
+import { sendTo } from './send.ts';
 
 function resolvePure(
   _: AnyActorScope,
@@ -111,4 +115,135 @@ export function pure<
   pure.resolve = resolvePure;
 
   return pure;
+}
+
+interface CreateActionExec {
+  assign: (...args: Parameters<typeof assign<any, any, any, any, any>>) => void;
+  raise: (...args: Parameters<typeof raise<any, any, any, any, any>>) => void;
+  sendTo: (
+    ...args: Parameters<typeof sendTo<any, any, any, any, any, any>>
+  ) => void;
+  action: (
+    action:
+      | ActionFunction<any, any, any, any, any, any, any, any>
+      | {
+          type: string;
+        }
+  ) => void;
+}
+
+function resolveCreateAction(
+  _: AnyActorScope,
+  state: AnyState,
+  args: ActionArgs<any, any, any>,
+  _actionParams: ParameterizedObject['params'] | undefined,
+  {
+    get
+  }: {
+    get: ({
+      context,
+      event,
+      exec
+    }: {
+      context: MachineContext;
+      event: EventObject;
+      exec: CreateActionExec;
+    }) => SingleOrArray<UnknownAction> | undefined;
+  }
+) {
+  const actions: any[] = [];
+  const exec: CreateActionExec = {
+    assign: (...args) => {
+      actions.push(assign(...args));
+    },
+    raise: (...args) => {
+      actions.push(raise(...args));
+    },
+    sendTo: (...args) => {
+      actions.push(sendTo(...args));
+    },
+    action: (action) => {
+      actions.push(action);
+    }
+  };
+  get({ context: args.context, event: args.event, exec });
+  return [state, undefined, actions];
+}
+
+export function createAction<
+  TContext extends MachineContext,
+  TExpressionEvent extends EventObject,
+  TParams extends ParameterizedObject['params'] | undefined =
+    | ParameterizedObject['params']
+    | undefined,
+  TEvent extends EventObject = TExpressionEvent,
+  TActor extends ProvidedActor = ProvidedActor,
+  TAction extends ParameterizedObject = ParameterizedObject,
+  TGuard extends ParameterizedObject = ParameterizedObject,
+  TDelay extends string = string
+>(
+  getActions: ({
+    context,
+    event,
+    exec
+  }: {
+    context: TContext;
+    event: TExpressionEvent;
+    exec: {
+      assign: (
+        ...args: Parameters<
+          typeof assign<TContext, TExpressionEvent, any, TEvent, TActor>
+        >
+      ) => void;
+      raise: (
+        ...args: Parameters<
+          typeof raise<TContext, TExpressionEvent, TEvent, any, TDelay>
+        >
+      ) => void;
+      sendTo: (
+        ...args: Parameters<
+          typeof sendTo<TContext, TExpressionEvent, any, any, TEvent, TDelay>
+        >
+      ) => void;
+      action: (
+        action:
+          | TAction
+          | ActionFunction<
+              TContext,
+              TExpressionEvent,
+              TEvent,
+              any,
+              TActor,
+              TAction,
+              TGuard,
+              TDelay
+            >
+      ) => void;
+    };
+  }) => void
+): PureAction<
+  TContext,
+  TExpressionEvent,
+  TParams,
+  TEvent,
+  TActor,
+  TAction,
+  TGuard,
+  TDelay
+> {
+  function createAction(
+    args: ActionArgs<TContext, TExpressionEvent, TEvent>,
+    params: TParams
+  ) {
+    if (isDevelopment) {
+      throw new Error(`This isn't supposed to be called`);
+    }
+  }
+
+  createAction.type = 'xstate.action';
+  createAction.get = getActions;
+
+  createAction.resolve = resolveCreateAction;
+
+  return createAction;
 }

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -10,15 +10,14 @@ import {
   Spawner,
   StateMachine,
   assign,
-  choose,
   createActor,
   createMachine,
   not,
-  pure,
   sendTo,
   stateIn,
   spawn
 } from '../src/index';
+import { createAction } from '../src/actions/pure';
 
 function noop(_x: unknown) {
   return;
@@ -2996,19 +2995,31 @@ describe('choose', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: [
-            {
-              type: 'greet',
-              params: {
-                name: 'Anders'
-              }
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: [
+      //       {
+      //         type: 'greet',
+      //         params: {
+      //           name: 'Anders'
+      //         }
+      //       }
+      //     ]
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action({
+            type: 'greet',
+            params: {
+              name: 'Anders',
+              // @ts-expect-error
+              foo: 'bar'
             }
-          ]
+          });
         }
-      ])
+      })
     });
   });
 
@@ -3017,18 +3028,27 @@ describe('choose', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: [
-            {
-              type: 'greet',
-              // @ts-expect-error
-              params: {}
-            }
-          ]
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: [
+      //       {
+      //         type: 'greet',
+      //         // @ts-expect-error
+      //         params: {}
+      //       }
+      //     ]
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action({
+            type: 'greet',
+            // @ts-expect-error
+            params: {}
+          });
         }
-      ])
+      })
     });
   });
 
@@ -3037,15 +3057,23 @@ describe('choose', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: choose([
-        {
-          guard: () => true,
-          // @ts-expect-error
-          actions: {
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     // @ts-expect-error
+      //     actions: {
+      //       type: 'other' as const
+      //     }
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action({
+            // @ts-expect-error
             type: 'other' as const
-          }
+          });
         }
-      ])
+      })
     });
   });
 
@@ -3054,12 +3082,17 @@ describe('choose', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: 'poke'
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: 'poke'
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action({ type: 'poke' });
         }
-      ])
+      })
     });
   });
 
@@ -3068,14 +3101,19 @@ describe('choose', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: {
-            type: 'poke'
-          }
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: {
+      //       type: 'poke'
+      //     }
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action({ type: 'poke' });
         }
-      ])
+      })
     });
   });
 
@@ -3084,22 +3122,35 @@ describe('choose', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: [
-            {
-              type: 'greet',
-              params: {
-                name: 'Anders'
-              }
-            },
-            {
-              type: 'poke'
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: [
+      //       {
+      //         type: 'greet',
+      //         params: {
+      //           name: 'Anders'
+      //         }
+      //       },
+      //       {
+      //         type: 'poke'
+      //       }
+      //     ]
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action({
+            type: 'greet',
+            params: {
+              name: 'Anders'
             }
-          ]
+          });
+          exec.action({
+            type: 'poke'
+          });
         }
-      ])
+      })
     });
   });
 
@@ -3108,14 +3159,21 @@ describe('choose', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: {
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: {
+      //       type: 'poke'
+      //     }
+      //   }
+      // ] as const)
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action({
             type: 'poke'
-          }
+          });
         }
-      ] as const)
+      })
     });
   });
 
@@ -3128,11 +3186,14 @@ describe('choose', () => {
       },
       {
         actions: {
-          foo: choose([
-            {
-              actions: () => {}
-            }
-          ])
+          // foo: choose([
+          //   {
+          //     actions: () => {}
+          //   }
+          // ])
+          foo: createAction(({ exec }) => {
+            exec.action(() => {});
+          })
         }
       }
     );
@@ -3154,12 +3215,17 @@ describe('choose', () => {
       },
       {
         actions: {
-          foo: choose([
-            {
-              actions: () => {},
-              guard: 'plainGuard'
+          // foo: choose([
+          //   {
+          //     actions: () => {},
+          //     guard: 'plainGuard'
+          //   }
+          // ])
+          foo: createAction(({ exec, guard }) => {
+            if (guard({ type: 'plainGuard' })) {
+              exec.action(() => {});
             }
-          ])
+          })
         }
       }
     );
@@ -3181,13 +3247,23 @@ describe('choose', () => {
       },
       {
         actions: {
-          foo: choose([
-            {
-              actions: () => {},
-              // @ts-expect-error
-              guard: 'other' as const
+          // foo: choose([
+          //   {
+          //     actions: () => {},
+          //     // @ts-expect-error
+          //     guard: 'other' as const
+          //   }
+          // ])
+          foo: createAction(({ exec, guard }) => {
+            if (
+              guard({
+                // @ts-expect-error
+                type: 'other'
+              })
+            ) {
+              exec.action(() => {});
             }
-          ])
+          })
         }
       }
     );
@@ -3205,17 +3281,29 @@ describe('choose', () => {
             }
           | { type: 'plainGuard' }
       },
-      entry: choose([
-        {
-          actions: 'someAction',
-          guard: (_, params) => {
+      // entry: choose([
+      //   {
+      //     actions: 'someAction',
+      //     guard: (_, params) => {
+      //       ((_accept: undefined) => {})(params);
+      //       // @ts-expect-error
+      //       ((_accept: 'not any') => {})(params);
+      //       return true;
+      //     }
+      //   }
+      // ])
+      entry: createAction(({ exec, guard }) => {
+        if (
+          guard((_, params) => {
             ((_accept: undefined) => {})(params);
             // @ts-expect-error
             ((_accept: 'not any') => {})(params);
             return true;
-          }
+          })
+        ) {
+          exec.action({ type: 'someAction' });
         }
-      ])
+      })
     });
   });
 
@@ -3235,17 +3323,29 @@ describe('choose', () => {
       },
       {
         actions: {
-          someGuard: choose([
-            {
-              actions: 'someAction',
-              guard: (_, params) => {
+          // someGuard: choose([
+          //   {
+          //     actions: 'someAction',
+          //     guard: (_, params) => {
+          //       ((_accept: undefined) => {})(params);
+          //       // @ts-expect-error
+          //       ((_accept: 'not any') => {})(params);
+          //       return true;
+          //     }
+          //   }
+          // ])
+          someGuard: createAction(({ exec, guard }) => {
+            if (
+              guard((_, params) => {
                 ((_accept: undefined) => {})(params);
                 // @ts-expect-error
                 ((_accept: 'not any') => {})(params);
                 return true;
-              }
+              })
+            ) {
+              exec.action({ type: 'someAction' });
             }
-          ])
+          })
         }
       }
     );
@@ -3258,15 +3358,23 @@ describe('pure', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: pure(() => {
-        return [
-          {
-            type: 'greet' as const, // contextual type isn't helping here and string widens so we need `as const`
-            params: {
-              name: 'Anders'
-            }
+      // entry: pure(() => {
+      //   return [
+      //     {
+      //       type: 'greet' as const, // contextual type isn't helping here and string widens so we need `as const`
+      //       params: {
+      //         name: 'Anders'
+      //       }
+      //     }
+      //   ];
+      // })
+      entry: createAction(({ exec }) => {
+        exec.action({
+          type: 'greet', // string doesn't widen ;-)
+          params: {
+            name: 'Anders'
           }
-        ];
+        });
       })
     });
   });
@@ -3276,11 +3384,17 @@ describe('pure', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      // @ts-expect-error
-      entry: pure(() => {
-        return {
+      // @x-ts-expect-error
+      // entry: pure(() => {
+      //   return {
+      //     type: 'other'
+      //   };
+      // })
+      entry: createAction(({ exec }) => {
+        exec.action({
+          // @ts-expect-error
           type: 'other'
-        };
+        });
       })
     });
   });
@@ -3290,18 +3404,29 @@ describe('pure', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: pure(() => {
-        return [
-          {
-            type: 'greet' as const,
-            params: {
-              name: 'Anders'
-            }
-          },
-          {
-            type: 'poke' as const
+      // entry: pure(() => {
+      //   return [
+      //     {
+      //       type: 'greet' as const,
+      //       params: {
+      //         name: 'Anders'
+      //       }
+      //     },
+      //     {
+      //       type: 'poke' as const
+      //     }
+      //   ];
+      // })
+      entry: createAction(({ exec }) => {
+        exec.action({
+          type: 'greet',
+          params: {
+            name: 'Anders'
           }
-        ];
+        });
+        exec.action({
+          type: 'poke'
+        });
       })
     });
   });
@@ -3311,12 +3436,17 @@ describe('pure', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: pure(() => {
-        return [
-          {
-            type: 'poke'
-          }
-        ] as const;
+      // entry: pure(() => {
+      //   return [
+      //     {
+      //       type: 'poke'
+      //     }
+      //   ] as const;
+      // })
+      entry: createAction(({ exec }) => {
+        exec.action({
+          type: 'poke'
+        });
       })
     });
   });
@@ -3326,8 +3456,11 @@ describe('pure', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: pure(() => {
-        return [() => {}];
+      // entry: pure(() => {
+      //   return [() => {}];
+      // })
+      entry: createAction(({ exec }) => {
+        exec.action(() => {});
       })
     });
   });
@@ -3337,8 +3470,11 @@ describe('pure', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: pure(() => {
-        return 'poke' as const;
+      // entry: pure(() => {
+      //   return 'poke' as const;
+      // })
+      entry: createAction(({ exec }) => {
+        exec.action({ type: 'poke' });
       })
     });
   });
@@ -3348,8 +3484,11 @@ describe('pure', () => {
       types: {} as {
         actions: { type: 'greet'; params: { name: string } } | { type: 'poke' };
       },
-      entry: pure(() => {
-        return ['poke' as const];
+      // entry: pure(() => {
+      //   return 'poke' as const;
+      // })
+      entry: createAction(({ exec }) => {
+        exec.action({ type: 'poke' });
       })
     });
   });
@@ -3367,8 +3506,11 @@ describe('pure', () => {
       },
       on: {
         SOMETHING: {
-          actions: pure(({ context }) => {
-            return raise({ type: 'SOMETHING_ELSE' });
+          // actions: pure(({ context }) => {
+          //   return raise({ type: 'SOMETHING_ELSE' });
+          // })
+          actions: createAction(({ exec }) => {
+            exec.raise({ type: 'SOMETHING_ELSE' });
           })
         }
       }
@@ -3389,8 +3531,14 @@ describe('pure', () => {
       on: {
         SOMETHING: {
           actions: [
-            pure(({ context }) => {
-              return raise({
+            // pure(({ context }) => {
+            //   return raise({
+            //     // @ts-expect-error
+            //     type: 'OTHER'
+            //   });
+            // })
+            createAction(({ exec }) => {
+              exec.raise({
                 // @ts-expect-error
                 type: 'OTHER'
               });
@@ -4121,12 +4269,17 @@ describe('delays', () => {
       types: {} as {
         delays: 'one second' | 'one minute';
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: raise({ type: 'FOO' }, { delay: 100 })
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: raise({ type: 'FOO' }, { delay: 100 })
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action(raise({ type: 'FOO' }, { delay: 100 }));
         }
-      ])
+      })
     });
   });
 
@@ -4135,12 +4288,17 @@ describe('delays', () => {
       types: {} as {
         delays: 'one second' | 'one minute';
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: raise({ type: 'FOO' }, { delay: 'one minute' })
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: raise({ type: 'FOO' }, { delay: 'one minute' })
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action(raise({ type: 'FOO' }, { delay: 'one minute' }));
         }
-      ])
+      })
     });
   });
 
@@ -4149,18 +4307,31 @@ describe('delays', () => {
       types: {} as {
         delays: 'one second' | 'one minute';
       },
-      entry: choose([
-        {
-          guard: () => true,
-          actions: raise(
-            { type: 'FOO' },
-            {
-              // @ts-expect-error
-              delay: 'unknown delay'
-            }
-          )
+      // entry: choose([
+      //   {
+      //     guard: () => true,
+      //     actions: raise(
+      //       { type: 'FOO' },
+      //       {
+      //         // @ts-expect-error
+      //         delay: 'unknown delay'
+      //       }
+      //     )
+      //   }
+      // ])
+      entry: createAction(({ exec }) => {
+        if (true) {
+          exec.action(
+            raise(
+              { type: 'FOO' },
+              {
+                // @ts-expect-error
+                delay: 'unknown delay'
+              }
+            )
+          );
         }
-      ])
+      })
     });
   });
 
@@ -4169,8 +4340,11 @@ describe('delays', () => {
       types: {} as {
         delays: 'one second' | 'one minute';
       },
-      entry: pure(() => {
-        return raise({ type: 'FOO' }, { delay: 100 });
+      // entry: pure(() => {
+      //   return raise({ type: 'FOO' }, { delay: 100 });
+      // })
+      entry: createAction(({ exec }) => {
+        exec.raise({ type: 'FOO' }, { delay: 100 });
       })
     });
   });
@@ -4180,8 +4354,11 @@ describe('delays', () => {
       types: {} as {
         delays: 'one second' | 'one minute';
       },
-      entry: pure(() => {
-        return raise({ type: 'FOO' }, { delay: 'one minute' });
+      // entry: pure(() => {
+      //   return raise({ type: 'FOO' }, { delay: 'one minute' });
+      // })
+      entry: createAction(({ exec }) => {
+        exec.raise({ type: 'FOO' }, { delay: 'one minute' });
       })
     });
   });
@@ -4191,8 +4368,17 @@ describe('delays', () => {
       types: {} as {
         delays: 'one second' | 'one minute';
       },
-      entry: pure(() => {
-        return raise(
+      // entry: pure(() => {
+      //   return raise(
+      //     { type: 'FOO' },
+      //     {
+      //       // @ts-expect-error
+      //       delay: 'unknown delay'
+      //     }
+      //   );
+      // })
+      entry: createAction(({ exec }) => {
+        exec.raise(
           { type: 'FOO' },
           {
             // @ts-expect-error


### PR DESCRIPTION
```ts
actions: createAction(({ context, event, exec }) => {
  exec.assign({
    count: context.count + 1
  });

  // Conditional actions (replaces choose(...))
  if (event.someOption) {
    exec.sendTo('someActor', { type: 'blah', thing: context.thing });
    
    // other actions
    exec.action('namedAction');
    // with params
    exec.action({ type: 'greet', params: { message: 'hello' }});
  } else {
    // inline
    exec.action(() => console.log('hello'));
  }

  // no return
})
```