### PR TITLE
[core] Do not clear undefined timer IDs

### DIFF
--- a/.changeset/lucky-horses-pay.md
+++ b/.changeset/lucky-horses-pay.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fix an issue where `clearTimeout(undefined)` was sometimes being called, which can cause errors for some clock implementations. See https://github.com/statelyai/xstate/issues/5001 for details.

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -139,7 +139,9 @@ export function createSystem<T extends ActorSystemInfo>(
       delete timerMap[scheduledEventId];
       delete system._snapshot._scheduledEvents[scheduledEventId];
 
-      clock.clearTimeout(timeout);
+      if (timeout !== undefined) {
+        clock.clearTimeout(timeout);
+      }
     },
     cancelAll: (actorRef) => {
       for (const scheduledEventId in system._snapshot._scheduledEvents) {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -3514,6 +3514,31 @@ describe('cancel', () => {
     expect(fooSpy).toHaveBeenCalledTimes(1);
     expect(barSpy).not.toHaveBeenCalled();
   });
+
+  it('should not try to clear an undefined timeout when canceling an unscheduled timer', async () => {
+    const spy = jest.fn();
+
+    const machine = createMachine({
+      on: {
+        FOO: {
+          actions: cancel('foo')
+        }
+      }
+    });
+
+    const actorRef = createActor(machine, {
+      clock: {
+        setTimeout,
+        clearTimeout: spy
+      }
+    }).start();
+
+    actorRef.send({
+      type: 'FOO'
+    });
+
+    expect(spy.mock.calls.length).toBe(0);
+  });
 });
 
 describe('assign action order', () => {

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -3384,7 +3384,7 @@ describe('raise', () => {
 });
 
 describe('cancel', () => {
-  it('should be possible to cancel a raised delayed event', () => {
+  it('should be possible to cancel a raised delayed event', async () => {
     const machine = createMachine({
       initial: 'a',
       states: {
@@ -3405,11 +3405,18 @@ describe('cancel', () => {
 
     const actor = createActor(machine).start();
 
+    // This should raise the 'RAISED' event after 1ms
+    actor.send({ type: 'NEXT' });
+
+    // This should cancel the 'RAISED' event
     actor.send({ type: 'CANCEL' });
 
-    setTimeout(() => {
-      expect(actor.getSnapshot().value).toBe('a');
-    }, 10);
+    await new Promise<void>((res) => {
+      setTimeout(() => {
+        expect(actor.getSnapshot().value).toBe('a');
+        res();
+      }, 10);
+    });
   });
 
   it('should cancel only the delayed event in the machine that scheduled it when canceling the event with the same ID in the machine that sent it first', async () => {

--- a/packages/core/test/after.test.ts
+++ b/packages/core/test/after.test.ts
@@ -1,4 +1,5 @@
-import { createMachine, createActor } from '../src/index.ts';
+import { sleep } from '@xstate-repo/jest-utils';
+import { createMachine, createActor, cancel } from '../src/index.ts';
 
 const lightMachine = createMachine({
   id: 'light',
@@ -43,28 +44,33 @@ describe('delayed transitions', () => {
     expect(actorRef.getSnapshot().value).toBe('yellow');
   });
 
-  it('should never try to clear an undefined timeout ID', () => {
+  it('should not try to clear an undefined timeout when exiting source state of a delayed transition', async () => {
     // https://github.com/statelyai/xstate/issues/5001
-    jest.useFakeTimers();
+    const spy = jest.fn();
 
-    const actorRef = createActor(lightMachine, {
+    const machine = createMachine({
+      initial: 'green',
+      states: {
+        green: {
+          after: {
+            1: 'yellow'
+          }
+        },
+        yellow: {}
+      }
+    });
+
+    const actorRef = createActor(machine, {
       clock: {
         setTimeout,
-        clearTimeout(id) {
-          if (id === undefined) {
-            // in some workflow implementations, clearing an undefined ID will error
-            throw new Error('undefined ID');
-          }
-        }
+        clearTimeout: spy
       }
     }).start();
-    expect(actorRef.getSnapshot().value).toBe('green');
 
-    jest.advanceTimersByTime(500);
-    expect(actorRef.getSnapshot().value).toBe('green');
-
-    jest.advanceTimersByTime(510);
+    // when the after transition gets executed it tries to clear its own timer when exiting its source state
+    await sleep(5);
     expect(actorRef.getSnapshot().value).toBe('yellow');
+    expect(spy.mock.calls.length).toBe(0);
   });
 
   it('should format transitions properly', () => {


### PR DESCRIPTION

Fix an issue where `clearTimeout(undefined)` was sometimes being called, which can cause errors for some clock implementations. See https://github.com/statelyai/xstate/issues/5001 for details.
