### PR TITLE
feat(core): add actor ID to DoneActorEvent, ErrorActorEvent

### DIFF
--- a/.changeset/giant-bananas-drive.md
+++ b/.changeset/giant-bananas-drive.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+`DoneActorEvent` and `ErrorActorEvent` now contain property `actorId`, which refers to the ID of the actor the event refers to.

--- a/packages/core/src/eventUtils.ts
+++ b/packages/core/src/eventUtils.ts
@@ -44,7 +44,8 @@ export function createDoneActorEvent(
 ): DoneActorEvent {
   return {
     type: `xstate.done.actor.${invokeId}`,
-    output
+    output,
+    actorId: invokeId
   };
 }
 
@@ -52,7 +53,7 @@ export function createErrorActorEvent(
   id: string,
   error?: unknown
 ): ErrorActorEvent {
-  return { type: `xstate.error.actor.${id}`, error };
+  return { type: `xstate.error.actor.${id}`, error, actorId: id };
 }
 
 export function createInitEvent(input: unknown) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1656,14 +1656,20 @@ export type Transitions<
   TEvent extends EventObject
 > = Array<TransitionDefinition<TContext, TEvent>>;
 
-export interface DoneActorEvent<TOutput = unknown> {
-  type: `xstate.done.actor.${string}`;
+export interface DoneActorEvent<TOutput = unknown, TId extends string = string>
+  extends EventObject {
+  type: `xstate.done.actor.${TId}`;
   output: TOutput;
+  actorId: TId;
 }
 
-export interface ErrorActorEvent<TErrorData = unknown> extends EventObject {
-  type: `xstate.error.actor.${string}`;
+export interface ErrorActorEvent<
+  TErrorData = unknown,
+  TId extends string = string
+> extends EventObject {
+  type: `xstate.error.actor.${TId}`;
   error: TErrorData;
+  actorId: TId;
 }
 
 export interface SnapshotEvent<

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -368,6 +368,7 @@ describe('inspect', () => {
         },
         {
           "event": {
+            "actorId": "0.(machine).loading",
             "output": 42,
             "type": "xstate.done.actor.0.(machine).loading",
           },
@@ -396,6 +397,7 @@ describe('inspect', () => {
         },
         {
           "event": {
+            "actorId": "child",
             "output": undefined,
             "type": "xstate.done.actor.child",
           },
@@ -406,6 +408,7 @@ describe('inspect', () => {
         {
           "actorId": "x:1",
           "event": {
+            "actorId": "child",
             "output": undefined,
             "type": "xstate.done.actor.child",
           },
@@ -418,6 +421,7 @@ describe('inspect', () => {
         {
           "actorId": "x:2",
           "event": {
+            "actorId": "0.(machine).loading",
             "output": 42,
             "type": "xstate.done.actor.0.(machine).loading",
           },

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -20,7 +20,8 @@ import {
   createActor,
   sendParent,
   Snapshot,
-  ActorRef
+  ActorRef,
+  DoneActorEvent
 } from '../src/index.ts';
 import { sleep } from '@xstate-repo/jest-utils';
 
@@ -3081,7 +3082,7 @@ describe('invoke', () => {
   });
 
   it('xstate.done.actor events should have unique names when invokee is a machine with an id property', (done) => {
-    const actual: string[] = [];
+    const actual: DoneActorEvent<void>[] = [];
 
     const childMachine = createMachine({
       id: 'child',
@@ -3121,7 +3122,7 @@ describe('invoke', () => {
       on: {
         '*': {
           actions: ({ event }) => {
-            actual.push(event.type);
+            actual.push(event as any);
           }
         }
       }
@@ -3132,8 +3133,16 @@ describe('invoke', () => {
     // check within a macrotask so all promise-induced microtasks have a chance to resolve first
     setTimeout(() => {
       expect(actual).toEqual([
-        'xstate.done.actor.0.(machine).first.fetch',
-        'xstate.done.actor.0.(machine).second.fetch'
+        {
+          type: 'xstate.done.actor.0.(machine).first.fetch',
+          output: undefined,
+          actorId: '0.(machine).first.fetch'
+        },
+        {
+          type: 'xstate.done.actor.0.(machine).second.fetch',
+          output: undefined,
+          actorId: '0.(machine).second.fetch'
+        }
       ]);
       done();
     }, 100);

--- a/packages/core/test/invoke.test.ts
+++ b/packages/core/test/invoke.test.ts
@@ -21,7 +21,7 @@ import {
   sendParent,
   Snapshot,
   ActorRef,
-  DoneActorEvent
+  AnyEventObject
 } from '../src/index.ts';
 import { sleep } from '@xstate-repo/jest-utils';
 
@@ -3082,7 +3082,7 @@ describe('invoke', () => {
   });
 
   it('xstate.done.actor events should have unique names when invokee is a machine with an id property', (done) => {
-    const actual: DoneActorEvent<void>[] = [];
+    const actual: AnyEventObject[] = [];
 
     const childMachine = createMachine({
       id: 'child',
@@ -3122,7 +3122,7 @@ describe('invoke', () => {
       on: {
         '*': {
           actions: ({ event }) => {
-            actual.push(event as any);
+            actual.push(event);
           }
         }
       }


### PR DESCRIPTION
This changes `DoneActorEvent` (`xstate.done.actor.*`) and `ErrorActorEvent` (`xstate.error.actor.*`) to have an `actorId` prop which is equal to the ID of the Actor associated with the event.

Previously, this information was only available by extracting it from the `type` property of the event object using string operations.

* * *

Updated a test for `DoneActorEvent` to prove that `actorId` gets passed, but may want the same test for an `ErrorActorEvent`.

Ref: https://discord.com/channels/795785288994652170/1250894522616123494