### PR TITLE
Allow escaped periods in state IDs

### DIFF
--- a/.changeset/brave-llamas-hammer.md
+++ b/.changeset/brave-llamas-hammer.md
@@ -1,0 +1,9 @@
+---
+'xstate': patch
+---
+
+State IDs that have periods in them are now supported if those periods are escaped.
+
+The motivation is that external tools, such as [Stately Studio](https://stately.ai/studio), may allow users to enter any text into the state ID field. This change allows those tools to escape periods in state IDs, so that they don't conflict with the internal path-based state IDs.
+
+E.g. if a state ID of `"Loading..."` is entered into the state ID field, instead of crashing either the external tool and/or the XState state machine, it should be converted by the tool to `"Loading\\.\\.\\."`, and those periods will be ignored by XState.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -405,8 +405,6 @@ export class StateMachine<
     let resolvedStateId = isStateId(fullPath[0])
       ? fullPath[0].slice(STATE_IDENTIFIER.length)
       : fullPath[0];
-    // replace escaped periods ('\.') with periods
-    resolvedStateId = resolvedStateId.replace(/\\\./g, '.');
 
     const stateNode = this.idMap.get(resolvedStateId);
     if (!stateNode) {

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -402,9 +402,11 @@ export class StateMachine<
   public getStateNodeById(stateId: string): StateNode<TContext, TEvent> {
     const fullPath = toStatePath(stateId);
     const relativePath = fullPath.slice(1);
-    const resolvedStateId = isStateId(fullPath[0])
+    let resolvedStateId = isStateId(fullPath[0])
       ? fullPath[0].slice(STATE_IDENTIFIER.length)
       : fullPath[0];
+    // replace escaped periods ('\.') with periods
+    resolvedStateId = resolvedStateId.replace(/\\\./g, '.');
 
     const stateNode = this.idMap.get(resolvedStateId);
     if (!stateNode) {

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -402,7 +402,7 @@ export class StateMachine<
   public getStateNodeById(stateId: string): StateNode<TContext, TEvent> {
     const fullPath = toStatePath(stateId);
     const relativePath = fullPath.slice(1);
-    let resolvedStateId = isStateId(fullPath[0])
+    const resolvedStateId = isStateId(fullPath[0])
       ? fullPath[0].slice(STATE_IDENTIFIER.length)
       : fullPath[0];
 

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -1,6 +1,5 @@
 import isDevelopment from '#is-development';
 import { assign } from './actions.ts';
-import { STATE_DELIMITER } from './constants.ts';
 import { $$ACTOR_TYPE, createActor } from './createActor.ts';
 import { createInitEvent } from './eventUtils.ts';
 import {
@@ -49,7 +48,7 @@ import type {
   TODO,
   TransitionDefinition
 } from './types.ts';
-import { resolveReferencedActor } from './utils.ts';
+import { resolveReferencedActor, toStatePath } from './utils.ts';
 
 export const STATE_IDENTIFIER = '#';
 export const WILDCARD = '*';
@@ -401,7 +400,7 @@ export class StateMachine<
   }
 
   public getStateNodeById(stateId: string): StateNode<TContext, TEvent> {
-    const fullPath = stateId.split(STATE_DELIMITER);
+    const fullPath = toStatePath(stateId);
     const relativePath = fullPath.slice(1);
     const resolvedStateId = isStateId(fullPath[0])
       ? fullPath[0].slice(STATE_IDENTIFIER.length)

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -581,9 +581,7 @@ export function getStateNode(
       `Unable to retrieve child state '${stateKey}' from '${stateNode.id}'; no child states exist.`
     );
   }
-  // replace escaped period ('\.') with just a period
-  const resolvedStateKey = stateKey.replace(/\\\./g, '.');
-  const result = stateNode.states[resolvedStateKey];
+  const result = stateNode.states[stateKey];
   if (!result) {
     throw new Error(
       `Child state '${resolvedStateKey}' does not exist on '${stateNode.id}'`

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -581,7 +581,7 @@ export function getStateNode(
   const result = stateNode.states[stateKey];
   if (!result) {
     throw new Error(
-      `Child state '${result}' does not exist on '${stateNode.id}'`
+      `Child state '${stateKey}' does not exist on '${stateNode.id}'`
     );
   }
   return result;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -236,8 +236,8 @@ export function getCandidates<TEvent extends EventObject>(
         // split the event descriptor from unescaped periods
         // e.g. 'foo.bar' is ['foo','bar']
         // e.g. 'foo\.bar' is ['foo\.bar']
-        const partialEventTokens = eventDescriptor.split(/(?<!\\)\./g);
-        const eventTokens = receivedEventType.split(/(?<!\\)\./g);
+        const partialEventTokens = eventDescriptor.split('.');
+        const eventTokens = receivedEventType.split('.');
 
         for (
           let tokenIndex = 0;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -233,9 +233,6 @@ export function getCandidates<TEvent extends EventObject>(
           );
         }
 
-        // split the event descriptor from unescaped periods
-        // e.g. 'foo.bar' is ['foo','bar']
-        // e.g. 'foo\.bar' is ['foo\.bar']
         const partialEventTokens = eventDescriptor.split('.');
         const eventTokens = receivedEventType.split('.');
 

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -581,10 +581,12 @@ export function getStateNode(
       `Unable to retrieve child state '${stateKey}' from '${stateNode.id}'; no child states exist.`
     );
   }
-  const result = stateNode.states[stateKey];
+  // replace escaped period ('\.') with just a period
+  const resolvedStateKey = stateKey.replace(/\\\./g, '.');
+  const result = stateNode.states[resolvedStateKey];
   if (!result) {
     throw new Error(
-      `Child state '${stateKey}' does not exist on '${stateNode.id}'`
+      `Child state '${resolvedStateKey}' does not exist on '${stateNode.id}'`
     );
   }
   return result;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -216,25 +216,28 @@ export function getCandidates<TEvent extends EventObject>(
   const candidates =
     stateNode.transitions.get(receivedEventType) ||
     [...stateNode.transitions.keys()]
-      .filter((descriptor) => {
+      .filter((eventDescriptor) => {
         // check if transition is a wildcard transition,
         // which matches any non-transient events
-        if (descriptor === WILDCARD) {
+        if (eventDescriptor === WILDCARD) {
           return true;
         }
 
-        if (!descriptor.endsWith('.*')) {
+        if (!eventDescriptor.endsWith('.*')) {
           return false;
         }
 
-        if (isDevelopment && /.*\*.+/.test(descriptor)) {
+        if (isDevelopment && /.*\*.+/.test(eventDescriptor)) {
           console.warn(
-            `Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "${descriptor}" event.`
+            `Wildcards can only be the last token of an event descriptor (e.g., "event.*") or the entire event descriptor ("*"). Check the "${eventDescriptor}" event.`
           );
         }
 
-        const partialEventTokens = descriptor.split('.');
-        const eventTokens = receivedEventType.split('.');
+        // split the event descriptor from unescaped periods
+        // e.g. 'foo.bar' is ['foo','bar']
+        // e.g. 'foo\.bar' is ['foo\.bar']
+        const partialEventTokens = eventDescriptor.split(/(?<!\\)\./g);
+        const eventTokens = receivedEventType.split(/(?<!\\)\./g);
 
         for (
           let tokenIndex = 0;
@@ -249,7 +252,7 @@ export function getCandidates<TEvent extends EventObject>(
 
             if (isDevelopment && !isLastToken) {
               console.warn(
-                `Infix wildcards in transition events are not allowed. Check the "${descriptor}" transition.`
+                `Infix wildcards in transition events are not allowed. Check the "${eventDescriptor}" transition.`
               );
             }
 

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -584,7 +584,7 @@ export function getStateNode(
   const result = stateNode.states[stateKey];
   if (!result) {
     throw new Error(
-      `Child state '${resolvedStateKey}' does not exist on '${stateNode.id}'`
+      `Child state '${result}' does not exist on '${stateNode.id}'`
     );
   }
   return result;

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -56,6 +56,8 @@ export function toStatePath(stateId: string | string[]): string[] {
     return stateId;
   }
 
+  // Split on periods, but not if they are escaped
+  // i.e. match a period only if it is not preceded by a backslash.
   return stateId.split(/(?<!\\)\./g);
 }
 

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -56,9 +56,31 @@ export function toStatePath(stateId: string | string[]): string[] {
     return stateId;
   }
 
-  // Split on periods, but not if they are escaped
-  // i.e. match a period only if it is not preceded by a backslash.
-  return stateId.split(/(?<!\\)\./g);
+  let result: string[] = [];
+  let segment = '';
+
+  for (let i = 0; i < stateId.length; i++) {
+    const char = stateId.charCodeAt(i);
+    switch (char) {
+      // \
+      case 92:
+        // consume the next character
+        segment += stateId[i + 1];
+        // and skip over it
+        i++;
+        continue;
+      // .
+      case 46:
+        result.push(segment);
+        segment = '';
+        continue;
+    }
+    segment += stateId[i];
+  }
+
+  result.push(segment);
+
+  return result;
 }
 
 export function toStateValue(

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -1,7 +1,7 @@
 import isDevelopment from '#is-development';
 import { isMachineSnapshot } from './State.ts';
 import type { StateNode } from './StateNode.ts';
-import { STATE_DELIMITER, TARGETLESS_KEY } from './constants.ts';
+import { TARGETLESS_KEY } from './constants.ts';
 import type {
   ActorLogic,
   AnyActorRef,
@@ -56,7 +56,7 @@ export function toStatePath(stateId: string | string[]): string[] {
     return stateId;
   }
 
-  return stateId.split(STATE_DELIMITER);
+  return stateId.split(/(?<!\\)\./g);
 }
 
 export function toStateValue(

--- a/packages/core/test/id.test.ts
+++ b/packages/core/test/id.test.ts
@@ -110,7 +110,7 @@ describe('State node IDs', () => {
     });
   });
 
-  it('should work with IDs that have escaped periods', () => {
+  it('should work with keys that have escaped periods', () => {
     const machine = createMachine({
       initial: 'start',
       states: {
@@ -120,7 +120,7 @@ describe('State node IDs', () => {
             unescaped: 'foo.bar'
           }
         },
-        'foo\\.bar': {},
+        'foo.bar': {},
         foo: {
           initial: 'bar',
           states: {
@@ -135,7 +135,43 @@ describe('State node IDs', () => {
       type: 'escaped'
     });
 
-    expect(escapedState.value).toEqual('foo\\.bar');
+    expect(escapedState.value).toEqual('foo.bar');
+
+    const unescapedState = getNextSnapshot(machine, initialState, {
+      type: 'unescaped'
+    });
+    expect(unescapedState.value).toEqual({ foo: 'bar' });
+  });
+
+  it('should work with IDs that have escaped periods', () => {
+    const machine = createMachine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            escaped: '#foo\\.bar',
+            unescaped: '#foo.bar'
+          }
+        },
+        stateWithDot: {
+          id: 'foo.bar'
+        },
+        foo: {
+          id: 'foo',
+          initial: 'bar',
+          states: {
+            bar: {}
+          }
+        }
+      }
+    });
+
+    const initialState = getInitialSnapshot(machine);
+    const escapedState = getNextSnapshot(machine, initialState, {
+      type: 'escaped'
+    });
+
+    expect(escapedState.value).toEqual('stateWithDot');
 
     const unescapedState = getNextSnapshot(machine, initialState, {
       type: 'unescaped'

--- a/packages/core/test/id.test.ts
+++ b/packages/core/test/id.test.ts
@@ -207,6 +207,6 @@ describe('State node IDs', () => {
       type: 'EV'
     });
 
-    expect(escapedState.value).toEqual({ baz: 'thing' });
+    expect(escapedState.value).toEqual({ bar: 'thing' });
   });
 });

--- a/packages/core/test/id.test.ts
+++ b/packages/core/test/id.test.ts
@@ -178,4 +178,35 @@ describe('State node IDs', () => {
     });
     expect(unescapedState.value).toEqual({ foo: 'bar' });
   });
+
+  it("should not treat escaped backslash as period's escape", () => {
+    const machine = createMachine({
+      initial: 'start',
+      states: {
+        start: {
+          on: {
+            EV: '#some\\\\.thing'
+          }
+        },
+        foo: {
+          id: 'some\\.thing'
+        },
+        bar: {
+          id: 'some\\',
+          initial: 'baz',
+          states: {
+            baz: {},
+            thing: {}
+          }
+        }
+      }
+    });
+
+    const initialState = getInitialSnapshot(machine);
+    const escapedState = getNextSnapshot(machine, initialState, {
+      type: 'EV'
+    });
+
+    expect(escapedState.value).toEqual({ baz: 'thing' });
+  });
 });


### PR DESCRIPTION
State IDs that have periods in them are now supported if those periods are escaped.

The motivation is that external tools, such as [Stately Studio](https://stately.ai/studio), may allow users to enter any text into the state ID field. This change allows those tools to escape periods in state IDs, so that they don't conflict with the internal path-based state IDs.

E.g. if a state ID of `"Loading..."` is entered into the state ID field, instead of crashing either the external tool and/or the XState state machine, it should be converted by the tool to `"Loading\\.\\.\\."`, and those periods will be ignored by XState.

---

Quick demo of the problem in Stately Studio:

https://github.com/statelyai/xstate/assets/1093738/3da093ac-fdb0-4534-a12b-1534b86b6112

The solution would be to escape the periods, but for that to be fully compatible with XState, we need to handle use-cases like that on the XState side too.
