### PR TITLE
Revert "Do not select always transitions when no regular transition gets selected (#4449)"

### DIFF
--- a/.changeset/always-as-pure.md
+++ b/.changeset/always-as-pure.md
@@ -1,5 +1,0 @@
----
-'xstate': major
----
-
-`always` transitions will no longer be selected when receiving an event that **doesn't** trigger any transition.

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1644,12 +1644,6 @@ export function macrostep(
   // Determine the next state based on the next microstep
   if (nextEvent.type !== XSTATE_INIT) {
     const transitions = selectTransitions(nextEvent, nextState);
-    if (!transitions.length) {
-      return {
-        state: nextState,
-        microstates: []
-      };
-    }
     nextState = microstep(
       transitions,
       state,


### PR DESCRIPTION
This reverts commit 5da17f20db96c485e9c93bef5404302ffd2fd577.

We had a follow-up discussion about this offline and finally, we couldn't agree on what is better so we decided to revert this change for the time being.