### PR TITLE
Types Improvement: prevent deep _parent access (a TODO fix)

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1993,8 +1993,7 @@ export interface ActorRef<
   getPersistedSnapshot: () => Snapshot<unknown>;
   stop: () => void;
   toJSON?: () => any;
-  // TODO: figure out how to hide this externally as `sendTo(ctx => ctx.actorRef._parent._parent._parent._parent)` shouldn't be allowed
-  _parent?: AnyActorRef;
+  _parent?: Omit<AnyActorRef, '_parent'>;
   system: AnyActorSystem;
   /** @internal */
   _processingStatus: ProcessingStatus;


### PR DESCRIPTION
```ts
 self._parent._parent
```

![Screenshot 2024-03-15 at 14 52 00@2x](https://github.com/statelyai/xstate/assets/11693557/565ff234-6f6b-4fbe-8c01-9ef846ba05d7)

This is a suggestion, I didn't check all the side effects.
