### PR TITLE
[core] Add `meta` types

### DIFF
--- a/.changeset/metal-elephants-impress.md
+++ b/.changeset/metal-elephants-impress.md
@@ -1,0 +1,30 @@
+---
+'xstate': minor
+---
+
+Meta objects for state nodes and transitions can now be specified in `setup({ types: … })`:
+
+```ts
+const machine = setup({
+  types: {
+    meta: {} as {
+      layout: string;
+    }
+  }
+}).createMachine({
+  initial: 'home',
+  states: {
+    home: {
+      meta: {
+        layout: 'full'
+      }
+    }
+  }
+});
+
+const actor = createActor(machine).start();
+
+actor.getSnapshot().getMeta().home;
+// => { layout: 'full' }
+// if in "home" state
+```

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -39,6 +39,7 @@ import type {
   MachineConfig,
   MachineContext,
   MachineImplementationsSimplified,
+  MetaObject,
   ParameterizedObject,
   ProvidedActor,
   Snapshot,
@@ -65,6 +66,7 @@ export class StateMachine<
   TInput,
   TOutput,
   TEmitted extends EventObject = EventObject, // TODO: remove default
+  TMeta extends MetaObject = MetaObject,
   TResolvedTypesMeta = ResolveTypegenMeta<
     TypegenDisabled,
     DoNotInfer<TEvent>,
@@ -77,7 +79,15 @@ export class StateMachine<
   >
 > implements
     ActorLogic<
-      MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput>,
+      MachineSnapshot<
+        TContext,
+        TEvent,
+        TChildren,
+        TStateValue,
+        TTag,
+        TOutput,
+        TMeta
+      >,
       TEvent,
       TInput,
       AnyActorSystem,
@@ -120,7 +130,8 @@ export class StateMachine<
       any,
       any,
       TOutput,
-      any
+      any, // TEmitted
+      any // TMeta
     > & {
       schemas?: unknown;
     },
@@ -193,6 +204,7 @@ export class StateMachine<
     TInput,
     TOutput,
     TEmitted,
+    TMeta, // TMeta
     TResolvedTypesMeta
   > {
     const { actions, guards, actors, delays } = this.implementations;
@@ -216,7 +228,15 @@ export class StateMachine<
     } & (Equals<TContext, MachineContext> extends false
       ? { context: unknown }
       : {})
-  ): MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput> {
+  ): MachineSnapshot<
+    TContext,
+    TEvent,
+    TChildren,
+    TStateValue,
+    TTag,
+    TOutput,
+    TMeta
+  > {
     const resolvedStateValue = resolveStateValue(this.root, config.value);
     const nodeSet = getAllStateNodes(
       getStateNodes(this.root, resolvedStateValue)
@@ -241,7 +261,8 @@ export class StateMachine<
       TChildren,
       TStateValue,
       TTag,
-      TOutput
+      TOutput,
+      TMeta
     >;
   }
 
@@ -259,11 +280,20 @@ export class StateMachine<
       TChildren,
       TStateValue,
       TTag,
-      TOutput
+      TOutput,
+      TMeta
     >,
     event: TEvent,
     actorScope: ActorScope<typeof snapshot, TEvent, AnyActorSystem, TEmitted>
-  ): MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput> {
+  ): MachineSnapshot<
+    TContext,
+    TEvent,
+    TChildren,
+    TStateValue,
+    TTag,
+    TOutput,
+    TMeta
+  > {
     return macrostep(snapshot, event, actorScope).snapshot as typeof snapshot;
   }
 
@@ -281,12 +311,21 @@ export class StateMachine<
       TChildren,
       TStateValue,
       TTag,
-      TOutput
+      TOutput,
+      TMeta
     >,
     event: TEvent,
     actorScope: AnyActorScope
   ): Array<
-    MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput>
+    MachineSnapshot<
+      TContext,
+      TEvent,
+      TChildren,
+      TStateValue,
+      TTag,
+      TOutput,
+      TMeta
+    >
   > {
     return macrostep(snapshot, event, actorScope).microstates;
   }
@@ -298,7 +337,8 @@ export class StateMachine<
       TChildren,
       TStateValue,
       TTag,
