### PR TITLE
Do not select always transitions when no regular transition gets selected

### DIFF
--- a/.changeset/always-as-pure.md
+++ b/.changeset/always-as-pure.md
@@ -1,0 +1,5 @@
+---
+'xstate': major
+---
+
+`always` transitions will no longer be selected when receiving an event that **doesn't** trigger any transition.

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1644,6 +1644,12 @@ export function macrostep(
   // Determine the next state based on the next microstep
   if (nextEvent.type !== XSTATE_INIT) {
     const transitions = selectTransitions(nextEvent, nextState);
+    if (!transitions.length) {
+      return {
+        state: nextState,
+        microstates: []
+      };
+    }
     nextState = microstep(
       transitions,
       state,

--- a/packages/core/test/transient.test.ts
+++ b/packages/core/test/transient.test.ts
@@ -474,6 +474,29 @@ describe('transient states (eventless transitions)', () => {
     expect(actorRef.getSnapshot().value).toBe('a');
   });
 
+  it('should be taken if there is a wildcard transition', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          always: {
+            target: 'b',
+            guard: ({ event }) => event.type === 'WHATEVER'
+          },
+          on: {
+            '*': {}
+          }
+        },
+        b: {}
+      }
+    });
+    const actorRef = createActor(machine).start();
+
+    actorRef.send({ type: 'WHATEVER' });
+
+    expect(actorRef.getSnapshot().value).toBe('b');
+  });
+
   it('should select subsequent always transitions after selecting a regular transition', () => {
     let shouldMatch = false;
 


### PR DESCRIPTION
This essentially reverts https://github.com/statelyai/xstate/pull/2343 . I open this PR to spark the conversation about this behavior. It wasn't a change requested by any user - we just did it to comply with SCXML. However, this behavior "promotes" impurity and I really wonder if we want to keep this behavior. 