### PR TITLE
[core] Ensure "stop" transitions are called in machine actors

### DIFF
--- a/.changeset/shaggy-kings-add.md
+++ b/.changeset/shaggy-kings-add.md
@@ -1,0 +1,23 @@
+---
+'xstate': patch
+---
+
+Ensure that "stop" transitions are called in machines:
+
+```ts
+const machine = createMachine({
+  on: {
+    'xstate.stop': {
+      actions: () => {
+        // do cleanup, etc...
+        console.log('Machine actor was just stopped');
+      }
+    }
+  }
+});
+
+const actor = createActor(machine).start();
+
+actor.stop();
+// Logs "Machine actor was just stopped"
+```

--- a/packages/core/test/actor.test.ts
+++ b/packages/core/test/actor.test.ts
@@ -31,6 +31,7 @@ import {
 } from '../src/index.ts';
 import { setup } from '../src/setup.ts';
 import { sleep } from '@xstate-repo/jest-utils';
+import { XSTATE_STOP } from '../src/constants.ts';
 
 describe('spawning machines', () => {
   const context = {
@@ -1009,6 +1010,23 @@ describe('actors', () => {
 
     expect(cleanup1).toBeCalledTimes(1);
     expect(cleanup2).toBeCalledTimes(1);
+  });
+
+  it('should receive an "xstate.stop" event when stopped', () => {
+    const spy = jest.fn();
+    const machine = createMachine({
+      on: {
+        [XSTATE_STOP]: {
+          actions: spy
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+
+    actor.stop();
+
+    expect(spy).toHaveBeenCalledTimes(1);
   });
 
   describe('with actor logic', () => {


### PR DESCRIPTION
This PR ensures that "stop" transitions are called in machines:

```ts
const machine = createMachine({
  on: {
    'xstate.stop': {
      actions: () => {
        // do cleanup, etc...
        console.log('Machine actor was just stopped');
      }
    }
  }
});

const actor = createActor(machine).start();

actor.stop();
// Logs "Machine actor was just stopped"
```
