### PR TITLE
[core] Add emit support for all actor logic creators

### DIFF
--- a/.changeset/smooth-crabs-dress.md
+++ b/.changeset/smooth-crabs-dress.md
@@ -2,7 +2,7 @@
 'xstate': minor
 ---
 
-All actor logic creators now support emitting events:
+All actor logic creators now support [emitting events](https://stately.ai/docs/event-emitter):
 
 **Promise actors**
 

--- a/.changeset/smooth-crabs-dress.md
+++ b/.changeset/smooth-crabs-dress.md
@@ -1,0 +1,60 @@
+---
+'xstate': minor
+---
+
+All actor logic creators now support emitting events:
+
+**Promise actors**
+
+```ts
+const logic = fromPromise(async ({ emit }) => {
+  // ...
+  emit({
+    type: 'emitted',
+    msg: 'hello'
+  });
+  // ...
+});
+```
+
+**Transition actors**
+
+```ts
+const logic = fromTransition((state, event, { emit }) => {
+  // ...
+  emit({
+    type: 'emitted',
+    msg: 'hello'
+  });
+  // ...
+  return state;
+}, {});
+```
+
+**Observable actors**
+
+```ts
+const logic = fromObservable(({ emit }) => {
+  // ...
+
+  emit({
+    type: 'emitted',
+    msg: 'hello'
+  });
+
+  // ...
+});
+```
+
+**Callback actors**
+
+```ts
+const logic = fromCallback(({ emit }) => {
+  // ...
+  emit({
+    type: 'emitted',
+    msg: 'hello'
+  });
+  // ...
+});
+```

--- a/packages/core/src/actors/transition.ts
+++ b/packages/core/src/actors/transition.ts
@@ -100,7 +100,12 @@ export function fromTransition<
   transition: (
     snapshot: TContext,
     event: TEvent,
-    actorScope: ActorScope<TransitionSnapshot<TContext>, TEvent, TSystem>
+    actorScope: ActorScope<
+      TransitionSnapshot<TContext>,
+      TEvent,
+      TSystem,
+      TEmitted
+    >
   ) => TContext,
   initialContext:
     | TContext

--- a/packages/core/test/emit.test.ts
+++ b/packages/core/test/emit.test.ts
@@ -3,6 +3,11 @@ import {
   createActor,
   createMachine,
   enqueueActions,
+  fromCallback,
+  fromEventObservable,
+  fromObservable,
+  fromPromise,
+  fromTransition,
   setup
 } from '../src';
 import { emit } from '../src/actions/emit';
@@ -220,5 +225,207 @@ describe('event emitter', () => {
     actor.send({ type: 'event' });
 
     expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('events can be emitted from promise logic', () => {
+    const spy = jest.fn();
+
+    const logic = fromPromise<any, any, { type: 'emitted'; msg: string }>(
+      async ({ emit }) => {
+        emit({
+          type: 'emitted',
+          msg: 'hello'
+        });
+      }
+    );
+
+    const actor = createActor(logic);
+
+    actor.on('emitted', (ev) => {
+      ev.type satisfies 'emitted';
+
+      // @ts-expect-error
+      ev.type satisfies 'whatever';
+
+      ev satisfies { msg: string };
+
+      spy(ev);
+    });
+
+    actor.start();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'emitted',
+        msg: 'hello'
+      })
+    );
+  });
+
+  it('events can be emitted from transition logic', () => {
+    const spy = jest.fn();
+
+    const logic = fromTransition<
+      any,
+      any,
+      any,
+      any,
+      { type: 'emitted'; msg: string }
+    >((s, e, { emit }) => {
+      if (e.type === 'emit') {
+        emit({
+          type: 'emitted',
+          msg: 'hello'
+        });
+      }
+      return s;
+    }, {});
+
+    const actor = createActor(logic);
+
+    actor.on('emitted', (ev) => {
+      ev.type satisfies 'emitted';
+
+      // @ts-expect-error
+      ev.type satisfies 'whatever';
+
+      ev satisfies { msg: string };
+
+      spy(ev);
+    });
+
+    actor.start();
+
+    actor.send({ type: 'emit' });
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'emitted',
+        msg: 'hello'
+      })
+    );
+  });
+
+  it('events can be emitted from observable logic', () => {
+    const spy = jest.fn();
+
+    const logic = fromObservable<any, any, { type: 'emitted'; msg: string }>(
+      ({ emit }) => {
+        emit({
+          type: 'emitted',
+          msg: 'hello'
+        });
+
+        return {
+          subscribe: () => {
+            return {
+              unsubscribe: () => {}
+            };
+          }
+        };
+      }
+    );
+
+    const actor = createActor(logic);
+
+    actor.on('emitted', (ev) => {
+      ev.type satisfies 'emitted';
+
+      // @ts-expect-error
+      ev.type satisfies 'whatever';
+
+      ev satisfies { msg: string };
+
+      spy(ev);
+    });
+
+    actor.start();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'emitted',
+        msg: 'hello'
+      })
+    );
+  });
+
+  it('events can be emitted from event observable logic', () => {
+    const spy = jest.fn();
+
+    const logic = fromEventObservable<
+      any,
+      any,
+      { type: 'emitted'; msg: string }
+    >(({ emit }) => {
+      emit({
+        type: 'emitted',
+        msg: 'hello'
+      });
+
+      return {
+        subscribe: () => {
+          return {
+            unsubscribe: () => {}
+          };
+        }
+      };
+    });
+
+    const actor = createActor(logic);
+
+    actor.on('emitted', (ev) => {
+      ev.type satisfies 'emitted';
+
+      // @ts-expect-error
+      ev.type satisfies 'whatever';
+
+      ev satisfies { msg: string };
+
+      spy(ev);
+    });
+
+    actor.start();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'emitted',
+        msg: 'hello'
+      })
+    );
+  });
+
+  it('events can be emitted from callback logic', () => {
+    const spy = jest.fn();
+
+    const logic = fromCallback<any, any, { type: 'emitted'; msg: string }>(
+      ({ emit }) => {
+        emit({
+          type: 'emitted',
+          msg: 'hello'
+        });
+      }
+    );
+
+    const actor = createActor(logic);
+
+    actor.on('emitted', (ev) => {
+      ev.type satisfies 'emitted';
+
+      // @ts-expect-error
+      ev.type satisfies 'whatever';
+
+      ev satisfies { msg: string };
+
+      spy(ev);
+    });
+
+    actor.start();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'emitted',
+        msg: 'hello'
+      })
+    );
   });
 });


### PR DESCRIPTION
This PR adds support for emitting events from all actor logic types:

**Promise actors**

```ts
const logic = fromPromise(async ({ emit }) => {
  // ...
  emit({
    type: 'emitted',
    msg: 'hello'
  });
  // ...
});
```

**Transition actors**

```ts
const logic = fromTransition((state, event, { emit }) => {
  // ...
  emit({
    type: 'emitted',
    msg: 'hello'
  });
  // ...
  return state;
}, {});
```

**Observable actors**

```ts
const logic = fromObservable(({ emit }) => {
  // ...

  emit({
    type: 'emitted',
    msg: 'hello'
  });

  // ...
});
```

**Callback actors**

```ts
const logic = fromCallback(({ emit }) => {
  // ...
  emit({
    type: 'emitted',
    msg: 'hello'
  });
  // ...
});
```
