### PR TITLE
Add `snapshot.sessionId`

### DIFF
--- a/.changeset/silver-donkeys-stare.md
+++ b/.changeset/silver-donkeys-stare.md
@@ -1,0 +1,10 @@
+---
+'xstate': minor
+---
+
+Add `snapshot.sessionId`. Two main motivations:
+
+- To be able to identify the actor `sessionId` a snapshot belonged to when inspecting, even if the actor is mutated (which can report an incorrect `actorRef.sessionId` if read directly)
+- Brings back a little compatibility with SCXML:
+
+> _\_sessionid_. The SCXML Processor must bind the variable \_sessionid at load time to the system-generated id for the current SCXML session. (This is of type NMTOKEN.) The Processor must keep the variable bound to this value until the session terminates.

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -183,6 +183,7 @@ interface MachineSnapshotBase<
       TOutput
     >
   ) => unknown;
+  sessionId: string | undefined;
 }
 
 interface ActiveMachineSnapshot<
@@ -385,7 +386,8 @@ export function createMachineSnapshot<
     hasTag: machineSnapshotHasTag,
     can: machineSnapshotCan,
     getMeta: machineSnapshotGetMeta,
-    toJSON: machineSnapshotToJSON
+    toJSON: machineSnapshotToJSON,
+    sessionId: config.sessionId
   };
 }
 

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -225,7 +225,8 @@ export class StateMachine<
           : config.status || 'active',
         output: config.output,
         error: config.error,
-        historyValue: config.historyValue
+        historyValue: config.historyValue,
+        sessionId: undefined
       },
       this
     ) as MachineSnapshot<
@@ -316,7 +317,8 @@ export class StateMachine<
           typeof context !== 'function' && context ? context : ({} as TContext),
         _nodes: [this.root],
         children: {},
-        status: 'active'
+        status: 'active',
+        sessionId: actorScope.sessionId
       },
       this
     );

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -188,12 +188,13 @@ export function fromCallback<
 
       return state;
     },
-    getInitialSnapshot: (_, input) => {
+    getInitialSnapshot: (actorScope, input) => {
       return {
         status: 'active',
         output: undefined,
         error: undefined,
-        input
+        input,
+        sessionId: actorScope.sessionId
       };
     },
     getPersistedSnapshot: (snapshot) => snapshot,

--- a/packages/core/src/actors/observable.ts
+++ b/packages/core/src/actors/observable.ts
@@ -130,14 +130,15 @@ export function fromObservable<TContext, TInput extends NonReducibleUnknown>(
           return snapshot;
       }
     },
-    getInitialSnapshot: (_, input) => {
+    getInitialSnapshot: (actorScope, input) => {
       return {
         status: 'active',
         output: undefined,
         error: undefined,
         context: undefined,
         input,
-        _subscription: undefined
+        _subscription: undefined,
+        sessionId: actorScope.sessionId
       };
     },
     start: (state, { self, system }) => {
@@ -270,14 +271,15 @@ export function fromEventObservable<
           return state;
       }
     },
-    getInitialSnapshot: (_, input) => {
+    getInitialSnapshot: (actorScope, input) => {
       return {
         status: 'active',
         output: undefined,
         error: undefined,
         context: undefined,
         input,
-        _subscription: undefined
+        _subscription: undefined,
+        sessionId: actorScope.sessionId
       };
     },
     start: (state, { self, system }) => {

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -154,12 +154,13 @@ export function fromPromise<TOutput, TInput = NonReducibleUnknown>(
         }
       );
     },
-    getInitialSnapshot: (_, input) => {
+    getInitialSnapshot: (actorScope, input) => {
       return {
         status: 'active',
         output: undefined,
         error: undefined,
-        input
+        input,
+        sessionId: actorScope.sessionId
       };
     },
     getPersistedSnapshot: (snapshot) => snapshot,

--- a/packages/core/src/actors/transition.ts
+++ b/packages/core/src/actors/transition.ts
@@ -116,7 +116,7 @@ export function fromTransition<
         )
       };
     },
