### PR TITLE
[core] Make actor status available

### DIFF
--- a/.changeset/tender-forks-sin.md
+++ b/.changeset/tender-forks-sin.md
@@ -1,0 +1,9 @@
+---
+'xstate': patch
+---
+
+The `actor._processingStatus` property is now public, and is used to determine the processing status of the actor:
+
+- `0` means the actor is not started
+- `1` means the actor is started and running
+- `2` means the actor is stopped

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -100,13 +100,13 @@ export class Actor<TLogic extends AnyActorLogic>
   > = new Map();
   private logger: (...args: any[]) => void;
 
-  /** @internal */
   public _processingStatus: ProcessingStatus = ProcessingStatus.NotStarted;
 
   // Actor Ref
   public _parent?: AnyActorRef;
   /** @internal */
   public _syncSnapshot?: boolean;
+  /** @deprecated */
   public ref: ActorRef<
     SnapshotFrom<TLogic>,
     EventFromLogic<TLogic>,

--- a/packages/core/src/spawn.ts
+++ b/packages/core/src/spawn.ts
@@ -121,7 +121,7 @@ export function createSpawner(
     }
   };
   return (src, options) => {
-    const actorRef = spawn(src, options) as TODO; // TODO: fix types
+    const actorRef = spawn(src, options);
     spawnedChildren[actorRef.id] = actorRef;
     actorScope.defer(() => {
       if (actorRef._processingStatus === ProcessingStatus.Stopped) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2159,6 +2159,9 @@ export interface ActorRef<
    * The unique identifier for this actor relative to its parent.
    */
   id: string;
+  /**
+   * The globally unique identifier for this actor.
+   */
   sessionId: string;
   /** @internal */
   _send: (event: TEvent) => void;
@@ -2171,7 +2174,6 @@ export interface ActorRef<
   // TODO: figure out how to hide this externally as `sendTo(ctx => ctx.actorRef._parent._parent._parent._parent)` shouldn't be allowed
   _parent?: AnyActorRef;
   system: AnyActorSystem;
-  /** @internal */
   _processingStatus: ProcessingStatus;
   src: string | AnyActorLogic;
   // TODO: remove from ActorRef interface


### PR DESCRIPTION
The `actor._processingStatus` property is now public, and is used to determine the processing status of the actor:

- `0` means the actor is not started
- `1` means the actor is started and running
- `2` means the actor is stopped