### PR TITLE
Minor Fix to todomvc-react Example Project

### DIFF
--- a/examples/todomvc-react/package.json
+++ b/examples/todomvc-react/package.json
@@ -1,12 +1,12 @@
 {
   "name": "todomvc-react",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build"
   },
   "dependencies": {
-    "@xstate/react": "beta",
+    "@xstate/react": "^4.0.0",
     "classnames": "^2.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/examples/todomvc-react/pnpm-lock.yaml
+++ b/examples/todomvc-react/pnpm-lock.yaml
@@ -1,9 +1,13 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
   '@xstate/react':
-    specifier: beta
-    version: 4.0.0-beta.10(@types/react@17.0.59)(react@17.0.2)(xstate@5.0.0-beta.40)
+    specifier: ^4.0.0
+    version: 4.0.1(@types/react@17.0.59)(react@17.0.2)(xstate@5.2.1)
   classnames:
     specifier: ^2.3.2
     version: 2.3.2
@@ -20,8 +24,8 @@ dependencies:
     specifier: ^1.0.5
     version: 1.0.5
   xstate:
-    specifier: beta
-    version: 5.0.0-beta.40
+    specifier: ^5.0.0
+    version: 5.2.1
 
 devDependencies:
   '@types/react':
@@ -629,11 +633,11 @@ packages:
     resolution: {integrity: sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==}
     dev: true
 
-  /@xstate/react@4.0.0-beta.10(@types/react@17.0.59)(react@17.0.2)(xstate@5.0.0-beta.40):
-    resolution: {integrity: sha512-S77ALlcoMYMiG9cVlf9qpcy0V6hZ6Va9K/jU4xidX21JsI6YI9i8HMtmMAiRbeV+chkwThe0otEEWFFUWXNHgg==}
+  /@xstate/react@4.0.1(@types/react@17.0.59)(react@17.0.2)(xstate@5.2.1):
+    resolution: {integrity: sha512-UB9qUC11wcaYd05wGea0mvEA3uTHikNaB4InMZfxD7MVFxzBFU+3JFkemjiN8bDdPJfDrObyP9ZPDVojq2LytA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      xstate: ^5.0.0-beta.29
+      xstate: ^5.1.0
     peerDependenciesMeta:
       xstate:
         optional: true
@@ -641,7 +645,7 @@ packages:
       react: 17.0.2
       use-isomorphic-layout-effect: 1.1.2(@types/react@17.0.59)(react@17.0.2)
       use-sync-external-store: 1.2.0(react@17.0.2)
-      xstate: 5.0.0-beta.40
+      xstate: 5.2.1
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -2347,8 +2351,8 @@ packages:
         optional: true
     dev: true
 
-  /xstate@5.0.0-beta.40:
-    resolution: {integrity: sha512-q3tGXbfaHC785Eol2YFU3NmYfRy3XIA/pN2m2rK2oHY5t70SCUO0TvmLqxheE5sB4yJI+47U6XX7pdCtCVA3hg==}
+  /xstate@5.2.1:
+    resolution: {integrity: sha512-qPYPnoYIvNSwSv4uIwV+V/uFeGk6houLGmZy0io1XsfImBrp1AKbw9ADNJytCksCDP/YOAg1EtiWjXFzsT1rdw==}
     dev: false
 
   /yallist@3.1.1:

--- a/examples/todomvc-react/readme.md
+++ b/examples/todomvc-react/readme.md
@@ -7,6 +7,20 @@ This is an implementation of [TodoMVC](https://todomvc.com/) built with:
 - TypeScript
 - Vite
 
-## [Open in CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/main/examples/todomvc-react)
+## How to run
+
+You may run the example locally with:
+
+```shell
+    cd examples/todomvc-react
+    pnpm install
+    pnpm run dev
+```
+
+__OR__
+
+[Open in CodeSandbox](https://codesandbox.io/p/sandbox/github/statelyai/xstate/tree/main/examples/todomvc-react)
+
+__OR__
 
 [![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/statelyai/xstate/tree/main/examples/todomvc-react)

--- a/examples/todomvc-react/src/Todos.tsx
+++ b/examples/todomvc-react/src/Todos.tsx
@@ -29,7 +29,7 @@ export function Todos() {
     todosActorRef.subscribe(() => {
       localStorage.setItem(
         'todos',
-        JSON.stringify(todosActorRef.getPersistedState?.())
+        JSON.stringify(todosActorRef.getPersistedSnapshot?.())
       );
     });
   }, [todosActorRef]);


### PR DESCRIPTION
Hello,

I hope I'm not stepping out of line here but I had pulled down the `xstate` repo to help myself learn about the library in more detail and attempted to run `examples/todomvc-react` but found a few minor issues related to the v5 upgrade:

• Initially, running `pnpm run dev` resulted in the error:

```
[vite] Dep optimization failed with error:
'ActorStatus' is not exported by node_modules/.pnpm/xstate@5.2.1/node_modules/xstate/dist/xstate.esm.js, imported by node_modules/.pnpm/@xstate+react@4.0.0-beta.10_@types+react@17.0.59_react@17.0.2_xstate@5.2.1/node_modules/@xstate/react/dist/xstate-react.esm.js
```

Pinning `xstate-react` at `^4.0.0` rather than `beta` resolved this issue.

• On using the example app re-opening the page caused a failure due to the change in state persistence method from `getPersistedState()` to `getPersistedSnapshot ()`. Moving to the new method name appears to resolve the issue.

I hope this PR is useful. Obviously, please let me know if there are any stylistic changes needed in order to make it a candidate to merge. I have not created a change set as that didn't seem appropriate for an example?

