### PR TITLE
Forbid using string references to implementations that were not set up

### DIFF
--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -117,7 +117,7 @@ export function raise<
   TParams extends ParameterizedObject['params'] | undefined =
     | ParameterizedObject['params']
     | undefined,
-  TDelay extends string = string
+  TDelay extends string = never
 >(
   eventOrExpr:
     | NoInfer<TEvent>

--- a/packages/core/test/setup.types.test.ts
+++ b/packages/core/test/setup.types.test.ts
@@ -771,28 +771,6 @@ describe('setup()', () => {
     });
   });
 
-  it(`should provide contextual parameters to input factory for an actor that doesn't specify any input`, () => {
-    setup({
-      types: {
-        context: {} as { count: number }
-      },
-      actors: {
-        child: fromPromise(() => Promise.resolve(1))
-      }
-    }).createMachine({
-      context: { count: 1 },
-      invoke: {
-        src: 'child',
-        input: ({ context }) => {
-          // @ts-expect-error
-          context.foo;
-
-          return undefined;
-        }
-      }
-    });
-  });
-
   it('should return the correct child type on the available snapshot when the child ID for the actor was configured', () => {
     const child = createMachine({
       types: {} as {
@@ -1374,4 +1352,17 @@ describe('setup()', () => {
       green: 'green'
     });
   });
+});
+
+setup({
+  // actors: {
+  //   // 'fetchUser': fromPromise(async () => ({ name: 'Andarist' }))
+  // },
+  actions: {
+    spawnPlumber: spawnChild('fetchUser')
+  }
+}).createMachine({
+  invoke: {
+    src: 'fetchUser'
+  }
 });


### PR DESCRIPTION
Currently, this doesn't work. The minimal repro case of this problem would be smth like this: [TS playground](https://www.typescriptlang.org/play?ts=5.4.0-dev.20231130#code/C4TwDgpgBAcg9gSQHYDMICcA8AVAfFAXigG1sBdUqCAD2AiQBMBnKAQyRCgH4oAGKAFxsOZANwAocQEskddClYBjaAFEAbvWAB5AEYArCIuBQA3uKhRQkIU2DoZAcwkBfSVejwkAJQgMAropSOgA2EACqSADWSHAA7kiEps5QAD5QSH7BwalQfowQKDK+EtKyGArKUAAKrOisALYQclIAXr66Bkam5pbgEDZ2jhIWYLUNTFxCnj7+gSHhUTHxLm59UACCRlJwSABieVs7mD3YAMI7dLQANCfqmlS09MxQd7IdhsA3Ftg1dfUsNDojBYvwaTQwrXa+g+xAARKM-kxYWQcnkGAUigwvlBsAARCDBVicQFPFi2exIBw3fBEMwWAAUtQcTCEJigigugKEZ05tCgziuUAR425oP+AEohGo4FIGMMoAB9OB+YAK7CvYCTHEa+VKlVq-GEkBavEEokuEoyOQVaBeVhSJgQTbAbZIY7fc5la4nMUAx7A6pjRrNNoMd5GOHC-7I1H5QpIXzY9UaWQPIHPDXhz4nQ1EtOkqDkxzU7oMpks0zs3nAbmey7GAVCoMVn7NyVQaWy3XK1XJzQmnU9PW93PG7mjlbidGKQnoaAoA4unZQOoOiDunF1wFJjX5gOZ6FGJO+vfPMXg+yhrOR5sxtJojEJhiEHoWNLnkNQzrAG+I5Gv2N0XjRMczNYl-WeItKUSBMNHQal6R6CAU20dAVGoMB0CmRBUAwHANVwbE4DAJckAmVkAPRI0tXgZA0CwU0jVweUBXEds7TXZ1XRwLdrhxX1BT7WRBNHZjJGnWd50XV1CyaPwwA3HkvWzb5dxJfcUKzJMuJ2P10xYHwOXQBgNwsKCqQAj8ISvQ8f3hW8UXvONMR6GkkiTUdTzJQZoKIWCMAQkxnAoix3HI0sLCrZSTV44B5QsZD+25QcLGceUlFI8K6Ui4gAGkoBkKBIggEA4BQHEdLIsghEq-YkEON0AI9atsUi7UUNayLsEqpg8rITrvlHACxNS+UqKJLKALygqEkYolqvSPx6h0DAWJcdtOzlSQrXKJRoAAWRAWKIo5PIa0W5bVvEVxxHcKBDt3WkencIRYV2LQtFhC1JEdYB5PpbKwtZZJWBYbKLA5ZShEO2L4qoFDoZAFL+WxDLXQrcGoAAeixqAUDgdBCzgRoVwgUHlwAAzmkAKcLF1FEiFhgDgSwAAtoEh8l7VTdm5wAnGoHRJgwCkOhBYKVhMhdaDgFZ1hjDuqNLBZ-zCZ0OBZZmqAKdXR1afYZ9Cop375IpgCmFZnshF1iAAd6awoDej7YX5cVOoFyKAD0uB6ViLHGkAMf53HYntYB1gAZUMHYGCEABGbFWOccUShoMACeMIKSgFqmNVph0oBCOAGd8PH0GJmb6PoSomBZ2JoEdaBZegCmD1s2nObsbnjHlgrgBYdOmFF11xAFnQVSgev2XYWToEt2Jtep-OWCAyXgjoZ9me11Xad5iBxBtu2Xsd97PtdiQPe98TDEkvHpOXOhbBwLy6YpBxcHpOB9C1bLpsK8ghB5GiHEJA61uQlE7qTJgUs46JEfsAekKdR64y9j7SBc5oHrwAExwIgLYAGycL4oIsFfdBeCpYAGZcH4LZKweOgodBCBwYQ5BbUr5ThvrUKS9VSKWDwcALBz91KQR8g4GCiV0Afy-noH+PQ-6zQWkApYoDrrtmwBA3SxgMFSwACzUIEYgohbC0GaKgVLAArPorBBCkEexISYsiWjyHrwAGxWLtnQqACdC5MPPqw1B4ggA)

We could fix this by making all of our "phantom properties" on actions etc required: [TS playground](https://www.typescriptlang.org/play?ts=5.4.0-dev.20231130#code/C4TwDgpgBAcg9gSQHYDMICcA8AVAfFAXigG1sBdUqCAD2AiQBMBnKAQyRCgH4oAGKAFxsOZANwAocQEskddClYBjaAFEAbvWAB5AEYArCIuBQA3uKhRQkIU2DoZAcwkBfSVejwkAJQgMAropSOgA2EACqSADWSHAA7kiEps5QAD5QSH7BwalQfowQKDK+EtKyGArKUAAKrOisALYQclIAXr66Bkam5pbgEDZ2jhIWYLUNTFxCnj7+gSHhUTHxLm59UACCRlJwSABieVs7mD3YAMI7dLQANCfqmlS09MxQd7IdhsA3Ftg1dfUsNDojBYvwaTQwrXa+g+xAARKM-kxYWQcnkGAUigwvlBsAARCDBVicQFPFi2exIBw3fBEMwWAAUtQcTCEJigigugKEZ05tCgziuUAR425oP+AEohGo4FIGMMoAB9OB+YAK7CvYDcjXypUqtX4wkgbkGokuEoyOQVaBeVhSJgQTbAbZIY7fc5la4nMUAx7A6pjRrNNoMd5GOHC-7I1H5QpIXzY9UaWQPIHPDWhz4nE3E33PcmOandBlMlmmdm8zU492XYwCoUB0s-BuSqDS2U65WqxOaLVJ4AdvV4glE43DkArcToxSE9DQFAHJ07KB1O0QV1VisJjUp0kvPsZhPend+sXg+zBjPhhtRtJojFxhiEHoWNKnoNQzrAK+I5HP6Po2N4yzMdjzzQZKUSOMNHQal6R6CB93QFRqDAdApkQVAMBwDVcGxOAwEXJAJlZP90UNSZYAwtAsCHQ1cHlAVxBbG1V0dZ0cGrQFBSbRFuI1bjs3oyQpxnOcF2dKB7WAPwwHXHkPUzb5txJP102hIwEzYnYfVTFgfA5dAGHXCx80pbELDfCEL3Ur94WvFFbxjTEehpJIE2zUCyXAhxIIQjBYJMZwSIsdxiKLCxywUij5JreULD82Rou1HpnHlJRCLCukIuIABpKAZCgSIIBAOAUBxLSiLIIQKv2JBDhdP83U3RqcX4lrsAqphcrIcyItook-yEixUp6MiiUyv9cvyhJ+pAKr0j8eodAwBiXBbNs5UkC1yiUaAAFkQE4vkso5PJKwyJaVvEVxxHcKADu3WkencIRYV2LQtFhM1JCkmT6Sy0LWWSVgWCyiwOQUoQDqO-s-wSysHr7BjsXS51SzBySAAtOyEFd7X+3prCgN6PthflxV6gB6SmIqgAA9Lg-0UVhgnqXE4iQIR6XFQh8EClLsTGkB0b-amoFiW1gHWABlQwdgYIQAEZsUY5xxRKGgwDgdBjECkpxCAA). However, this breaks usage of inline functions.

The fix for this would be to include `| undefined` in the constraint of `TDelay`: [TS playground](https://www.typescriptlang.org/play?ts=5.4.0-dev.20231130#code/C4TwDgpgBAcg9gSQHYDMICcA8AVAfFAXigG1sBdUqCAD2AiQBMBnKAQyRCgH4oAGKAFxsOZANwAocQEskddClYBjaAFEAbvWAB5AEYArCIuBQA3uKhRQkIU2DoZAcwkBfSVejwkAJQgMAropSOgA2EACqSADWSHAA7kiEps5QAD5QSH7BwalQfowQKDK+EtKyGArKUAAKrOisALYQclIAXr66Bkam5pbgEDZ2jhIWYLUNTFxCnj7+gSHhUTHxLm59UACCRlJwSABieVs7mD3YAMI7dLQANCfqmlS09MxQd7IdhsA3Ftg1dfUsNDojBYvwaTQwrXa+g+xAARKM-kxYWQcnkGAUigwvlBsAARCDBVicQFPFi2exIBw3fBEMwWAAUtQcTCEJigigugKEZ05tCgziuUAR425oP+AEohGo4FIGMMoAB9OB+YAK7CvYCTHEa+VKlVq-GEkBavEEokuEoyOQVaBeVhSJgQTbAbZIY7fc5la4nMUAx7A6pjRrNNoMd5GOHC-7I1H5QpIXzY9UaWQPIHPDXhz4nQ1EtOkqDkxyx9HxxPifB0qCM9DM1ns3nAbmey7GAVCoMsnG+yVQaWy3XK1XJzQmnU9PXD3PG7nTlbidGKQnoaAoA4unZQOoOiDunEtwFJjX5gOZ6FGJO+k-PMXg+yhrORzsxtJojEJhiEHoWNK3kNQzpgCfRFkW-Et33Lb5p2vMlBkpcCy0-IgEw0dBqXpHoIBTbR0BUagwHQKZEFQDAcA1XBsTgMANyQCZWTA9EjS1eBkDQLBTSNXB5QFcReztHdnVdHAD2ubtO0FEdZAk6cuMkRdl1XddXULJo-DAPceS9bNvmPElT2wrMk0EnY-XTFgfA5dAGD3Cwi0pbELD-CEH3PID4WfFFXzjTEehpJIk2gvTnjshxEhQjB0JMZx6Isdw6O6CwLA5LSTRE4B5QsLDR25ccLGceUlBo+KqwsYgAGkoBkKBIggEA4BQHFjNosghCa-YkEON0wI9RsHMSyTtMS74mqYcqyD6qCzRAMDZLy+VGKJYqwPKyqEg4okWvSPx6h0DBuJcXt+zlSQrXKJRoAAWRANKEobPImy2na9vEVxxHcKAruPWkencIRYV2LQtFhC1JEdYA1PpKs4tZZJWBYEqGy0oQrrSjKqGw5GQFy-lsUK10uwRpgAAshyEbdHUh3prCgf7AdhflxT6gB6JmhoAPS4MDFFYYJ6lxOIkCEelxUIStXDy7EFpAAmwJZqBYntYB1gAZUMHYGCEABGbEeOccUShoMA4HQYwopKcQgA). A similar change should be done for all of our phantomable generics - this requires some additional thought and experimentation so now is not the best time to explore this. I'll revisit this when I can.