### PR TITLE
[core] Add warning for imperative built-in action calls

### DIFF
--- a/.changeset/twenty-parrots-add.md
+++ b/.changeset/twenty-parrots-add.md
@@ -1,0 +1,17 @@
+---
+'xstate': patch
+---
+
+XState will now warn when calling built-in actions like `assign`, `sendTo`, `raise`, `emit`, etc. directly inside of a custom action. See https://stately.ai/docs/actions#built-in-actions for more details.
+
+```ts
+const machine = createMachine({
+  entry: () => {
+    // Will warn:
+    // "Custom actions should not call \`assign()\` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details."
+    assign({
+      // ...
+    });
+  }
+});
+```

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ const { constants } = require('jest-config');
  * @type {import('@jest/types').Config.InitialOptions}
  */
 module.exports = {
+  prettierPath: null,
   setupFilesAfterEnv: ['@xstate-repo/jest-utils/setup'],
   transform: {
     [constants.DEFAULT_JS_PATTERN]: 'babel-jest',

--- a/packages/core/src/actions/assign.ts
+++ b/packages/core/src/actions/assign.ts
@@ -1,6 +1,7 @@
 import isDevelopment from '#is-development';
 import { cloneMachineSnapshot } from '../State.ts';
 import { Spawner, createSpawner } from '../spawn.ts';
+import { executingCustomAction } from '../stateUtils.ts';
 import type {
   ActionArgs,
   AnyActorScope,
@@ -156,6 +157,12 @@ export function assign<
   never,
   never
 > {
+  if (isDevelopment && executingCustomAction) {
+    console.warn(
+      'Custom actions should not call `assign()` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.'
+    );
+  }
+
   function assign(
     args: ActionArgs<TContext, TExpressionEvent, TEvent>,
     params: TParams

--- a/packages/core/src/actions/emit.ts
+++ b/packages/core/src/actions/emit.ts
@@ -1,4 +1,5 @@
 import isDevelopment from '#is-development';
+import { executingCustomAction } from '../stateUtils.ts';
 import {
   ActionArgs,
   AnyActorScope,
@@ -121,6 +122,12 @@ export function emit<
   never,
   TEmitted
 > {
+  if (isDevelopment && executingCustomAction) {
+    console.warn(
+      'Custom actions should not call `emit()` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.'
+    );
+  }
+
   function emit(
     args: ActionArgs<TContext, TExpressionEvent, TEvent>,
     params: TParams

--- a/packages/core/src/actions/raise.ts
+++ b/packages/core/src/actions/raise.ts
@@ -1,4 +1,5 @@
 import isDevelopment from '#is-development';
+import { executingCustomAction } from '../stateUtils.ts';
 import {
   ActionArgs,
   ActionFunction,
@@ -141,6 +142,12 @@ export function raise<
   TDelay,
   never
 > {
+  if (isDevelopment && executingCustomAction) {
+    console.warn(
+      'Custom actions should not call `raise()` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.'
+    );
+  }
+
   function raise(
     args: ActionArgs<TContext, TExpressionEvent, TEvent>,
     params: TParams

--- a/packages/core/src/actions/send.ts
+++ b/packages/core/src/actions/send.ts
@@ -1,6 +1,7 @@
 import isDevelopment from '#is-development';
 import { XSTATE_ERROR } from '../constants.ts';
 import { createErrorActorEvent } from '../eventUtils.ts';
+import { executingCustomAction } from '../stateUtils.ts';
 import {
   ActionArgs,
   ActionFunction,
@@ -232,6 +233,12 @@ export function sendTo<
   TDelay,
   never
 > {
+  if (isDevelopment && executingCustomAction) {
+    console.warn(
+      'Custom actions should not call `raise()` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.'
+    );
+  }
+
   function sendTo(
     args: ActionArgs<TContext, TExpressionEvent, TEvent>,
     params: TParams

--- a/packages/core/src/actions/spawnChild.ts
+++ b/packages/core/src/actions/spawnChild.ts
@@ -1,6 +1,7 @@
 import isDevelopment from '#is-development';
 import { cloneMachineSnapshot } from '../State.ts';
 import { ProcessingStatus, createActor } from '../createActor.ts';
+import { executingCustomAction } from '../stateUtils.ts';
 import {
   ActionArgs,
   ActionFunction,
@@ -205,6 +206,12 @@ export function spawnChild<
   never,
   never
 > {
+  if (isDevelopment && executingCustomAction) {
+    console.warn(
+      'Custom actions should not call `spawnChild()` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.'
+    );
+  }
+
   function spawnChild(
     args: ActionArgs<TContext, TExpressionEvent, TEvent>,
     params: TParams

--- a/packages/core/src/actions/spawnChild.ts
+++ b/packages/core/src/actions/spawnChild.ts
@@ -206,12 +206,6 @@ export function spawnChild<
   never,
   never
 > {
-  if (isDevelopment && executingCustomAction) {
-    console.warn(
-      'Custom actions should not call `spawnChild()` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.'
-    );
-  }
-
   function spawnChild(
     args: ActionArgs<TContext, TExpressionEvent, TEvent>,
     params: TParams

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1554,7 +1554,6 @@ function resolveAndExecuteActionsWithContext(
           : undefined;
 
     function executeAction() {
-      executingCustomAction = resolvedAction;
       actorScope.system._sendInspectionEvent({
         type: '@xstate.action',
         actorRef: actorScope.self,
@@ -1569,6 +1568,7 @@ function resolveAndExecuteActionsWithContext(
         }
       });
       try {
+        executingCustomAction = resolvedAction;
         resolvedAction(actionArgs, actionParams);
       } finally {
         executingCustomAction = false;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1491,6 +1491,8 @@ interface BuiltinAction {
   execute: (actorScope: AnyActorScope, params: unknown) => void;
 }
 
+export let executingCustomAction = false;
+
 function resolveAndExecuteActionsWithContext(
   currentSnapshot: AnyMachineSnapshot,
   event: AnyEventObject,
@@ -1568,10 +1570,14 @@ function resolveAndExecuteActionsWithContext(
 
     if (!('resolve' in resolvedAction)) {
       if (actorScope.self._processingStatus === ProcessingStatus.Running) {
+        executingCustomAction = true;
         executeAction();
+        executingCustomAction = false;
       } else {
         actorScope.defer(() => {
+          executingCustomAction = true;
           executeAction();
+          executingCustomAction = false;
         });
       }
       continue;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1491,7 +1491,9 @@ interface BuiltinAction {
   execute: (actorScope: AnyActorScope, params: unknown) => void;
 }
 
-export let executingCustomAction = false;
+export let executingCustomAction:
+  | ActionFunction<any, any, any, any, any, any, any, any, any>
+  | false = false;
 
 function resolveAndExecuteActionsWithContext(
   currentSnapshot: AnyMachineSnapshot,
@@ -1570,12 +1572,12 @@ function resolveAndExecuteActionsWithContext(
 
     if (!('resolve' in resolvedAction)) {
       if (actorScope.self._processingStatus === ProcessingStatus.Running) {
-        executingCustomAction = true;
+        executingCustomAction = resolvedAction;
         executeAction();
         executingCustomAction = false;
       } else {
         actorScope.defer(() => {
-          executingCustomAction = true;
+          executingCustomAction = resolvedAction;
           executeAction();
           executingCustomAction = false;
         });

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1554,6 +1554,7 @@ function resolveAndExecuteActionsWithContext(
           : undefined;
 
     function executeAction() {
+      executingCustomAction = resolvedAction;
       actorScope.system._sendInspectionEvent({
         type: '@xstate.action',
         actorRef: actorScope.self,
@@ -1576,14 +1577,10 @@ function resolveAndExecuteActionsWithContext(
 
     if (!('resolve' in resolvedAction)) {
       if (actorScope.self._processingStatus === ProcessingStatus.Running) {
-        executingCustomAction = resolvedAction;
         executeAction();
-        executingCustomAction = false;
       } else {
         actorScope.defer(() => {
-          executingCustomAction = resolvedAction;
           executeAction();
-          executingCustomAction = false;
         });
       }
       continue;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1569,10 +1569,8 @@ function resolveAndExecuteActionsWithContext(
       });
       try {
         resolvedAction(actionArgs, actionParams);
-      } catch (err) {
+      } finally {
         executingCustomAction = false;
-        // rethrow err
-        throw err;
       }
     }
 

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1567,7 +1567,13 @@ function resolveAndExecuteActionsWithContext(
           params: actionParams
         }
       });
-      resolvedAction(actionArgs, actionParams);
+      try {
+        resolvedAction(actionArgs, actionParams);
+      } catch (err) {
+        executingCustomAction = false;
+        // rethrow err
+        throw err;
+      }
     }
 
     if (!('resolve' in resolvedAction)) {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -3945,7 +3945,6 @@ describe('actions', () => {
         raise({ type: '' });
         sendTo('', { type: '' });
         emit({ type: '' });
-        spawnChild('');
       }
     });
 
@@ -3964,9 +3963,6 @@ describe('actions', () => {
   ],
   [
     "Custom actions should not call \`emit()\` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.",
-  ],
-  [
-    "Custom actions should not call \`spawnChild()\` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.",
   ],
 ]
 `);

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -1,11 +1,13 @@
 import { sleep } from '@xstate-repo/jest-utils';
 import {
   cancel,
+  emit,
   enqueueActions,
   log,
   raise,
   sendParent,
   sendTo,
+  spawnChild,
   stopChild
 } from '../src/actions.ts';
 import { CallbackActorRef, fromCallback } from '../src/actors/callback.ts';
@@ -3934,5 +3936,39 @@ describe('actions', () => {
     expect(spy).toHaveBeenCalledWith({
       foo: 'bar'
     });
+  });
+
+  it('should warn if called in custom action', () => {
+    const machine = createMachine({
+      entry: () => {
+        assign({});
+        raise({ type: '' });
+        sendTo('', { type: '' });
+        emit({ type: '' });
+        spawnChild('');
+      }
+    });
+
+    createActor(machine).start();
+
+    expect(console.warn).toMatchMockCallsInlineSnapshot(`
+[
+  [
+    "Custom actions should not call \`assign()\` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.",
+  ],
+  [
+    "Custom actions should not call \`raise()\` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.",
+  ],
+  [
+    "Custom actions should not call \`raise()\` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.",
+  ],
+  [
+    "Custom actions should not call \`emit()\` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.",
+  ],
+  [
+    "Custom actions should not call \`spawnChild()\` directly, as it is not imperative. See https://stately.ai/docs/actions#built-in-actions for more details.",
+  ],
+]
+`);
   });
 });


### PR DESCRIPTION
This PR warns for improper imperative calls of built-in actions, which is a very common problem.

https://stately.ai/docs/actions#built-in-actions