### PR TITLE
[core] Wildcard emitted event listener

### DIFF
--- a/.changeset/big-ghosts-develop.md
+++ b/.changeset/big-ghosts-develop.md
@@ -1,0 +1,11 @@
+---
+'xstate': patch
+---
+
+You can now use a wildcard to listen for _any_ emitted event from an actor:
+
+```ts
+actor.on('*', (emitted) => {
+  console.log(emitted); // Any emitted event
+});
+```

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -71,8 +71,7 @@ const defaultOptions = {
  * An Actor is a running process that can receive events, send events and change its behavior based on the events it receives, which can cause effects outside of the actor. When you run a state machine, it becomes an actor.
  */
 export class Actor<TLogic extends AnyActorLogic>
-  implements
-    ActorRef<SnapshotFrom<TLogic>, EventFromLogic<TLogic>, EmittedFrom<TLogic>>
+  implements ActorRef<SnapshotFrom<TLogic>, EventFromLogic<TLogic>>
 {
   /**
    * The current internal state of the actor.
@@ -107,11 +106,7 @@ export class Actor<TLogic extends AnyActorLogic>
   public _parent?: AnyActorRef;
   /** @internal */
   public _syncSnapshot?: boolean;
-  public ref: ActorRef<
-    SnapshotFrom<TLogic>,
-    EventFromLogic<TLogic>,
-    EmittedFrom<TLogic>
-  >;
+  public ref: ActorRef<SnapshotFrom<TLogic>, EventFromLogic<TLogic>>;
   // TODO: add typings for system
   private _actorScope: ActorScope<
     SnapshotFrom<TLogic>,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2148,8 +2148,7 @@ export interface ActorLike<TCurrent, TEvent extends EventObject>
 
 export interface ActorRef<
   TSnapshot extends Snapshot<unknown>,
-  TEvent extends EventObject,
-  TEmitted extends EventObject = EventObject
+  TEvent extends EventObject
 > extends Subscribable<TSnapshot>,
     InteropObservable<TSnapshot> {
   /**
@@ -2173,7 +2172,7 @@ export interface ActorRef<
   src: string | AnyActorLogic;
 }
 
-export type AnyActorRef = ActorRef<any, any, any>;
+export type AnyActorRef = ActorRef<any, any>;
 
 export type ActorLogicFrom<T> = ReturnTypeOrValue<T> extends infer R
   ? R extends StateMachine<
@@ -2224,8 +2223,7 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
           TOutput,
           TMeta
         >,
-        TEvent,
-        TEmitted
+        TEvent
       >
     : R extends Promise<infer U>
       ? ActorRefFrom<PromiseActorLogic<U>>
@@ -2236,7 +2234,7 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
             infer _TSystem,
             infer TEmitted
           >
-        ? ActorRef<TSnapshot, TEvent, TEmitted>
+        ? ActorRef<TSnapshot, TEvent>
         : never
   : never;
 
@@ -2334,7 +2332,7 @@ export interface ActorScope<
   TSystem extends AnyActorSystem = AnyActorSystem,
   TEmitted extends EventObject = EventObject
 > {
-  self: ActorRef<TSnapshot, TEvent, TEmitted>;
+  self: ActorRef<TSnapshot, TEvent>;
   id: string;
   sessionId: string;
   logger: (...args: any[]) => void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2171,10 +2171,6 @@ export interface ActorRef<
   /** @internal */
   _processingStatus: ProcessingStatus;
   src: string | AnyActorLogic;
-  on: <TType extends TEmitted['type']>(
-    type: TType,
-    handler: (emitted: TEmitted & { type: TType }) => void
-  ) => Subscription;
 }
 
 export type AnyActorRef = ActorRef<any, any, any>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2148,7 +2148,8 @@ export interface ActorLike<TCurrent, TEvent extends EventObject>
 
 export interface ActorRef<
   TSnapshot extends Snapshot<unknown>,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TEmitted extends EventObject = EventObject
 > extends Subscribable<TSnapshot>,
     InteropObservable<TSnapshot> {
   /**
@@ -2170,6 +2171,14 @@ export interface ActorRef<
   /** @internal */
   _processingStatus: ProcessingStatus;
   src: string | AnyActorLogic;
+  // TODO: remove from ActorRef interface
+  // (should only be available on Actor)
+  on: <TType extends TEmitted['type'] | '*'>(
+    type: TType,
+    handler: (
+      emitted: TEmitted & (TType extends '*' ? {} : { type: TType })
+    ) => void
+  ) => Subscription;
 }
 
 export type AnyActorRef = ActorRef<any, any>;


### PR DESCRIPTION
You can now use a wildcard to listen for _any_ emitted event from an actor:

```ts
actor.on('*', (emitted) => {
  console.log(emitted); // Any emitted event
});
```
