### PR TITLE
Fixed a type issue that prevent `sendParent` to be accepted by `setup` when `delays` stayed not configured

### DIFF
--- a/.changeset/healthy-camels-report.md
+++ b/.changeset/healthy-camels-report.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed a type issue that prevent `sendParent` to be accepted by `setup` when `delays` stayed not configured.

--- a/packages/core/src/actions/enqueueActions.ts
+++ b/packages/core/src/actions/enqueueActions.ts
@@ -120,12 +120,12 @@ function resolveEnqueueActions(
     actions.push(cancel(...args));
   };
   enqueue.raise = (...args) => {
-    // for some reason it fails to infer `TDelay` from `...args` here and infers `picks` its default (`never`)
+    // for some reason it fails to infer `TDelay` from `...args` here and picks its default (`never`)
     // then it fails to typecheck that because `...args` use `string` in place of `TDelay`
     actions.push((raise as typeof enqueue.raise)(...args));
   };
   enqueue.sendTo = (...args) => {
-    // for some reason it fails to infer `TDelay` from `...args` here and infers `picks` its default (`never`)
+    // for some reason it fails to infer `TDelay` from `...args` here and picks its default (`never`)
     // then it fails to typecheck that because `...args` use `string` in place of `TDelay
     actions.push((sendTo as typeof enqueue.sendTo)(...args));
   };

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -266,7 +266,8 @@ export function sendParent<
   TParams extends ParameterizedObject['params'] | undefined,
   TSentEvent extends EventObject = AnyEventObject,
   TEvent extends EventObject = AnyEventObject,
-  TDelay extends string = string
+  TDelay extends string = never,
+  TUsedDelay extends TDelay = never
 >(
   event:
     | TSentEvent
@@ -276,7 +277,7 @@ export function sendParent<
     TExpressionEvent,
     TParams,
     TEvent,
-    TDelay
+    TUsedDelay
   >
 ) {
   return sendTo<
@@ -285,7 +286,8 @@ export function sendParent<
     TParams,
     AnyActorRef,
     TEvent,
-    TDelay
+    TDelay,
+    TUsedDelay
   >(SpecialTargets.Parent, event, options as any);
 }
 
@@ -313,7 +315,8 @@ export function forwardTo<
   TExpressionEvent extends EventObject,
   TParams extends ParameterizedObject['params'] | undefined,
   TEvent extends EventObject,
-  TDelay extends string
+  TDelay extends string = never,
+  TUsedDelay extends TDelay = never
 >(
   target: Target<TContext, TExpressionEvent, TParams, TEvent>,
   options?: SendToActionOptions<
@@ -321,7 +324,7 @@ export function forwardTo<
     TExpressionEvent,
     TParams,
     TEvent,
-    TDelay
+    TUsedDelay
   >
 ) {
   if (isDevelopment && (!target || typeof target === 'function')) {
@@ -346,6 +349,6 @@ export function forwardTo<
     AnyActorRef,
     TEvent,
     TDelay,
-    TDelay
+    TUsedDelay
   >(target, ({ event }: any) => event, options);
 }

--- a/packages/core/test/setup.types.test.ts
+++ b/packages/core/test/setup.types.test.ts
@@ -11,6 +11,7 @@ import {
   log,
   not,
   raise,
+  sendParent,
   sendTo,
   setup,
   spawnChild,
@@ -770,6 +771,25 @@ describe('setup()', () => {
       },
       actions: {
         sendFoo: sendTo(({ self }) => self, {
+          type: 'FOO'
+        })
+      }
+    });
+  });
+
+  it('should accept a `sendParent` action when delays are not configured', () => {
+    setup({
+      types: {} as {
+        events:
+          | {
+              type: 'FOO';
+            }
+          | {
+              type: 'BAR';
+            };
+      },
+      actions: {
+        sendFoo: sendParent({
           type: 'FOO'
         })
       }


### PR DESCRIPTION
fixes https://github.com/statelyai/xstate/discussions/4770 (a regression of sorts from https://github.com/statelyai/xstate/pull/4750 )