### PR TITLE
update issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,14 @@
 blank_issues_enabled: true
 contact_links:
   - name: ✨ Feature Request
-    url: https://github.com/statelyai/xstate/discussions/new
-    about: Have an idea for a new feature or integration? Share it here!
+    url: https://github.com/statelyai/xstate/discussions/new?category=ideas
+    about: Propose new features or integrations to enhance XState's functionality.
   - name: ❓ Ask a Question
-    url: https://github.com/statelyai/xstate/discussions/new
-    about: If you have any questions about how to do something in XState, ask it here.
+    url: https://github.com/statelyai/xstate/discussions/new?category=q-a
+    about: Need help with XState? Ask your questions and get support from the community.
+  - name: 📖 Documentation
+    url: https://github.com/statelyai/docs/issues/new
+    about: Found a problem or have suggestions for improving our documentation? Let us know here.
+  - name: 🛠️ Stately Studio
+    url: https://github.com/statelyai/studio-issues/issues/new/choose
+    about: Report issues or request features specific to Stately Studio.


### PR DESCRIPTION
This PR updates this repo's issue template config:

- update `url` for Feature Request/Ask a Question to point to the corresponding discussions category
- update `about` text for Feature Request/Ask a Question
- add entry for Documentation linking to new issue page of the `statelyai/docs` repo
- add entry for Stately Studio linking to the issue page of the `statelyai/studio-issues` repo

Here's what the updated new issue page will look like:

<img width="989" alt="image" src="https://github.com/statelyai/xstate/assets/1954752/006c517f-ca1a-41e7-8c73-6d287ecea79f">
