### PR TITLE
#4734 bugfix: removed `this` from snapshot methods

### DIFF
--- a/.changeset/fifty-beds-love.md
+++ b/.changeset/fifty-beds-love.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Removed `this` from actor snapshot methods to resolve [#4734](https://github.com/statelyai/xstate/issues/4734)
+Removed `this` from machine snapshot methods to fix issues with accessing those methods from union of actors and their snapshots.

--- a/.changeset/fifty-beds-love.md
+++ b/.changeset/fifty-beds-love.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Removed `this` from actor snapshot methods to resolve [#4734](https://github.com/statelyai/xstate/issues/4734)

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -114,33 +114,13 @@ interface MachineSnapshotBase<
    * Whether the current state value is a subset of the given partial state value.
    * @param partialStateValue
    */
-  matches: (
-    this: MachineSnapshot<
-      TContext,
-      TEvent,
-      TChildren,
-      TStateValue,
-      TTag,
-      TOutput
-    >,
-    partialStateValue: ToTestStateValue<TStateValue>
-  ) => boolean;
+  matches: (partialStateValue: ToTestStateValue<TStateValue>) => boolean;
 
   /**
    * Whether the current state nodes has a state node with the specified `tag`.
    * @param tag
    */
-  hasTag: (
-    this: MachineSnapshot<
-      TContext,
-      TEvent,
-      TChildren,
-      TStateValue,
-      TTag,
-      TOutput
-    >,
-    tag: TTag
-  ) => boolean;
+  hasTag: (tag: TTag) => boolean;
 
   /**
    * Determines whether sending the `event` will cause a non-forbidden transition
@@ -150,39 +130,11 @@ interface MachineSnapshotBase<
    * @param event The event to test
    * @returns Whether the event will cause a transition
    */
-  can: (
-    this: MachineSnapshot<
-      TContext,
-      TEvent,
-      TChildren,
-      TStateValue,
-      TTag,
-      TOutput
-    >,
-    event: TEvent
-  ) => boolean;
+  can: (event: TEvent) => boolean;
 
-  getMeta: (
-    this: MachineSnapshot<
-      TContext,
-      TEvent,
-      TChildren,
-      TStateValue,
-      TTag,
-      TOutput
-    >
-  ) => Record<string, any>;
+  getMeta: () => Record<string, any>;
 
-  toJSON: (
-    this: MachineSnapshot<
-      TContext,
-      TEvent,
-      TChildren,
-      TStateValue,
-      TTag,
-      TOutput
-    >
-  ) => unknown;
+  toJSON: () => unknown;
 }
 
 interface ActiveMachineSnapshot<

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -4392,21 +4392,21 @@ describe('snapshot methods', () => {
     const snapshot = ref.getSnapshot();
 
     snapshot.can({ type: 'one' });
-    // @ts-expect-error should error both snapshots don't match
+    // @ts-expect-error
     snapshot.can({ type: 'two' });
-    // @ts-expect-error should error if no snapshot matches
+    // @ts-expect-error
     snapshot.can({ type: 'three' });
 
     snapshot.hasTag('one');
-    // @ts-expect-error should error both snapshots don't match
+    // @ts-expect-error
     snapshot.hasTag('two');
-    // @ts-expect-error should error if no snapshot matches
+    // @ts-expect-error
     snapshot.hasTag('three');
 
     snapshot.matches('one');
-    // @ts-expect-error should error both snapshots don't match
+    // @ts-expect-error
     snapshot.matches('two');
-    // @ts-expect-error should error if no snapshot matches
+    // @ts-expect-error
     snapshot.matches('three');
 
     snapshot.getMeta();

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -4392,15 +4392,24 @@ describe('snapshot methods', () => {
     const snapshot = ref.getSnapshot();
 
     snapshot.can({ type: 'one' });
-    // @ts-expect-error
+    // @ts-expect-error should error both snapshots don't match
+    snapshot.can({ type: 'two' });
+    // @ts-expect-error should error if no snapshot matches
     snapshot.can({ type: 'three' });
+
     snapshot.hasTag('one');
-    // @ts-expect-error
+    // @ts-expect-error should error both snapshots don't match
+    snapshot.hasTag('two');
+    // @ts-expect-error should error if no snapshot matches
     snapshot.hasTag('three');
+
+    snapshot.matches('one');
+    // @ts-expect-error should error both snapshots don't match
+    snapshot.matches('two');
+    // @ts-expect-error should error if no snapshot matches
+    snapshot.matches('three');
+
     snapshot.getMeta();
     snapshot.toJSON();
-    snapshot.matches('one');
-    // @ts-expect-error
-    snapshot.matches('three');
   });
 });

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -4339,6 +4339,24 @@ describe('self', () => {
       })
     });
   });
+
+  it('should allow actor union snap snapshot methods to be called', () => {
+    const typeOne = createMachine({
+      types: {} as { events: { type: 'one' } }
+    });
+    type TypeOneRef = ActorRefFrom<typeof typeOne>;
+
+    const typeTwo = createMachine({
+      types: {} as { events: { type: 'one' } | { type: 'two' } }
+    });
+    type TypeTwoRef = ActorRefFrom<typeof typeTwo>;
+
+    const canMethod = (ref: TypeOneRef | TypeTwoRef) => {
+      ref.getSnapshot().can({ type: 'one' });
+    };
+
+    canMethod(createActor(typeOne));
+  });
 });
 
 describe('createActor', () => {


### PR DESCRIPTION
Resolves https://github.com/statelyai/xstate/issues/4734. I tested locally using the same scenario as used in the issue and the types behaved as expected. I couldn't really figure out a way to programmatically prove work and test the types directly. Please advise if there is something you'd like to see there.