### PR TITLE
Bump version of @xtate/immer package to align with updated dependencies

### DIFF
--- a/packages/xstate-immer/package.json
+++ b/packages/xstate-immer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xstate/immer",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "XState with Immer",
   "keywords": [
     "immer",


### PR DESCRIPTION
Fixes inconsistent non-bumping of package version like other xstate packages that had the same recent updates of peer dependencies four days ago (inconsistent how packages such as `@xstate/react` and `@xstate/svelte` were handled when their peer dependencies were updated). 