### PR TITLE
ci(github-actions): bump node to v20

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -2,10 +2,10 @@ name: 'CI setup'
 runs:
   using: 'composite'
   steps:
-    - name: Use Node.js 16.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v3
       with:
-        node-version: 16.x
+        node-version: 20.x
 
     - name: Install Dependencies
       run: yarn


### PR DESCRIPTION
Node 16 is EOL: https://nodejs.org/en/blog/announcements/nodejs16-eol

Bump github-actions CI to NodeJS v20.

Using Node 16 will block (future) dependency updates: https://github.com/statelyai/xstate/pull/3637

cc: @davidkpiano 