### PR TITLE
Merge `createActor` overloads into one

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -696,17 +696,15 @@ export class Actor<TLogic extends AnyActorLogic>
  * @param options - Actor options
  */
 export function createActor<TLogic extends AnyActorLogic>(
-  logic: TLogic,
+  logic: TLogic extends AnyStateMachine
+    ? AreAllImplementationsAssumedToBeProvided<
+        TLogic['__TResolvedTypesMeta']
+      > extends true
+      ? TLogic
+      : MissingImplementationsError<TLogic['__TResolvedTypesMeta']>
+    : TLogic,
   options?: ActorOptions<TLogic>
 ): Actor<TLogic>;
-export function createActor<TMachine extends AnyStateMachine>(
-  machine: AreAllImplementationsAssumedToBeProvided<
-    TMachine['__TResolvedTypesMeta']
-  > extends true
-    ? TMachine
-    : MissingImplementationsError<TMachine['__TResolvedTypesMeta']>,
-  options?: ActorOptions<TMachine>
-): Actor<TMachine>;
 export function createActor(logic: any, options?: ActorOptions<any>): any {
   const interpreter = new Actor(logic, options);
 

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -1,15 +1,13 @@
+import { fromCallback, fromPromise } from '../src/actors/index.ts';
+import { PromiseActorLogic } from '../src/actors/promise.ts';
+import { createMachine } from '../src/createMachine.ts';
 import {
-  ActorLogic,
   assign,
   createActor,
   MachineContext,
   StateMachine
 } from '../src/index.ts';
-import { fromPromise } from '../src/actors/index.ts';
-import { fromCallback } from '../src/actors/index.ts';
-import { createMachine } from '../src/createMachine.ts';
 import { TypegenMeta } from '../src/typegenTypes.ts';
-import { PromiseActorLogic } from '../src/actors/promise.ts';
 
 describe('typegen types', () => {
   it('should not require implementations when creating machine using `createMachine`', () => {
@@ -255,6 +253,12 @@ describe('typegen types', () => {
   it('should allow valid string `matches`', () => {
     interface TypesMeta extends TypegenMeta {
       matchesStates: 'a' | 'b' | 'c';
+      missingImplementations: {
+        actions: never;
+        delays: never;
+        guards: never;
+        actors: never;
+      };
     }
 
     const machine = createMachine({
@@ -275,6 +279,12 @@ describe('typegen types', () => {
   it('should allow valid object `matches`', () => {
     interface TypesMeta extends TypegenMeta {
       matchesStates: 'a' | { a: 'b' } | { a: 'c' };
+      missingImplementations: {
+        actions: never;
+        delays: never;
+        guards: never;
+        actors: never;
+      };
     }
 
     const machine = createMachine({
@@ -292,6 +302,12 @@ describe('typegen types', () => {
   it('should not allow invalid string `matches`', () => {
     interface TypesMeta extends TypegenMeta {
       matchesStates: 'a' | 'b' | 'c';
+      missingImplementations: {
+        actions: never;
+        delays: never;
+        guards: never;
+        actors: never;
+      };
     }
 
     const machine = createMachine({
@@ -306,13 +322,21 @@ describe('typegen types', () => {
       }
     });
 
-    // @ts-expect-error
-    createActor(machine).getSnapshot().matches('d');
+    createActor(machine).getSnapshot().matches(
+      // @ts-expect-error
+      'd'
+    );
   });
 
   it('should not allow invalid object `matches`', () => {
     interface TypesMeta extends TypegenMeta {
       matchesStates: 'a' | { a: 'b' } | { a: 'c' };
+      missingImplementations: {
+        actions: never;
+        delays: never;
+        guards: never;
+        actors: never;
+      };
     }
 
     const machine = createMachine({
@@ -324,13 +348,21 @@ describe('typegen types', () => {
       }
     });
 
-    // @ts-expect-error
-    createActor(machine).getSnapshot().matches({ a: 'd' });
+    createActor(machine).getSnapshot().matches({
+      // @ts-expect-error
+      a: 'd'
+    });
   });
 
   it('should allow a valid tag with `hasTag`', () => {
     interface TypesMeta extends TypegenMeta {
       tags: 'a' | 'b' | 'c';
+      missingImplementations: {
+        actions: never;
+        delays: never;
+        guards: never;
+        actors: never;
+      };
     }
 
     const machine = createMachine({
@@ -351,6 +383,12 @@ describe('typegen types', () => {
   it('should not allow an invalid tag with `hasTag`', () => {
     interface TypesMeta extends TypegenMeta {
       tags: 'a' | 'b' | 'c';
+      missingImplementations: {
+        actions: never;
+        delays: never;
+        guards: never;
+        actors: never;
+      };
     }
 
     const machine = createMachine({
@@ -365,8 +403,10 @@ describe('typegen types', () => {
       }
     });
 
-    // @ts-expect-error
-    createActor(machine).getSnapshot().hasTag('d');
+    createActor(machine).getSnapshot().hasTag(
+      // @ts-expect-error
+      'd'
+    );
   });
 
   it('`withConfig` should require all missing implementations ', () => {
@@ -449,8 +489,7 @@ describe('typegen types', () => {
       }
     });
 
-    // TODO: rethink this; should probably be done as a linter rule instead
-    // @x-ts-expect-error
+    // @ts-expect-error
     createActor(machine);
   });
 
@@ -997,6 +1036,12 @@ describe('typegen types', () => {
   it("shouldn't end up with `any` context after calling `state.matches`", () => {
     interface TypesMeta extends TypegenMeta {
       matchesStates: 'a' | 'b' | 'c';
+      missingImplementations: {
+        actions: never;
+        delays: never;
+        guards: never;
+        actors: never;
+      };
     }
 
     const machine = createMachine({
@@ -1022,6 +1067,12 @@ describe('typegen types', () => {
   it("shouldn't end up with `never` within a branch after two `state.matches` calls", () => {
     interface TypesMeta extends TypegenMeta {
       matchesStates: 'a' | 'a.b';
+      missingImplementations: {
+        actions: never;
+        delays: never;
+        guards: never;
+        actors: never;
+      };
     }
 
     const machine = createMachine({

--- a/packages/xstate-vue/src/useActorRef.ts
+++ b/packages/xstate-vue/src/useActorRef.ts
@@ -17,7 +17,7 @@ export function useActorRef<TLogic extends AnyActorLogic>(
     | Observer<SnapshotFrom<TLogic>>
     | ((value: SnapshotFrom<TLogic>) => void)
 ): ActorRefFrom<TLogic> {
-  const actorRef = createActor(actorLogic, options);
+  const actorRef = createActor(actorLogic as any, options);
 
   let sub: Subscription;
   onMounted(() => {


### PR DESCRIPTION
fixes https://github.com/statelyai/xstate/pull/4416/files#r1407630794

Before the final release, we might consider removing all those `AreAllImplementationsAssumedToBeProvided` code paths. For the time being though this is kinda a bug so let's fix it and then bikeshed that removal.