### PR TITLE
Allow `event` in transitions to be narrowed down even when its `.type` is defined using a union

### DIFF
--- a/.changeset/tender-rocks-lay.md
+++ b/.changeset/tender-rocks-lay.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Allow `event` in transitions to be narrowed down even when its `.type` is defined using a union.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1908,6 +1908,11 @@ export interface Subscribable<T> extends InteropSubscribable<T> {
   ): Subscription;
 }
 
+type EventDescriptorMatches<
+  TEventType extends string,
+  TNormalizedDescriptor
+> = TEventType extends TNormalizedDescriptor ? true : false;
+
 export type ExtractEvent<
   TEvent extends EventObject,
   TDescriptor extends EventDescriptor<TEvent>
@@ -1915,7 +1920,11 @@ export type ExtractEvent<
   ? TEvent
   : NormalizeDescriptor<TDescriptor> extends infer TNormalizedDescriptor
     ? TEvent extends any
-      ? TEvent['type'] extends TNormalizedDescriptor
+      ? // true is the check type here to match both true and boolean
+        true extends EventDescriptorMatches<
+          TEvent['type'],
+          TNormalizedDescriptor
+        >
         ? TEvent
         : never
       : never

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -722,6 +722,31 @@ describe('events', () => {
       }
     });
   });
+
+  it('should provide contextual `event` type in transition actions when the matching event has a union `.type`', () => {
+    createMachine({
+      types: {} as {
+        events:
+          | {
+              type: 'FOO' | 'BAR';
+              value: string;
+            }
+          | {
+              type: 'OTHER';
+            };
+      },
+      on: {
+        FOO: {
+          actions: ({ event }) => {
+            event.type satisfies 'FOO' | 'BAR'; // it could be narrowed down to `FOO` but it's not worth the effort/complexity
+            event.value satisfies string;
+            // @ts-expect-error
+            event.value satisfies number;
+          }
+        }
+      }
+    });
+  });
 });
 
 describe('interpreter', () => {


### PR DESCRIPTION
fixes https://discord.com/channels/795785288994652170/1190416887063007263/1190416887063007263