### PR TITLE
Fixed an inference issue that prevented `emit` used directly in `setup` (or bare `createMachine`) to benefit from `types.emitted` types

### DIFF
--- a/.changeset/empty-seas-live.md
+++ b/.changeset/empty-seas-live.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed an inference issue that prevented `emit` used directly in `setup` (or bare `createMachine`) to benefit from `types.emitted` types.

--- a/packages/core/src/actions/emit.ts
+++ b/packages/core/src/actions/emit.ts
@@ -2,13 +2,14 @@ import isDevelopment from '#is-development';
 import { executingCustomAction } from '../stateUtils.ts';
 import {
   ActionArgs,
+  ActionFunction,
   AnyActorScope,
   AnyMachineSnapshot,
+  DoNotInfer,
   EventObject,
   MachineContext,
-  SendExpr,
   ParameterizedObject,
-  ActionFunction
+  SendExpr
 } from '../types.ts';
 
 function resolveEmit(
@@ -109,8 +110,14 @@ export function emit<
 >(
   /** The event to emit, or an expression that returns an event to emit. */
   eventOrExpr:
-    | TEmitted
-    | SendExpr<TContext, TExpressionEvent, TParams, TEmitted, TEvent>
+    | DoNotInfer<TEmitted>
+    | SendExpr<
+        TContext,
+        TExpressionEvent,
+        TParams,
+        DoNotInfer<TEmitted>,
+        TEvent
+      >
 ): ActionFunction<
   TContext,
   TExpressionEvent,

--- a/packages/core/src/actions/emit.ts
+++ b/packages/core/src/actions/emit.ts
@@ -4,6 +4,7 @@ import {
   ActionArgs,
   ActionFunction,
   AnyActorScope,
+  AnyEventObject,
   AnyMachineSnapshot,
   DoNotInfer,
   EventObject,
@@ -106,7 +107,7 @@ export function emit<
   TExpressionEvent extends EventObject,
   TParams extends ParameterizedObject['params'] | undefined,
   TEvent extends EventObject,
-  TEmitted extends EventObject
+  TEmitted extends AnyEventObject
 >(
   /** The event to emit, or an expression that returns an event to emit. */
   eventOrExpr:

--- a/packages/core/test/setup.types.test.ts
+++ b/packages/core/test/setup.types.test.ts
@@ -6,9 +6,9 @@ import {
   ContextFrom,
   createActor,
   createMachine,
+  emit,
   enqueueActions,
   EventFrom,
-  EventObject,
   fromPromise,
   fromTransition,
   log,
@@ -794,6 +794,45 @@ describe('setup()', () => {
       actions: {
         sendFoo: sendParent({
           type: 'FOO'
+        })
+      }
+    });
+  });
+
+  it('should accept an `emit` action that emits a known event', () => {
+    setup({
+      types: {} as {
+        emitted:
+          | {
+              type: 'FOO';
+            }
+          | {
+              type: 'BAR';
+            };
+      },
+      actions: {
+        emitFoo: emit({
+          type: 'FOO'
+        })
+      }
+    });
+  });
+
+  it('should not accept an `emit` action that emits an unknown event', () => {
+    setup({
+      types: {} as {
+        emitted:
+          | {
+              type: 'FOO';
+            }
+          | {
+              type: 'BAR';
+            };
+      },
+      actions: {
+        emitFoo: emit({
+          // @ts-expect-error
+          type: 'BAZ'
         })
       }
     });
@@ -2110,7 +2149,7 @@ describe('setup()', () => {
     });
   });
 
-  it('should allow `cancel` action to be configured', () => {
+  it('should allow `log` action to be configured', () => {
     setup({
       actions: {
         writeDown: log('foo')


### PR DESCRIPTION
fixes https://github.com/statelyai/xstate/issues/5038