-    getInitialSnapshot: (_, input) => {
+    getInitialSnapshot: (actorScope, input) => {
       return {
         status: 'active',
         output: undefined,
@@ -124,7 +124,8 @@ export function fromTransition<
         context:
           typeof initialContext === 'function'
             ? (initialContext as any)({ input })
-            : initialContext
+            : initialContext,
+        sessionId: actorScope.sessionId
       };
     },
     getPersistedSnapshot: (snapshot) => snapshot,

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -673,7 +673,12 @@ export class Actor<TLogic extends AnyActorLogic>
    */
   public getPersistedSnapshot(): Snapshot<unknown>;
   public getPersistedSnapshot(options?: unknown): Snapshot<unknown> {
-    return this.logic.getPersistedSnapshot(this._snapshot, options);
+    const persistedSnapshot = this.logic.getPersistedSnapshot(
+      this._snapshot,
+      options
+    );
+    delete persistedSnapshot.sessionId;
+    return persistedSnapshot;
   }
 
   public [symbolObservable](): InteropSubscribable<SnapshotFrom<TLogic>> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2132,21 +2132,25 @@ export type Snapshot<TOutput> =
       status: 'active';
       output: undefined;
       error: undefined;
+      sessionId: string | undefined;
     }
   | {
       status: 'done';
       output: TOutput;
       error: undefined;
+      sessionId: string | undefined;
     }
   | {
       status: 'error';
       output: undefined;
       error: unknown;
+      sessionId: string | undefined;
     }
   | {
       status: 'stopped';
       output: undefined;
       error: undefined;
+      sessionId: string | undefined;
     };
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1720,6 +1720,7 @@ export interface StateConfig<
     any,
     any
   >;
