### PR TITLE
Fixed annoying Babel warning

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,12 @@ export * from './types.ts';
 export { waitFor } from './waitFor.ts';
 import { createMachine } from './createMachine.ts';
 export { getInitialSnapshot, getNextSnapshot } from './getNextSnapshot.ts';
-import { Actor, createActor, interpret, Interpreter } from './createActor.ts';
+import {
+  Actor,
+  createActor,
+  interpret,
+  type Interpreter
+} from './createActor.ts';
 import { StateNode } from './StateNode.ts';
 // TODO: decide from where those should be exported
 export { and, not, or, stateIn } from './guards.ts';


### PR DESCRIPTION
Fixes the warning that we got during builds etc:
```
The exported identifier "Interpreter" is not declared in Babel's scope tracker
as a JavaScript value binding, and "@babel/plugin-transform-typescript"
never encountered it as a TypeScript type declaration.
It will be treated as a JavaScript value.

This problem is likely caused by another plugin injecting
"Interpreter" without registering it in the scope tracker. If you are the author
 of that plugin, please use "scope.registerDeclaration(declarationPath)".
```