### PR TITLE
[v5] Remove `waitFor` timeout

### DIFF
--- a/.changeset/shy-poets-sleep.md
+++ b/.changeset/shy-poets-sleep.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+The default `timeout` for `waitFor(...)` is now `Infinity` instead of 10 seconds.

--- a/packages/core/src/waitFor.ts
+++ b/packages/core/src/waitFor.ts
@@ -12,7 +12,7 @@ interface WaitForOptions {
 }
 
 const defaultWaitForOptions: WaitForOptions = {
-  timeout: 10_000 // 10 seconds
+  timeout: Infinity // much more than 10 seconds
 };
 
 /**


### PR DESCRIPTION
The default `timeout` for `waitFor(...)` is now `Infinity` instead of 10 seconds.
