### PR TITLE
[core] Add `self` and `system` to `enqueueActions(...)`

### DIFF
--- a/.changeset/strong-jobs-unite.md
+++ b/.changeset/strong-jobs-unite.md
@@ -1,0 +1,12 @@
+---
+'xstate': patch
+---
+
+Update the argument object of `enqueueActions(...)` to include a `self` property:
+
+```ts
+// ...
+entry: enqueueActions(({ self }) => {
+  // ...
+});
+```

--- a/.changeset/strong-jobs-unite.md
+++ b/.changeset/strong-jobs-unite.md
@@ -2,11 +2,11 @@
 'xstate': patch
 ---
 
-Update the argument object of `enqueueActions(...)` to include a `self` property:
+Update the argument object of `enqueueActions(...)` to include the `self` and `system` properties:
 
 ```ts
 // ...
-entry: enqueueActions(({ self }) => {
+entry: enqueueActions(({ self, system }) => {
   // ...
 });
 ```

--- a/packages/core/src/actions/enqueueActions.ts
+++ b/packages/core/src/actions/enqueueActions.ts
@@ -79,7 +79,7 @@ interface ActionEnqueuer<
 }
 
 function resolveEnqueueActions(
-  _: AnyActorScope,
+  actorScope: AnyActorScope,
   snapshot: AnyMachineSnapshot,
   args: ActionArgs<any, any, any>,
   _actionParams: ParameterizedObject['params'] | undefined,
@@ -90,7 +90,8 @@ function resolveEnqueueActions(
       context,
       event,
       enqueue,
-      check
+      check,
+      self
     }: {
       context: MachineContext;
       event: EventObject;
@@ -111,6 +112,7 @@ function resolveEnqueueActions(
           ParameterizedObject
         >
       ) => boolean;
+      self: AnyActorRef;
     }) => void;
   }
 ) {
@@ -144,7 +146,8 @@ function resolveEnqueueActions(
     event: args.event,
     enqueue,
     check: (guard) =>
-      evaluateGuard(guard, snapshot.context, args.event, snapshot)
+      evaluateGuard(guard, snapshot.context, args.event, snapshot),
+    self: actorScope.self
   });
 
   return [snapshot, undefined, actions];
@@ -180,7 +183,8 @@ export function enqueueActions<
     context,
     event,
     check,
-    enqueue
+    enqueue,
+    self
   }: {
     context: TContext;
     event: TExpressionEvent;
@@ -196,6 +200,7 @@ export function enqueueActions<
       TGuard,
       TDelay
     >;
+    self: AnyActorRef;
   }) => void
 ): EnqueueActionsAction<
   TContext,
@@ -217,7 +222,6 @@ export function enqueueActions<
 
   enqueueActions.type = 'xstate.enqueueActions';
   enqueueActions.collect = collect;
-
   enqueueActions.resolve = resolveEnqueueActions;
 
   return enqueueActions;

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2807,6 +2807,16 @@ describe('enqueueActions', () => {
       ]
     `);
   });
+  it('should provide self', () => {
+    expect.assertions(1);
+    const machine = createMachine({
+      entry: enqueueActions(({ self }) => {
+        expect(self.send).toBeDefined();
+      })
+    });
+
+    createActor(machine).start();
+  });
 });
 
 describe('sendParent', () => {


### PR DESCRIPTION

Updates the argument object of `enqueueActions(...)` to include a `self` property:

```ts
// ...
entry: enqueueActions(({ self }) => {
  // ...
});
```
