### PR TITLE
Fixed an issue with `spawn` within `assign` not returning a narrowed down `ActorRef` type on TypeScrip 5.0

### DIFF
--- a/.changeset/eighty-jars-watch.md
+++ b/.changeset/eighty-jars-watch.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an issue with `spawn` within `assign` not returning a narrowed down `ActorRef` type on TypeScrip 5.0

--- a/packages/core/src/spawn.ts
+++ b/packages/core/src/spawn.ts
@@ -37,13 +37,21 @@ type SpawnOptions<
     >
   : never;
 
+// it's likely-ish that `(TActor & { src: TSrc })['logic']` would be faster
+// but it's only possible to do it since https://github.com/microsoft/TypeScript/pull/53098 (TS 5.1)
+// and we strive to support TS 5.0 whenever possible
+type GetConcreteLogic<
+  TActor extends ProvidedActor,
+  TSrc extends TActor['src']
+> = Extract<TActor, { src: TSrc }>['logic'];
+
 export type Spawner<TActor extends ProvidedActor> = IsLiteralString<
   TActor['src']
 > extends true
   ? <TSrc extends TActor['src']>(
       logic: TSrc,
       ...[options = {} as any]: SpawnOptions<TActor, TSrc>
-    ) => ActorRefFrom<(TActor & { src: TSrc })['logic']>
+    ) => ActorRefFrom<GetConcreteLogic<TActor, TSrc>>
   : // TODO: do not accept machines without all implementations
     <TLogic extends AnyActorLogic | string>(
       src: TLogic,

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -1469,6 +1469,53 @@ describe('spawner in assign', () => {
       })
     });
   });
+
+  it(`should return a concrete actor ref type based on the used string reference`, () => {
+    const child = createMachine({
+      types: {} as {
+        context: {
+          counter: number;
+        };
+      },
+      context: {
+        counter: 100
+      }
+    });
+
+    const otherChild = createMachine({
+      types: {} as {
+        context: {
+          title: string;
+        };
+      },
+      context: {
+        title: 'The Answer'
+      }
+    });
+
+    createMachine({
+      types: {} as {
+        context: {
+          myChild?: ActorRefFrom<typeof child>;
+        };
+        actors:
+          | {
+              src: 'child';
+              logic: typeof child;
+            }
+          | {
+              src: 'other';
+              logic: typeof otherChild;
+            };
+      },
+      context: {},
+      entry: assign({
+        myChild: ({ spawn }) => {
+          return spawn('child');
+        }
+      })
+    });
+  });
 });
 
 describe('invoke', () => {


### PR DESCRIPTION
fixes https://github.com/statelyai/xstate/issues/4566