### PR TITLE
export actor logic-specific ActorRef types

### DIFF
--- a/.changeset/mighty-guests-hunt.md
+++ b/.changeset/mighty-guests-hunt.md
@@ -6,7 +6,7 @@ Added exports for actor logic-specific `ActorRef` types: `CallbackActorRef`, `Ob
 
 Each type represents `ActorRef` narrowed to the corresponding type of logic (the type of `self` within the actor's logic):
 
-- `CallbackActorRef`: actor created by [ `fromCallback`](https://stately.ai/docs/actors#fromcallback)
+- `CallbackActorRef`: actor created by [`fromCallback`](https://stately.ai/docs/actors#fromcallback)
 
   ```ts
   import { fromCallback, createActor } from 'xstate';

--- a/.changeset/mighty-guests-hunt.md
+++ b/.changeset/mighty-guests-hunt.md
@@ -1,0 +1,133 @@
+---
+'xstate': minor
+---
+
+Added exports for actor logic-specific `ActorRef` types: `CallbackActorRef`, `ObservableActorRef`, `PromiseActorRef`, and `TransitionActorRef`.
+
+Each type represents `ActorRef` narrowed to the corresponding type of logic (the type of `self` within the actor's logic):
+
+- `CallbackActorRef`: actor created by [ `fromCallback`](https://stately.ai/docs/actors#fromcallback)
+
+  ```ts
+  import { fromCallback, createActor } from 'xstate';
+
+  /** The events the actor receives. */
+  type Event = { type: 'someEvent' };
+  /** The actor's input. */
+  type Input = { name: string };
+
+  /** Actor logic that logs whenever it receives an event of type `someEvent`. */
+  const logic = fromCallback<Event, Input>(({ self, input, receive }) => {
+    self;
+    // ^? CallbackActorRef<Event, Input>
+
+    receive((event) => {
+      if (event.type === 'someEvent') {
+        console.log(`${input.name}: received "someEvent" event`);
+        // logs 'myActor: received "someEvent" event'
+      }
+    });
+  });
+
+  const actor = createActor(logic, { input: { name: 'myActor' } });
+  //    ^? CallbackActorRef<Event, Input>
+  ```
+
+- `ObservableActorRef`: actor created by [`fromObservable`](https://stately.ai/docs/actors#fromobservable) and [`fromEventObservable`](https://stately.ai/docs/actors#fromeventobservable)
+
+  ```ts
+  import { fromObservable, createActor } from 'xstate';
+  import { interval } from 'rxjs';
+
+  /** The type of the value observed by the actor's logic. */
+  type Context = number;
+  /** The actor's input. */
+  type Input = { period?: number };
+
+  /**
+   * Actor logic that observes a number incremented every `input.period`
+   * milliseconds (default: 1_000).
+   */
+  const logic = fromObservable<Context, Input>(({ input, self }) => {
+    self;
+    // ^? ObservableActorRef<Event, Input>
+
+    return interval(input.period ?? 1_000);
+  });
+
+  const actor = createActor(logic, { input: { period: 2_000 } });
+  //    ^? ObservableActorRef<Event, Input>
+  ```
+
+- `PromiseActorRef`: actor created by [`fromPromise`](https://stately.ai/docs/actors#actors-as-promises)
+
+  ```ts
+  import { fromPromise, createActor } from 'xstate';
+
+  /** The actor's resolved output. */
+  type Output = string;
+  /** The actor's input. */
+  type Input = { message: string };
+
+  /** Actor logic that fetches the url of an image of a cat saying `input.message`. */
+  const logic = fromPromise<Output, Input>(async ({ input, self }) => {
+    self;
+    // ^? PromiseActorRef<Output, Input>
+
+    const data = await fetch(`https://cataas.com/cat/says/${input.message}`);
+    const url = await data.json();
+    return url;
+  });
+
+  const actor = createActor(logic, { input: { message: 'hello world' } });
+  //    ^? PromiseActorRef<Output, Input>
+  ```
+
+- `TransitionActorRef`: actor created by [`fromTransition`](https://stately.ai/docs/actors#fromtransition)
+
+  ```ts
+  import { fromTransition, createActor, type AnyActorSystem } from 'xstate';
+
+  /** The actor's stored context. */
+  type Context = {
+    /** The current count. */
+    count: number;
+    /** The amount to increase `count` by. */
+    step: number;
+  };
+  /** The events the actor receives. */
+  type Event = { type: 'increment' };
+  /** The actor's input. */
+  type Input = { step?: number };
+
+  /**
+   * Actor logic that increments `count` by `step` when it receives an event of
+   * type `increment`.
+   */
+  const logic = fromTransition<Context, Event, AnyActorSystem, Input>(
+    (state, event, actorScope) => {
+      actorScope.self;
+      //         ^? TransitionActorRef<Context, Event>
+
+      if (event.type === 'increment') {
+        return {
+          ...state,
+          count: state.count + state.step
+        };
+      }
+      return state;
+    },
+    ({ input, self }) => {
+      self;
+      // ^? TransitionActorRef<Context, Event>
+
+      return {
+        count: 0,
+        step: input.step ?? 1
+      };
+    }
+  );
+
+  const actor = createActor(logic, { input: { step: 10 } });
+  //    ^? TransitionActorRef<Context, Event>
+  ```

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -36,6 +36,40 @@ export type CallbackActorLogic<
   TEmitted
 >;
 
+/**
+ * Represents an actor created by `fromCallback`.
+ *
+ * The type of `self` within the actor's logic.
+ *
+ * @example
+ *
+ * ```ts
+ * import { fromCallback, createActor } from 'xstate';
+ *
+ * // The events the actor receives.
+ * type Event = { type: 'someEvent' };
+ * // The actor's input.
+ * type Input = { name: string };
+ *
+ * // Actor logic that logs whenever it receives an event of type `someEvent`.
+ * const logic = fromCallback<Event, Input>(({ self, input, receive }) => {
+ *   self;
+ *   // ^? CallbackActorRef<Event, Input>
+ *
+ *   receive((event) => {
+ *     if (event.type === 'someEvent') {
+ *       console.log(`${input.name}: received "someEvent" event`);
+ *       // logs 'myActor: received "someEvent" event'
+ *     }
+ *   });
+ * });
+ *
+ * const actor = createActor(logic, { input: { name: 'myActor' } });
+ * //    ^? CallbackActorRef<Event, Input>
+ * ```
+ *
+ * @see {@link fromCallback}
+ */
 export type CallbackActorRef<
   TEvent extends EventObject,
   TInput = NonReducibleUnknown

--- a/packages/core/src/actors/index.ts
+++ b/packages/core/src/actors/index.ts
@@ -4,22 +4,26 @@ import { fromTransition } from './transition.ts';
 export {
   fromCallback,
   type CallbackActorLogic,
+  type CallbackActorRef,
   type CallbackSnapshot
 } from './callback.ts';
 export {
   fromEventObservable,
   fromObservable,
   type ObservableActorLogic,
+  type ObservableActorRef,
   type ObservableSnapshot
 } from './observable.ts';
 export {
   fromPromise,
   type PromiseActorLogic,
+  type PromiseActorRef,
   type PromiseSnapshot
 } from './promise.ts';
 export {
   fromTransition,
   type TransitionActorLogic,
+  type TransitionActorRef,
   type TransitionSnapshot
 } from './transition.ts';
 

--- a/packages/core/src/actors/observable.ts
+++ b/packages/core/src/actors/observable.ts
@@ -35,6 +35,38 @@ export type ObservableActorLogic<
   TEmitted
 >;
 
+/**
+ * Represents an actor created by `fromObservable` or `fromEventObservable`.
+ *
+ * The type of `self` within the actor's logic.
+ *
+ * @example
+ *
+ * ```ts
+ * import { fromObservable, createActor } from 'xstate';
+ * import { interval } from 'rxjs';
+ *
+ * // The type of the value observed by the actor's logic.
+ * type Context = number;
+ * // The actor's input.
+ * type Input = { period?: number };
+ *
+ * // Actor logic that observes a number incremented every `input.period`
+ * // milliseconds (default: 1_000).
+ * const logic = fromObservable<Context, Input>(({ input, self }) => {
+ *   self;
+ *   // ^? ObservableActorRef<Event, Input>
+ *
+ *   return interval(input.period ?? 1_000);
+ * });
+ *
+ * const actor = createActor(logic, { input: { period: 2_000 } });
+ * //    ^? ObservableActorRef<Event, Input>
+ * ```
+ *
+ * @see {@link fromObservable}
+ * @see {@link fromEventObservable}
+ */
 export type ObservableActorRef<TContext> = ActorRefFrom<
   ObservableActorLogic<TContext, any>
 >;

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -28,6 +28,39 @@ export type PromiseActorLogic<
   TEmitted // TEmitted
 >;
 
+/**
+ * Represents an actor created by `fromPromise`.
+ *
+ * The type of `self` within the actor's logic.
+ *
+ * @example
+ *
+ * ```ts
+ * import { fromPromise, createActor } from 'xstate';
+ *
+ * // The actor's resolved output
+ * type Output = string;
+ * // The actor's input.
+ * type Input = { message: string };
+ *
+ * // Actor logic that fetches the url of an image of a cat saying `input.message`.
+ * const logic = fromPromise<Output, Input>(async ({ input, self }) => {
+ *   self;
+ *   // ^? PromiseActorRef<Output, Input>
+ *
+ *   const data = await fetch(
+ *     `https://cataas.com/cat/says/${input.message}`
+ *   );
+ *   const url = await data.json();
+ *   return url;
+ * });
+ *
+ * const actor = createActor(logic, { input: { message: 'hello world' } });
+ * //    ^? PromiseActorRef<Output, Input>
+ * ```
+ *
+ * @see {@link fromPromise}
+ */
 export type PromiseActorRef<TOutput> = ActorRefFrom<
   PromiseActorLogic<TOutput, unknown>
 >;

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -32,6 +32,8 @@ export type PromiseActorRef<TOutput> = ActorRefFrom<
   PromiseActorLogic<TOutput, unknown>
 >;
 
+const controllerMap = new WeakMap<AnyActorRef, AbortController>();
+
 /**
  * An actor logic creator which returns promise logic as defined by an async
  * process that resolves or rejects after some time.
@@ -82,9 +84,6 @@ export type PromiseActorRef<TOutput> = ActorRefFrom<
  *
  * @see {@link https://stately.ai/docs/input | Input docs} for more information about how input is passed
  */
-
-const controllerMap = new WeakMap<AnyActorRef, AbortController>();
-
 export function fromPromise<
   TOutput,
   TInput = NonReducibleUnknown,

--- a/packages/core/src/actors/transition.ts
+++ b/packages/core/src/actors/transition.ts
@@ -25,6 +25,64 @@ export type TransitionActorLogic<
   TEmitted
 >;
 
+/**
+ * Represents an actor created by `fromTransition`.
+ *
+ * The type of `self` within the actor's logic.
+ *
+ * @example
+ *
+ * ```ts
+ * import {
+ *   fromTransition,
+ *   createActor,
+ *   type AnyActorSystem
+ * } from 'xstate';
+ *
+ * //* The actor's stored context.
+ * type Context = {
+ *   // The current count.
+ *   count: number;
+ *   // The amount to increase `count` by.
+ *   step: number;
+ * };
+ * // The events the actor receives.
+ * type Event = { type: 'increment' };
+ * // The actor's input.
+ * type Input = { step?: number };
+ *
+ * // Actor logic that increments `count` by `step` when it receives an event of
+ * // type `increment`.
+ * const logic = fromTransition<Context, Event, AnyActorSystem, Input>(
+ *   (state, event, actorScope) => {
+ *     actorScope.self;
+ *     //         ^? TransitionActorRef<Context, Event>
+ *
+ *     if (event.type === 'increment') {
+ *       return {
+ *         ...state,
+ *         count: state.count + state.step
+ *       };
+ *     }
+ *     return state;
+ *   },
+ *   ({ input, self }) => {
+ *     self;
+ *     // ^? TransitionActorRef<Context, Event>
+ *
+ *     return {
+ *       count: 0,
+ *       step: input.step ?? 1
+ *     };
+ *   }
+ * );
+ *
+ * const actor = createActor(logic, { input: { step: 10 } });
+ * //    ^? TransitionActorRef<Context, Event>
+ * ```
+ *
+ * @see {@link fromTransition}
+ */
 export type TransitionActorRef<
   TContext,
   TEvent extends EventObject


### PR DESCRIPTION
This PR exports actor logic-specific `ActorRef` types. Noticed in #4974 that these weren't actually exported.

In addition to exporting them, I added a `jsdoc` comment block for each.

Also fixed a small issue where the `jsdoc` block for `fromPromise` was attached to a variable defined before `fromPromise` rather than `fromPromise` itself. 