### PR TITLE
[core] Expose actor snapshot `status` type as SnapshotStatus

### DIFF
--- a/.changeset/famous-crabs-build.md
+++ b/.changeset/famous-crabs-build.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+The actor snapshot `status` type (`'active' | 'done' | 'error' | 'stopped'`) is now exposed as SnapshotStatus

--- a/.changeset/famous-crabs-build.md
+++ b/.changeset/famous-crabs-build.md
@@ -2,4 +2,4 @@
 'xstate': minor
 ---
 
-The actor snapshot `status` type (`'active' | 'done' | 'error' | 'stopped'`) is now exposed as SnapshotStatus
+The actor snapshot `status` type (`'active' | 'done' | 'error' | 'stopped'`) is now exposed as `SnapshotStatus`

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -16,7 +16,8 @@ import type {
   Snapshot,
   ParameterizedObject,
   IsNever,
-  MetaObject
+  MetaObject,
+  SnapshotStatus
 } from './types.ts';
 import { matchesState } from './utils.ts';
 
@@ -96,7 +97,7 @@ interface MachineSnapshotBase<
    */
   value: TStateValue;
   /** The current status of this snapshot. */
-  status: 'active' | 'done' | 'error' | 'stopped';
+  status: SnapshotStatus;
   error: unknown;
   context: TContext;
 

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -46,7 +46,8 @@ import type {
   StateMachineDefinition,
   StateValue,
   TransitionDefinition,
-  ResolvedStateMachineTypes
+  ResolvedStateMachineTypes,
+  SnapshotStatus
 } from './types.ts';
 import { resolveReferencedActor, toStatePath } from './utils.ts';
 
@@ -213,7 +214,7 @@ export class StateMachine<
       value: StateValue;
       context?: TContext;
       historyValue?: HistoryValue<TContext, TEvent>;
-      status?: 'active' | 'done' | 'error' | 'stopped';
+      status?: SnapshotStatus;
       output?: TOutput;
       error?: unknown;
     } & (Equals<TContext, MachineContext> extends false

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2133,6 +2133,8 @@ export type AnyActorScope = ActorScope<
   any // TEmitted
 >;
 
+export type SnapshotStatus = 'active' | 'done' | 'error' | 'stopped';
+
 export type Snapshot<TOutput> =
   | {
       status: 'active';

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1711,7 +1711,7 @@ export interface StateConfig<
   /** @internal */
   _nodes: Array<StateNode<TContext, TEvent>>;
   children: Record<string, AnyActorRef>;
-  status: 'active' | 'done' | 'error' | 'stopped';
+  status: SnapshotStatus;
   output?: any;
   error?: unknown;
   machine?: StateMachine<


### PR DESCRIPTION
This PR exports a new `SnapshotStatus` type which represents the `status` type of an actor snapshot— `'active' | 'done' | 'error' | 'stopped'`.

Hardcoded uses of this string union were also replaced with the type.

[Discussion](https://discord.com/channels/795785288994652170/989186412450553957/1266027308201021491)