### PR TITLE
Update xstate.js.org/docs for v5 (encourage folks to use stately.ai/docs instead)

### DIFF
--- a/.changeset/fresh-steaks-fly.md
+++ b/.changeset/fresh-steaks-fly.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Flag that docs in this repo are deprecated in favour of docs at stately.ai/docs/xstate

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,4 @@
 <p align="center">
-  <a href="https://xstate.js.org">
   <br />
 
   <picture>
@@ -7,51 +6,50 @@
     <img alt="XState logotype" src="https://raw.githubusercontent.com/statelyai/public-assets/main/logos/xstate-logo-black-nobg.svg" width="200">
   </picture>
   <br />
-    <sub><strong>JavaScript state machines and statecharts</strong></sub>
+    <strong>Actor-based state management & orchestration for complex app logic.</strong> <a href="https://stately.ai/docs">→ Documentation</a>
   <br />
   <br />
-  </a>
 </p>
 
-[![npm version](https://badge.fury.io/js/xstate.svg)](https://badge.fury.io/js/xstate)
-<img src="https://opencollective.com/xstate/tiers/backer/badge.svg?label=sponsors&color=brightgreen" />
+XState is a state management and orchestration solution for JavaScript and TypeScript apps. It has _zero_ dependencies, and is useful for frontend and backend application logic.
 
-JavaScript and TypeScript [finite state machines](https://en.wikipedia.org/wiki/Finite-state_machine) and [statecharts](https://www.sciencedirect.com/science/article/pii/0167642387900359/pdf) for the modern web.
+It uses event-driven programming, state machines, statecharts, and the actor model to handle complex logic in predictable, robust, and visual ways. XState provides a powerful and flexible way to manage application and workflow state by allowing developers to model logic as actors and state machines.
 
-📖 [Read the documentation](https://stately.ai/docs/xstate)
+### ✨ Create state machines visually in Stately Studio → [state.new](https://state.new)
 
-💙 [Explore our catalogue of examples](https://xstate-catalogue.com/)
+---
+
+📖 [Read the documentation](https://stately.ai/docs)
 
 ➡️ [Create state machines with the Stately Editor](https://stately.ai/editor)
 
 🖥 [Download our VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode)
 
-📑 Adheres to the [SCXML specification](https://www.w3.org/TR/scxml/)
+📑 Inspired by the [SCXML specification](https://www.w3.org/TR/scxml/)
 
 💬 Chat on the [Stately Discord Community](https://discord.gg/xstate)
 
 ## Packages
 
-- 🤖 `xstate` - Core finite state machine and statecharts library + interpreter
-- [📉 `@xstate/graph`](https://github.com/statelyai/xstate/tree/main/packages/xstate-graph) - Graph traversal utilities for XState
-- [⚛️ `@xstate/react`](https://github.com/statelyai/xstate/tree/main/packages/xstate-react) - React hooks and utilities for using XState in React applications
-- [💚 `@xstate/vue`](https://github.com/statelyai/xstate/tree/main/packages/xstate-vue) - Vue composition functions and utilities for using XState in Vue applications
-- [🎷 `@xstate/svelte`](https://github.com/statelyai/xstate/tree/main/packages/xstate-svelte) - Svelte utilities for using XState in Svelte applications
-- [🥏 `@xstate/solid`](https://github.com/statelyai/xstate/tree/main/packages/xstate-solid) - Solid hooks and utilities for using XState in Solid applications
-- [✅ `@xstate/test`](https://github.com/statelyai/xstate/tree/main/packages/xstate-test) - Model-Based-Testing utilities (using XState) for testing any software
-- [🔍 `@xstate/inspect`](https://github.com/statelyai/xstate/tree/main/packages/xstate-inspect) - Inspection utilities for XState
+| Package                                                                                       | Description                                                                  |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| 🤖 `xstate`                                                                                   | Core finite state machine and statecharts library + interpreter              |
+| [📉 `@xstate/graph`](https://github.com/statelyai/xstate/tree/main/packages/xstate-graph)     | Graph traversal utilities for XState                                         |
+| [⚛️ `@xstate/react`](https://github.com/statelyai/xstate/tree/main/packages/xstate-react)     | React hooks and utilities for using XState in React applications             |
+| [💚 `@xstate/vue`](https://github.com/statelyai/xstate/tree/main/packages/xstate-vue)         | Vue composition functions and utilities for using XState in Vue applications |
+| [🎷 `@xstate/svelte`](https://github.com/statelyai/xstate/tree/main/packages/xstate-svelte)   | Svelte utilities for using XState in Svelte applications                     |
+| [🥏 `@xstate/solid`](https://github.com/statelyai/xstate/tree/main/packages/xstate-solid)     | Solid hooks and utilities for using XState in Solid applications             |
+| [✅ `@xstate/test`](https://github.com/statelyai/xstate/tree/main/packages/xstate-test)       | Model-Based-Testing utilities (using XState) for testing any software        |
+| [🔍 `@xstate/inspect`](https://github.com/statelyai/xstate/tree/main/packages/xstate-inspect) | Inspection utilities for XState                                              |
 
 ## Templates
 
 Get started by forking one of these templates on CodeSandbox:
 
-- [XState Template](https://codesandbox.io/s/xstate-example-template-m4ckv) - no framework
-- [XState + TypeScript Template](https://codesandbox.io/s/xstate-typescript-template-s9kz8) - no framework
-- [XState + React Template](https://codesandbox.io/s/xstate-react-template-3t2tg)
-- [XState + React + TypeScript Template](https://codesandbox.io/s/xstate-react-typescript-template-wjdvn)
-- [XState + Vue Template](https://codesandbox.io/s/xstate-vue-template-composition-api-1n23l)
-- [XState + Vue 3 Template](https://codesandbox.io/s/xstate-vue-3-template-vrkk9)
-- [XState + Svelte Template](https://codesandbox.io/s/xstate-svelte-template-jflv1)
+| Template                                                                                                        |                          |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| [XState Template](https://codesandbox.io/p/devbox/github/statelyai/xstate/tree/main/templates/vanilla-ts)       | TypeScript, no framework |
+| [XState + React Template](https://codesandbox.io/p/devbox/github/statelyai/xstate/tree/main/templates/react-ts) | TypeScript, React        |
 
 ## Super quick start
 
@@ -59,115 +57,57 @@ Get started by forking one of these templates on CodeSandbox:
 npm install xstate
 ```
 
-```js
-import { createMachine, interpret } from 'xstate';
+```ts
+import { createMachine, createActor, assign } from 'xstate';
 
-// Stateless machine definition
-// machine.transition(...) is a pure function used by the interpreter.
+// State machine
 const toggleMachine = createMachine({
   id: 'toggle',
   initial: 'inactive',
-  states: {
-    inactive: { on: { TOGGLE: 'active' } },
-    active: { on: { TOGGLE: 'inactive' } }
-  }
-});
-
-// Machine instance with internal state
-const toggleService = interpret(toggleMachine)
-  .onTransition((state) => console.log(state.value))
-  .start();
-// => 'inactive'
-
-toggleService.send('TOGGLE');
-// => 'active'
-
-toggleService.send('TOGGLE');
-// => 'inactive'
-```
-
-## Promise example
-
-[📉 See the visualization on stately.ai/viz](https://stately.ai/viz?gist=bbcb4379b36edea0458f597e5eec2f91)
-
-<details>
-<summary>See the code</summary>
-
-```js
-import { createMachine, interpret, assign } from 'xstate';
-
-const fetchMachine = createMachine({
-  id: 'Dog API',
-  initial: 'idle',
   context: {
-    dog: null
+    count: 0
   },
   states: {
-    idle: {
+    inactive: {
       on: {
-        FETCH: 'loading'
+        TOGGLE: { target: 'active' }
       }
     },
-    loading: {
-      invoke: {
-        id: 'fetchDog',
-        src: (context, event) =>
-          fetch('https://dog.ceo/api/breeds/image/random').then((data) =>
-            data.json()
-          ),
-        onDone: {
-          target: 'resolved',
-          actions: assign({
-            dog: (_, event) => event.data
-          })
-        },
-        onError: 'rejected'
-      },
+    active: {
+      entry: assign({ count: ({ context }) => context.count + 1 }),
       on: {
-        CANCEL: 'idle'
-      }
-    },
-    resolved: {
-      type: 'final'
-    },
-    rejected: {
-      on: {
-        FETCH: 'loading'
+        TOGGLE: { target: 'inactive' }
       }
     }
   }
 });
 
-const dogService = interpret(fetchMachine)
-  .onTransition((state) => console.log(state.value))
-  .start();
+// Actor (instance of the machine logic, like a store)
+const toggleActor = createActor(toggleMachine);
+toggleActor.subscribe((state) => console.log(state.value, state.context));
+toggleActor.start();
+// => logs 'inactive', { count: 0 }
 
-dogService.send('FETCH');
+toggleActor.send({ type: 'TOGGLE' });
+// => logs 'active', { count: 1 }
+
+toggleActor.send({ type: 'TOGGLE' });
+// => logs 'inactive', { count: 1 }
 ```
 
-</details>
+## [Stately Studio](https://stately.ai)
 
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+- Visually create, edit, and collaborate on state machines
+- Export to many formats, including XState v5
+- Test path & documentation autogeneration
+- Deploy to Stately Sky
+- Generate & modify machines with Stately AI
 
-- [Visualizer](#visualizer)
-- [Why?](#why)
-- [Finite State Machines](#finite-state-machines)
-- [Hierarchical (Nested) State Machines](#hierarchical-nested-state-machines)
-- [Parallel State Machines](#parallel-state-machines)
-- [History States](#history-states)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-## Visualizer
-
-**[Visualize, simulate, inspect, and share your statecharts in XState Viz](https://stately.ai/viz)**
-
-<a href="https://stately.ai/viz" title="XState Viz">
-  <img src="https://user-images.githubusercontent.com/1093738/131729181-5db835fc-77e7-4740-b03f-46bd0093baa1.png" alt="XState Viz" width="400" />
+<a href="stately.ai/registry/new?ref=github" title="Stately Studio">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/74ed9cbc-b824-4ed7-a16d-f104947af8a7" alt="XState Viz" width="800" />
 </a>
 
-**[stately.ai/viz](https://stately.ai/viz)**
+**[state.new](https://stately.ai/registry/new?ref=github)**
 
 ## Why?
 
@@ -183,15 +123,14 @@ Read [📽 the slides](http://slides.com/davidkhourshid/finite-state-machines) (
 
 ## Finite State Machines
 
-<a href="https://stately.ai/viz/2ac5915f-789a-493f-86d3-a8ec079773f4" title="Finite states">
-  <img src="https://user-images.githubusercontent.com/1093738/131727631-916d28a7-1a40-45ed-8636-c0c0fc1c3889.gif" alt="Finite states" width="400" />
-  <br />
-  <small>Open in Stately Viz</small>
-</a>
-<br />
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
 
 ```js
-import { createMachine } from 'xstate';
+import { createMachine, createActor } from 'xstate';
 
 const lightMachine = createMachine({
   id: 'light',
@@ -215,24 +154,57 @@ const lightMachine = createMachine({
   }
 });
 
-const currentState = 'green';
+const actor = createActor(lightMachine);
 
-const nextState = lightMachine.transition(currentState, 'TIMER').value;
+actor.subscribe((state) => {
+  console.log(state.value);
+});
 
-// => 'yellow'
+actor.start();
+// logs 'green'
+
+actor.send({ type: 'TIMER' });
+// logs 'yellow'
 ```
 
-## Hierarchical (Nested) State Machines
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
 
-<a href="https://stately.ai/viz/d3aeda4f-7f8e-44df-bdf9-dd3cdafb3312" title="Hierarchical states">
-  <img src="https://user-images.githubusercontent.com/1093738/131727794-86b63c76-5ee0-4d73-b84c-6992a1f0814e.gif" alt="Hierarchical states" width="400" />
+</td>
+<td>
+
+</td>
+</tr>
+</tbody>
+</table>
+
+</td>
+<td>
+
+<a href="https://stately.ai/registry/editor/fa443471-b416-4014-8e6f-12417863e4d4?mode=design&machineId=27e86036-f2f7-40f1-9d1e-66ce6e1accc0" title="Finite states">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/36d4b6b5-e3d0-4c19-9f41-2e3425ceac88" alt="Finite states" width="400" />
   <br />
-  <small>Open in Stately Viz</small>
+  Open in Stately Studio
 </a>
 <br />
 
+</td>
+</tbody>
+</table>
+
+## Hierarchical (Nested) State Machines
+
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
+
 ```js
-import { createMachine } from 'xstate';
+import { createMachine, createActor } from 'xstate';
 
 const pedestrianStates = {
   initial: 'walk',
@@ -274,46 +246,49 @@ const lightMachine = createMachine({
   }
 });
 
-const currentState = 'yellow';
+const actor = createActor(lightMachine);
 
-const nextState = lightMachine.transition(currentState, 'TIMER').value;
-// => {
-//   red: 'walk'
-// }
+actor.subscribe((state) => {
+  console.log(state.value);
+});
 
-lightMachine.transition('red.walk', 'PED_TIMER').value;
-// => {
-//   red: 'wait'
-// }
+actor.start();
+// logs 'green'
+
+actor.send({ type: 'TIMER' });
+// logs 'yellow'
+
+actor.send({ type: 'TIMER' });
+// logs { red: 'walk' }
+
+actor.send({ type: 'PED_TIMER' });
+// logs { red: 'wait' }
 ```
 
-**Object notation for hierarchical states:**
-
-```js
-// ...
-const waitState = lightMachine.transition({ red: 'walk' }, 'PED_TIMER').value;
-
-// => { red: 'wait' }
-
-lightMachine.transition(waitState, 'PED_TIMER').value;
-
-// => { red: 'stop' }
-
-lightMachine.transition({ red: 'stop' }, 'TIMER').value;
-
-// => 'green'
-```
+</td>
+<td>
+<a href="https://stately.ai/registry/editor/fa443471-b416-4014-8e6f-12417863e4d4?mode=design&machineId=30dffcdd-16c2-49e2-bfc6-a674057cb271" title="Hierarchical states">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/32b0692b-1c29-4469-b5e3-03146e3ef249" alt="Hierarchical states" width="400" />
+  <br />
+  Open in Stately Studio
+</a>
+<br />
+</td>
+</tr>
+</tbody>
+</table>
 
 ## Parallel State Machines
 
-<a href="https://stately.ai/viz/9eb9c189-254d-4c87-827a-fab0c2f71508" title="Parallel states">
-  <img src="https://user-images.githubusercontent.com/1093738/131727915-23da4b4b-5e7e-46ea-9c56-5093e37e60e6.gif" alt="Parallel states" width="400" />
-  <br />
-  <small>Open in Stately Viz</small>
-</a>
-<br />
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
 
-```js
+```ts
+import { createMachine, createActor } from 'xstate';
+
 const wordMachine = createMachine({
   id: 'word',
   type: 'parallel',
@@ -355,56 +330,82 @@ const wordMachine = createMachine({
       initial: 'none',
       states: {
         none: {
-          on: { BULLETS: 'bullets', NUMBERS: 'numbers' }
+          on: {
+            BULLETS: 'bullets',
+            NUMBERS: 'numbers'
+          }
         },
         bullets: {
-          on: { NONE: 'none', NUMBERS: 'numbers' }
+          on: {
+            NONE: 'none',
+            NUMBERS: 'numbers'
+          }
         },
         numbers: {
-          on: { BULLETS: 'bullets', NONE: 'none' }
+          on: {
+            BULLETS: 'bullets',
+            NONE: 'none'
+          }
         }
       }
     }
   }
 });
 
-const boldState = wordMachine.transition('bold.off', 'TOGGLE_BOLD').value;
+const actor = createActor(wordMachine);
 
-// {
+actor.subscribe((state) => {
+  console.log(state.value);
+});
+
+actor.start();
+// logs {
+//   bold: 'off',
+//   italics: 'off',
+//   underline: 'off',
+//   list: 'none'
+// }
+
+actor.send({ type: 'TOGGLE_BOLD' });
+// logs {
 //   bold: 'on',
 //   italics: 'off',
 //   underline: 'off',
 //   list: 'none'
 // }
 
-const nextState = wordMachine.transition(
-  {
-    bold: 'off',
-    italics: 'off',
-    underline: 'on',
-    list: 'bullets'
-  },
-  'TOGGLE_ITALICS'
-).value;
-
-// {
-//   bold: 'off',
+actor.send({ type: 'TOGGLE_ITALICS' });
+// logs {
+//   bold: 'on',
 //   italics: 'on',
-//   underline: 'on',
-//   list: 'bullets'
+//   underline: 'off',
+//   list: 'none'
 // }
 ```
 
+</td>
+<td>
+<a href="https://stately.ai/registry/editor/fa443471-b416-4014-8e6f-12417863e4d4?mode=design&machineId=980f50d8-e1ff-4441-8c8b-afe41c1610f2" title="Parallel states">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/3b1989c0-f4a9-4653-baf2-4df3a40e91a6" alt="Parallel states" width="400" />
+  <br />
+  Open in Stately Studio
+</a>
+</td>
+</tr>
+</tbody>
+</table>
+
 ## History States
 
-<a href="https://stately.ai/viz/33fd92e1-f9e6-49e6-bdeb-cef9e60195ec" title="History states">
-  <img src="https://user-images.githubusercontent.com/1093738/131728111-819cc824-9881-4ecf-948a-00c1162cd9e9.gif" alt="History state" width="400" />
-  <br />
-  <small>Open in Stately Viz</small>
-</a>
-<br />
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
 
 ```js
+import { createMachine, createActor } from 'xstate';
+
 const paymentMachine = createMachine({
   id: 'payment',
   initial: 'method',
@@ -412,8 +413,16 @@ const paymentMachine = createMachine({
     method: {
       initial: 'cash',
       states: {
-        cash: { on: { SWITCH_CHECK: 'check' } },
-        check: { on: { SWITCH_CASH: 'cash' } },
+        cash: {
+          on: {
+            SWITCH_CHECK: 'check'
+          }
+        },
+        check: {
+          on: {
+            SWITCH_CASH: 'cash'
+          }
+        },
         hist: { type: 'history' }
       },
       on: { NEXT: 'review' }
@@ -424,24 +433,58 @@ const paymentMachine = createMachine({
   }
 });
 
-const checkState = paymentMachine.transition('method.cash', 'SWITCH_CHECK');
+const actor = createActor(paymentMachine);
 
-// => State {
+actor.subscribe((state) => {
+  console.log(state.value);
+});
+
+actor.start();
+// logs {
+//   value: { method: 'cash' },
+// }
+
+actor.send({ type: 'SWITCH_CHECK' });
+// logs {
 //   value: { method: 'check' },
-//   history: State { ... }
 // }
 
-const reviewState = paymentMachine.transition(checkState, 'NEXT');
-
-// => State {
+actor.send({ type: 'NEXT' });
+// logs {
 //   value: 'review',
-//   history: State { ... }
 // }
 
-const previousState = paymentMachine.transition(reviewState, 'PREVIOUS').value;
-
-// => { method: 'check' }
+actor.send({ type: 'PREVIOUS' });
+// logs {
+//   value: { method: 'check' },
+// }
 ```
+
+</td>
+<td>
+<a href="https://stately.ai/registry/editor/fa443471-b416-4014-8e6f-12417863e4d4?mode=design&machineId=d1a9bb95-db97-4af3-b38b-71b005c643d3" title="History states">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/1be5c495-d560-4660-94f2-5341efbf7128" alt="History state" width="400" />
+  <br />
+  Open in Stately Studio
+</a>
+</td>
+</tr>
+</tbody>
+</table>
+
+## Sponsors
+
+Special thanks to the sponsors who support this open-source project:
+
+<img src="https://opencollective.com/xstate/tiers/backer/badge.svg?label=sponsors&color=brightgreen" />
+
+<a href="https://transloadit.com/?utm_source=xstate&utm_medium=referral&utm_campaign=sponsorship&utm_content=github">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
+    <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
+  </picture>
+</a>
 
 ## SemVer Policy
 

--- a/docs/about/concepts.md
+++ b/docs/about/concepts.md
@@ -1,6 +1,9 @@
 # Concepts
 
-:::tip Check out our new docs!
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
 🆕 Learn the concepts in [all-new Stately and XState documentation](https://stately.ai/docs/state-machines-and-statecharts).
 :::
 

--- a/docs/about/glossary.md
+++ b/docs/about/glossary.md
@@ -1,10 +1,13 @@
 # Glossary
 
-This glossary is a guide to the most common terms in statecharts and state machines.
+:::warning These XState v4 docs are no longer maintained
 
-:::tip Check out our new docs!
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
 🆕 Find more terms in our [all-new Stately and XState glossary](https://stately.ai/docs/glossary).
 :::
+
+This glossary is a guide to the most common terms in statecharts and state machines.
 
 ## State machines
 

--- a/docs/about/goals.md
+++ b/docs/about/goals.md
@@ -1,5 +1,11 @@
 # Goals
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 ## API Goals
 
 - Adherence to the [W3C SCXML Specification](https://www.w3.org/TR/scxml/) and David Harel's original statecharts formalism

--- a/docs/about/resources.md
+++ b/docs/about/resources.md
@@ -1,5 +1,11 @@
 # Resources
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 Below is an incomplete collection of many resources for learning and applying XState in real-world applications. Check out the [Awesome XState](https://github.com/darrylhebbes/awesome_xstate) collection on GitHub for even more resources!
 
 ![Stately member](/docs/stately.png) - Resource from a Stately member

--- a/docs/about/showcase.md
+++ b/docs/about/showcase.md
@@ -1,5 +1,11 @@
 # Showcase
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 There are many developers and teams using XState [in the wild](https://github.com/statelyai/xstate/issues/255), to help control various aspects of their applications, in the frontend and backend, and in many different frameworks (or even without a framework!):
 
 - [Nhost](https://nhost.io) uses XState to manage the authentication state and transitions of their [Vanilla, React and Vue libraries](https://github.com/nhost/nhost). Nhost is an Open Source Firebase Alternative with GraphQL.
@@ -18,6 +24,6 @@ There are many developers and teams using XState [in the wild](https://github.co
 - "We're now using xstate to power a couple of the more complicated interactions at my place in our Behavior Insights Engine at [Maritz](https://www.maritz.com/).
 - At [Cypress](https://cypress.io) we chose XState to manage state for our open source [Real World App](https://github.com/cypress-io/cypress-realworld-app). The app is a payment application used to demonstrate real-world usage of Cypress testing methods, patterns, and workflows. [The machines](https://github.com/cypress-io/cypress-realworld-app/tree/develop/src/machines) are used for several different types of scenarios present in modern, responsive web applications.
 - "We use XState at the backend in projects to control entity state" (https://www.linkedin.com/in/haltentech-team)
-- [Sunflower Land](https://sunflower-land.com/), a decentralized and community driven MetaVerse style game, uses XState to control and manage the user and session using a State Machine approach.  ([see here](https://github.com/sunflower-land/sunflower-land))
+- [Sunflower Land](https://sunflower-land.com/), a decentralized and community driven MetaVerse style game, uses XState to control and manage the user and session using a State Machine approach. ([see here](https://github.com/sunflower-land/sunflower-land))
 - "I used XState to create an (open source) version of the classic Tower of Hanoi puzzle game. Two state machines are used, one for screen interaction logic and the other for game interaction logic. Also includes automated test generation with model based testing tools." [Tower of Hanoi app](https://towerofhanoi.app)
 - "XState completely changed how I think about programming complex logic for fullstack applications - all core logic for streaming summaries on [YouTube Summarized](https://www.youtubesummarized.com) is now encapsulated in XState machines both on the frontend and backend. The visual editor makes it easy to spot edge cases and error states that should be handled, resulting in a very robust and stable system."

--- a/docs/about/tutorials.md
+++ b/docs/about/tutorials.md
@@ -1,5 +1,11 @@
 # Tutorials
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 🆕 Please see [Resources](./resources.md) for an up-to-date listing of various XState resources collected around the web!
 
 ## Articles

--- a/docs/examples/calculator.md
+++ b/docs/examples/calculator.md
@@ -1,5 +1,11 @@
 # Calculator
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 ## React
 
 - Uses React, @xstate/react and Xstate 4.x.

--- a/docs/examples/counter.md
+++ b/docs/examples/counter.md
@@ -1,5 +1,11 @@
 # Counter
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 This counter app example demonstrates a counter that has a single `'active'` state and two possible events:
 
 - `'INC'` - an intent to increment the current count by 1

--- a/docs/examples/covid-tracker.md
+++ b/docs/examples/covid-tracker.md
@@ -1,5 +1,11 @@
 # Covid Tracker
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 This example shows a current statistics about COVID-19 pandemic filtered by countries using XState and React. It contains:
 
 - `covidMachine` - handles country selection, including a "sub-state" responsible for fetching the list of all countries across the globe

--- a/docs/examples/todomvc.md
+++ b/docs/examples/todomvc.md
@@ -1,5 +1,11 @@
 # TodoMVC Examples
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 Both demos share the same machines.
 
 ## TodoMVC with React

--- a/docs/guides/actions.md
+++ b/docs/guides/actions.md
@@ -1,5 +1,13 @@
 # Actions
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find our [actions in XState explainer](https://stately.ai/docs/actions/) in our new docs, along with a [no-code introduction to actions in statecharts and the Stately Studio](https://stately.ai/docs/actions#entry-and-exit-actions).
+
+:::
+
 ::: warning
 <Badge text="4.33+" />
 
@@ -28,10 +36,6 @@ Actions are fire-and-forget [effects](./effects.md). They can be declared in thr
 - transition actions are executed when a transition is taken
 
 To learn more, read about [actions in our introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#actions).
-
-:::tip Check out our new docs!
-🆕 Find our [actions in XState explainer](https://stately.ai/docs/actions/) in our new docs, along with a [no-code introduction to actions in statecharts and the Stately Studio](https://stately.ai/docs/actions#entry-and-exit-actions).
-:::
 
 ## API
 

--- a/docs/guides/activities.md
+++ b/docs/guides/activities.md
@@ -1,5 +1,11 @@
 # Activities
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 ::: warning Deprecated
 Activities are deprecated and will be removed in XState version 5. The recommended approach is to [invoke an actor](./actors.md) instead:
 

--- a/docs/guides/actors.md
+++ b/docs/guides/actors.md
@@ -1,7 +1,10 @@
 # Actors <Badge text="4.6+"/>
 
-:::tip Check out our new docs!
-🆕 Find our [actors in XState explainer](https://stately.ai/docs/actors) in our new docs, along with a [no-code introduction to actors in statecharts and the Stately Studio](https://stately.ai/docs/actors#using-actors-in-stately-studio).
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find our [actors in XState explainer](https://stately.ai/docs/actors) in our new docs, along with a [no-code introduction to actors in statecharts and the Stately Studio](https://stately.ai/docs/editor-actions-and-actors#add-invoked-actors).
 :::
 
 [:rocket: Quick Reference](#quick-reference)
@@ -104,7 +107,7 @@ const todosMachine = createMachine({
 ```
 
 If you do not provide a `name` argument to `spawn(...)`, a unique name will be automatically generated. This name will be nondeterministic :warning:.
-A *named actor* is easier to be referenced in other API calls, see [Sending Events to Actors](#sending-events-to-actors).
+A _named actor_ is easier to be referenced in other API calls, see [Sending Events to Actors](#sending-events-to-actors).
 
 ::: tip
 Treat `const actorRef = spawn(someMachine)` as just a normal value in `context`. You can place this `actorRef` anywhere within `context`, based on your logic requirements. As long as it's within an assignment function in `assign(...)`, it will be scoped to the service from where it was spawned.

--- a/docs/guides/communication.md
+++ b/docs/guides/communication.md
@@ -1,6 +1,9 @@
 # Invoking Services
 
-:::tip Check out our new docs!
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
 🆕 Our [section on actors in XState](https://stately.ai/docs/actors) has explainers and examples for promises, callbacks, observables, actions, and actors.
 :::
 

--- a/docs/guides/context.md
+++ b/docs/guides/context.md
@@ -2,7 +2,10 @@
 
 [:rocket: Quick Reference](#quick-reference)
 
-:::tip Check out our new docs!
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
 🆕 Find more about [context in XState](https://stately.ai/docs/context) in our new docs.
 :::
 

--- a/docs/guides/delays.md
+++ b/docs/guides/delays.md
@@ -1,10 +1,13 @@
 # Delayed events and transitions
 
-Delays and timeouts can be handled declaratively with statecharts. To learn more, see the section in our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#delayed-transitions).
+:::warning These XState v4 docs are no longer maintained
 
-:::tip Check out our new docs!
-🆕 Find more about [delayed (after) transitions in XState](https://stately.ai/docs/delayed-transitions) as well as a [no-code introduction to delayed transitions](https://stately.ai/docs/delayed-transitions#using-delayed-transitions-in-stately-studio) in our new docs.
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [delayed (after) transitions in XState](https://stately.ai/docs/delayed-transitions) as well as a [no-code introduction to delayed transitions](https://stately.ai/docs/editor-states-and-transitions#delayed-after-transitions) in our new docs.
 :::
+
+Delays and timeouts can be handled declaratively with statecharts. To learn more, see the section in our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#delayed-transitions).
 
 ## Delayed transitions
 

--- a/docs/guides/effects.md
+++ b/docs/guides/effects.md
@@ -1,7 +1,10 @@
 # Effects
 
-:::tip Check out our new docs!
-🆕 Find more about [effects and actions in XState](https://stately.ai/docs/xstate-v4/xstate/actions#side-effects) in our new docs.
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [effects and actions in XState](https://stately.ai/docs/xstate/actions) in our new docs.
 :::
 
 In statecharts, "side-effects" can be grouped into two categories:

--- a/docs/guides/events.md
+++ b/docs/guides/events.md
@@ -1,7 +1,10 @@
 # Events
 
-:::tip Check out our new docs!
-🆕 Find more about [events in XState](https://stately.ai/docs/transitions) as well as a [no-code introduction to events and transitions featuring puppies](https://stately.ai/docs/state-machines-and-statecharts#transitions-and-events).
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [events in XState](https://stately.ai/docs/transitions) as well as a [no-code introduction to events and transitions featuring puppies](https://stately.ai/docs/editor-states-and-transitions#transitions-and-events).
 :::
 
 An event is what causes a state machine to [transition](./transitions.md) from its current [state](./states.md) to its next state. To learn more, read [the events section in our introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#transitions-and-events).

--- a/docs/guides/final.md
+++ b/docs/guides/final.md
@@ -1,7 +1,10 @@
 # Final states
 
-:::tip Check out our new docs!
-🆕 Find more about [final states in XState](https://stately.ai/docs/final-states) as well as a [no-code introduction to final states](https://stately.ai/docs/state-machines-and-statecharts#final-state).
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [final states in XState](https://stately.ai/docs/final-states) as well as a [no-code introduction to final states](https://stately.ai/docs/editor-states-and-transitions#final-states).
 :::
 
 In statecharts, you can declare a state as a **final state**. The final state indicates that its parent state is “done”. To learn more, read the [final state section in our introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#final-state).

--- a/docs/guides/guards.md
+++ b/docs/guides/guards.md
@@ -1,7 +1,10 @@
 # Guarded Transitions
 
-:::tip Check out our new docs!
-🆕 Find more about [guards in XState](https://stately.ai/docs/guards) as well as a [no-code introduction to guards](https://stately.ai/docs/guards#using-guards-in-stately-studio).
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [guards in XState](https://stately.ai/docs/guards) as well as a [no-code introduction to guards](https://stately.ai/docs/editor-states-and-transitions#add-guards).
 :::
 
 Many times, you'll want a transition between states to only take place if certain conditions on the state (finite or extended) or the event are met. For instance, let's say you're creating a machine for a search form, and you only want search to be allowed if:

--- a/docs/guides/hierarchical.md
+++ b/docs/guides/hierarchical.md
@@ -1,7 +1,10 @@
 # Hierarchical state nodes
 
-:::tip Check out our new docs!
-🆕 Find more about [parent and child states in XState](https://stately.ai/docs/parent-states) as well as a [no-code introduction to parent states](https://stately.ai/docs/state-machines-and-statecharts#parent-states).
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [parent and child states in XState](https://stately.ai/docs/parent-states) as well as a [no-code introduction to parent states](https://stately.ai/docs/editor-states-and-transitions#parent-and-child-states).
 :::
 
 In statecharts, states can be nested _within other states_. These nested states are called **compound states**. To learn more, read the [compound states section in our introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#compound-states).

--- a/docs/guides/history.md
+++ b/docs/guides/history.md
@@ -1,7 +1,11 @@
 # History
 
-:::tip Check out our new docs!
-🆕 Find more about [parent and child states in XState](https://stately.ai/docs/history-states) as well as a [no-code introduction to history states](https://stately.ai/docs/history-states#using-history-states-in-stately-studio).
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [parent and child states in XState](https://stately.ai/docs/history-states).
+
 :::
 
 A history [state node](./statenodes.md) is a special kind of state node that, when reached, tells the machine to go to the last state value of that region. There's two types of history states:

--- a/docs/guides/ids.md
+++ b/docs/guides/ids.md
@@ -1,5 +1,11 @@
 # Identifying State Nodes
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 [:rocket: Quick Reference](#quick-reference)
 
 By default, a state node's `id` is its delimited full path. You can use this default `id` to specify a state node:

--- a/docs/guides/installation.md
+++ b/docs/guides/installation.md
@@ -1,10 +1,13 @@
 # Installation
 
-You can install XState from NPM or Yarn, or you can embed the `<script>` directly from a CDN.
+:::warning These XState v4 docs are no longer maintained
 
-:::tip Check out our new docs!
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
 🆕 Find more about [installing XState](https://stately.ai/docs/installation) in our new docs.
 :::
+
+You can install XState from NPM or Yarn, or you can embed the `<script>` directly from a CDN.
 
 ## Package Manager
 

--- a/docs/guides/interpretation.md
+++ b/docs/guides/interpretation.md
@@ -1,6 +1,9 @@
 # Interpreting Machines
 
-:::tip Check out our new docs!
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
 🆕 Find more about [creating actors using XState](https://stately.ai/docs/actors#creating-actors) in our new docs.
 :::
 

--- a/docs/guides/introduction-to-state-machines-and-statecharts/index.md
+++ b/docs/guides/introduction-to-state-machines-and-statecharts/index.md
@@ -1,7 +1,9 @@
 # Introduction to state machines and statecharts
 
-:::tip Check out our new docs!
-🆕 Find an updated [introduction to state machines and statecharts](https://stately.ai/docs/state-machines-and-statecharts) in our new docs.
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
 :::
 
 Statecharts are a visual language used to describe the states in a process.

--- a/docs/guides/machines.md
+++ b/docs/guides/machines.md
@@ -1,10 +1,13 @@
 # Machines
 
-A state machine is a finite set of states that can transition to each other deterministically due to events. To learn more, read our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md).
+:::warning These XState v4 docs are no longer maintained
 
-:::tip Check out our new docs!
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
 🆕 Find more about [creating machines using XState](https://stately.ai/docs/machines#creating-a-state-machine) in our new docs.
 :::
+
+A state machine is a finite set of states that can transition to each other deterministically due to events. To learn more, read our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md).
 
 ## Configuration
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -1,5 +1,11 @@
 # Models
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 ::: warning
 
 The `createModel(...)` function is deprecated and will be removed in XState version 5. It is recommended to use [Typegen](https://stately.ai/blog/introducing-typescript-typegen-for-xstate) instead.

--- a/docs/guides/parallel.md
+++ b/docs/guides/parallel.md
@@ -1,10 +1,13 @@
 # Parallel State Nodes
 
-In statecharts, you can declare a state as a **parallel state**. This means that all its child states will run _at the same time_. To learn more, see the section in our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#parallel-states).
+:::warning These XState v4 docs are no longer maintained
 
-:::tip Check out our new docs!
-🆕 Find more about [parallel states in XState](https://stately.ai/docs/parallel-states) as well as a [no-code introduction to parallel states](https://stately.ai/docs/state-machines-and-statecharts#parallel-states).
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [parallel states in XState](https://stately.ai/docs/parallel-states) as well as a [no-code introduction to parallel states](https://stately.ai/docs/editor-states-and-transitions#parallel-states).
 :::
+
+In statecharts, you can declare a state as a **parallel state**. This means that all its child states will run _at the same time_. To learn more, see the section in our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#parallel-states).
 
 ## API
 

--- a/docs/guides/scxml.md
+++ b/docs/guides/scxml.md
@@ -1,10 +1,12 @@
 # SCXML
 
-XState is compatible with the [SCXML (State Chart XML: State Machine Notation for Control Abstraction) specification](https://www.w3.org/TR/scxml/). This page contains details on where our API relates to the SCXML specification.
+:::warning These XState v4 docs are no longer maintained
 
-:::tip Check out our new docs!
-🆕 Find more about [SCXML compatibility in XState](https://stately.ai/docs/xstate-v4/xstate/advanced/scxml) in our new docs.
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
 :::
+
+XState is compatible with the [SCXML (State Chart XML: State Machine Notation for Control Abstraction) specification](https://www.w3.org/TR/scxml/). This page contains details on where our API relates to the SCXML specification.
 
 ## Events
 

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -1,5 +1,11 @@
 # Getting Started
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 ## Our first machine
 
 Suppose we want to model a [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) as a state machine. First, install XState using NPM or Yarn:

--- a/docs/guides/statenodes.md
+++ b/docs/guides/statenodes.md
@@ -1,5 +1,11 @@
 # State Nodes
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 A state machine contains state nodes (explained below) that collectively describe the [overall state](./states.md) a machine can be in. In the `fetchMachine` described in the next section, there are **state nodes**, such as:
 
 ```js

--- a/docs/guides/states.md
+++ b/docs/guides/states.md
@@ -1,10 +1,13 @@
 # States
 
-A state is an abstract representation of a system (such as an application) at a specific point in time. To learn more, read the [section on states in our introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#states).
+:::warning These XState v4 docs are no longer maintained
 
-:::tip Check out our new docs!
-🆕 Find more about [states in XState](https://stately.ai/docs/states) as well as a [no-code introduction to states](https://stately.ai/docs/state-machines-and-statecharts#states).
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [states in XState](https://stately.ai/docs/states) as well as a [no-code introduction to states](https://stately.ai/docs/editor-states-and-transitions).
 :::
+
+A state is an abstract representation of a system (such as an application) at a specific point in time. To learn more, read the [section on states in our introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#states).
 
 ## API
 

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,12 +1,15 @@
 # Testing Machines
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [testing using XState](https://stately.ai/docs/testing) in our new docs.
+:::
+
 In general, testing state machines and statecharts should be done by testing the _overall behavior_ of the machine; that is:
 
 > Given a **current state**, when some **sequence of events** occurs, the system under test should be in **a certain state** and/or exhibit a specific **output**.
-
-:::tip Check out our new docs!
-🆕 Find more about [model-based testing using XState](https://stately.ai/docs/xstate-v4/xstate/model-based-testing/intro) in our new docs.
-:::
 
 This follows [behavior-driven development (BDD)](https://en.wikipedia.org/wiki/Behavior-driven_development) and [black-box testing](https://en.wikipedia.org/wiki/Black-box_testing) strategies. The internal workings of a machine should not be directly tested; rather, the observed behavior should be tested instead. This makes testing machines closer to integration or end-to-end (E2E) tests than unit tests.
 

--- a/docs/guides/transitions.md
+++ b/docs/guides/transitions.md
@@ -1,10 +1,13 @@
 # Transitions
 
-Transitions define how the machine reacts to [events](./events.md). To learn more, see the section in our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#transitions-and-events).
+:::warning These XState v4 docs are no longer maintained
 
-:::tip Check out our new docs!
-🆕 Find more about [transitions in XState](https://stately.ai/docs/transitions) as well as a [no-code introduction to transitions](https://stately.ai/docs/state-machines-and-statecharts#transitions-and-events).
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+🆕 Find more about [transitions in XState](https://stately.ai/docs/transitions) as well as a [no-code introduction to transitions](https://stately.ai/docs/editor-states-and-transitions#transitions-and-events).
 :::
+
+Transitions define how the machine reacts to [events](./events.md). To learn more, see the section in our [introduction to statecharts](./introduction-to-state-machines-and-statecharts/index.md#transitions-and-events).
 
 ## API
 

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -1,5 +1,11 @@
 ## Using TypeScript
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 As XState is written in [TypeScript](https://www.typescriptlang.org/), strongly typing your statecharts is useful and encouraged.
 
 ```typescript

--- a/docs/packages/core/index.md
+++ b/docs/packages/core/index.md
@@ -1,29 +1,55 @@
 <p align="center">
-  <a href="https://xstate.js.org">
   <br />
-  <img src="https://i.imgur.com/FshbFOv.png" alt="XState" width="100"/>
+
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/statelyai/public-assets/main/logos/xstate-logo-white-nobg.svg">
+    <img alt="XState logotype" src="https://raw.githubusercontent.com/statelyai/public-assets/main/logos/xstate-logo-black-nobg.svg" width="200">
+  </picture>
   <br />
-    <sub><strong>JavaScript state machines and statecharts</strong></sub>
+    <strong>Actor-based state management & orchestration for complex app logic.</strong> <a href="https://stately.ai/docs">→ Documentation</a>
   <br />
   <br />
-  </a>
 </p>
 
-[![npm version](https://badge.fury.io/js/xstate.svg)](https://badge.fury.io/js/xstate)
-[![Statecharts gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/statecharts/statecharts)
-<img src="https://opencollective.com/xstate/tiers/backer/badge.svg?label=sponsors&color=brightgreen" />
+XState is a state management and orchestration solution for JavaScript and TypeScript apps. It has _zero_ dependencies, and is useful for frontend and backend application logic.
 
-JavaScript and TypeScript [finite state machines](https://en.wikipedia.org/wiki/Finite-state_machine) and [statecharts](https://www.sciencedirect.com/science/article/pii/0167642387900359/pdf) for the modern web.
+It uses event-driven programming, state machines, statecharts, and the actor model to handle complex logic in predictable, robust, and visual ways. XState provides a powerful and flexible way to manage application and workflow state by allowing developers to model logic as actors and state machines.
 
-📖 [Read the documentation](https://xstate.js.org/docs)
-📑 Adheres to the [SCXML specification](https://www.w3.org/TR/scxml/).
+### ✨ Create state machines visually in Stately Studio → [state.new](https://state.new)
+
+---
+
+📖 [Read the documentation](https://stately.ai/docs)
+
+➡️ [Create state machines with the Stately Editor](https://stately.ai/editor)
+
+🖥 [Download our VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode)
+
+📑 Inspired by the [SCXML specification](https://www.w3.org/TR/scxml/)
+
+💬 Chat on the [Stately Discord Community](https://discord.gg/xstate)
 
 ## Packages
 
-- 🤖 `xstate` - Core finite state machine and statecharts library + interpreter
-- [📉 `@xstate/graph`](https://github.com/statelyai/xstate/tree/main/packages/xstate-graph) - Graph traversal utilities for XState
-- [⚛️ `@xstate/react`](https://github.com/statelyai/xstate/tree/main/packages/xstate-react) - React hooks and utilities for using XState in React applications
-- [✅ `@xstate/test`](https://github.com/statelyai/xstate/tree/main/packages/xstate-test) - Model-based testing utilities for XState
+| Package                                                                                       | Description                                                                  |
+| --------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| 🤖 `xstate`                                                                                   | Core finite state machine and statecharts library + interpreter              |
+| [📉 `@xstate/graph`](https://github.com/statelyai/xstate/tree/main/packages/xstate-graph)     | Graph traversal utilities for XState                                         |
+| [⚛️ `@xstate/react`](https://github.com/statelyai/xstate/tree/main/packages/xstate-react)     | React hooks and utilities for using XState in React applications             |
+| [💚 `@xstate/vue`](https://github.com/statelyai/xstate/tree/main/packages/xstate-vue)         | Vue composition functions and utilities for using XState in Vue applications |
+| [🎷 `@xstate/svelte`](https://github.com/statelyai/xstate/tree/main/packages/xstate-svelte)   | Svelte utilities for using XState in Svelte applications                     |
+| [🥏 `@xstate/solid`](https://github.com/statelyai/xstate/tree/main/packages/xstate-solid)     | Solid hooks and utilities for using XState in Solid applications             |
+| [✅ `@xstate/test`](https://github.com/statelyai/xstate/tree/main/packages/xstate-test)       | Model-Based-Testing utilities (using XState) for testing any software        |
+| [🔍 `@xstate/inspect`](https://github.com/statelyai/xstate/tree/main/packages/xstate-inspect) | Inspection utilities for XState                                              |
+
+## Templates
+
+Get started by forking one of these templates on CodeSandbox:
+
+| Template                                                                                                        |                          |
+| --------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| [XState Template](https://codesandbox.io/p/devbox/github/statelyai/xstate/tree/main/templates/vanilla-ts)       | TypeScript, no framework |
+| [XState + React Template](https://codesandbox.io/p/devbox/github/statelyai/xstate/tree/main/templates/react-ts) | TypeScript, React        |
 
 ## Super quick start
 
@@ -31,46 +57,57 @@ JavaScript and TypeScript [finite state machines](https://en.wikipedia.org/wiki/
 npm install xstate
 ```
 
-```js
-import { createMachine, interpret } from 'xstate';
+```ts
+import { createMachine, createActor, assign } from 'xstate';
 
-// Stateless machine definition
-// machine.transition(...) is a pure function used by the interpreter.
+// State machine
 const toggleMachine = createMachine({
   id: 'toggle',
   initial: 'inactive',
+  context: {
+    count: 0
+  },
   states: {
-    inactive: { on: { TOGGLE: 'active' } },
-    active: { on: { TOGGLE: 'inactive' } }
+    inactive: {
+      on: {
+        TOGGLE: { target: 'active' }
+      }
+    },
+    active: {
+      entry: assign({ count: ({ context }) => context.count + 1 }),
+      on: {
+        TOGGLE: { target: 'inactive' }
+      }
+    }
   }
 });
 
-// Machine instance with internal state
-const toggleService = interpret(toggleMachine)
-  .onTransition((state) => console.log(state.value))
-  .start();
-// => 'inactive'
+// Actor (instance of the machine logic, like a store)
+const toggleActor = createActor(toggleMachine);
+toggleActor.subscribe((state) => console.log(state.value, state.context));
+toggleActor.start();
+// => logs 'inactive', { count: 0 }
 
-toggleService.send({ type: 'TOGGLE' });
-// => 'active'
+toggleActor.send({ type: 'TOGGLE' });
+// => logs 'active', { count: 1 }
 
-toggleService.send({ type: 'TOGGLE' });
-// => 'inactive'
+toggleActor.send({ type: 'TOGGLE' });
+// => logs 'inactive', { count: 1 }
 ```
 
-- [Visualizer](#visualizer)
-- [Why? (info about statecharts)](#why)
-- [Installation](https://xstate.js.org/docs/guides/installation.html)
-- [Finite State Machines](#finite-state-machines)
-- [Hierarchical (Nested) State Machines](#hierarchical-nested-state-machines)
-- [Parallel State Machines](#parallel-state-machines)
-- [History States](#history-states)
+## [Stately Studio](https://stately.ai)
 
-## Visualizer
+- Visually create, edit, and collaborate on state machines
+- Export to many formats, including XState v5
+- Test path & documentation autogeneration
+- Deploy to Stately Sky
+- Generate & modify machines with Stately AI
 
-**[Visualize, simulate, and share your statecharts in XState Viz!](https://stately.ai/viz)**
+<a href="stately.ai/registry/new?ref=github" title="Stately Studio">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/74ed9cbc-b824-4ed7-a16d-f104947af8a7" alt="XState Viz" width="800" />
+</a>
 
-<a href="https://stately.ai/viz" title="xstate visualizer"><img src="https://i.imgur.com/3pEB0B3.png" alt="xstate visualizer" width="300" /></a>
+**[state.new](https://stately.ai/registry/new?ref=github)**
 
 ## Why?
 
@@ -86,10 +123,14 @@ Read [📽 the slides](http://slides.com/davidkhourshid/finite-state-machines) (
 
 ## Finite State Machines
 
-<img src="https://imgur.com/rqqmkJh.png" alt="Light Machine" width="300" />
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
 
 ```js
-import { createMachine } from 'xstate';
+import { createMachine, createActor } from 'xstate';
 
 const lightMachine = createMachine({
   id: 'light',
@@ -113,21 +154,57 @@ const lightMachine = createMachine({
   }
 });
 
-const currentState = 'green';
+const actor = createActor(lightMachine);
 
-const nextState = lightMachine.transition(currentState, {
-  type: 'TIMER'
-}).value;
+actor.subscribe((state) => {
+  console.log(state.value);
+});
 
-// => 'yellow'
+actor.start();
+// logs 'green'
+
+actor.send({ type: 'TIMER' });
+// logs 'yellow'
 ```
+
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
+
+</td>
+<td>
+
+</td>
+</tr>
+</tbody>
+</table>
+
+</td>
+<td>
+
+<a href="https://stately.ai/registry/editor/fa443471-b416-4014-8e6f-12417863e4d4?mode=design&machineId=27e86036-f2f7-40f1-9d1e-66ce6e1accc0" title="Finite states">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/36d4b6b5-e3d0-4c19-9f41-2e3425ceac88" alt="Finite states" width="400" />
+  <br />
+  Open in Stately Studio
+</a>
+<br />
+
+</td>
+</tbody>
+</table>
 
 ## Hierarchical (Nested) State Machines
 
-<img src="https://imgur.com/GDZAeB9.png" alt="Hierarchical Light Machine" width="300" />
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
 
 ```js
-import { createMachine } from 'xstate';
+import { createMachine, createActor } from 'xstate';
 
 const pedestrianStates = {
   initial: 'walk',
@@ -169,46 +246,49 @@ const lightMachine = createMachine({
   }
 });
 
-const currentState = 'yellow';
+const actor = createActor(lightMachine);
 
-const nextState = lightMachine.transition(currentState, {
-  type: 'TIMER'
-}).value;
-// => {
-//   red: 'walk'
-// }
+actor.subscribe((state) => {
+  console.log(state.value);
+});
 
-lightMachine.transition('red.walk', { type: 'PED_TIMER' }).value;
-// => {
-//   red: 'wait'
-// }
+actor.start();
+// logs 'green'
+
+actor.send({ type: 'TIMER' });
+// logs 'yellow'
+
+actor.send({ type: 'TIMER' });
+// logs { red: 'walk' }
+
+actor.send({ type: 'PED_TIMER' });
+// logs { red: 'wait' }
 ```
 
-**Object notation for hierarchical states:**
-
-```js
-// ...
-const waitState = lightMachine.transition(
-  { red: 'walk' },
-  { type: 'PED_TIMER' }
-).value;
-
-// => { red: 'wait' }
-
-lightMachine.transition(waitState, { type: 'PED_TIMER' }).value;
-
-// => { red: 'stop' }
-
-lightMachine.transition({ red: 'stop' }, { type: 'TIMER' }).value;
-
-// => 'green'
-```
+</td>
+<td>
+<a href="https://stately.ai/registry/editor/fa443471-b416-4014-8e6f-12417863e4d4?mode=design&machineId=30dffcdd-16c2-49e2-bfc6-a674057cb271" title="Hierarchical states">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/32b0692b-1c29-4469-b5e3-03146e3ef249" alt="Hierarchical states" width="400" />
+  <br />
+  Open in Stately Studio
+</a>
+<br />
+</td>
+</tr>
+</tbody>
+</table>
 
 ## Parallel State Machines
 
-<img src="https://imgur.com/GKd4HwR.png" width="300" alt="Parallel state machine" />
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
 
-```js
+```ts
+import { createMachine, createActor } from 'xstate';
+
 const wordMachine = createMachine({
   id: 'word',
   type: 'parallel',
@@ -250,53 +330,82 @@ const wordMachine = createMachine({
       initial: 'none',
       states: {
         none: {
-          on: { BULLETS: 'bullets', NUMBERS: 'numbers' }
+          on: {
+            BULLETS: 'bullets',
+            NUMBERS: 'numbers'
+          }
         },
         bullets: {
-          on: { NONE: 'none', NUMBERS: 'numbers' }
+          on: {
+            NONE: 'none',
+            NUMBERS: 'numbers'
+          }
         },
         numbers: {
-          on: { BULLETS: 'bullets', NONE: 'none' }
+          on: {
+            BULLETS: 'bullets',
+            NONE: 'none'
+          }
         }
       }
     }
   }
 });
 
-const boldState = wordMachine.transition('bold.off', {
-  type: 'TOGGLE_BOLD'
-}).value;
+const actor = createActor(wordMachine);
 
-// {
+actor.subscribe((state) => {
+  console.log(state.value);
+});
+
+actor.start();
+// logs {
+//   bold: 'off',
+//   italics: 'off',
+//   underline: 'off',
+//   list: 'none'
+// }
+
+actor.send({ type: 'TOGGLE_BOLD' });
+// logs {
 //   bold: 'on',
 //   italics: 'off',
 //   underline: 'off',
 //   list: 'none'
 // }
 
-const nextState = wordMachine.transition(
-  {
-    bold: 'off',
-    italics: 'off',
-    underline: 'on',
-    list: 'bullets'
-  },
-  { type: 'TOGGLE_ITALICS' }
-).value;
-
-// {
-//   bold: 'off',
+actor.send({ type: 'TOGGLE_ITALICS' });
+// logs {
+//   bold: 'on',
 //   italics: 'on',
-//   underline: 'on',
-//   list: 'bullets'
+//   underline: 'off',
+//   list: 'none'
 // }
 ```
 
+</td>
+<td>
+<a href="https://stately.ai/registry/editor/fa443471-b416-4014-8e6f-12417863e4d4?mode=design&machineId=980f50d8-e1ff-4441-8c8b-afe41c1610f2" title="Parallel states">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/3b1989c0-f4a9-4653-baf2-4df3a40e91a6" alt="Parallel states" width="400" />
+  <br />
+  Open in Stately Studio
+</a>
+</td>
+</tr>
+</tbody>
+</table>
+
 ## History States
 
-<img src="https://imgur.com/I4QsQsz.png" width="300" alt="Machine with history state" />
+<table>
+<thead><tr><th>Code</th><th>Statechart</th></tr></thead>
+<tbody>
+<tr>
+<td>
 
 ```js
+import { createMachine, createActor } from 'xstate';
+
 const paymentMachine = createMachine({
   id: 'payment',
   initial: 'method',
@@ -304,8 +413,16 @@ const paymentMachine = createMachine({
     method: {
       initial: 'cash',
       states: {
-        cash: { on: { SWITCH_CHECK: 'check' } },
-        check: { on: { SWITCH_CASH: 'cash' } },
+        cash: {
+          on: {
+            SWITCH_CHECK: 'check'
+          }
+        },
+        check: {
+          on: {
+            SWITCH_CASH: 'cash'
+          }
+        },
         hist: { type: 'history' }
       },
       on: { NEXT: 'review' }
@@ -316,32 +433,75 @@ const paymentMachine = createMachine({
   }
 });
 
-const checkState = paymentMachine.transition('method.cash', {
-  type: 'SWITCH_CHECK'
+const actor = createActor(paymentMachine);
+
+actor.subscribe((state) => {
+  console.log(state.value);
 });
 
-// => State {
+actor.start();
+// logs {
+//   value: { method: 'cash' },
+// }
+
+actor.send({ type: 'SWITCH_CHECK' });
+// logs {
 //   value: { method: 'check' },
-//   history: State { ... }
 // }
 
-const reviewState = paymentMachine.transition(checkState, { type: 'NEXT' });
-
-// => State {
+actor.send({ type: 'NEXT' });
+// logs {
 //   value: 'review',
-//   history: State { ... }
 // }
 
-const previousState = paymentMachine.transition(reviewState, {
-  type: 'PREVIOUS'
-}).value;
-
-// => { method: 'check' }
+actor.send({ type: 'PREVIOUS' });
+// logs {
+//   value: { method: 'check' },
+// }
 ```
+
+</td>
+<td>
+<a href="https://stately.ai/registry/editor/fa443471-b416-4014-8e6f-12417863e4d4?mode=design&machineId=d1a9bb95-db97-4af3-b38b-71b005c643d3" title="History states">
+  <img src="https://github.com/statelyai/xstate/assets/1093738/1be5c495-d560-4660-94f2-5341efbf7128" alt="History state" width="400" />
+  <br />
+  Open in Stately Studio
+</a>
+</td>
+</tr>
+</tbody>
+</table>
 
 ## Sponsors
 
-Huge thanks to the following companies for sponsoring `xstate`. You can sponsor further `xstate` development [on OpenCollective](https://opencollective.com/xstate).
+Special thanks to the sponsors who support this open-source project:
 
-<a href="https://tipe.io" title="Tipe.io"><img src="https://cdn.tipe.io/tipe/tipe-logo.svg?w=240" style="background:#613DEF" /></a>
-<a href="https://webflow.com" title="Webflow"><img src="https://uploads-ssl.webflow.com/583347ca8f6c7ee058111b3b/5b03bde0971fdd75d75b5591_webflow.png" height="100" /></a>
+<img src="https://opencollective.com/xstate/tiers/backer/badge.svg?label=sponsors&color=brightgreen" />
+
+<a href="https://transloadit.com/?utm_source=xstate&utm_medium=referral&utm_campaign=sponsorship&utm_content=github">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-dark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg">
+    <img src="https://assets.transloadit.com/assets/images/sponsorships/logo-default.svg" alt="Transloadit Logo">
+  </picture>
+</a>
+
+## SemVer Policy
+
+We understand the importance of the public contract and do not intend to release any breaking changes to the **runtime** API in a minor or patch release. We consider this with any changes we make to the XState libraries and aim to minimize their effects on existing users.
+
+### Breaking changes
+
+XState executes much of the user logic itself. Therefore, almost any change to its behavior might be considered a breaking change. We recognize this as a potential problem but believe that treating every change as a breaking change is not practical. We do our best to implement new features thoughtfully to enable our users to implement their logic in a better, safer way.
+
+Any change _could_ affect how existing XState machines behave if those machines are using particular configurations. We do not introduce behavior changes on a whim and aim to avoid making changes that affect most existing machines. But we reserve the right to make _some_ behavior changes in minor releases. Our best judgment of the situation will always dictate such changes. Please always read our release notes before deciding to upgrade.
+
+### TypeScript changes
+
+We also reserve a similar right to adjust declared TypeScript definitions or drop support for older versions of TypeScript in a minor release. The TypeScript language itself evolves quickly and often introduces breaking changes in its minor releases. Our team is also continuously learning how to leverage TypeScript more effectively - and the types improve as a result.
+
+For these reasons, it is impractical for our team to be bound by decisions taken when an older version of TypeScript was its latest version or when we didn’t know how to declare our types in a better way. We won’t introduce declaration changes often - but we are more likely to do so than with runtime changes.
+
+### Packages
+
+Most of the packages in the XState family declare a peer dependency on XState itself. We’ll be cautious about maintaining compatibility with already-released packages when releasing a new version of XState, **but** each release of packages depending on XState will always adjust the declared peer dependency range to include the latest version of XState. For example, you should always be able to update `xstate` without `@xstate/react`. But when you update `@xstate/react`, we highly recommend updating `xstate` too.

--- a/docs/packages/xstate-cli/index.md
+++ b/docs/packages/xstate-cli/index.md
@@ -1,5 +1,11 @@
 # @xstate/cli
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 The [@xstate/cli package](https://github.com/statelyai/xstate-tools/tree/master/apps/cli) contains commands for running typegen. It's pretty small right now, but we're planning on adding many cool features.
 
 ## Installation

--- a/docs/packages/xstate-dev/index.md
+++ b/docs/packages/xstate-dev/index.md
@@ -1,5 +1,11 @@
 # @xstate/devtools
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 Developer tools for XState.
 
 ## Quick Start

--- a/docs/packages/xstate-graph/index.md
+++ b/docs/packages/xstate-graph/index.md
@@ -1,5 +1,11 @@
 # @xstate/graph
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 The [@xstate/graph package](https://github.com/statelyai/xstate/tree/main/packages/xstate-graph) contains graph algorithms and utilities for XState machines.
 
 ## Quick Start

--- a/docs/packages/xstate-immer/index.md
+++ b/docs/packages/xstate-immer/index.md
@@ -1,5 +1,11 @@
 # @xstate/immer
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 <p align="center">
   <a href="https://xstate.js.org">
   <br />

--- a/docs/packages/xstate-inspect/index.md
+++ b/docs/packages/xstate-inspect/index.md
@@ -1,5 +1,11 @@
 # `@xstate/inspect`
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 The [@xstate/inspect package](https://github.com/statelyai/xstate/tree/main/packages/xstate-inspect) contains inspection tools for XState.
 
 - [XState (Vanilla)](https://codesandbox.io/s/xstate-ts-viz-template-qzdvv)

--- a/docs/packages/xstate-react/index.md
+++ b/docs/packages/xstate-react/index.md
@@ -1,5 +1,11 @@
 # @xstate/react
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 The [@xstate/react package](https://github.com/statelyai/xstate/tree/main/packages/xstate-react) contains utilities for using [XState](https://github.com/statelyai/xstate) with [React](https://github.com/facebook/react/).
 
 [[toc]]

--- a/docs/packages/xstate-solid/index.md
+++ b/docs/packages/xstate-solid/index.md
@@ -1,5 +1,11 @@
 # @xstate/solid
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 The [@xstate/solid package](https://github.com/statelyai/xstate/tree/main/packages/xstate-solid) contains utilities for using [XState](https://github.com/statelyai/xstate) with [SolidJS](https://github.com/solidjs/solid).
 
 [[toc]]

--- a/docs/packages/xstate-svelte/index.md
+++ b/docs/packages/xstate-svelte/index.md
@@ -1,5 +1,11 @@
 # @xstate/svelte
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 The [@xstate/svelte package](https://github.com/statelyai/xstate/tree/main/packages/xstate-svelte) contains utilities for using [XState](https://github.com/statelyai/xstate) with [Svelte](https://github.com/sveltejs/svelte).
 
 ## Quick Start

--- a/docs/patterns/sequence.md
+++ b/docs/patterns/sequence.md
@@ -1,5 +1,11 @@
 # Sequence
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 A sequence are a number of steps that happen in a specific order, and one at a time. This can be modeled with a state machine:
 
 ```js

--- a/docs/recipes/deno.md
+++ b/docs/recipes/deno.md
@@ -1,5 +1,11 @@
 # Usage with Deno
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 [Deno](https://deno.land/) is an alternate TypeScript/JavaScript runtime, similar to NodeJS, but has built-in TypeScript support and is not intantly compatible with most npm packages.
 
 So to run XState on Deno, you need to import it differently, via [Skypack](https://www.skypack.dev/). Packages are 'installed' at runtime; no more `/node_modules`!

--- a/docs/recipes/ember.md
+++ b/docs/recipes/ember.md
@@ -1,5 +1,11 @@
 # Usage with Ember
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 The most straightforward way of using XState with Ember.js is through the [ember-statecharts](https://ember-statecharts.com)-addon.
 You can also write a custom integration layer yourself if you want to.
 

--- a/docs/recipes/react.md
+++ b/docs/recipes/react.md
@@ -1,5 +1,11 @@
 # Usage with React
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 XState can be used with React to:
 
 - Coordinate local state

--- a/docs/recipes/rxjs.md
+++ b/docs/recipes/rxjs.md
@@ -1,5 +1,11 @@
 # Usage with RxJS
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 The [interpreted machine](../guides/interpretation.md) (i.e., `service`) is subscribable.
 
 ```js

--- a/docs/recipes/solid.md
+++ b/docs/recipes/solid.md
@@ -1,5 +1,11 @@
 # Usage with SolidJS
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 XState can be used with SolidJS to:
 
 - Coordinate local state

--- a/docs/recipes/stencil.md
+++ b/docs/recipes/stencil.md
@@ -1,5 +1,11 @@
 # Usage with Stencil
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 [Stencil](https://stenciljs.com/) web components work very well with XState.
 
 ### `src/helpers/toggle-machine.ts`

--- a/docs/recipes/svelte.md
+++ b/docs/recipes/svelte.md
@@ -1,5 +1,11 @@
 # Usage with Svelte
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 This guides you through setting up XState in a Svelte project. For new Svelte or SvelteKit projects, we recommend using [Vite](https://vitejs.dev/guide/) as your build tool, and we’ve tailored this documentation to such projects. If you're working on an older project that relies on Rollup, please refer to the [Legacy Svelte projects based on Rollup section](#legacy-svelte-projects-based-on-rollup) below.
 
 ## Svelte projects based on Vite

--- a/docs/recipes/vue.md
+++ b/docs/recipes/vue.md
@@ -1,5 +1,11 @@
 # Usage with Vue
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 Usage of XState in a Vue application may vary depending on which version of Vue your application is running. This page focuses on Vue 2 only. To see how to use XState with Vue 3 check the documentation for the XState [`@xstate/vue` package](../packages/xstate-vue).
 
 There are two ways you can use XState with Vue 2:

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -5,4 +5,10 @@ styleGuideVersion: 0
 
 # Roadmap
 
-Find [our live roadmap on Canny](https://statelyai.canny.io).
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
+Find [our live roadmap](https://feedback.stately.ai).

--- a/docs/tutorials/7guis/counter.md
+++ b/docs/tutorials/7guis/counter.md
@@ -1,5 +1,11 @@
 # Task 1: Counter
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 This is the first of [The 7 Tasks from 7GUIs](https://eugenkiss.github.io/7guis/tasks#counter):
 
 > _Challenge:_ Understanding the basic ideas of a language/toolkit.

--- a/docs/tutorials/7guis/flight.md
+++ b/docs/tutorials/7guis/flight.md
@@ -1,5 +1,11 @@
 # Task 3: Flight Booker
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 This is the third of [The 7 Tasks from 7GUIs](https://eugenkiss.github.io/7guis/tasks#flight):
 
 > Challenges: constraints.

--- a/docs/tutorials/7guis/temperature.md
+++ b/docs/tutorials/7guis/temperature.md
@@ -1,5 +1,11 @@
 # Task 2: Temperature
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 This is the second of [The 7 Tasks from 7GUIs](https://eugenkiss.github.io/7guis/tasks#temp):
 
 > Challenges: bidirectional data flow, user-provided text input.

--- a/docs/tutorials/7guis/timer.md
+++ b/docs/tutorials/7guis/timer.md
@@ -1,5 +1,11 @@
 # Task 4: Timer
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 This is the fourth of [The 7 Tasks from 7GUIs](https://eugenkiss.github.io/7guis/tasks#timer):
 
 > Challenges: concurrency, competing user/signal interactions, responsiveness.

--- a/docs/tutorials/reddit.md
+++ b/docs/tutorials/reddit.md
@@ -1,5 +1,11 @@
 # Reddit API
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 _Adapted from the [Redux Docs: Advanced Tutorial](https://redux.js.org/advanced/advanced-tutorial)_
 
 Suppose we wanted to create an app that displays a selected subreddit's posts. The app should be able to:

--- a/docs/updates/README.md
+++ b/docs/updates/README.md
@@ -4,5 +4,11 @@ updatesIndex: true
 
 # Updates
 
+:::warning These XState v4 docs are no longer maintained
+
+XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5) and [check out the XState v5 docs](https://stately.ai/docs/xstate).
+
+:::
+
 <!-- Show a reverse chronological list of posts from inside /updates: -->
 <UpdatesIndex />

--- a/docs/visualizer/README.md
+++ b/docs/visualizer/README.md
@@ -5,6 +5,12 @@ styleGuideVersion: 0
 
 # Visualizer
 
+:::warning These XState v4 docs are no longer maintained
+
+[Stately Studio](https://stately.ai) is now the best way to visualize your state machines. And XState v5 is out now! [Read more about XState v5](https://stately.ai/blog/2023-12-01-xstate-v5)
+
+:::
+
 The [XState Visualizer](https://stately.ai/viz) is a tool for creating and inspecting statecharts to visualize the state of your applications.
 
 As a visual tool, the Visualizer helps developers get an overview of their application logic, as well as making it easy to share and with designers, project managers and the rest of the team.


### PR DESCRIPTION
XState v5 is now here! So these docs are even more outdated than before. This PR:

- updates existing `tip` admonitions pointing folks to Stately docs to `warning` admonitions, explaining that these docs are no longer maintained and linking to new/equivalent v5 docs at stately.ai/docs
- adds new `warning` admonitions so they’re present on every page of the docs, explaining that these docs are no longer maintained and linking to v5 docs at stately.ai/docs
- updates the readme pages to mirror the XState readme, just in case they’re being mirrored elsewhere