### PR TITLE
[poc] Use a `functionBrand` to make limited callback actors possible

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -684,7 +684,7 @@ export type InvokeConfig<
         | Mapper<TContext, TEvent, NonReducibleUnknown, TEvent>
         | null
         | undefined
-        | NotAFunction<{}>;
+        | NotAFunction<{ [k: PropertyKey]: unknown }>;
       /**
        * The transition to take upon the invoked child machine reaching its final top-level state.
        */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,8 @@ import {
   TypegenDisabled
 } from './typegenTypes.ts';
 
+type Primitive = string | number | boolean | symbol | bigint | null | undefined;
+
 declare const functionBrand: unique symbol;
 type NotAFunction<T> = T & { [functionBrand]?: never };
 declare global {
@@ -682,8 +684,7 @@ export type InvokeConfig<
 
       input?:
         | Mapper<TContext, TEvent, NonReducibleUnknown, TEvent>
-        | null
-        | undefined
+        | Primitive
         | NotAFunction<{ [k: PropertyKey]: unknown }>;
       /**
        * The transition to take upon the invoked child machine reaching its final top-level state.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,14 @@ import {
   TypegenDisabled
 } from './typegenTypes.ts';
 
+declare const functionBrand: unique symbol;
+type NotAFunction<T> = T & { [functionBrand]?: never };
+declare global {
+  interface Function {
+    [functionBrand]?: true;
+  }
+}
+
 export type Identity<T> = { [K in keyof T]: T[K] };
 
 export type HomomorphicPick<T, K extends keyof any> = {
@@ -674,7 +682,9 @@ export type InvokeConfig<
 
       input?:
         | Mapper<TContext, TEvent, NonReducibleUnknown, TEvent>
-        | NonReducibleUnknown;
+        | null
+        | undefined
+        | NotAFunction<{}>;
       /**
        * The transition to take upon the invoked child machine reaching its final top-level state.
        */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -685,7 +685,8 @@ export type InvokeConfig<
       input?:
         | Mapper<TContext, TEvent, NonReducibleUnknown, TEvent>
         | Primitive
-        | NotAFunction<{ [k: PropertyKey]: unknown }>;
+        | NotAFunction<{ [k: PropertyKey]: unknown }>
+        | NotAFunction<object>;
       /**
        * The transition to take upon the invoked child machine reaching its final top-level state.
        */


### PR DESCRIPTION
reusing the brand trick from https://github.com/statelyai/xstate/pull/4256 to allow implementing type-safe~ callbacks actors that can only be used within machines that accept events that they might `sendBack` to them

related to https://discord.com/channels/795785288994652170/1177607380905775165/1184957932878696458