### PR TITLE
Merge `createActorContext` options with Provider options

### DIFF
--- a/.changeset/honest-spoons-drum.md
+++ b/.changeset/honest-spoons-drum.md
@@ -1,0 +1,18 @@
+---
+'@xstate/react': patch
+---
+
+Options in `createActorContext` are now properly merged with provider options. Previously, provider options replaced the actor options.
+
+```tsx
+const { inspect } = createBrowserInspector();
+
+const SomeContext = createActorContext(someMachine, { inspect });
+
+// ...
+// Options are now merged:
+// { inspect: inspect, input: 10 }
+<SomeContext.Provider options={{ input: 10 }}>
+  {/* ... */}
+</SomeContext.Provider>;
+```

--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -5,7 +5,7 @@ import { useSelector as useSelectorUnbound } from './useSelector';
 
 export function createActorContext<TLogic extends AnyActorLogic>(
   actorLogic: TLogic,
-  interpreterOptions?: ActorOptions<TLogic>
+  actorOptions?: ActorOptions<TLogic>
 ): {
   useSelector: <T>(
     selector: (snapshot: SnapshotFrom<TLogic>) => T,
@@ -30,7 +30,7 @@ export function createActorContext<TLogic extends AnyActorLogic>(
     children,
     logic: providedLogic = actorLogic,
     machine,
-    options: providedOptions = interpreterOptions
+    options: providedOptions = actorOptions
   }: {
     children: React.ReactNode;
     logic: TLogic;
@@ -46,7 +46,10 @@ export function createActorContext<TLogic extends AnyActorLogic>(
       );
     }
 
-    const actor = useActorRef(providedLogic, providedOptions);
+    const actor = useActorRef(providedLogic, {
+      ...actorOptions,
+      ...providedOptions
+    });
 
     return React.createElement(OriginalProvider, {
       value: actor,

--- a/packages/xstate-react/src/createActorContext.ts
+++ b/packages/xstate-react/src/createActorContext.ts
@@ -30,7 +30,7 @@ export function createActorContext<TLogic extends AnyActorLogic>(
     children,
     logic: providedLogic = actorLogic,
     machine,
-    options: providedOptions = actorOptions
+    options: providedOptions
   }: {
     children: React.ReactNode;
     logic: TLogic;

--- a/packages/xstate-react/test/createActorContext.test.tsx
+++ b/packages/xstate-react/test/createActorContext.test.tsx
@@ -1,4 +1,10 @@
-import { createMachine, assign, fromPromise, Snapshot } from 'xstate';
+import {
+  createMachine,
+  assign,
+  fromPromise,
+  Snapshot,
+  InspectionEvent
+} from 'xstate';
 import { fireEvent, screen, render, waitFor } from '@testing-library/react';
 import { useSelector, createActorContext, shallowEqual } from '../src';
 
@@ -472,7 +478,7 @@ describe('createActorContext', () => {
   });
 
   it('should merge createActorContext options with options passed to the provider', () => {
-    const events = [];
+    const events: InspectionEvent[] = [];
     const SomeContext = createActorContext(
       createMachine({
         types: {
@@ -505,5 +511,12 @@ describe('createActorContext', () => {
     render(<App />);
 
     expect(events.length).toBeGreaterThan(0);
+    expect(events).toContain(
+      expect.objectContaining({
+        snapshot: expect.objectContaining({
+          context: { count: 10 }
+        })
+      })
+    );
   });
 });

--- a/packages/xstate-react/test/createActorContext.test.tsx
+++ b/packages/xstate-react/test/createActorContext.test.tsx
@@ -470,4 +470,40 @@ describe('createActorContext', () => {
 
     expect(screen.getByTestId('value').textContent).toBe('84');
   });
+
+  it('should merge createActorContext options with options passed to the provider', () => {
+    const events = [];
+    const SomeContext = createActorContext(
+      createMachine({
+        types: {
+          context: {} as { count: number },
+          input: {} as number
+        },
+        context: ({ input }) => ({ count: input })
+      }),
+      {
+        inspect: (ev) => {
+          events.push(ev);
+        }
+      }
+    );
+
+    const Component = () => {
+      const count = SomeContext.useSelector((state) => state.context.count);
+
+      return <div data-testid="value">{count}</div>;
+    };
+
+    const App = () => {
+      return (
+        <SomeContext.Provider options={{ input: 10 }}>
+          <Component />
+        </SomeContext.Provider>
+      );
+    };
+
+    render(<App />);
+
+    expect(events.length).toBeGreaterThan(0);
+  });
 });

--- a/packages/xstate-react/test/createActorContext.test.tsx
+++ b/packages/xstate-react/test/createActorContext.test.tsx
@@ -511,7 +511,7 @@ describe('createActorContext', () => {
     render(<App />);
 
     expect(events.length).toBeGreaterThan(0);
-    expect(events).toContain(
+    expect(events).toContainEqual(
       expect.objectContaining({
         snapshot: expect.objectContaining({
           context: { count: 10 }


### PR DESCRIPTION
Options in `createActorContext` are now properly merged with provider options. Previously, provider options replaced the actor options.

```tsx
const { inspect } = createBrowserInspector();

const SomeContext = createActorContext(someMachine, { inspect });

// ...
// Options are now merged:
// { inspect: inspect, input: 10 }
<SomeContext.Provider options={{ input: 10 }}>
  {/* ... */}
</SomeContext.Provider>;
```