### PR TITLE
feat(core): expose UnknownActorRef

### DIFF
--- a/.changeset/strange-fireants-tap.md
+++ b/.changeset/strange-fireants-tap.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Expose type `UnknownActorRef` for use when calling `getSnapshot()` on an unknown `ActorRef`.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2186,6 +2186,8 @@ export interface ActorRef<
 
 export type AnyActorRef = ActorRef<any, any, any>;
 
+export type UnknownActorRef = ActorRef<Snapshot<unknown>, EventObject>;
+
 export type ActorLogicFrom<T> = ReturnTypeOrValue<T> extends infer R
   ? R extends StateMachine<
       any,

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -2,7 +2,12 @@ import { from } from 'rxjs';
 import { log } from '../src/actions/log';
 import { raise } from '../src/actions/raise';
 import { stopChild } from '../src/actions/stopChild';
-import { PromiseActorLogic, fromCallback, fromPromise } from '../src/actors';
+import {
+  PromiseActorLogic,
+  createEmptyActor,
+  fromCallback,
+  fromPromise
+} from '../src/actors';
 import {
   ActorRefFrom,
   InputFrom,
@@ -19,7 +24,8 @@ import {
   spawnChild,
   stateIn,
   setup,
-  toPromise
+  toPromise,
+  UnknownActorRef
 } from '../src/index';
 
 function noop(_x: unknown) {
@@ -4566,4 +4572,11 @@ it('fromPromise should not have issues with actors with emitted types', () => {
   const actor = createActor(machine).start();
 
   toPromise(actor);
+});
+
+it('UnknownActorRef should return a Snapshot-typed value from getSnapshot()', () => {
+  const actor: UnknownActorRef = createEmptyActor();
+
+  // @ts-expect-error
+  actor.getSnapshot().status === 'FOO';
 });


### PR DESCRIPTION
`AnyActorRef` is problematic for some use cases, because the result of the `AnyActorRef['getSnapshot']` function is of type `any`.

However, changing `AnyActorRef` to use a narrow type in `ActorRef`'s first type argument, `TSnapshot`, breaks conditional types which perform inference based on `TSnapshot`.

This change introduces `UnknownActorRef`, which is like `AnyActorRef`, but is not intended to be inferred from in future conditional types. A consumer can use `UnknownActorRef` like so:

```ts
const actor: UnknownActorRef = getSomeActor();

// inferred as `Snapshot<unknown>`
const snapshot = actor.getSnapshot();

// do things w/ snapshot
```

`AnyActorRef` would return `any` from `actor.getSnapshot()`, which make it unsuitable for this use-case in a strictly-typed environment.