### PR TITLE
Allow `invoke` IDs to be resolvable at type-level

### DIFF
--- a/packages/core/src/actions/spawnChild.ts
+++ b/packages/core/src/actions/spawnChild.ts
@@ -1,29 +1,27 @@
 import isDevelopment from '#is-development';
 import { cloneMachineSnapshot } from '../State.ts';
-import { createErrorActorEvent } from '../eventUtils.ts';
 import { ProcessingStatus, createActor } from '../interpreter.ts';
 import {
   ActionArgs,
-  AnyActorScope,
-  AnyActorRef,
-  AnyActor,
-  AnyMachineSnapshot,
-  EventObject,
-  MachineContext,
-  ParameterizedObject,
   AnyActorLogic,
-  ProvidedActor,
-  IsLiteralString,
-  InputFrom,
-  UnifiedArg,
-  Mapper,
-  RequiredActorOptions,
+  AnyActorRef,
+  AnyActorScope,
+  AnyMachineSnapshot,
   ConditionalRequired,
-  IsNotNever
+  EventObject,
+  InputFrom,
+  IsLiteralString,
+  IsNotNever,
+  MachineContext,
+  Mapper,
+  ParameterizedObject,
+  ProvidedActor,
+  RequiredActorOptions,
+  UnifiedArg
 } from '../types.ts';
 import { resolveReferencedActor } from '../utils.ts';
 
-type ResolvableActorId<
+export type ResolvableActorId<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
   TEvent extends EventObject,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,11 +2,12 @@ import type { MachineSnapshot } from './State.ts';
 import type { StateMachine } from './StateMachine.ts';
 import type { StateNode } from './StateNode.ts';
 import { AssignArgs } from './actions/assign.ts';
+import { ResolvableActorId } from './actions/spawnChild.ts';
 import { PromiseActorLogic } from './actors/promise.ts';
 import { Guard, GuardPredicate, UnknownGuard } from './guards.ts';
 import type { Actor, ProcessingStatus } from './interpreter.ts';
 import { Spawner } from './spawn.ts';
-import { AnyActorSystem, InspectionEvent, Clock } from './system.js';
+import { AnyActorSystem, Clock, InspectionEvent } from './system.js';
 import {
   AreAllImplementationsAssumedToBeProvided,
   MarkAllImplementationsAsProvided,
@@ -592,7 +593,7 @@ type DistributeActors<
          * The unique identifier for the invoked machine. If not specified, this
          * will be the machine's own `id`, or the URL (from `src`).
          */
-        id?: TSpecificActor['id'];
+        id?: ResolvableActorId<TContext, TEvent, TEvent, TSpecificActor['id']>;
 
         // TODO: currently we do not enforce required inputs here
         // in a sense, we shouldn't - they could be provided within the `implementations` object
@@ -664,7 +665,7 @@ export type InvokeConfig<
        * The unique identifier for the invoked machine. If not specified, this
        * will be the machine's own `id`, or the URL (from `src`).
        */
-      id?: string;
+      id?: ResolvableActorId<TContext, TEvent, TEvent, string>;
 
       systemId?: string;
       /**

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -3353,6 +3353,35 @@ describe('invoke', () => {
     await sleep(3);
     expect(actorRef.getSnapshot().status).toBe('done');
   });
+
+  it('should handle a dynamic id', () => {
+    const spy = jest.fn();
+
+    const child = createMachine({
+      on: {
+        FOO: {
+          actions: spy
+        }
+      }
+    });
+
+    const machine = createMachine({
+      context: {
+        childId: 'myChild'
+      },
+      invoke: {
+        src: child,
+        id: ({ context }) => context.childId
+      },
+      entry: sendTo('myChild', {
+        type: 'FOO'
+      })
+    });
+
+    createActor(machine).start();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('invoke input', () => {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -881,6 +881,41 @@ describe('spawnChild action', () => {
     });
   });
 
+  it(`should reject dynamic wrong id`, () => {
+    const child = fromPromise(() => Promise.resolve('foo'));
+
+    createMachine({
+      types: {} as {
+        actors: {
+          src: 'child';
+          logic: typeof child;
+          id: 'a' | 'b';
+        };
+      },
+      entry: spawnChild('child', {
+        // @ts-expect-error
+        id: () => 'c'
+      })
+    });
+  });
+
+  it(`should allow dynamic correct id`, () => {
+    const child = fromPromise(() => Promise.resolve('foo'));
+
+    createMachine({
+      types: {} as {
+        actors: {
+          src: 'child';
+          logic: typeof child;
+          id: 'a' | 'b';
+        };
+      },
+      entry: spawnChild('child', {
+        id: () => 'b'
+      })
+    });
+  });
+
   it(`should reject static wrong input`, () => {
     const child = fromPromise(({}: { input: number }) =>
       Promise.resolve('foo')
@@ -1663,6 +1698,43 @@ describe('invoke', () => {
       // @ts-expect-error
       invoke: {
         src: child2
+      }
+    });
+  });
+
+  it(`should reject dynamic wrong id`, () => {
+    const child = fromPromise(() => Promise.resolve('foo'));
+
+    createMachine({
+      types: {} as {
+        actors: {
+          src: 'child';
+          logic: typeof child;
+          id: 'a' | 'b';
+        };
+      },
+      // @ts-expect-error
+      invoke: {
+        src: 'child',
+        id: () => 'c' as const
+      }
+    });
+  });
+
+  it(`should allow dynamic correct id`, () => {
+    const child = fromPromise(() => Promise.resolve('foo'));
+
+    createMachine({
+      types: {} as {
+        actors: {
+          src: 'child';
+          logic: typeof child;
+          id: 'a' | 'b';
+        };
+      },
+      invoke: {
+        src: 'child',
+        id: () => 'b' as const
       }
     });
   });


### PR DESCRIPTION
closes https://github.com/statelyai/xstate/issues/4605

TODO: 
- [ ] tests