### PR TITLE
feat(core): add signal option to waitFor

### DIFF
--- a/.changeset/pretty-chicken-lie.md
+++ b/.changeset/pretty-chicken-lie.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+`waitFor()` now accepts a `{signal: AbortSignal}` in `WaitForOptions`

--- a/packages/core/src/waitFor.ts
+++ b/packages/core/src/waitFor.ts
@@ -9,6 +9,9 @@ interface WaitForOptions {
    * @defaultValue Infinity
    */
   timeout: number;
+
+  /** A signal which stops waiting when aborted. */
+  signal?: AbortSignal;
 }
 
 const defaultWaitForOptions: WaitForOptions = {
@@ -46,6 +49,11 @@ export function waitFor<TActorRef extends AnyActorRef>(
     ...options
   };
   return new Promise((res, rej) => {
+    const { signal } = resolvedOptions;
+    if (signal?.aborted) {
+      rej(signal.reason);
+      return;
+    }
     let done = false;
     if (isDevelopment && resolvedOptions.timeout < 0) {
       console.error(
@@ -56,7 +64,7 @@ export function waitFor<TActorRef extends AnyActorRef>(
       resolvedOptions.timeout === Infinity
         ? undefined
         : setTimeout(() => {
-            sub!.unsubscribe();
+            dispose();
             rej(new Error(`Timeout of ${resolvedOptions.timeout} ms exceeded`));
           }, resolvedOptions.timeout);
 
@@ -64,6 +72,9 @@ export function waitFor<TActorRef extends AnyActorRef>(
       clearTimeout(handle!);
       done = true;
       sub?.unsubscribe();
+      if (abortListener) {
+        signal!.removeEventListener('abort', abortListener);
+      }
     };
 
     function checkEmitted(emitted: SnapshotFrom<TActorRef>) {
@@ -73,12 +84,27 @@ export function waitFor<TActorRef extends AnyActorRef>(
       }
     }
 
+    /**
+     * If the `signal` option is provided, this will be the listener for its
+     * `abort` event
+     */
+    let abortListener: () => void | undefined;
     let sub: Subscription | undefined; // avoid TDZ when disposing synchronously
 
     // See if the current snapshot already matches the predicate
     checkEmitted(actorRef.getSnapshot());
     if (done) {
       return;
+    }
+
+    // only define the `abortListener` if the `signal` option is provided
+    if (signal) {
+      abortListener = () => {
+        dispose();
+        // XState does not "own" the signal, so we should reject with its reason (if any)
+        rej(signal.reason);
+      };
+      signal.addEventListener('abort', abortListener);
     }
 
     sub = actorRef.subscribe({


### PR DESCRIPTION
This PR adds a `signal?: AbortSignal` option to `WaitForOptions`, so that a call to `waitFor()` can be externally aborted.
