### PR TITLE
[core] Tighten `StateMachine` types and fix issue #5008

### DIFF
--- a/.changeset/cold-suits-build.md
+++ b/.changeset/cold-suits-build.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+The internal types for `StateMachine<...>` have been improved so that all type params are required, to prevent errors when using the types. This fixes weird issues like #5008.

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -73,7 +73,8 @@ interface MachineSnapshotBase<
     unknown,
     TOutput,
     EventObject, // TEmitted
-    any // TMeta
+    any, // TMeta
+    TConfig
   >;
   /** The tags of the active state nodes that represent the current state value. */
   tags: Set<string>;

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -19,7 +19,8 @@ import type {
   MetaObject,
   StateSchema,
   StateId,
-  SnapshotStatus
+  SnapshotStatus,
+  SnapshotFrom
 } from './types.ts';
 import { matchesState } from './utils.ts';
 
@@ -56,7 +57,7 @@ interface MachineSnapshotBase<
   TTag extends string,
   TOutput,
   TMeta,
-  TConfig extends StateSchema = StateSchema
+  TConfig extends StateSchema
 > {
   /** The state machine that produced this state snapshot. */
   machine: StateMachine<
@@ -198,7 +199,7 @@ interface ErrorMachineSnapshot<
   TTag extends string,
   TOutput,
   TMeta extends MetaObject,
-  TConfig extends StateSchema = StateSchema
+  TConfig extends StateSchema
 > extends MachineSnapshotBase<
     TContext,
     TEvent,
@@ -222,7 +223,7 @@ interface StoppedMachineSnapshot<
   TTag extends string,
   TOutput,
   TMeta extends MetaObject,
-  TConfig extends StateSchema = StateSchema
+  TConfig extends StateSchema
 > extends MachineSnapshotBase<
     TContext,
     TEvent,
@@ -246,7 +247,7 @@ export type MachineSnapshot<
   TTag extends string,
   TOutput,
   TMeta extends MetaObject,
-  TConfig extends StateSchema = StateSchema
+  TConfig extends StateSchema
 > =
   | ActiveMachineSnapshot<
       TContext,
@@ -355,7 +356,8 @@ export function createMachineSnapshot<
   TChildren extends Record<string, AnyActorRef | undefined>,
   TStateValue extends StateValue,
   TTag extends string,
-  TMeta extends MetaObject
+  TMeta extends MetaObject,
+  TStateSchema extends StateSchema
 >(
   config: StateConfig<TContext, TEvent>,
   machine: AnyStateMachine
@@ -366,7 +368,8 @@ export function createMachineSnapshot<
   TStateValue,
   TTag,
   undefined,
-  TMeta
+  TMeta,
+  TStateSchema
 > {
   return {
     status: config.status as never,
@@ -413,7 +416,8 @@ export function getPersistedSnapshot<
     TStateValue,
     TTag,
     TOutput,
-    TMeta
+    TMeta,
+    any // state schema
   >,
   options?: unknown
 ): Snapshot<unknown> {

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -66,9 +66,9 @@ export class StateMachine<
   TTag extends string,
   TInput,
   TOutput,
-  TEmitted extends EventObject = EventObject, // TODO: remove default
-  TMeta extends MetaObject = MetaObject,
-  TConfig extends StateSchema = StateSchema
+  TEmitted extends EventObject,
+  TMeta extends MetaObject,
+  TConfig extends StateSchema
 > implements
     ActorLogic<
       MachineSnapshot<

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -199,7 +199,8 @@ export class StateMachine<
     TInput,
     TOutput,
     TEmitted,
-    TMeta
+    TMeta,
+    TConfig
   > {
     const { actions, guards, actors, delays } = this.implementations;
 

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -117,7 +117,8 @@ export class StateNode<
     any, // input
     any, // output
     any, // emitted
-    any // meta
+    any, // meta
+    any // state schema
   >;
   /**
    * The meta data associated with this state node, which will be returned in
@@ -368,7 +369,8 @@ export class StateNode<
       any,
       any,
       any,
-      any // TMeta
+      any, // TMeta
+      any // TStateSchema
     >,
     event: TEvent
   ): TransitionDefinition<TContext, TEvent>[] | undefined {

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -1,5 +1,5 @@
 import { StateMachine } from './StateMachine.ts';
-import { ResolvedStateMachineTypes } from './types.ts';
+import { ResolvedStateMachineTypes, TODO } from './types.ts';
 import {
   AnyActorRef,
   EventObject,
@@ -174,7 +174,8 @@ export function createMachine<
   TInput,
   TOutput,
   TEmitted,
-  TMeta // TMeta
+  TMeta, // TMeta
+  TODO // TStateSchema
 > {
   return new StateMachine<
     any,

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -189,6 +189,7 @@ export function createMachine<
     any,
     any,
     any, // TEmitted
-    any // TMeta
+    any, // TMeta
+    any // TStateSchema
   >(config as any, implementations as any);
 }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -660,7 +660,8 @@ function transitionAtomicNode<
     any,
     any,
     any,
-    any // TMeta
+    any, // TMeta
+    any // TStateSchema
   >,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
@@ -687,7 +688,8 @@ function transitionCompoundNode<
     any,
     any,
     any,
-    any // TMeta
+    any, // TMeta
+    any // TStateSchema
   >,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
@@ -721,7 +723,8 @@ function transitionParallelNode<
     any,
     any,
     any,
-    any // TMeta
+    any, // TMeta
+    any // TStateSchema
   >,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
@@ -758,7 +761,16 @@ export function transitionNode<
 >(
   stateNode: AnyStateNode,
   stateValue: StateValue,
-  snapshot: MachineSnapshot<TContext, TEvent, any, any, any, any, any>,
+  snapshot: MachineSnapshot<
+    TContext,
+    TEvent,
+    any,
+    any,
+    any,
+    any,
+    any,
+    any // TStateSchema
+  >,
   event: TEvent
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   // leaf node

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1732,6 +1732,7 @@ export interface StateConfig<
     any,
     any,
     any,
+    any,
     any, // TMeta
     any // TStateSchema
   >;
@@ -1984,6 +1985,7 @@ export type UnknownActorRef = ActorRef<Snapshot<unknown>, EventObject>;
 
 export type ActorLogicFrom<T> = ReturnTypeOrValue<T> extends infer R
   ? R extends StateMachine<
+      any,
       any,
       any,
       any,
@@ -2385,6 +2387,7 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
             infer _TAction,
             infer _TGuard,
             infer _TDelay,
+            infer _TStateValue,
             infer _TTag,
             infer _TInput,
             infer _TOutput,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -110,7 +110,8 @@ export interface UnifiedArg<
       StateValue,
       string,
       unknown,
-      TODO // TMeta
+      TODO, // TMeta
+      TODO // State schema
     >,
     TEvent,
     AnyEventObject
@@ -139,7 +140,8 @@ export type InputFrom<T> = T extends StateMachine<
   infer TInput,
   infer _TOutput,
   infer _TEmitted,
-  infer _TMeta
+  infer _TMeta,
+  infer _TStateSchema
 >
   ? TInput
   : T extends ActorLogic<
@@ -1122,7 +1124,8 @@ export type AnyStateMachine = StateMachine<
   any, // input
   any, // output
   any, // emitted
-  any // TMeta
+  any, // TMeta
+  any // TStateSchema
 >;
 
 export type AnyStateConfig = StateConfig<any, AnyEventObject>;
@@ -1321,7 +1324,8 @@ export type ContextFactory<
       StateValue,
       string,
       unknown,
-      TODO // TMeta
+      TODO, // TMeta
+      TODO // State schema
     >,
     TEvent,
     AnyEventObject
@@ -1627,7 +1631,8 @@ export type Mapper<
       StateValue,
       string,
       unknown,
-      TODO // TMeta
+      TODO, // TMeta
+      TODO // State schema
     >,
     TEvent,
     AnyEventObject
@@ -1728,7 +1733,7 @@ export interface StateConfig<
     any,
     any,
     any, // TMeta
-    any
+    any // TStateSchema
   >;
 }
 
@@ -1991,7 +1996,7 @@ export type ActorLogicFrom<T> = ReturnTypeOrValue<T> extends infer R
       any,
       any,
       any, // TMeta
-      any
+      any // TStateSchema
     >
     ? R
     : R extends Promise<infer U>
@@ -2013,7 +2018,8 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer TOutput,
       infer TEmitted,
-      infer TMeta
+      infer TMeta,
+      infer TStateSchema
     >
     ? ActorRef<
         MachineSnapshot<
@@ -2023,7 +2029,8 @@ export type ActorRefFrom<T> = ReturnTypeOrValue<T> extends infer R
           TStateValue,
           TTag,
           TOutput,
-          TMeta
+          TMeta,
+          TStateSchema
         >,
         TEvent,
         TEmitted
@@ -2059,7 +2066,8 @@ export type InterpreterFrom<
   infer TInput,
   infer TOutput,
   infer TEmitted,
-  infer TMeta
+  infer TMeta,
+  infer TStateSchema
 >
   ? Actor<
       ActorLogic<
@@ -2070,7 +2078,8 @@ export type InterpreterFrom<
           TStateValue,
           TTag,
           TOutput,
-          TMeta
+          TMeta,
+          TStateSchema
         >,
         TEvent,
         TInput,
@@ -2095,7 +2104,8 @@ export type MachineImplementationsFrom<
   infer _TInput,
   infer _TOutput,
   infer TEmitted,
-  infer _TMeta
+  infer _TMeta,
+  infer _TStateSchema
 >
   ? InternalMachineImplementations<
       ResolvedStateMachineTypes<
@@ -2311,7 +2321,8 @@ type ResolveEventType<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer _TOutput,
       infer _TEmitted,
-      infer _TMeta
+      infer _TMeta,
+      infer _TStateSchema
     >
     ? TEvent
     : R extends MachineSnapshot<
@@ -2321,7 +2332,8 @@ type ResolveEventType<T> = ReturnTypeOrValue<T> extends infer R
           infer _TStateValue,
           infer _TTag,
           infer _TOutput,
-          infer _TMeta
+          infer _TMeta,
+          infer _TStateSchema
         >
       ? TEvent
       : R extends ActorRef<infer _TSnapshot, infer TEvent, infer _TEmitted>
@@ -2349,7 +2361,8 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
       infer _TInput,
       infer _TOutput,
       infer _TEmitted,
-      infer _TMeta
+      infer _TMeta,
+      infer _TStateSchema
     >
     ? TContext
     : R extends MachineSnapshot<
@@ -2359,7 +2372,8 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
           infer _TStateValue,
           infer _TTag,
           infer _TOutput,
-          infer _TMeta
+          infer _TMeta,
+          infer _TStateSchema
         >
       ? TContext
       : R extends Actor<infer TActorLogic>
@@ -2376,7 +2390,7 @@ export type ContextFrom<T> = ReturnTypeOrValue<T> extends infer R
             infer _TOutput,
             infer _TEmitted,
             infer _TMeta,
-            infer _TTypes
+            infer _TStateSchema
           >
           ? TContext
           : never
@@ -2443,29 +2457,35 @@ export type StateSchema = {
   states?: Record<string, StateSchema>;
 };
 
+type Test = SnapshotFrom<AnyStateMachine>;
+
+['getMeta'];
+
 export type StateId<
   TSchema extends StateSchema,
   TKey extends string = '(machine)',
   TParentKey extends string | null = null
-> =
-  | (TSchema extends { id: string }
-      ? TSchema['id']
-      : TParentKey extends null
-        ? TKey
-        : `${TParentKey}.${TKey}`)
-  | (TSchema['states'] extends Record<string, any>
-      ? Values<{
-          [K in keyof TSchema['states'] & string]: StateId<
-            TSchema['states'][K],
-            K,
-            TParentKey extends string
-              ? `${TParentKey}.${TKey}`
-              : TSchema['id'] extends string
-                ? TSchema['id']
-                : TKey
-          >;
-        }>
-      : never);
+> = IsAny<TSchema> extends true
+  ? string
+  :
+      | (TSchema extends { id: string }
+          ? TSchema['id']
+          : TParentKey extends null
+            ? TKey
+            : `${TParentKey}.${TKey}`)
+      | (TSchema['states'] extends Record<string, any>
+          ? Values<{
+              [K in keyof TSchema['states'] & string]: StateId<
+                TSchema['states'][K],
+                K,
+                TParentKey extends string
+                  ? `${TParentKey}.${TKey}`
+                  : TSchema['id'] extends string
+                    ? TSchema['id']
+                    : TKey
+              >;
+            }>
+          : never);
 
 export interface StateMachineTypes {
   context: MachineContext;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2468,27 +2468,25 @@ export type StateId<
   TSchema extends StateSchema,
   TKey extends string = '(machine)',
   TParentKey extends string | null = null
-> = IsAny<TSchema> extends true
-  ? string
-  :
-      | (TSchema extends { id: string }
-          ? TSchema['id']
-          : TParentKey extends null
-            ? TKey
-            : `${TParentKey}.${TKey}`)
-      | (TSchema['states'] extends Record<string, any>
-          ? Values<{
-              [K in keyof TSchema['states'] & string]: StateId<
-                TSchema['states'][K],
-                K,
-                TParentKey extends string
-                  ? `${TParentKey}.${TKey}`
-                  : TSchema['id'] extends string
-                    ? TSchema['id']
-                    : TKey
-              >;
-            }>
-          : never);
+> =
+  | (TSchema extends { id: string }
+      ? TSchema['id']
+      : TParentKey extends null
+        ? TKey
+        : `${TParentKey}.${TKey}`)
+  | (TSchema['states'] extends Record<string, any>
+      ? Values<{
+          [K in keyof TSchema['states'] & string]: StateId<
+            TSchema['states'][K],
+            K,
+            TParentKey extends string
+              ? `${TParentKey}.${TKey}`
+              : TSchema['id'] extends string
+                ? TSchema['id']
+                : TKey
+          >;
+        }>
+      : never);
 
 export interface StateMachineTypes {
   context: MachineContext;

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -398,6 +398,7 @@ it('should work with generic context', () => {
     any,
     any,
     any,
+    any,
     any, // TMeta
     any
   > {
@@ -532,6 +533,7 @@ describe('events', () => {
       _machine: StateMachine<
         TContext,
         TEvent,
+        any,
         any,
         any,
         any,

--- a/packages/xstate-graph/src/TestModel.ts
+++ b/packages/xstate-graph/src/TestModel.ts
@@ -354,7 +354,8 @@ function serializeMachineTransition(
     StateValue,
     string,
     unknown,
-    TODO // TMeta
+    TODO, // TMeta
+    TODO // TStateSchema
   >,
   event: AnyEventObject | undefined,
   previousSnapshot:
@@ -365,7 +366,8 @@ function serializeMachineTransition(
         StateValue,
         string,
         unknown,
-        TODO // TMeta
+        TODO, // TMeta
+        TODO // TStateSchema
       >
     | undefined,
   { serializeEvent }: { serializeEvent: (event: AnyEventObject) => string }

--- a/packages/xstate-graph/src/types.ts
+++ b/packages/xstate-graph/src/types.ts
@@ -255,7 +255,8 @@ export interface TestMeta<T, TContext extends MachineContext> {
       any,
       any,
       any,
-      any // TMeta
+      any, // TMeta
+      any // TStateSchema
     >
   ) => Promise<void> | void;
   description?:
@@ -268,7 +269,8 @@ export interface TestMeta<T, TContext extends MachineContext> {
           any,
           any,
           any,
-          any // TMeta
+          any, // TMeta
+          any // TStateSchema
         >
       ) => string);
   skip?: boolean;
@@ -365,7 +367,8 @@ export interface TestTransitionConfig<
       any,
       any,
       any,
-      any // TMeta
+      any, // TMeta
+      any // TStateSchema
     >,
     testContext: TTestContext
   ) => void;

--- a/packages/xstate-graph/test/index.test.ts
+++ b/packages/xstate-graph/test/index.test.ts
@@ -413,33 +413,33 @@ describe('state tests', () => {
   });
 
   it('should test with input', () => {
-    const model = createTestModel(
-      setup({
-        types: {
-          input: {} as {
-            name: string;
-          },
-          context: {} as {
-            name: string;
-          }
+    const machine = setup({
+      types: {
+        input: {} as {
+          name: string;
+        },
+        context: {} as {
+          name: string;
         }
-      }).createMachine({
-        context: (x) => ({
-          name: x.input.name
-        }),
-        initial: 'checking',
-        states: {
-          checking: {
-            always: [
-              { guard: (x) => x.context.name.length > 3, target: 'longName' },
-              { target: 'shortName' }
-            ]
-          },
-          longName: {},
-          shortName: {}
-        }
-      })
-    );
+      }
+    }).createMachine({
+      context: (x) => ({
+        name: x.input.name
+      }),
+      initial: 'checking',
+      states: {
+        checking: {
+          always: [
+            { guard: (x) => x.context.name.length > 3, target: 'longName' },
+            { target: 'shortName' }
+          ]
+        },
+        longName: {},
+        shortName: {}
+      }
+    });
+
+    const model = createTestModel(machine);
 
     const path1 = model.getShortestPaths({
       input: { name: 'ed' }

--- a/packages/xstate-react/test/types.test.tsx
+++ b/packages/xstate-react/test/types.test.tsx
@@ -1,6 +1,7 @@
 import { render } from '@testing-library/react';
-import { ActorRefFrom, assign, createMachine } from 'xstate';
+import { ActorRefFrom, assign, createMachine, setup } from 'xstate';
 import { useMachine, useSelector } from '../src/index.ts';
+import { useEffect, useMemo } from 'react';
 
 describe('useMachine', () => {
   interface YesNoContext {
@@ -118,4 +119,25 @@ describe('useMachine', () => {
 
     noop(App);
   });
+});
+
+it('useMachine types work for machines with a specified id and state with an after property #5008', () => {
+  // https://github.com/statelyai/xstate/issues/5008
+  const cheatCodeMachine = setup({}).createMachine({
+    id: 'cheatCodeMachine',
+    initial: 'disabled',
+    states: {
+      disabled: {
+        after: {}
+      },
+      enabled: {}
+    }
+  });
+
+  function _useCheatCode(): boolean {
+    // This should typecheck without errors
+    const [state] = useMachine(cheatCodeMachine);
+
+    return state.matches('enabled');
+  }
 });


### PR DESCRIPTION
The internal types for `StateMachine<...>` have been improved so that all type params are required, to prevent errors when using the types. This fixes weird issues like #5008.
