### PR TITLE
Add initial support for xstate/store/solid

### DIFF
--- a/.changeset/mean-peaches-decide.md
+++ b/.changeset/mean-peaches-decide.md
@@ -1,0 +1,24 @@
+---
+'@xstate/store': minor
+---
+
+You can now use the xstate/store package with SolidJS.
+
+Import `useSelector` from `@xstate/store/solid`. Select the data you want via `useSelector(…)` and send events using `store.send(eventObject)`:
+
+```tsx
+import { donutStore } from './donutStore.ts';
+import { useSelector } from '@xstate/store/solid';
+
+function DonutCounter() {
+  const donutCount = useSelector(donutStore, (state) => state.context.donuts);
+
+  return (
+    <div>
+      <button onClick={() => donutStore.send({ type: 'addDonut' })}>
+        Add donut ({donutCount()})
+      </button>
+    </div>
+  );
+}
+```

--- a/babel.config.js
+++ b/babel.config.js
@@ -49,7 +49,7 @@ module.exports = {
       ]
     },
     {
-      test: /\/xstate-solid\//,
+      test: /\/xstate-solid\/|solid\.test\.tsx$/,
       presets: ['babel-preset-solid']
     }
   ],

--- a/packages/xstate-store/README.md
+++ b/packages/xstate-store/README.md
@@ -74,6 +74,27 @@ function DonutCounter() {
 }
 ```
 
+## Usage with SolidJS
+
+Import `useSelector` from `@xstate/store/solid`. Select the data you want via `useSelector(…)` and send events using `store.send(eventObject)`:
+
+```tsx
+import { donutStore } from './donutStore.ts';
+import { useSelector } from '@xstate/store/solid';
+
+function DonutCounter() {
+  const donutCount = useSelector(donutStore, (state) => state.context.donuts);
+
+  return (
+    <div>
+      <button onClick={() => donutStore.send({ type: 'addDonut' })}>
+        Add donut ({donutCount()})
+      </button>
+    </div>
+  );
+}
+```
+
 ## Usage with Immer
 
 XState Store makes it really easy to integrate with immutable update libraries like [Immer](https://github.com/immerjs/immer) or [Mutative](https://github.com/unadlib/mutative). Pass the `produce` function into `createStoreWithProducer(producer, …)`, and update `context` in transition functions using the convenient pseudo-mutative API:

--- a/packages/xstate-store/package.json
+++ b/packages/xstate-store/package.json
@@ -30,18 +30,27 @@
       "import": "./react/dist/xstate-store-react.cjs.mjs",
       "default": "./react/dist/xstate-store-react.cjs.js"
     },
+    "./solid": {
+      "types": {
+        "import": "./solid/dist/xstate-store-solid.cjs.mjs",
+        "default": "./solid/dist/xstate-store-solid.cjs.js"
+      },
+      "module": "./solid/dist/xstate-store-solid.esm.js",
+      "import": "./solid/dist/xstate-store-solid.cjs.mjs",
+      "default": "./solid/dist/xstate-store-solid.cjs.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [
     "dist",
-    "react"
+    "react",
+    "solid"
   ],
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/statelyai/xstate.git"
   },
-  "scripts": {},
   "bugs": {
     "url": "https://github.com/statelyai/xstate/issues"
   },
@@ -53,13 +62,19 @@
     "immer": "^10.0.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "solid-js": "^1.7.6",
+    "solid-testing-library": "^0.3.0",
     "xstate": "^5.17.4"
   },
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0",
+    "solid-js": "^1.7.6"
   },
   "peerDependenciesMeta": {
     "react": {
+      "optional": true
+    },
+    "solid-js": {
       "optional": true
     }
   },
@@ -67,7 +82,8 @@
     "umdName": "XStateStore",
     "entrypoints": [
       "./index.ts",
-      "./react.ts"
+      "./react.ts",
+      "./solid.ts"
     ]
   }
 }

--- a/packages/xstate-store/solid/package.json
+++ b/packages/xstate-store/solid/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/xstate-store-solid.cjs.js",
+  "module": "dist/xstate-store-solid.esm.js"
+}

--- a/packages/xstate-store/src/solid.ts
+++ b/packages/xstate-store/src/solid.ts
@@ -7,27 +7,10 @@ function defaultCompare<T>(a: T | undefined, b: T) {
   return a === b;
 }
 
-function useSelectorWithCompare<
-  TStore extends
-    | Store<any, any>
-    | Pick<AnyActorRef, 'subscribe' | 'getSnapshot'>,
-  T
->(
-  selector: (
-    snapshot: TStore extends Store<any, any>
-      ? SnapshotFromStore<TStore>
-      : TStore extends { getSnapshot(): infer TSnapshot }
-        ? TSnapshot
-        : never
-  ) => T,
-  compare: (a: T | undefined, b: T) => boolean = defaultCompare
-): (
-  snapshot: TStore extends Store<any, any>
-    ? SnapshotFromStore<TStore>
-    : TStore extends { getSnapshot(): infer TSnapshot }
-      ? TSnapshot
-      : never
-) => T {
+function useSelectorWithCompare<TStore extends Store<any, any>, T>(
+  selector: (snapshot: SnapshotFromStore<TStore>) => T,
+  compare: (a: T | undefined, b: T) => boolean
+): (snapshot: SnapshotFromStore<TStore>) => T {
   let previous: T | undefined;
 
   return (state): T => {
@@ -71,20 +54,9 @@ function useSelectorWithCompare<
  *   previously selected value
  * @returns A read-only signal of the selected value
  */
-export function useSelector<
-  TStore extends
-    | Store<any, any>
-    | Pick<AnyActorRef, 'subscribe' | 'getSnapshot'>,
-  T
->(
+export function useSelector<TStore extends Store<any, any>, T>(
   store: TStore,
-  selector: (
-    snapshot: TStore extends Store<any, any>
-      ? SnapshotFromStore<TStore>
-      : TStore extends { getSnapshot(): infer TSnapshot }
-        ? TSnapshot
-        : never
-  ) => T,
+  selector: (snapshot: SnapshotFromStore<TStore>) => T,
   compare: (a: T | undefined, b: T) => boolean = defaultCompare
 ): () => T {
   const selectorWithCompare = useSelectorWithCompare(selector, compare);

--- a/packages/xstate-store/src/solid.ts
+++ b/packages/xstate-store/src/solid.ts
@@ -1,0 +1,107 @@
+/* @jsxImportSource solid-js */
+import { AnyActorRef } from 'xstate';
+import { createEffect, createSignal, onCleanup } from 'solid-js';
+import { Store, SnapshotFromStore } from './types';
+
+function defaultCompare<T>(a: T | undefined, b: T) {
+  return a === b;
+}
+
+function useSelectorWithCompare<
+  TStore extends
+    | Store<any, any>
+    | Pick<AnyActorRef, 'subscribe' | 'getSnapshot'>,
+  T
+>(
+  selector: (
+    snapshot: TStore extends Store<any, any>
+      ? SnapshotFromStore<TStore>
+      : TStore extends { getSnapshot(): infer TSnapshot }
+        ? TSnapshot
+        : never
+  ) => T,
+  compare: (a: T | undefined, b: T) => boolean = defaultCompare
+): (
+  snapshot: TStore extends Store<any, any>
+    ? SnapshotFromStore<TStore>
+    : TStore extends { getSnapshot(): infer TSnapshot }
+      ? TSnapshot
+      : never
+) => T {
+  let previous: T | undefined;
+
+  return (state): T => {
+    const next = selector(state);
+
+    if (previous === undefined || !compare(previous, next)) {
+      previous = next;
+    }
+
+    return previous;
+  };
+}
+
+/**
+ * Creates a selector which subscribes to the store and selects a value from the
+ * store's snapshot, using an optional comparison function.
+ *
+ * @example
+ *
+ * ```tsx
+ * import { donutStore } from './donutStore.ts';
+ * import { useSelector } from '@xstate/store/solid';
+ *
+ * function DonutCounter() {
+ *   const donutCount = useSelector(donutStore, (state) => state.context.donuts);
+ *
+ *   return (
+ *     <div>
+ *       <button onClick={() => donutStore.send({ type: 'addDonut' })}>
+ *         Add donut ({donutCount()})
+ *       </button>
+ *     </div>
+ *   );
+ * }
+ * ```
+ *
+ * @param store The store, created from `createStore(…)`
+ * @param selector A function which takes in the snapshot and returns a selected
+ *   value from it
+ * @param compare An optional function which compares the selected value to the
+ *   previously selected value
+ * @returns A read-only signal of the selected value
+ */
+export function useSelector<
+  TStore extends
+    | Store<any, any>
+    | Pick<AnyActorRef, 'subscribe' | 'getSnapshot'>,
+  T
+>(
+  store: TStore,
+  selector: (
+    snapshot: TStore extends Store<any, any>
+      ? SnapshotFromStore<TStore>
+      : TStore extends { getSnapshot(): infer TSnapshot }
+        ? TSnapshot
+        : never
+  ) => T,
+  compare: (a: T | undefined, b: T) => boolean = defaultCompare
+): () => T {
+  const selectorWithCompare = useSelectorWithCompare(selector, compare);
+  const [selectedValue, setSelectedValue] = createSignal(
+    selectorWithCompare(store.getSnapshot() as any)
+  );
+
+  createEffect(() => {
+    const subscription = store.subscribe(() => {
+      const newValue = selectorWithCompare(store.getSnapshot() as any);
+      setSelectedValue(() => newValue);
+    });
+
+    onCleanup(() => {
+      subscription.unsubscribe();
+    });
+  });
+
+  return selectedValue;
+}

--- a/packages/xstate-store/src/solid.ts
+++ b/packages/xstate-store/src/solid.ts
@@ -1,5 +1,4 @@
 /* @jsxImportSource solid-js */
-import { AnyActorRef } from 'xstate';
 import { createEffect, createSignal, onCleanup } from 'solid-js';
 import { Store, SnapshotFromStore } from './types';
 
@@ -61,12 +60,14 @@ export function useSelector<TStore extends Store<any, any>, T>(
 ): () => T {
   const selectorWithCompare = useSelectorWithCompare(selector, compare);
   const [selectedValue, setSelectedValue] = createSignal(
-    selectorWithCompare(store.getSnapshot() as any)
+    selectorWithCompare(store.getSnapshot() as SnapshotFromStore<TStore>)
   );
 
   createEffect(() => {
     const subscription = store.subscribe(() => {
-      const newValue = selectorWithCompare(store.getSnapshot() as any);
+      const newValue = selectorWithCompare(
+        store.getSnapshot() as SnapshotFromStore<TStore>
+      );
       setSelectedValue(() => newValue);
     });
 

--- a/packages/xstate-store/src/solid.ts
+++ b/packages/xstate-store/src/solid.ts
@@ -1,6 +1,6 @@
 /* @jsxImportSource solid-js */
 import { createEffect, createSignal, onCleanup } from 'solid-js';
-import { Store, SnapshotFromStore } from './types';
+import type { Store, SnapshotFromStore } from './types';
 
 function defaultCompare<T>(a: T | undefined, b: T) {
   return a === b;

--- a/packages/xstate-store/test/solid.test.tsx
+++ b/packages/xstate-store/test/solid.test.tsx
@@ -1,0 +1,337 @@
+/* @jsxImportSource solid-js */
+import type { ActorRefFrom } from 'xstate';
+import type { Accessor, Component } from 'solid-js';
+
+import { useActor, useActorRef } from '@xstate/solid';
+import { createRenderEffect, createSignal } from 'solid-js';
+import { fireEvent, render, screen } from 'solid-testing-library';
+
+import { createStore, fromStore } from '../src/index.ts';
+import { useSelector } from '../src/solid.ts';
+
+describe('Solid.js integration', () => {
+  describe('useSelector', () => {
+    // Ensure selectors react and result in renders as expected
+    it('should minimize rerenders', () => {
+      const store = createCounterStore();
+
+      render(() => <Counter store={store} />);
+
+      const counterLabel = screen.getByTestId('counter-label-value');
+      const containerRenders = screen.getByTestId('counter-container-renders');
+      const labelRenders = screen.getByTestId('counter-label-renders');
+      const incrementButton = screen.getByTestId('increment-button');
+      const otherButton = screen.getByTestId('other-button');
+
+      expect(containerRenders.textContent).toBe('1');
+      expect(labelRenders.textContent).toBe('1');
+      expect(counterLabel.textContent).toBe('0');
+
+      fireEvent.click(incrementButton);
+
+      expect(counterLabel.textContent).toBe('1');
+      expect(containerRenders.textContent).toBe('1');
+      expect(labelRenders.textContent).toBe('2');
+
+      fireEvent.click(otherButton);
+      fireEvent.click(otherButton);
+      fireEvent.click(otherButton);
+      fireEvent.click(otherButton);
+
+      expect(labelRenders.textContent).toBe('2');
+
+      fireEvent.click(incrementButton);
+
+      expect(counterLabel.textContent).toBe('2');
+      expect(containerRenders.textContent).toBe('1');
+      expect(labelRenders.textContent).toBe('3');
+    });
+
+    // Validate the expected behaviours of default and custom comparison functions
+    it('can use a custom comparison function', async () => {
+      const INITIAL_ITEMS = [1, 2];
+      const DIFFERENT_ITEMS = [3, 4];
+      const INITIAL_ITEMS_STRING = INITIAL_ITEMS.join(',');
+
+      const store = createItemStore(INITIAL_ITEMS, DIFFERENT_ITEMS);
+
+      const Container = () => {
+        return (
+          <>
+            <ItemList store={store} name="default" comparison={undefined} />
+            <ItemList
+              store={store}
+              name="custom"
+              comparison={(a, b) => JSON.stringify(a) === JSON.stringify(b)}
+            />
+
+            <button
+              data-testid="same"
+              onClick={() => {
+                store.send({ type: 'same' });
+              }}
+            >
+              Change
+            </button>
+            <button
+              data-testid="different"
+              onClick={() => {
+                store.send({ type: 'different' });
+              }}
+            >
+              Change
+            </button>
+          </>
+        );
+      };
+
+      render(() => <Container />);
+
+      const defaultRendersDiv = await screen.findByTestId(
+        'default-selector-renders'
+      );
+      const customRendersDiv = await screen.findByTestId(
+        'custom-selector-renders'
+      );
+
+      const defaultItemsDiv = await screen.findByTestId(
+        'default-selector-items'
+      );
+      const customItemsDiv = await screen.findByTestId('custom-selector-items');
+      const differentButton = await screen.findByTestId('different');
+      const sameButton = await screen.findByTestId('same');
+
+      expect(defaultItemsDiv.textContent).toBe(INITIAL_ITEMS_STRING);
+      expect(defaultRendersDiv.textContent).toBe('1');
+
+      expect(customItemsDiv.textContent).toBe(INITIAL_ITEMS_STRING);
+      expect(customRendersDiv.textContent).toBe('1');
+
+      // Should cause a rerender for default selector, but not for custom selector
+      fireEvent.click(sameButton);
+
+      expect(defaultItemsDiv.textContent).toBe(INITIAL_ITEMS_STRING);
+      expect(defaultRendersDiv.textContent).toBe('2');
+
+      expect(customItemsDiv.textContent).toBe(INITIAL_ITEMS_STRING);
+      expect(defaultRendersDiv.textContent).toBe('2');
+      expect(customRendersDiv.textContent).toBe('1');
+
+      // Toggling [1, 2] to [3, 4] should trigger a rerender for both selectors
+      fireEvent.click(differentButton);
+
+      expect(defaultItemsDiv.textContent).toBe('3,4');
+      expect(customItemsDiv.textContent).toBe('3,4');
+      expect(defaultRendersDiv.textContent).toBe('3');
+      expect(customRendersDiv.textContent).toBe('2');
+
+      // Both should rerender
+      fireEvent.click(sameButton);
+
+      expect(defaultItemsDiv.textContent).toBe(INITIAL_ITEMS_STRING);
+      expect(customItemsDiv.textContent).toBe(INITIAL_ITEMS_STRING);
+      expect(defaultRendersDiv.textContent).toBe('4');
+      expect(customRendersDiv.textContent).toBe('3');
+
+      // Only default selector should rerender
+      fireEvent.click(sameButton);
+      fireEvent.click(sameButton);
+
+      expect(defaultItemsDiv.textContent).toBe(INITIAL_ITEMS_STRING);
+      expect(customItemsDiv.textContent).toBe(INITIAL_ITEMS_STRING);
+      expect(defaultRendersDiv.textContent).toBe('6');
+      expect(customRendersDiv.textContent).toBe('3');
+    });
+
+    it('should allow batched updates', () => {
+      const store = createCounterStore();
+
+      const BatchCounter = () => {
+        const count = useSelector(store, (s) => s.context.count);
+
+        return (
+          <div
+            data-testid="count"
+            onClick={() => {
+              store.send({ type: 'increment' });
+              store.send({ type: 'increment' });
+            }}
+          >
+            {count()}
+          </div>
+        );
+      };
+
+      render(() => <BatchCounter />);
+
+      const countDiv = screen.getByTestId('count');
+
+      expect(countDiv.textContent).toEqual('0');
+
+      fireEvent.click(countDiv);
+
+      expect(countDiv.textContent).toEqual('2');
+    });
+  });
+
+  describe('XState compatibility', () => {
+    it('useActor (@xstate/solid) should work', () => {
+      const store = fromStore(
+        { count: 0 },
+        {
+          inc: { count: (ctx) => ctx.count + 1 }
+        }
+      );
+
+      const Counter = () => {
+        const [snapshot, send] = useActor(store);
+
+        return (
+          <div
+            data-testid="count"
+            onClick={() => {
+              send({ type: 'inc' });
+            }}
+          >
+            {snapshot.context.count}
+          </div>
+        );
+      };
+
+      render(() => <Counter />);
+
+      const countDiv = screen.getByTestId('count');
+
+      expect(countDiv.textContent).toEqual('0');
+
+      fireEvent.click(countDiv);
+
+      expect(countDiv.textContent).toEqual('1');
+    });
+
+    it('useActorRef (@xstate/solid) should work', () => {
+      const store = fromStore(
+        { count: 0 },
+        { inc: { count: (ctx) => ctx.count + 1 } }
+      );
+
+      const Counter = () => {
+        const actorRef = useActorRef(store);
+        const count = useSelector(actorRef, (s) => s.context.count);
+
+        return (
+          <div
+            data-testid="count"
+            onClick={() => {
+              actorRef.send({ type: 'inc' });
+            }}
+          >
+            {count()}
+          </div>
+        );
+      };
+
+      render(() => <Counter />);
+
+      const countDiv = screen.getByTestId('count');
+
+      expect(countDiv.textContent).toEqual('0');
+
+      fireEvent.click(countDiv);
+      fireEvent.click(countDiv);
+      fireEvent.click(countDiv);
+
+      expect(countDiv.textContent).toEqual('3');
+    });
+  });
+});
+
+const useRenderTracker = (...accessors: Accessor<unknown>[]) => {
+  const [renders, setRenders] = createSignal(0);
+  createRenderEffect(() => {
+    accessors.forEach((s) => s());
+    setRenders((p) => p + 1);
+  });
+  return renders;
+};
+
+/**
+ * A simple store that has `count` and `other` properties, and two actions which
+ * increment `count`. It's paired with 2 small components to aid with testing
+ * store behaviours.
+ */
+const createCounterStore = () =>
+  createStore(
+    { count: 0, other: 0 },
+    {
+      increment: { count: ({ count }) => count + 1 },
+      other: { other: ({ other }) => other + 1 }
+    }
+  );
+
+type CounterStore = ReturnType<typeof createCounterStore>;
+
+const CounterLabel: Component<{ store: CounterStore }> = ({ store }) => {
+  const count = useSelector(store, (s) => s.context.count);
+  const renders = useRenderTracker(count);
+
+  return (
+    <>
+      <div data-testid="counter-label-value">{count()}</div>;
+      <div data-testid="counter-label-renders">{renders()}</div>;
+    </>
+  );
+};
+
+const Counter: Component<{ store: CounterStore }> = ({ store }) => {
+  const renders = useRenderTracker();
+
+  return (
+    <div>
+      <div data-testid="counter-container-renders">{renders()}</div>;
+      <CounterLabel store={store} />
+      <button
+        data-testid="other-button"
+        onclick={() => store.send({ type: 'other' })}
+      />
+      <button
+        data-testid="increment-button"
+        onclick={() => store.send({ type: 'increment' })}
+      />
+    </div>
+  );
+};
+
+/**
+ * A store that has an `items` property, and two actions which change `items`
+ * between two different arrays. It's paired with 2 small components to aid with
+ * testing store behaviours.
+ *
+ * The `comparison` parameter is used to determine whether the selectors should
+ * be re-evaluated. If not provided, the selectors will be re-evaluated on every
+ * change.
+ */
+const createItemStore = (initialItems: number[], differentItems: number[]) =>
+  createStore(
+    { items: initialItems },
+    {
+      same: { items: () => [...initialItems] },
+      different: { items: () => differentItems }
+    }
+  );
+
+const ItemList: Component<{
+  store: ReturnType<typeof createItemStore>;
+  name: string;
+  comparison?: (a: number[] | undefined, b: number[]) => boolean;
+}> = ({ store, name, comparison }) => {
+  const items = useSelector(store, (s) => s.context.items, comparison);
+  const renders = useRenderTracker(items);
+
+  return (
+    <div>
+      <div data-testid={`${name}-selector-renders`}>{renders()}</div>
+      <div data-testid={`${name}-selector-items`}>{items().join(',')}</div>
+    </div>
+  );
+};

--- a/packages/xstate-store/test/solid.test.tsx
+++ b/packages/xstate-store/test/solid.test.tsx
@@ -1,10 +1,8 @@
 /* @jsxImportSource solid-js */
 import type { Accessor, Component } from 'solid-js';
-
 import { createRenderEffect, createSignal } from 'solid-js';
 import { fireEvent, render, screen } from 'solid-testing-library';
-
-import { createStore, fromStore } from '../src/index.ts';
+import { createStore } from '../src/index.ts';
 import { useSelector } from '../src/solid.ts';
 
 /** A function that tracks renders caused by the given accessors changing */

--- a/packages/xstate-store/test/solid.test.tsx
+++ b/packages/xstate-store/test/solid.test.tsx
@@ -175,41 +175,7 @@ describe('Solid.js integration', () => {
   });
 
   describe('XState compatibility', () => {
-    it('useActor (@xstate/solid) should work', () => {
-      const store = fromStore(
-        { count: 0 },
-        {
-          inc: { count: (ctx) => ctx.count + 1 }
-        }
-      );
-
-      const Counter = () => {
-        const [snapshot, send] = useActor(store);
-
-        return (
-          <div
-            data-testid="count"
-            onClick={() => {
-              send({ type: 'inc' });
-            }}
-          >
-            {snapshot.context.count}
-          </div>
-        );
-      };
-
-      render(() => <Counter />);
-
-      const countDiv = screen.getByTestId('count');
-
-      expect(countDiv.textContent).toEqual('0');
-
-      fireEvent.click(countDiv);
-
-      expect(countDiv.textContent).toEqual('1');
-    });
-
-    it('useActorRef (@xstate/solid) should work', () => {
+    it('useActorRef (@xstate/solid) should work with useSelector', () => {
       const store = fromStore(
         { count: 0 },
         { inc: { count: (ctx) => ctx.count + 1 } }


### PR DESCRIPTION
I've added `useSelector` support to xstate/store for SolidJS which seems to be working well in my tests. Let me know what I can improve and I'd be happy to do it.