### PR TITLE
[@xstate/store] Add `store.inspect(…)`

### DIFF
--- a/.changeset/sweet-tools-compare.md
+++ b/.changeset/sweet-tools-compare.md
@@ -1,0 +1,16 @@
+---
+'@xstate/store': minor
+---
+
+You can now inspect XState stores using the `.inspect(inspector)` method:
+
+```ts
+import { someStore } from './someStore';
+
+someStore.inspect((inspEv) => {
+  console.log(inspEv);
+  // logs "@xstate.event" events and "@xstate.snapshot" events
+  // whenever an event is sent to the store
+});
+// The "@xstate.actor" event is immediately logged
+```

--- a/packages/core/src/inspection.ts
+++ b/packages/core/src/inspection.ts
@@ -1,4 +1,5 @@
 import {
+  ActorRefLike,
   AnyActorRef,
   AnyEventObject,
   AnyTransitionDefinition,
@@ -21,7 +22,7 @@ interface BaseInspectionEventProperties {
    * - For event events, this is the target `actorRef` (recipient of event).
    * - For actor events, this is the `actorRef` of the registered actor.
    */
-  actorRef: AnyActorRef;
+  actorRef: ActorRefLike;
 }
 
 export interface InspectedSnapshotEvent extends BaseInspectionEventProperties {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1981,6 +1981,11 @@ export interface ActorRef<
 
 export type AnyActorRef = ActorRef<any, any, any>;
 
+export type ActorRefLike = Pick<
+  AnyActorRef,
+  'sessionId' | 'send' | 'getSnapshot'
+>;
+
 export type UnknownActorRef = ActorRef<Snapshot<unknown>, EventObject>;
 
 export type ActorLogicFrom<T> = ReturnTypeOrValue<T> extends infer R

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -66,6 +66,13 @@ export interface Store<TContext, Ev extends EventObject>
   send: (event: Ev) => void;
   getSnapshot: () => StoreSnapshot<TContext>;
   getInitialSnapshot: () => StoreSnapshot<TContext>;
+  /**
+   * Subscribes to [inspection events](https://stately.ai/docs/inspection) from
+   * the store.
+   *
+   * Inspectors that call `store.inspect(…)` will immediately receive an
+   * "@xstate.actor" inspection event.
+   */
   inspect: (
     observer:
       | Observer<InspectionEvent>

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -1,3 +1,5 @@
+import { InspectionEvent } from 'xstate';
+
 export type EventPayloadMap = Record<string, {} | null | undefined>;
 
 export type ExtractEventsFromPayloadMap<T extends EventPayloadMap> = Values<{
@@ -64,6 +66,12 @@ export interface Store<TContext, Ev extends EventObject>
   send: (event: Ev) => void;
   getSnapshot: () => StoreSnapshot<TContext>;
   getInitialSnapshot: () => StoreSnapshot<TContext>;
+  inspect: (
+    observer:
+      | Observer<InspectionEvent>
+      | ((inspectionEvent: InspectionEvent) => void)
+  ) => Subscription;
+  sessionId: string;
 }
 
 export type SnapshotFromStore<TStore extends Store<any, any>> =

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -166,3 +166,40 @@ it('can be observed', () => {
 
   expect(counts).toEqual([1, 2, 3]);
 });
+
+it('can be inspected', () => {
+  const store = createStore(
+    {
+      count: 0
+    },
+    {
+      inc: {
+        count: (ctx) => ctx.count + 1
+      }
+    }
+  );
+
+  const evs: any[] = [];
+
+  store.inspect((ev) => evs.push(ev));
+
+  store.send({ type: 'inc' });
+
+  expect(evs).toEqual([
+    expect.objectContaining({
+      type: '@xstate.actor'
+    }),
+    expect.objectContaining({
+      type: '@xstate.snapshot',
+      snapshot: expect.objectContaining({ context: { count: 0 } })
+    }),
+    expect.objectContaining({
+      type: '@xstate.event',
+      event: { type: 'inc' }
+    }),
+    expect.objectContaining({
+      type: '@xstate.snapshot',
+      snapshot: expect.objectContaining({ context: { count: 1 } })
+    })
+  ]);
+});


### PR DESCRIPTION

You can now inspect XState stores using the `.inspect(inspector)` method:

```ts
import { someStore } from './someStore';

someStore.inspect((inspEv) => {
  console.log(inspEv);
  // logs "@xstate.event" events and "@xstate.snapshot" events
  // whenever an event is sent to the store
});
// The "@xstate.actor" event is immediately logged
```