### PR TITLE
TypeScript 5.4

### DIFF
--- a/.changeset/tall-actors-call.md
+++ b/.changeset/tall-actors-call.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Upgrade to TypeScript 5.4

--- a/.changeset/tall-actors-call.md
+++ b/.changeset/tall-actors-call.md
@@ -1,5 +1,0 @@
----
-'xstate': patch
----
-
-Upgrade to TypeScript 5.4

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "synckit": "^0.8.5",
     "tslib": "^2.3.1",
     "tslint": "^5.11.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.4.2",
     "vue": "^3.0.11",
     "webpack-dev-middleware": "^3.6.0"
   },

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -38,14 +38,12 @@ import type {
   MachineConfig,
   MachineContext,
   MachineImplementationsSimplified,
-  NoInfer,
   ParameterizedObject,
   ProvidedActor,
   Snapshot,
   SnapshotFrom,
   StateMachineDefinition,
   StateValue,
-  TODO,
   TransitionDefinition
 } from './types.ts';
 import { resolveReferencedActor, toStatePath } from './utils.ts';

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -30,6 +30,7 @@ import type {
   AnyActorRef,
   AnyActorScope,
   AnyEventObject,
+  DoNotInfer,
   Equals,
   EventDescriptor,
   EventObject,
@@ -66,7 +67,7 @@ export class StateMachine<
   TEmitted extends EventObject = EventObject, // TODO: remove default
   TResolvedTypesMeta = ResolveTypegenMeta<
     TypegenDisabled,
-    NoInfer<TEvent>,
+    DoNotInfer<TEvent>,
     TActor,
     TAction,
     TGuard,

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -8,7 +8,6 @@ import {
   DelayExpr,
   EventObject,
   MachineContext,
-  NoInfer,
   ParameterizedObject,
   RaiseActionOptions,
   SendExpr

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -6,6 +6,7 @@ import {
   AnyEventObject,
   AnyMachineSnapshot,
   DelayExpr,
+  DoNotInfer,
   EventObject,
   MachineContext,
   ParameterizedObject,
@@ -120,13 +121,13 @@ export function raise<
   TUsedDelay extends TDelay = never
 >(
   eventOrExpr:
-    | NoInfer<TEvent>
-    | SendExpr<TContext, TExpressionEvent, TParams, NoInfer<TEvent>, TEvent>,
+    | DoNotInfer<TEvent>
+    | SendExpr<TContext, TExpressionEvent, TParams, DoNotInfer<TEvent>, TEvent>,
   options?: RaiseActionOptions<
     TContext,
     TExpressionEvent,
     TParams,
-    NoInfer<TEvent>,
+    DoNotInfer<TEvent>,
     TUsedDelay
   >
 ): ActionFunction<

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -10,6 +10,7 @@ import {
   AnyMachineSnapshot,
   Cast,
   DelayExpr,
+  DoNotInfer,
   EventFrom,
   EventObject,
   InferEvent,
@@ -217,7 +218,7 @@ export function sendTo<
     TContext,
     TExpressionEvent,
     TParams,
-    NoInfer<TEvent>,
+    DoNotInfer<TEvent>,
     TUsedDelay
   >
 ): ActionFunction<

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -4,7 +4,6 @@ import { createErrorActorEvent } from '../eventUtils.ts';
 import {
   ActionArgs,
   ActionFunction,
-  ActorRef,
   AnyActorRef,
   AnyActorScope,
   AnyEventObject,
@@ -15,7 +14,6 @@ import {
   EventObject,
   InferEvent,
   MachineContext,
-  NoInfer,
   ParameterizedObject,
   SendExpr,
   SendToActionOptions,

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -6,7 +6,6 @@ import type {
   ParameterizedObject,
   AnyMachineSnapshot,
   NoRequiredParams,
-  NoInfer,
   WithDynamicParams,
   Identity,
   Elements

--- a/packages/core/src/guards.ts
+++ b/packages/core/src/guards.ts
@@ -8,7 +8,8 @@ import type {
   NoRequiredParams,
   WithDynamicParams,
   Identity,
-  Elements
+  Elements,
+  DoNotInfer
 } from './types.ts';
 import { isStateId } from './stateUtils.ts';
 
@@ -173,7 +174,7 @@ export function not<
   TContext,
   TExpressionEvent,
   unknown,
-  NormalizeGuardArg<NoInfer<TArg>>
+  NormalizeGuardArg<DoNotInfer<TArg>>
 > {
   function not(args: GuardArgs<TContext, TExpressionEvent>, params: unknown) {
     if (isDevelopment) {
@@ -247,7 +248,7 @@ export function and<
   TContext,
   TExpressionEvent,
   unknown,
-  NormalizeGuardArgArray<NoInfer<TArg>>
+  NormalizeGuardArgArray<DoNotInfer<TArg>>
 > {
   function and(args: GuardArgs<TContext, TExpressionEvent>, params: unknown) {
     if (isDevelopment) {
@@ -319,7 +320,7 @@ export function or<
   TContext,
   TExpressionEvent,
   unknown,
-  NormalizeGuardArgArray<NoInfer<TArg>>
+  NormalizeGuardArgArray<DoNotInfer<TArg>>
 > {
   function or(args: GuardArgs<TContext, TExpressionEvent>, params: unknown) {
     if (isDevelopment) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -71,7 +71,9 @@ export type Equals<A1 extends any, A2 extends any> = (<A>() => A extends A2
   : false;
 export type IsAny<T> = Equals<T, any>;
 export type Cast<A, B> = A extends B ? A : B;
-export type NoInfer<T> = [T][T extends any ? 0 : any];
+// @TODO: Replace with native `NoInfer` when TS issue gets fixed:
+// https://github.com/microsoft/TypeScript/pull/57673
+export type DoNotInfer<T> = [T][T extends any ? 0 : any];
 export type LowInfer<T> = T & {};
 
 export type MetaObject = Record<string, any>;
@@ -1380,15 +1382,15 @@ export type MachineConfig<
   TTypesMeta = TypegenDisabled
 > = (Omit<
   StateNodeConfig<
-    NoInfer<TContext>,
-    NoInfer<TEvent>,
-    NoInfer<TActor>,
-    NoInfer<TAction>,
-    NoInfer<TGuard>,
-    NoInfer<TDelay>,
-    NoInfer<TTag>,
-    NoInfer<TOutput>,
-    NoInfer<TEmitted>
+    DoNotInfer<TContext>,
+    DoNotInfer<TEvent>,
+    DoNotInfer<TActor>,
+    DoNotInfer<TAction>,
+    DoNotInfer<TGuard>,
+    DoNotInfer<TDelay>,
+    DoNotInfer<TTag>,
+    DoNotInfer<TOutput>,
+    DoNotInfer<TEmitted>
   >,
   'output'
 > & {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -74,6 +74,10 @@ export type Cast<A, B> = A extends B ? A : B;
 // @TODO: Replace with native `NoInfer` when TS issue gets fixed:
 // https://github.com/microsoft/TypeScript/pull/57673
 export type DoNotInfer<T> = [T][T extends any ? 0 : any];
+/**
+ * @deprecated Use the built-in `NoInfer` type instead
+ */
+export type NoInfer<T> = DoNotInfer<T>;
 export type LowInfer<T> = T & {};
 
 export type MetaObject = Record<string, any>;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9198,10 +9198,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^5.0.3, typescript@^5.2.2:
+typescript@^5.0.3:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
   integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
+typescript@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.2.tgz#0ae9cebcfae970718474fe0da2c090cad6577372"
+  integrity sha512-+2/g0Fds1ERlP6JsakQQDXjZdZMM+rqpamFZJEKh4kwTIn3iDkgKtby0CeNd5ATNZ4Ry1ax15TMx0W2V+miizQ==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR updates the TypeScript version in the XState monorepo to 5.4, which includes replacing `NoInfer` with the native `NoInfer` (doesn't work yet)