### PR TITLE
[chore] refactored `guards` internals to standardize built-in guard definitions and clarify logic flow

### DIFF
--- a/.changeset/friendly-goats-jam.md
+++ b/.changeset/friendly-goats-jam.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+refactored `guards` internals to standardize built-in guard definitions and clarify logic flow

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -36,6 +36,21 @@ type NormalizeGuardArgArray<TArg extends unknown[]> = Elements<{
   [K in keyof TArg]: NormalizeGuardArg<TArg[K]>;
 }>;
 
+type LogicGuards<
+  TContext extends MachineContext,
+  TExpressionEvent extends EventObject,
+  TArg extends unknown[]
+> = readonly [
+  ...{
+    [K in keyof TArg]: SingleGuardArg<
+      TContext,
+      TExpressionEvent,
+      unknown,
+      TArg[K]
+    >;
+  }
+];
+
 export type GuardPredicate<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,
@@ -258,16 +273,7 @@ export function and<
   TExpressionEvent extends EventObject,
   TArg extends unknown[]
 >(
-  guards: readonly [
-    ...{
-      [K in keyof TArg]: SingleGuardArg<
-        TContext,
-        TExpressionEvent,
-        unknown,
-        TArg[K]
-      >;
-    }
-  ]
+  guards: LogicGuards<TContext, TExpressionEvent, TArg>
 ): GuardPredicate<
   TContext,
   TExpressionEvent,
@@ -330,16 +336,7 @@ export function or<
   TExpressionEvent extends EventObject,
   TArg extends unknown[]
 >(
-  guards: readonly [
-    ...{
-      [K in keyof TArg]: SingleGuardArg<
-        TContext,
-        TExpressionEvent,
-        unknown,
-        TArg[K]
-      >;
-    }
-  ]
+  guards: LogicGuards<TContext, TExpressionEvent, TArg>
 ): GuardPredicate<
   TContext,
   TExpressionEvent,

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -162,7 +162,7 @@ function checkNot(
     }
   });
   ```
- * @returns A guard 
+ * @returns A guard
  */
 export function not<
   TContext extends MachineContext,
@@ -358,7 +358,7 @@ export function evaluateGuard<
     throw new Error(
       `Guard '${
         typeof guard === 'string' ? guard : guard.type
-      }' is not implemented.'.`
+      }' is not implemented.`
     );
   }
 

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -102,6 +102,30 @@ function checkStateIn(
   return snapshot.matches(stateValue);
 }
 
+/**
+* Guard that evaluates to `true` when the `stateValue` passed to it matches the current machine state.
+*
+* @category Guards
+* @example
+  ```ts
+  import { setup, stateIn } from 'xstate';
+
+  const machine = setup({}).createMachine({
+    on: {
+      someEvent: {
+        guard: stateIn('someState'),
+        actions: () => {
+          // will be executed if machine is in `someState`
+        }
+      }
+    },
+    states: {
+      someState: {}
+    }
+  });
+  ```
+* @returns A guard
+*/
 export function stateIn<
   TContext extends MachineContext,
   TExpressionEvent extends EventObject,

--- a/packages/core/test/guards.test.ts
+++ b/packages/core/test/guards.test.ts
@@ -253,7 +253,7 @@ describe('guard conditions', () => {
       [
         [
           [Error: Unable to evaluate guard 'doesNotExist' in transition for event 'BAD_COND' in state node '(machine).foo':
-      Guard 'doesNotExist' is not implemented.'.],
+      Guard 'doesNotExist' is not implemented.],
         ],
       ]
     `);
@@ -888,7 +888,7 @@ describe('referencing guards', () => {
       [
         [
           [Error: Unable to evaluate guard 'missing-predicate' in transition for event 'EVENT' in state node 'invalid-predicate.active':
-      Guard 'missing-predicate' is not implemented.'.],
+      Guard 'missing-predicate' is not implemented.],
         ],
       ]
     `);


### PR DESCRIPTION
- [fixed typo in error message](https://github.com/statelyai/xstate/pull/4717/commits/4262d1126df873d59c978f8f7ae475e2495cb527)
- [added documentation for `stateIn`](https://github.com/statelyai/xstate/pull/4717/commits/f3f3f2fdf39f86c8b62cc1b9348ca55c0e677029)
- [refactored `evaluateGuard` to clarify logic flow](https://github.com/statelyai/xstate/pull/4717/commits/857463b3316c60012e82d6d519816e343325a377)
- [consolidated repeated definitions into `LogicGuards` type](https://github.com/statelyai/xstate/pull/4717/commits/86300daa985171737fabc3d7c47696c9f6a8d505)
- [implemented abstractions to standardize built-in guard definitions](https://github.com/statelyai/xstate/pull/4717/commits/eabe830604b4e7e3cc616a8532a082fff34e6cb9)
- [added changeset](https://github.com/statelyai/xstate/pull/4717/commits/d7ca549b92f84c3f3c5b69fcd7f70200ec2e2e60)