### PR TITLE
[core] Add `enqueue.sendParent(…)`

### DIFF
--- a/.changeset/nervous-snails-help.md
+++ b/.changeset/nervous-snails-help.md
@@ -1,0 +1,15 @@
+---
+'xstate': minor
+---
+
+Added `sendParent` to the `enqueueActions` feature. This allows users to enqueue actions that send events to the parent actor within the `enqueueActions` block.
+
+```js
+import { createMachine, enqueueActions } from 'xstate';
+
+const childMachine = createMachine({
+  entry: enqueueActions(({ enqueue }) => {
+    enqueue.sendParent({ type: 'CHILD_READY' });
+  })
+});
+```

--- a/packages/core/src/actions/enqueueActions.ts
+++ b/packages/core/src/actions/enqueueActions.ts
@@ -6,6 +6,7 @@ import {
   ActionFunction,
   AnyActorRef,
   AnyActorScope,
+  AnyEventObject,
   AnyMachineSnapshot,
   EventObject,
   MachineContext,
@@ -17,7 +18,7 @@ import { assign } from './assign.ts';
 import { cancel } from './cancel.ts';
 import { emit } from './emit.ts';
 import { raise } from './raise.ts';
-import { sendTo } from './send.ts';
+import { sendParent, sendTo } from './send.ts';
 import { spawnChild } from './spawnChild.ts';
 import { stopChild } from './stopChild.ts';
 
@@ -73,6 +74,19 @@ interface ActionEnqueuer<
         TExpressionEvent,
         undefined,
         TTargetActor,
+        TEvent,
+        TDelay,
+        TDelay
+      >
+    >
+  ) => void;
+  sendParent: (
+    ...args: Parameters<
+      typeof sendParent<
+        TContext,
+        TExpressionEvent,
+        undefined,
+        AnyEventObject,
         TEvent,
         TDelay,
         TDelay
@@ -138,6 +152,9 @@ function resolveEnqueueActions(
     // for some reason it fails to infer `TDelay` from `...args` here and picks its default (`never`)
     // then it fails to typecheck that because `...args` use `string` in place of `TDelay
     actions.push((sendTo as typeof enqueue.sendTo)(...args));
+  };
+  enqueue.sendParent = (...args) => {
+    actions.push((sendParent as typeof enqueue.sendParent)(...args));
   };
   enqueue.spawnChild = (...args) => {
     actions.push(spawnChild(...args));

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2883,6 +2883,51 @@ describe('enqueueActions', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('should enqueue.sendParent', () => {
+    interface ChildEvent {
+      type: 'CHILD_EVENT';
+    }
+
+    interface ParentEvent {
+      type: 'PARENT_EVENT';
+    }
+
+    const childMachine = setup({
+      types: {} as {
+        events: ChildEvent;
+      },
+      actions: {
+        sendToParent: enqueueActions(({ context, enqueue }) => {
+          enqueue.sendParent({ type: 'PARENT_EVENT' });
+        })
+      }
+    }).createMachine({
+      entry: 'sendToParent'
+    });
+
+    const parentSpy = jest.fn();
+
+    const parentMachine = setup({
+      types: {} as { events: ParentEvent },
+      actors: {
+        child: childMachine
+      }
+    }).createMachine({
+      on: {
+        PARENT_EVENT: {
+          actions: parentSpy
+        }
+      },
+      invoke: {
+        src: 'child'
+      }
+    });
+
+    const actorRef = createActor(parentMachine).start();
+
+    expect(parentSpy).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('sendParent', () => {


### PR DESCRIPTION
Added `sendParent` to the `enqueueActions` feature. This allows users to enqueue actions that send events to the parent actor within the `enqueueActions` block.

```js
import { createMachine, enqueueActions } from 'xstate';

const childMachine = createMachine({
  entry: enqueueActions(({ enqueue }) => {
    enqueue.sendParent({ type: 'CHILD_READY' });
  })
});
```
