### PR TITLE
[v5] `event.data` -> `event.error` for error events

### DIFF
--- a/.changeset/rotten-spoons-sleep.md
+++ b/.changeset/rotten-spoons-sleep.md
@@ -1,0 +1,18 @@
+---
+'xstate': major
+---
+
+The error event (`type: 'xstate.error.*'`) now has the error data on the `event.error` instead of `event.data`:
+
+```diff
+// ...
+invoke: {
+  src: 'someSrc',
+  onError: {
+    actions: ({ event }) => {
+-     event.data;
++     event.error;
+    }
+  }
+}
+```

--- a/packages/core/src/eventUtils.ts
+++ b/packages/core/src/eventUtils.ts
@@ -50,9 +50,9 @@ export function createDoneActorEvent(
 
 export function createErrorActorEvent(
   id: string,
-  data?: unknown
+  error?: unknown
 ): ErrorActorEvent {
-  return { type: `xstate.error.actor.${id}`, data };
+  return { type: `xstate.error.actor.${id}`, error };
 }
 
 export function createInitEvent(input: unknown) {

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1642,7 +1642,7 @@ export function macrostep(
       // similarly `xstate.error.actor.*` and `xstate.error.actor.todo.*` have to be considered too
       nextSnapshot = cloneMachineSnapshot<typeof snapshot>(snapshot, {
         status: 'error',
-        error: currentEvent.data
+        error: currentEvent.error
       });
       states.push(nextSnapshot);
       return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1442,7 +1442,7 @@ export interface DoneActorEvent<TOutput = unknown> {
 
 export interface ErrorActorEvent<TErrorData = unknown> extends EventObject {
   type: `xstate.error.actor.${string}`;
-  data: TErrorData;
+  error: TErrorData;
 }
 
 export interface SnapshotEvent<

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1133,7 +1133,7 @@ describe('actors', () => {
               'xstate.error.actor.test': {
                 target: 'success',
                 guard: ({ event }) => {
-                  return event.data === errorMessage;
+                  return event.error === errorMessage;
                 }
               }
             }

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -1655,7 +1655,8 @@ describe('invoke', () => {
                 target: 'failed',
                 guard: ({ event }) => {
                   return (
-                    event.data instanceof Error && event.data.message === 'test'
+                    event.error instanceof Error &&
+                    event.error.message === 'test'
                   );
                 }
               }
@@ -1997,10 +1998,10 @@ describe('invoke', () => {
               onError: {
                 target: 'success',
                 guard: ({ context, event }) => {
-                  expect((event.data as any).message).toEqual('some error');
+                  expect((event.error as any).message).toEqual('some error');
                   return (
                     context.count === 4 &&
-                    (event.data as any).message === 'some error'
+                    (event.error as any).message === 'some error'
                   );
                 }
               }
@@ -2186,10 +2187,10 @@ describe('invoke', () => {
               onError: {
                 target: 'success',
                 guard: ({ context, event }) => {
-                  expect((event.data as any).message).toEqual('some error');
+                  expect((event.error as any).message).toEqual('some error');
                   return (
                     context.count === 4 &&
-                    (event.data as any).message === 'some error'
+                    (event.error as any).message === 'some error'
                   );
                 }
               }


### PR DESCRIPTION
The error event (`type: 'xstate.error.*'`) now has the error data on the `event.error` instead of `event.data`:

```diff
// ...
invoke: {
  src: 'someSrc',
  onError: {
    actions: ({ event }) => {
-     event.data;
+     event.error;
    }
  }
}
```
