### PR TITLE
Use node 18 on CodeSandbox CI

### DIFF
--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -6,5 +6,5 @@
     "packages/xstate-test"
   ],
   "sandboxes": ["xstate-example-template-m4ckv", "xstate-react-template-3t2tg"],
-  "node": "16"
+  "node": "20"
 }

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -6,5 +6,5 @@
     "packages/xstate-test"
   ],
   "sandboxes": ["xstate-example-template-m4ckv", "xstate-react-template-3t2tg"],
-  "node": "20"
+  "node": "18"
 }


### PR DESCRIPTION
Node 16 is EOL: https://nodejs.org/en/blog/announcements/nodejs16-eol

Bump codesandbox CI to NodeJS v20.

Follow up of: https://github.com/statelyai/xstate/pull/4579

Blocking: https://github.com/statelyai/xstate/pull/3637

https://ci.codesandbox.io/status/statelyai/xstate/pr/3637/builds/455896
```shell
error lint-staged@15.2.0: The engine "node" is incompatible with this module. Expected version ">=18.12.0". Got "16.18.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process rejected with status code 1
    at ChildProcess.<anonymous> (/app/dist/utils/exec.js:20:27)
    at ChildProcess.emit (node:events:517:28)
    at ChildProcess._handle.onexit (node:internal/child_process:292:12) {
  code: 1
}
```

c: @davidkpiano