-      TOutput
+      TOutput,
+      TMeta
     >,
     event: TEvent
   ): Array<TransitionDefinition<TContext, TEvent>> {
@@ -313,7 +353,15 @@ export class StateMachine<
     actorScope: AnyActorScope,
     initEvent: any,
     internalQueue: AnyEventObject[]
-  ): MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput> {
+  ): MachineSnapshot<
+    TContext,
+    TEvent,
+    TChildren,
+    TStateValue,
+    TTag,
+    TOutput,
+    TMeta
+  > {
     const { context } = this.config;
 
     const preInitial = createMachineSnapshot(
@@ -347,13 +395,29 @@ export class StateMachine<
    */
   public getInitialSnapshot(
     actorScope: ActorScope<
-      MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput>,
+      MachineSnapshot<
+        TContext,
+        TEvent,
+        TChildren,
+        TStateValue,
+        TTag,
+        TOutput,
+        TMeta
+      >,
       TEvent,
       AnyActorSystem,
       TEmitted
     >,
     input?: TInput
-  ): MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput> {
+  ): MachineSnapshot<
+    TContext,
+    TEvent,
+    TChildren,
+    TStateValue,
+    TTag,
+    TOutput,
+    TMeta
+  > {
     const initEvent = createInitEvent(input) as unknown as TEvent; // TODO: fix;
     const internalQueue: AnyEventObject[] = [];
     const preInitialState = this.getPreInitialState(
@@ -396,7 +460,8 @@ export class StateMachine<
       TChildren,
       TStateValue,
       TTag,
-      TOutput
+      TOutput,
+      TMeta
     >
   ): void {
     Object.values(snapshot.children as Record<string, AnyActorRef>).forEach(
@@ -439,7 +504,8 @@ export class StateMachine<
       TChildren,
       TStateValue,
       TTag,
-      TOutput
+      TOutput,
+      TMeta
     >,
     options?: unknown
   ) {
@@ -449,12 +515,28 @@ export class StateMachine<
   public restoreSnapshot(
     snapshot: Snapshot<unknown>,
     _actorScope: ActorScope<
-      MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput>,
+      MachineSnapshot<
+        TContext,
+        TEvent,
+        TChildren,
+        TStateValue,
+        TTag,
+        TOutput,
+        TMeta
+      >,
       TEvent,
       AnyActorSystem,
       TEmitted
     >
-  ): MachineSnapshot<TContext, TEvent, TChildren, TStateValue, TTag, TOutput> {
+  ): MachineSnapshot<
+    TContext,
+    TEvent,
+    TChildren,
+    TStateValue,
+    TTag,
+    TOutput,
+    TMeta
+  > {
     const children: Record<string, AnyActorRef> = {};
     const snapshotChildren: Record<
       string,
@@ -506,7 +588,8 @@ export class StateMachine<
       TChildren,
       TStateValue,
       TTag,
-      TOutput
+      TOutput,
+      TMeta
     >;
 
     let seen = new Set();

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -129,6 +129,7 @@ export class StateNode<
     any, // input
     any, // output
     any, // emitted
+    any, // TMeta
     any // typegen
   >;
   /**
@@ -166,7 +167,8 @@ export class StateNode<
       TODO, // delays
       TODO, // tags
       TODO, // output
-      TODO // emitted
+      TODO, // emitted
+      TODO // meta
     >,
     options: StateNodeOptions<TContext, TEvent>
   ) {
@@ -300,7 +302,9 @@ export class StateNode<
       ProvidedActor,
       ParameterizedObject,
       ParameterizedObject,
-      string
+      string,
+      TODO, // TEmitted
+      TODO // TMeta
     >
   > {
     return memo(this, 'invoke', () =>
@@ -331,7 +335,9 @@ export class StateNode<
           ProvidedActor,
           ParameterizedObject,
           ParameterizedObject,
-          string
+          string,
+          TODO, // TEmitted
+          TODO // TMeta
         >;
       })
     );
@@ -373,7 +379,15 @@ export class StateNode<
 
   /** @internal */
   public next(
-    snapshot: MachineSnapshot<TContext, TEvent, any, any, any, any>,
+    snapshot: MachineSnapshot<
+      TContext,
+      TEvent,
+      any,
+      any,
+      any,
+      any,
+      any // TMeta
+    >,
     event: TEvent
   ): TransitionDefinition<TContext, TEvent>[] | undefined {
     const eventType = event.type;

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -19,7 +19,8 @@ import {
   Prop,
   ProvidedActor,
   StateValue,
-  ToChildren
+  ToChildren,
+  MetaObject
 } from './types.ts';
 
 type TestValue =
@@ -117,6 +118,7 @@ export function createMachine<
   TInput,
   TOutput extends NonReducibleUnknown,
   TEmitted extends EventObject,
+  TMeta extends MetaObject,
   // it's important to have at least one default type parameter here
   // it allows us to benefit from contextual type instantiation as it makes us to pass the hasInferenceCandidatesOrDefault check in the compiler
   // we should be able to remove this when we start inferring TConfig, with it we'll always have an inference candidate
@@ -134,6 +136,7 @@ export function createMachine<
       TInput,
       TOutput,
       TEmitted,
+      TMeta,
       TTypesMeta
     >;
     schemas?: unknown;
@@ -148,6 +151,7 @@ export function createMachine<
     TInput,
     TOutput,
     TEmitted,
+    TMeta,
     TTypesMeta
   >,
   implementations?: InternalMachineImplementations<
@@ -191,6 +195,7 @@ export function createMachine<
   TInput,
   TOutput,
   TEmitted,
+  TMeta, // TMeta
   ResolveTypegenMeta<
     TTypesMeta,
     TEvent,
@@ -215,6 +220,7 @@ export function createMachine<
     any,
     any,
     any, // TEmitted
+    any, // TMeta
     any
   >(config as any, implementations as any);
 }

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -14,6 +14,7 @@ import {
   IsNever,
   MachineConfig,
   MachineContext,
+  MetaObject,
   NonReducibleUnknown,
   ParameterizedObject,
   SetupTypes,
@@ -124,7 +125,8 @@ export function setup<
   TTag extends string = string,
   TInput = NonReducibleUnknown,
   TOutput extends NonReducibleUnknown = NonReducibleUnknown,
-  TEmitted extends EventObject = EventObject
+  TEmitted extends EventObject = EventObject,
+  TMeta extends MetaObject = MetaObject
 >({
   schemas,
   actors,
@@ -140,7 +142,8 @@ export function setup<
     TTag,
     TInput,
     TOutput,
-    TEmitted
+    TEmitted,
+    TMeta
   >;
   actors?: {
     // union here enforces that all configured children have to be provided in actors
@@ -193,6 +196,7 @@ export function setup<
       TInput,
       TOutput,
       TEmitted,
+      TMeta,
       ResolveTypegenMeta<
         TypegenDisabled,
         TEvent,
@@ -222,6 +226,7 @@ export function setup<
     TInput,
     TOutput,
     TEmitted,
+    TMeta,
     ResolveTypegenMeta<
       TypegenDisabled,
       TEvent,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -663,7 +663,15 @@ export function transitionAtomicNode<
 >(
   stateNode: AnyStateNode,
   stateValue: string,
-  snapshot: MachineSnapshot<TContext, TEvent, any, any, any, any>,
+  snapshot: MachineSnapshot<
+    TContext,
+    TEvent,
+    any,
+    any,
+    any,
+    any,
+    any // TMeta
+  >,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   const childStateNode = getStateNode(stateNode, stateValue);
@@ -682,7 +690,15 @@ export function transitionCompoundNode<
 >(
   stateNode: AnyStateNode,
   stateValue: StateValueMap,
-  snapshot: MachineSnapshot<TContext, TEvent, any, any, any, any>,
+  snapshot: MachineSnapshot<
+    TContext,
+    TEvent,
+    any,
+    any,
+    any,
+    any,
+    any // TMeta
+  >,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   const subStateKeys = Object.keys(stateValue);
@@ -708,7 +724,15 @@ export function transitionParallelNode<
 >(
   stateNode: AnyStateNode,
   stateValue: StateValueMap,
-  snapshot: MachineSnapshot<TContext, TEvent, any, any, any, any>,
+  snapshot: MachineSnapshot<
+    TContext,
+    TEvent,
+    any,
+    any,
+    any,
+    any,
+    any // TMeta
+  >,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   const allInnerTransitions: Array<TransitionDefinition<TContext, TEvent>> = [];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -118,7 +118,8 @@ export interface UnifiedArg<
       Record<string, AnyActorRef | undefined>, // TODO: this should be replaced with `TChildren`
       StateValue,
       string,
-      unknown
+      unknown,
+      TODO // TMeta
     >,
     TEvent
   >;
@@ -145,6 +146,8 @@ export type InputFrom<T> = T extends StateMachine<
   infer _TTag,
   infer TInput,
   infer _TOutput,
+  infer _TEmitted,
+  infer _TMeta,
   infer _TResolvedTypesMeta
 >
   ? TInput
@@ -313,7 +316,8 @@ export interface TransitionConfig<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEmitted extends EventObject = EventObject
+  TEmitted extends EventObject = EventObject,
+  TMeta extends MetaObject = MetaObject
 > {
   guard?: Guard<TContext, TExpressionEvent, undefined, TGuard>;
   actions?: Actions<
@@ -329,7 +333,7 @@ export interface TransitionConfig<
   >;
   reenter?: boolean;
   target?: TransitionTarget | undefined;
-  meta?: Record<string, any>;
+  meta?: TMeta;
   description?: string;
 }
 
@@ -347,19 +351,23 @@ export interface InitialTransitionConfig<
     TActor,
     TAction,
     TGuard,
-    TDelay
+    TDelay,
+    TODO, // TEmitted
+    TODO // TMeta
   > {
   target: string;
 }
 
 export type AnyTransitionConfig = TransitionConfig<
-  any,
-  any,
-  any,
-  any,
-  any,
-  any,
-  any
+  any, // TContext
+  any, // TExpressionEvent
+  any, // TEvent
+  any, // TActor
+  any, // TAction
+  any, // TGuard
+  any, // TDelay
+  any, // TEmitted
+  any // TMeta
 >;
 
 export interface InvokeDefinition<
@@ -368,7 +376,9 @@ export interface InvokeDefinition<
   TActor extends ProvidedActor,
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
-  TDelay extends string
+  TDelay extends string,
+  TEmitted extends EventObject,
+  TMeta extends MetaObject
 > {
   id: string;
 
@@ -394,7 +404,9 @@ export interface InvokeDefinition<
           TActor,
           TAction,
           TGuard,
-          TDelay
+          TDelay,
+          TEmitted,
+          TMeta
         >
       >;
   /**
@@ -410,7 +422,9 @@ export interface InvokeDefinition<
           TActor,
           TAction,
           TGuard,
-          TDelay
+          TDelay,
+          TEmitted,
+          TMeta
         >
       >;
 
@@ -424,12 +438,23 @@ export interface InvokeDefinition<
           TActor,
           TAction,
           TGuard,
-          TDelay
+          TDelay,
+          TEmitted,
+          TMeta
         >
       >;
 
   toJSON: () => Omit<
-    InvokeDefinition<TContext, TEvent, TActor, TAction, TGuard, TDelay>,
+    InvokeDefinition<
+      TContext,
+      TEvent,
+      TActor,
+      TAction,
+      TGuard,
+      TDelay,
+      TEmitted,
+      TMeta
+    >,
     'onDone' | 'onError' | 'toJSON'
   >;
 }
@@ -454,7 +479,9 @@ export type DelayedTransitions<
           TActor,
           TAction,
           TGuard,
-          TDelay
+          TDelay,
+          TODO, // TEmitted
+          TODO // TMeta
         >
       >;
 };
@@ -485,7 +512,8 @@ export type StatesConfig<
   TDelay extends string,
   TTag extends string,
   TOutput,
-  TEmitted extends EventObject
+  TEmitted extends EventObject,
+  TMeta extends MetaObject
 > = {
   [K in string]: StateNodeConfig<
     TContext,
@@ -496,7 +524,8 @@ export type StatesConfig<
     TDelay,
     TTag,
     TOutput,
-    TEmitted
+    TEmitted,
+    TMeta
   >;
 };
 
@@ -517,7 +546,8 @@ export type TransitionConfigOrTarget<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEmitted extends EventObject
+  TEmitted extends EventObject,
+  TMeta extends MetaObject
 > = SingleOrArray<
   | TransitionConfigTarget
   | TransitionConfig<
@@ -528,7 +558,8 @@ export type TransitionConfigOrTarget<
       TAction,
       TGuard,
       TDelay,
-      TEmitted
+      TEmitted,
+      TMeta
     >
 >;
 
@@ -539,7 +570,8 @@ export type TransitionsConfig<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEmitted extends EventObject
+  TEmitted extends EventObject,
+  TMeta extends MetaObject
 > = {
   [K in EventDescriptor<TEvent>]?: TransitionConfigOrTarget<
     TContext,
@@ -549,7 +581,8 @@ export type TransitionsConfig<
     TAction,
     TGuard,
     TDelay,
-    TEmitted
+    TEmitted,
+    TMeta
   >;
 };
 
@@ -579,6 +612,7 @@ type DistributeActors<
   TGuard extends ParameterizedObject,
   TDelay extends string,
   TEmitted extends EventObject,
+  TMeta extends MetaObject,
   TSpecificActor extends ProvidedActor
 > = TSpecificActor extends { src: infer TSrc }
   ?
@@ -621,7 +655,8 @@ type DistributeActors<
                     TAction,
                     TGuard,
                     TDelay,
-                    TEmitted
+                    TEmitted,
+                    TMeta
                   >
                 >;
             /**
@@ -638,7 +673,8 @@ type DistributeActors<
                     TAction,
                     TGuard,
                     TDelay,
-                    TEmitted
+                    TEmitted,
+                    TMeta
                   >
                 >;
 
@@ -653,7 +689,8 @@ type DistributeActors<
                     TAction,
                     TGuard,
                     TDelay,
-                    TEmitted
+                    TEmitted,
+                    TMeta
                   >
                 >;
           } & { [K in RequiredActorOptions<TSpecificActor>]: unknown }
@@ -676,7 +713,8 @@ type DistributeActors<
                   TAction,
                   TGuard,
                   TDelay,
-                  TEmitted
+                  TEmitted,
+                  TMeta
                 >
               >;
           onError?:
@@ -690,7 +728,8 @@ type DistributeActors<
                   TAction,
                   TGuard,
                   TDelay,
-                  TEmitted
+                  TEmitted,
+                  TMeta
                 >
               >;
 
@@ -705,7 +744,8 @@ type DistributeActors<
                   TAction,
                   TGuard,
                   TDelay,
-                  TEmitted
+                  TEmitted,
+                  TMeta
                 >
               >;
         }
@@ -718,7 +758,8 @@ export type InvokeConfig<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEmitted extends EventObject
+  TEmitted extends EventObject,
+  TMeta extends MetaObject
 > = IsLiteralString<TActor['src']> extends true
   ? DistributeActors<
       TContext,
@@ -728,6 +769,7 @@ export type InvokeConfig<
       TGuard,
       TDelay,
       TEmitted,
+      TMeta,
       TActor
     >
   : {
@@ -760,7 +802,8 @@ export type InvokeConfig<
               TAction,
               TGuard,
               TDelay,
-              TEmitted
+              TEmitted,
+              TMeta
             >
           >;
       /**
@@ -777,7 +820,8 @@ export type InvokeConfig<
               TAction,
               TGuard,
               TDelay,
-              TEmitted
+              TEmitted,
+              TMeta
             >
           >;
 
@@ -792,12 +836,22 @@ export type InvokeConfig<
               TAction,
               TGuard,
               TDelay,
-              TEmitted
+              TEmitted,
+              TMeta
             >
           >;
     };
 
-export type AnyInvokeConfig = InvokeConfig<any, any, any, any, any, any, any>;
+export type AnyInvokeConfig = InvokeConfig<
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any,
+  any // TMeta
+>;
 
 export interface StateNodeConfig<
   TContext extends MachineContext,
@@ -808,7 +862,8 @@ export interface StateNodeConfig<
   TDelay extends string,
   TTag extends string,
   TOutput,
-  TEmitted extends EventObject
+  TEmitted extends EventObject,
+  TMeta extends MetaObject
 > {
   /**
    * The initial state transition.
@@ -846,14 +901,24 @@ export interface StateNodeConfig<
         TDelay,
         TTag,
         NonReducibleUnknown,
-        TEmitted
+        TEmitted,
+        TMeta
       >
     | undefined;
   /**
    * The services to invoke upon entering this state node. These services will be stopped upon exiting this state node.
    */
   invoke?: SingleOrArray<
-    InvokeConfig<TContext, TEvent, TActor, TAction, TGuard, TDelay, TEmitted>
+    InvokeConfig<
+      TContext,
+      TEvent,
+      TActor,
+      TAction,
+      TGuard,
+      TDelay,
+      TEmitted,
+      TMeta
+    >
   >;
   /**
    * The mapping of event types to their potential transition(s).
@@ -865,7 +930,8 @@ export interface StateNodeConfig<
     TAction,
     TGuard,
     TDelay,
-    TEmitted
+    TEmitted,
+    TMeta
   >;
   /**
    * The action(s) to be executed upon entering the state node.
@@ -910,7 +976,9 @@ export interface StateNodeConfig<
           TActor,
           TAction,
           TGuard,
-          TDelay
+          TDelay,
+          TEmitted,
+          TMeta
         >
       >
     | undefined;
@@ -931,13 +999,14 @@ export interface StateNodeConfig<
     TAction,
     TGuard,
     TDelay,
-    TEmitted
+    TEmitted,
+    TMeta
   >;
   parent?: StateNode<TContext, TEvent>;
   /**
    * The meta data associated with this state node, which will be returned in State instances.
    */
-  meta?: any;
+  meta?: TMeta;
   /**
    * The output data sent with the "xstate.done.state._id_" event if this is a final state node.
    *
@@ -979,7 +1048,8 @@ export type AnyStateNodeConfig = StateNodeConfig<
   any,
   any,
   any,
-  any
+  any, // emitted
+  any // meta
 >;
 
 export interface StateNodeDefinition<
@@ -1009,9 +1079,21 @@ export interface StateNodeDefinition<
     string,
     string,
     unknown,
-    EventObject // TEmitted
+    EventObject, // TEmitted
+    any // TMeta
   >['output'];
-  invoke: Array<InvokeDefinition<TContext, TEvent, TODO, TODO, TODO, TODO>>;
+  invoke: Array<
+    InvokeDefinition<
+      TContext,
+      TEvent,
+      TODO,
+      TODO,
+      TODO,
+      TODO,
+      TODO, // TEmitted
+      TODO // TMeta
+    >
+  >;
   description?: string;
   tags: string[];
 }
@@ -1051,6 +1133,7 @@ export type AnyStateMachine = StateMachine<
   any, // input
   any, // output
   any, // emitted
+  any, // TMeta
   any // typegen
 >;
 
@@ -1068,7 +1151,8 @@ export interface AtomicStateNodeConfig<
     TODO,
     TODO,
     TODO,
-    TODO
+    TODO, // emitted
+    TODO // meta
   > {
   initial?: undefined;
   parallel?: false | undefined;
@@ -1089,7 +1173,18 @@ export type SimpleOrStateNodeConfig<
   TEvent extends EventObject
 > =
   | AtomicStateNodeConfig<TContext, TEvent>
-  | StateNodeConfig<TContext, TEvent, TODO, TODO, TODO, TODO, TODO, TODO, TODO>;
+  | StateNodeConfig<
+      TContext,
+      TEvent,
+      TODO,
+      TODO,
+      TODO,
+      TODO,
+      TODO,
+      TODO,
+      TODO, // emitted
+      TODO // meta
+    >;
 
 export type ActionFunctionMap<
   TContext extends MachineContext,
@@ -1423,7 +1518,8 @@ export type ContextFactory<
       Record<string, AnyActorRef | undefined>, // TODO: this should be replaced with `TChildren`
       StateValue,
       string,
-      unknown
+      unknown,
+      TODO // TMeta
     >,
     TEvent
   >;
@@ -1440,6 +1536,7 @@ export type MachineConfig<
   TInput = any,
   TOutput = unknown,
   TEmitted extends EventObject = EventObject,
+  TMeta extends MetaObject = MetaObject,
   TTypesMeta = TypegenDisabled
 > = (Omit<
   StateNodeConfig<
@@ -1451,7 +1548,8 @@ export type MachineConfig<
     DoNotInfer<TDelay>,
     DoNotInfer<TTag>,
     DoNotInfer<TOutput>,
-    DoNotInfer<TEmitted>
+    DoNotInfer<TEmitted>,
+    DoNotInfer<TMeta>
   >,
   'output'
 > & {
@@ -1484,7 +1582,8 @@ export interface SetupTypes<
   TTag extends string,
   TInput,
   TOutput,
-  TEmitted extends EventObject
+  TEmitted extends EventObject,
+  TMeta extends MetaObject
 > {
   context?: TContext;
   events?: TEvent;
@@ -1493,6 +1592,7 @@ export interface SetupTypes<
   input?: TInput;
   output?: TOutput;
   emitted?: TEmitted;
+  meta?: TMeta;
 }
 
 export interface MachineTypes<
@@ -1506,6 +1606,7 @@ export interface MachineTypes<
   TInput,
   TOutput,
   TEmitted extends EventObject,
+  TMeta extends MetaObject,
   TTypesMeta = TypegenDisabled
 > extends SetupTypes<
     TContext,
@@ -1516,13 +1617,15 @@ export interface MachineTypes<
     TTag,
     TInput,
     TOutput,
-    TEmitted
+    TEmitted,
+    TMeta
   > {
   actors?: TActor;
   actions?: TAction;
   guards?: TGuard;
   delays?: TDelay;
   typegen?: TTypesMeta;
+  meta?: TMeta;
 }
 
 export interface HistoryStateNode<TContext extends MachineContext>
@@ -1721,7 +1824,8 @@ export type Mapper<
       Record<string, AnyActorRef>, // TODO: this should be replaced with `TChildren`
       StateValue,
       string,
-      unknown
+      unknown,
+      TODO // TMeta
     >,
     TEvent
   >;
@@ -1731,7 +1835,17 @@ export interface TransitionDefinition<
   TContext extends MachineContext,
   TEvent extends EventObject
 > extends Omit<
-    TransitionConfig<TContext, TEvent, TEvent, TODO, TODO, TODO, TODO>,
+    TransitionConfig<
+      TContext,
+      TEvent,
+      TEvent,
+      TODO,
+      TODO,
+      TODO,
+      TODO,
+      TODO, // TEmitted
+      TODO // TMeta
+    >,
     | 'target'
     // `guard` is correctly rejected by `extends` here and `actions` should be too
     // however, `any` passed to `TransitionConfig` as `TAction` collapses its `.actions` to `any` and it's accidentally allowed here
@@ -1812,6 +1926,7 @@ export interface StateConfig<
     any,
     any,
     any,
+    any, // TMeta
     any
   >;
 }
@@ -2077,6 +2192,7 @@ export type ActorLogicFrom<T> = ReturnTypeOrValue<T> extends infer R
       any,
       any,
       any,
+      any, // TMeta
       any
     >
     ? R
@@ -2099,6 +2215,7 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer TOutput,
       infer TEmitted,
+      infer TMeta,
       infer _TResolvedTypesMeta
     >
     ? ActorRef<
@@ -2108,7 +2225,8 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
           TChildren,
           TStateValue,
           TTag,
-          TOutput
+          TOutput,
+          TMeta
         >,
         TEvent,
         TEmitted
@@ -2146,6 +2264,7 @@ export type InterpreterFrom<
   infer TInput,
   infer TOutput,
   infer TEmitted,
+  infer TMeta,
   infer _TResolvedTypesMeta
 >
   ? Actor<
@@ -2156,7 +2275,8 @@ export type InterpreterFrom<
           TChildren,
           TStateValue,
           TTag,
-          TOutput
+          TOutput,
+          TMeta
         >,
         TEvent,
         TInput,
@@ -2182,6 +2302,7 @@ export type MachineImplementationsFrom<
   infer _TInput,
   infer _TOutput,
   infer _TEmitted,
+  infer _TMeta,
   infer TResolvedTypesMeta
 >
   ? InternalMachineImplementations<
@@ -2205,6 +2326,7 @@ export type __ResolvedTypesMetaFrom<T> = T extends StateMachine<
   any, // input
   any, // output
   any, // emitted
+  any, // TMeta
   infer TResolvedTypesMeta
 >
   ? TResolvedTypesMeta
@@ -2402,6 +2524,7 @@ type ResolveEventType<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer _TOutput,
       infer _TEmitted,
+      infer _TMeta,
       infer _TResolvedTypesMeta
     >
     ? TEvent
@@ -2411,7 +2534,8 @@ type ResolveEventType<T> = ReturnTypeOrValue<T> extends infer R
           infer _TChildren,
           infer _TStateValue,
           infer _TTag,
-          infer _TOutput
+          infer _TOutput,
+          infer _TMeta
         >
       ? TEvent
       : R extends ActorRef<infer _, infer TEvent>
@@ -2439,6 +2563,7 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer _TOutput,
       infer _TEmitted,
+      infer _TMeta,
       infer _TResolvedTypesMeta
     >
     ? TContext
@@ -2448,7 +2573,8 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
           infer _TChildren,
           infer _TStateValue,
           infer _TTag,
-          infer _TOutput
+          infer _TOutput,
+          infer _TMeta
         >
       ? TContext
       : R extends Actor<infer TActorLogic>
@@ -2464,6 +2590,7 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
             infer _TInput,
             infer _TOutput,
             infer _TEmitted,
+            infer _TMeta,
             infer _TResolvedTypesMeta
           >
           ? TContext

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -278,7 +278,16 @@ export function resolveReferencedActor(machine: AnyStateMachine, src: string) {
   return (
     Array.isArray(invokeConfig)
       ? invokeConfig[indexStr as any]
-      : (invokeConfig as InvokeConfig<any, any, any, any, any, any, any>)
+      : (invokeConfig as InvokeConfig<
+          any,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any, // TEmitted
+          any // TMeta
+        >)
   ).src;
 }
 

--- a/packages/core/test/setup.types.test.ts
+++ b/packages/core/test/setup.types.test.ts
@@ -2130,4 +2130,65 @@ describe('setup()', () => {
       }
     });
   });
+
+  it('should support typing meta properties', () => {
+    const machine = setup({
+      types: {
+        meta: {} as {
+          layout: string;
+        }
+      }
+    }).createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          meta: {
+            layout: 'a-layout'
+          }
+        },
+        b: {
+          meta: {
+            // @ts-expect-error
+            notLayout: 'uh oh'
+          }
+        },
+        c: {}, // no meta
+        d: {
+          meta: {
+            // @ts-expect-error
+            layout: 42
+          }
+        }
+      },
+      on: {
+        e1: {
+          meta: {
+            layout: 'event-layout'
+          }
+        },
+        e2: {
+          meta: {
+            // @ts-expect-error
+            notLayout: 'uh oh'
+          }
+        },
+        e3: {}, // no meta
+        // @ts-expect-error (for some reason the error is here)
+        e4: {
+          meta: {
+            layout: 42
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine);
+
+    actor.getSnapshot().getMeta().a! satisfies { layout: string } | undefined;
+
+    actor.getSnapshot().getMeta().a!.layout satisfies string;
+
+    // @ts-expect-error
+    actor.getSnapshot().getMeta().a.whatever;
+  });
 });

--- a/packages/core/test/setup.types.test.ts
+++ b/packages/core/test/setup.types.test.ts
@@ -2184,11 +2184,9 @@ describe('setup()', () => {
 
     const actor = createActor(machine);
 
-    actor.getSnapshot().getMeta().a! satisfies { layout: string } | undefined;
-
-    actor.getSnapshot().getMeta().a!.layout satisfies string;
+    actor.getSnapshot().getMeta().a satisfies { layout: string } | undefined;
 
     // @ts-expect-error
-    actor.getSnapshot().getMeta().a.whatever;
+    actor.getSnapshot().getMeta().a?.whatever;
   });
 });

--- a/packages/core/test/typegenTypes.test.ts
+++ b/packages/core/test/typegenTypes.test.ts
@@ -921,6 +921,7 @@ describe('typegen types', () => {
         any,
         any,
         any,
+        any, // TMeta
         any
       >
     ) {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -391,6 +391,7 @@ it('should work with generic context', () => {
     any,
     any,
     any,
+    any, // TMeta
     any
   > {
     return createMachine({ context });
@@ -533,6 +534,7 @@ describe('events', () => {
         any,
         any,
         any,
+        any, // TMeta
         any
       >
     ) {}

--- a/packages/xstate-test/src/machine.ts
+++ b/packages/xstate-test/src/machine.ts
@@ -14,7 +14,8 @@ import {
   MachineSnapshot,
   __unsafe_getAllOwnEventDescriptors,
   AnyActorRef,
-  EventFromLogic
+  EventFromLogic,
+  TODO
 } from 'xstate';
 import { TestModel } from './TestModel.ts';
 import {
@@ -78,7 +79,8 @@ function serializeMachineTransition(
     Record<string, AnyActorRef | undefined>,
     StateValue,
     string,
-    unknown
+    unknown,
+    TODO // TMeta
   >,
   event: AnyEventObject | undefined,
   previousSnapshot:
@@ -88,7 +90,8 @@ function serializeMachineTransition(
         Record<string, AnyActorRef | undefined>,
         StateValue,
         string,
-        unknown
+        unknown,
+        TODO // TMeta
       >
     | undefined,
   { serializeEvent }: { serializeEvent: (event: AnyEventObject) => string }

--- a/packages/xstate-test/src/types.ts
+++ b/packages/xstate-test/src/types.ts
@@ -44,7 +44,8 @@ export interface TestMachineConfig<
     TODO, // tags
     TODO, // input
     TODO, // output
-    TODO, //emitted
+    TODO, // emitted
+    TODO, // meta
     TTypesMeta
   >;
 }
@@ -62,7 +63,8 @@ export interface TestStateNodeConfig<
       TODO,
       TODO,
       TODO,
-      TODO
+      TODO, // emitted
+      TODO // meta
     >,
     | 'type'
     | 'history'
@@ -104,11 +106,29 @@ export type TestMachineOptions<
 export interface TestMeta<T, TContext extends MachineContext> {
   test?: (
     testContext: T,
-    state: MachineSnapshot<TContext, any, any, any, any, any>
+    state: MachineSnapshot<
+      TContext,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any // TMeta
+    >
   ) => Promise<void> | void;
   description?:
     | string
-    | ((state: MachineSnapshot<TContext, any, any, any, any, any>) => string);
+    | ((
+        state: MachineSnapshot<
+          TContext,
+          any,
+          any,
+          any,
+          any,
+          any,
+          any // TMeta
+        >
+      ) => string);
   skip?: boolean;
 }
 interface TestStateResult {
@@ -184,9 +204,27 @@ export interface TestTransitionConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TTestContext
-> extends TransitionConfig<TContext, TEvent, TEvent, TODO, TODO, TODO, string> {
+> extends TransitionConfig<
+    TContext,
+    TEvent,
+    TEvent,
+    TODO,
+    TODO,
+    TODO,
+    string,
+    TODO, // TEmitted
+    TODO // TMeta
+  > {
   test?: (
-    state: MachineSnapshot<TContext, TEvent, any, any, any, any>,
+    state: MachineSnapshot<
+      TContext,
+      TEvent,
+      any,
+      any,
+      any,
+      any,
+      any // TMeta
+    >,
     testContext: TTestContext
   ) => void;
 }


### PR DESCRIPTION
Meta objects for state nodes and transitions can now be specified in `setup({ types: … })`:

```ts
const machine = setup({
  types: {
    meta: {} as {
      layout: string;
    }
  }
}).createMachine({
  initial: 'home',
  states: {
    home: {
      meta: {
        layout: 'full' // strongly typed
      }
    }
  }
});

const actor = createActor(machine).start();

actor.getSnapshot().getMeta().home!;
// typed as { layout: string }
```

Fixes #809 
