### PR TITLE
[@xstate/store] Fix `createStoreWithProducer(…)` types

### DIFF
--- a/.changeset/nice-spiders-perform.md
+++ b/.changeset/nice-spiders-perform.md
@@ -1,0 +1,21 @@
+---
+'@xstate/store': patch
+---
+
+The `context` type for `createStoreWithProducer(producer, context, transitions)` will now be properly inferred.
+
+```ts
+const store = createStoreWithProducer(
+  produce,
+  {
+    count: 0
+  },
+  {
+    // ...
+  }
+);
+
+store.getSnapshot().context;
+// BEFORE: StoreContext
+// NOW: { count: number }
+```

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -187,10 +187,7 @@ export function createStoreWithProducer<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap
 >(
-  producer: (
-    context: TContext,
-    recipe: (context: TContext) => void
-  ) => TContext,
+  producer: <T>(context: T, recipe: (context: T) => void) => T,
   initialContext: TContext,
   transitions: {
     [K in keyof TEventPayloadMap & string]: (

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -187,7 +187,10 @@ export function createStoreWithProducer<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap
 >(
-  producer: <T>(context: T, recipe: (context: T) => void) => T,
+  producer: NoInfer<(
+    context: TContext,
+    recipe: (context: TContext) => void
+  ) => TContext>,
   initialContext: TContext,
   transitions: {
     [K in keyof TEventPayloadMap & string]: (

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -97,7 +97,7 @@ it('updates state from sent events', () => {
   expect(store.getSnapshot().context).toEqual({ count: 0 });
 });
 
-it('works with immer', () => {
+it('createStoreWithProducer(…) works with an immer producer', () => {
   const store = createStoreWithProducer(
     produce,
     {
@@ -118,6 +118,22 @@ it('works with immer', () => {
 
   expect(store.getSnapshot().context).toEqual({ count: 3 });
   expect(store.getInitialSnapshot().context).toEqual({ count: 0 });
+});
+
+it('createStoreWithProducer(…) infers the context type properly with a producer', () => {
+  const store = createStoreWithProducer(
+    produce,
+    {
+      count: 0
+    },
+    {
+      inc: (ctx, ev: { by: number }) => {
+        ctx.count += ev.by;
+      }
+    }
+  );
+
+  store.getSnapshot().context satisfies { count: number };
 });
 
 it('can be observed', () => {


### PR DESCRIPTION

The `context` type for `createStoreWithProducer(producer, context, transitions)` will now be properly inferred.

```ts
const store = createStoreWithProducer(
  produce,
  {
    count: 0
  },
  {
    // ...
  }
);

store.getSnapshot().context;
// BEFORE: StoreContext
// NOW: { count: number }
```