+  sessionId: string | undefined;
 }
 
 export interface ActorOptions<TLogic extends AnyActorLogic> {

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -1158,7 +1158,8 @@ describe('actors', () => {
         getInitialSnapshot: () => ({
           status: 'active',
           output: undefined,
-          error: undefined
+          error: undefined,
+          sessionId: undefined
         }),
         getPersistedSnapshot: (s) => s
       };

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -833,7 +833,8 @@ describe('error handling', () => {
       status: 'error',
       output: undefined,
       error: 'immediate error!',
-      context: undefined
+      context: undefined,
+      sessionId: undefined
     });
 
     const machine = createMachine(

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -31,7 +31,11 @@ function simplifyEvent(inspectionEvent: InspectionEvent) {
       actorId: inspectionEvent.actorRef.sessionId,
       snapshot: isMachineSnapshot(inspectionEvent.snapshot)
         ? { value: inspectionEvent.snapshot.value }
-        : inspectionEvent.snapshot,
+        : {
+            output: inspectionEvent.snapshot.output,
+            context: (inspectionEvent.snapshot as any).context,
+            status: inspectionEvent.snapshot.status
+          },
       event: inspectionEvent.event,
       status: inspectionEvent.snapshot.status
     };
@@ -286,8 +290,7 @@ describe('inspect', () => {
             "type": "xstate.init",
           },
           "snapshot": {
-            "error": undefined,
-            "input": undefined,
+            "context": undefined,
             "output": undefined,
             "status": "active",
           },
@@ -393,8 +396,7 @@ describe('inspect', () => {
             "type": "xstate.promise.resolve",
           },
           "snapshot": {
-            "error": undefined,
-            "input": undefined,
+            "context": undefined,
             "output": 42,
             "status": "done",
           },

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -2264,7 +2264,8 @@ describe('invoke', () => {
           status: 'active',
           output: undefined,
           error: undefined,
-          context: 0
+          context: 0,
+          sessionId: undefined
         }),
         getPersistedSnapshot: (s) => s
       };
@@ -2305,7 +2306,8 @@ describe('invoke', () => {
         getInitialSnapshot: () => ({
           status: 'active',
           output: undefined,
-          error: undefined
+          error: undefined,
+          sessionId: undefined
         }),
         getPersistedSnapshot: (s) => s
       };

--- a/packages/core/test/state.test.ts
+++ b/packages/core/test/state.test.ts
@@ -507,4 +507,12 @@ describe('State', () => {
       expect(snapshot.status).toBe('stopped');
     });
   });
+
+  it('includes the sessionId in the snapshot', () => {
+    const machine = createMachine({});
+    const actor = createActor(machine).start();
+
+    expect(actor.getSnapshot().sessionId).toBeDefined();
+    expect(actor.getSnapshot().sessionId).toBe(actor.sessionId);
+  });
 });

--- a/packages/core/test/typeHelpers.test.ts
+++ b/packages/core/test/typeHelpers.test.ts
@@ -362,7 +362,8 @@ describe('ActorRefFrom', () => {
       getInitialSnapshot: () => ({
         status: 'active',
         output: undefined,
-        error: undefined
+        error: undefined,
+        sessionId: undefined
       }),
       getPersistedSnapshot: (s) => s
     };

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -18,6 +18,7 @@ import {
   spawnChild,
   stateIn
 } from '../src/index';
+import { getInitialSnapshot } from '../src/getNextSnapshot';
 
 function noop(_x: unknown) {
   return;
@@ -202,7 +203,7 @@ describe('output', () => {
       }
     });
 
-    const state = machine.getInitialSnapshot(null as any);
+    const state = getInitialSnapshot(machine);
 
     ((_accept: number | undefined) => {})(state.output);
     // @ts-expect-error

--- a/packages/xstate-inspect/test/inspect.test.ts
+++ b/packages/xstate-inspect/test/inspect.test.ts
@@ -97,7 +97,7 @@ describe('@xstate/inspect', () => {
           "machine": "{"id":"whatever","key":"whatever","type":"compound","initial":{"target":["#whatever.active"],"source":"#whatever","actions":[],"eventType":null},"history":false,"states":{"active":{"id":"whatever.active","key":"active","type":"atomic","initial":{"target":[],"source":"#whatever.active","actions":[],"eventType":null},"history":false,"states":{},"on":{},"transitions":[],"entry":[],"exit":[],"order":1,"invoke":[],"tags":[]}},"on":{},"transitions":[],"entry":[],"exit":[],"order":-1,"invoke":[],"tags":[]}",
           "parent": undefined,
           "sessionId": "x:1",
-          "state": "{"status":"active","context":{"cycle":"[Circular]"},"value":"active","children":{},"historyValue":{},"tags":[]}",
+          "state": "{"status":"active","context":{"cycle":"[Circular]"},"value":"active","children":{},"historyValue":{},"sessionId":"x:1","tags":[]}",
           "type": "service.register",
         },
       ]
@@ -148,7 +148,7 @@ describe('@xstate/inspect', () => {
         },
         {
           "sessionId": "x:3",
-          "state": "{"status":"active","context":{},"value":"active","children":{},"historyValue":{},"tags":[]}",
+          "state": "{"status":"active","context":{},"value":"active","children":{},"historyValue":{},"sessionId":"x:3","tags":[]}",
           "type": "service.state",
         },
       ]
@@ -205,7 +205,7 @@ describe('@xstate/inspect', () => {
           "machine": "{"id":"(machine)","key":"(machine)","type":"compound","initial":{"target":["#(machine).active"],"source":"#(machine)","actions":[],"eventType":null},"history":false,"states":{"active":{"id":"(machine).active","key":"active","type":"atomic","initial":{"target":[],"source":"#(machine).active","actions":[],"eventType":null},"history":false,"states":{},"on":{},"transitions":[],"entry":[],"exit":[],"order":1,"invoke":[],"tags":[]}},"on":{},"transitions":[],"entry":[],"exit":[],"order":-1,"invoke":[],"tags":[]}",
           "parent": undefined,
           "sessionId": "x:5",
-          "state": "{"status":"active","context":{"map":"map","deep":{"map":"map"}},"value":"active","children":{},"historyValue":{},"tags":[]}",
+          "state": "{"status":"active","context":{"map":"map","deep":{"map":"map"}},"value":"active","children":{},"historyValue":{},"sessionId":"x:5","tags":[]}",
           "type": "service.register",
         },
         {
@@ -215,7 +215,7 @@ describe('@xstate/inspect', () => {
         },
         {
           "sessionId": "x:5",
-          "state": "{"status":"active","context":{"map":"map","deep":{"map":"map"}},"value":"active","children":{},"historyValue":{},"tags":[]}",
+          "state": "{"status":"active","context":{"map":"map","deep":{"map":"map"}},"value":"active","children":{},"historyValue":{},"sessionId":"x:5","tags":[]}",
           "type": "service.state",
         },
       ]
@@ -324,7 +324,7 @@ describe('@xstate/inspect', () => {
         },
         {
           "sessionId": "x:7",
-          "state": "{"status":"active","context":{"value":{"unsafe":"[unsafe]"}},"value":{},"children":{},"historyValue":{},"tags":[]}",
+          "state": "{"status":"active","context":{"value":{"unsafe":"[unsafe]"}},"value":{},"children":{},"historyValue":{},"sessionId":"x:7","tags":[]}",
           "type": "service.state",
         },
       ]
@@ -346,7 +346,7 @@ describe('@xstate/inspect', () => {
         },
         {
           "sessionId": "x:7",
-          "state": "{"status":"active","context":{"value":{"unsafe":"[unsafe]"}},"value":{},"children":{},"historyValue":{},"tags":[]}",
+          "state": "{"status":"active","context":{"value":{"unsafe":"[unsafe]"}},"value":{},"children":{},"historyValue":{},"sessionId":"x:7","tags":[]}",
           "type": "service.state",
         },
       ]


### PR DESCRIPTION
Add `snapshot.sessionId`. Two main motivations:

- To be able to identify the actor `sessionId` a snapshot belonged to when inspecting, even if the actor is mutated (which can report an incorrect `actorRef.sessionId` if read directly)
- Brings back a little compatibility with SCXML:

> _\_sessionid_. The SCXML Processor must bind the variable \_sessionid at load time to the system-generated id for the current SCXML session. (This is of type NMTOKEN.) The Processor must keep the variable bound to this value until the session terminates.