### PR TITLE
[core] Inspect subscription

### DIFF
--- a/.changeset/cold-planes-clap.md
+++ b/.changeset/cold-planes-clap.md
@@ -1,0 +1,24 @@
+---
+'xstate': minor
+---
+
+Inspecting an actor system via `actor.system.inspect(ev => …)` now accepts a function or observer, and returns a subscription:
+
+```ts
+const actor = createActor(someMachine);
+
+const sub = actor.system.inspect((inspectionEvent) => {
+  console.log(inspectionEvent);
+});
+
+// Inspection events will be logged
+actor.start();
+actor.send({ type: 'anEvent' });
+
+// ...
+
+sub.unsubscribe();
+
+// Will no longer log inspection events
+actor.send({ type: 'someEvent' });
+```

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -1032,4 +1032,94 @@ describe('inspect', () => {
     actor.start();
     actor.send({ type: 'any' });
   });
+
+  it('actor.system.inspect(…) can inspect actors', () => {
+    const actor = createActor(createMachine({}));
+    const events: InspectionEvent[] = [];
+
+    actor.system.inspect((ev) => {
+      events.push(ev);
+    });
+
+    actor.start();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: '@xstate.event'
+      })
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: '@xstate.snapshot'
+      })
+    );
+  });
+
+  it('actor.system.inspect(…) can inspect actors (observer)', () => {
+    const actor = createActor(createMachine({}));
+    const events: InspectionEvent[] = [];
+
+    actor.system.inspect({
+      next: (ev) => {
+        events.push(ev);
+      }
+    });
+
+    actor.start();
+
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: '@xstate.event'
+      })
+    );
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: '@xstate.snapshot'
+      })
+    );
+  });
+
+  it('actor.system.inspect(…) can be unsubscribed', () => {
+    const actor = createActor(createMachine({}));
+    const events: InspectionEvent[] = [];
+
+    const sub = actor.system.inspect((ev) => {
+      events.push(ev);
+    });
+
+    actor.start();
+
+    expect(events.length).toEqual(2);
+
+    events.length = 0;
+
+    sub.unsubscribe();
+
+    actor.send({ type: 'someEvent' });
+
+    expect(events.length).toEqual(0);
+  });
+
+  it('actor.system.inspect(…) can be unsubscribed (observer)', () => {
+    const actor = createActor(createMachine({}));
+    const events: InspectionEvent[] = [];
+
+    const sub = actor.system.inspect({
+      next: (ev) => {
+        events.push(ev);
+      }
+    });
+
+    actor.start();
+
+    expect(events.length).toEqual(2);
+
+    events.length = 0;
+
+    sub.unsubscribe();
+
+    actor.send({ type: 'someEvent' });
+
+    expect(events.length).toEqual(0);
+  });
 });


### PR DESCRIPTION

Inspecting an actor system via `actor.system.inspect(ev => …)` now accepts a function or observer, and returns a subscription:

```ts
const actor = createActor(someMachine);

const sub = actor.system.inspect((inspectionEvent) => {
  console.log(inspectionEvent);
});

// Inspection events will be logged
actor.start();
actor.send({ type: 'anEvent' });

// ...

sub.unsubscribe();

// Will no longer log inspection events
actor.send({ type: 'someEvent' });
```