### PR TITLE
Call `complete` listeners exclusively when the actor reaches its done status

### DIFF
--- a/packages/core/src/interpreter.ts
+++ b/packages/core/src/interpreter.ts
@@ -513,7 +513,6 @@ export class Actor<TLogic extends AnyActorLogic>
     this.update(nextState, event);
     if (event.type === XSTATE_STOP) {
       this._stopProcedure();
-      this._complete();
     }
   }
 

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1414,20 +1414,18 @@ describe('interpreter', () => {
       expect(completeCb).toHaveBeenCalledTimes(1);
     });
 
-    it('should call complete() once the interpreter is stopped', () => {
-      const completeCb = jest.fn();
+    it('should not call complete() once the actor is stopped', () => {
+      const spy = jest.fn();
 
-      const service = createActor(createMachine({})).start();
+      const actorRef = createActor(createMachine({})).start();
 
-      service.subscribe({
-        complete: () => {
-          completeCb();
-        }
+      actorRef.subscribe({
+        complete: spy
       });
 
-      service.stop();
+      actorRef.stop();
 
-      expect(completeCb).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledTimes(0);
     });
   });
 


### PR DESCRIPTION
related to https://github.com/statelyai/xstate/discussions/4608

this removes the ability to listen for "on stop" **but** `complete` was already **not** called in different scenarios for stopped snapshots:
- like in `subscribe` [here](https://github.com/statelyai/xstate/blob/12e062bd594a1d05c8bc3eab7c15300384c04367/packages/core/src/interpreter.ts#L368)
- or like when starting an actor with a rehydrated stopped snapshot [here](https://github.com/statelyai/xstate/blob/12e062bd594a1d05c8bc3eab7c15300384c04367/packages/core/src/interpreter.ts#L440)

So this is currently inconsistent, one way or another, and we should unify it. When it comes to the "on stop" listener - personally, I just don't see a lot of use cases for it. A different modeling approach is always possible and I'd prefer to steer people towards explicit modeling and away from adding implicit ad-hoc logic in listeners like this.