### PR TITLE
[core] Export `CallbackLogicFunction` (prev. `InvokeCallback`)

### DIFF
--- a/.changeset/mean-news-sell.md
+++ b/.changeset/mean-news-sell.md
@@ -2,10 +2,10 @@
 'xstate': patch
 ---
 
-The `CallbackActorFunction` type (previously `InvokeCallback`) is now exported. This is the callback function that you pass into `fromCallback(callbackActorFn)` to create an actor from a callback function.
+The `CallbackLogicFunction` type (previously `InvokeCallback`) is now exported. This is the callback function that you pass into `fromCallback(callbackActorFn)` to create an actor from a callback function.
 
 ```ts
-import { type CallbackActorFunction } from 'xstate';
+import { type CallbackLogicFunction } from 'xstate';
 
 // ...
 ```

--- a/.changeset/mean-news-sell.md
+++ b/.changeset/mean-news-sell.md
@@ -2,7 +2,7 @@
 'xstate': patch
 ---
 
-The `CallbackLogicFunction` type (previously `InvokeCallback`) is now exported. This is the callback function that you pass into `fromCallback(callbackActorFn)` to create an actor from a callback function.
+The `CallbackLogicFunction` type (previously `InvokeCallback`) is now exported. This is the callback function that you pass into `fromCallback(callbackLogicFn)` to create an actor from a callback function.
 
 ```ts
 import { type CallbackLogicFunction } from 'xstate';

--- a/.changeset/mean-news-sell.md
+++ b/.changeset/mean-news-sell.md
@@ -1,0 +1,11 @@
+---
+'xstate': patch
+---
+
+The `CallbackActorFunction` type (previously `InvokeCallback`) is now exported. This is the callback function that you pass into `fromCallback(callbackActorFn)` to create an actor from a callback function.
+
+```ts
+import { type CallbackActorFunction } from 'xstate';
+
+// ...
+```

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -163,9 +163,8 @@ export type CallbackLogicFunction<
  * });
  * ```
  *
- * @param invokeCallback - The callback function used to describe the callback
- *   logic The callback function is passed an object with the following
- *   properties:
+ * @param callback - The callback function used to describe the callback logic
+ *   The callback function is passed an object with the following properties:
  *
  *   - `receive` - A function that can send events back to the parent actor; the
  *       listener is then called whenever events are received by the callback
@@ -186,15 +185,10 @@ export function fromCallback<
   TInput = NonReducibleUnknown,
   TEmitted extends EventObject = EventObject
 >(
-  callback: CallbackLogicFunction<
-    TEvent,
-    AnyEventObject,
-    TInput,
-    TEmitted
-  >
+  callback: CallbackLogicFunction<TEvent, AnyEventObject, TInput, TEmitted>
 ): CallbackActorLogic<TEvent, TInput, TEmitted> {
   const logic: CallbackActorLogic<TEvent, TInput, TEmitted> = {
-    config: invokeCallback,
+    config: callback,
     start: (state, actorScope) => {
       const { self, system, emit } = actorScope;
 
@@ -205,7 +199,7 @@ export function fromCallback<
 
       instanceStates.set(self, callbackState);
 
-      callbackState.dispose = invokeCallback({
+      callbackState.dispose = callback({
         input: state.input,
         system,
         self,

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -186,7 +186,7 @@ export function fromCallback<
   TInput = NonReducibleUnknown,
   TEmitted extends EventObject = EventObject
 >(
-  invokeCallback: CallbackLogicFunction<
+  callback: CallbackLogicFunction<
     TEvent,
     AnyEventObject,
     TInput,

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -81,7 +81,7 @@ type Receiver<TEvent extends EventObject> = (
   }['bivarianceHack']
 ) => void;
 
-type InvokeCallback<
+export type CallbackLogicFunction<
   TEvent extends EventObject = AnyEventObject,
   TSentEvent extends EventObject = AnyEventObject,
   TInput = NonReducibleUnknown,
@@ -178,7 +178,7 @@ type InvokeCallback<
  *       when the actor is stopped.
  *
  * @returns Callback logic
- * @see {@link InvokeCallback} for more information about the callback function and its object argument
+ * @see {@link CallbackLogicFunction} for more information about the callback function and its object argument
  * @see {@link https://stately.ai/docs/input | Input docs} for more information about how input is passed
  */
 export function fromCallback<
@@ -186,7 +186,12 @@ export function fromCallback<
   TInput = NonReducibleUnknown,
   TEmitted extends EventObject = EventObject
 >(
-  invokeCallback: InvokeCallback<TEvent, AnyEventObject, TInput, TEmitted>
+  invokeCallback: CallbackLogicFunction<
+    TEvent,
+    AnyEventObject,
+    TInput,
+    TEmitted
+  >
 ): CallbackActorLogic<TEvent, TInput, TEmitted> {
   const logic: CallbackActorLogic<TEvent, TInput, TEmitted> = {
     config: invokeCallback,

--- a/packages/core/src/actors/index.ts
+++ b/packages/core/src/actors/index.ts
@@ -5,7 +5,8 @@ export {
   fromCallback,
   type CallbackActorLogic,
   type CallbackActorRef,
-  type CallbackSnapshot
+  type CallbackSnapshot,
+  type CallbackLogicFunction
 } from './callback.ts';
 export {
   fromEventObservable,


### PR DESCRIPTION
The `CallbackLogicFunction` type (previously `InvokeCallback`) is now exported. This is the callback function that you pass into `fromCallback(callbackActorFn)` to create an actor from a callback function.

```ts
import { type CallbackLogicFunction } from 'xstate';

// ...
```
