### PR TITLE
add `registry-url` to `actions/setup-node`

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -10,6 +10,7 @@ runs:
       with:
         node-version: 20.x
         cache: 'pnpm'
+        registry-url: 'https://registry.npmjs.org'
 
     - name: Install Dependencies
       run: pnpm install


### PR DESCRIPTION
This PR should hopefully fix the `ENEEDAUTH` error we're receiving in actions. 

According to https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry:

> Please note that you need to set the `registry-url` to https://registry.npmjs.org/ in `setup-node` to properly configure your credentials.