### PR TITLE
[@xstate/store] Fix `useSelector(…)` infinite loop 

### DIFF
--- a/.changeset/selfish-lions-switch.md
+++ b/.changeset/selfish-lions-switch.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+The `useSelector(…)` hook will no longer result in an infinite loop when an object-like value is returned from the selector function.

--- a/packages/xstate-store/src/solid.ts
+++ b/packages/xstate-store/src/solid.ts
@@ -1,6 +1,6 @@
 /* @jsxImportSource solid-js */
 import { createEffect, createSignal, onCleanup } from 'solid-js';
-import type { Store, SnapshotFromStore, AnyStore } from './types';
+import type { SnapshotFromStore, AnyStore } from './types';
 
 function defaultCompare<T>(a: T | undefined, b: T) {
   return a === b;

--- a/packages/xstate-store/src/useSyncExternalStoreWithSelector.ts
+++ b/packages/xstate-store/src/useSyncExternalStoreWithSelector.ts
@@ -3,8 +3,6 @@ import * as React from 'react';
 const is = (a: any, b: any) => a === b;
 import { useSyncExternalStore } from 'react';
 
-// Intentionally not using named imports because Rollup uses dynamic dispatch
-// for CommonJS interop.
 const { useRef, useEffect, useMemo, useDebugValue } = React;
 
 // Same as useSyncExternalStore, but supports selector and isEqual arguments.
@@ -15,7 +13,6 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
   selector: (snapshot: Snapshot) => Selection,
   isEqual?: (a: Selection, b: Selection) => boolean
 ): Selection {
-  // Use this to track the rendered snapshot.
   const instRef = useRef<
     | {
         hasValue: true;
@@ -39,23 +36,15 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
   }
 
   const [getSelection, getServerSelection] = useMemo(() => {
-    // Track the memoized state using closure variables that are local to this
-    // memoized instance of a getSnapshot function. Intentionally not using a
-    // useRef hook, because that state would be shared across all concurrent
-    // copies of the hook/component.
     let hasMemo = false;
     let memoizedSnapshot: Snapshot;
     let memoizedSelection: Selection;
     const memoizedSelector = (nextSnapshot: Snapshot) => {
       if (!hasMemo) {
-        // The first time the hook is called, there is no memoized result.
         hasMemo = true;
         memoizedSnapshot = nextSnapshot;
         const nextSelection = selector(nextSnapshot);
         if (isEqual !== undefined) {
-          // Even if the selector has changed, the currently rendered selection
-          // may be equal to the new selection. We should attempt to reuse the
-          // current value if possible, to preserve downstream memoizations.
           if (inst.hasValue) {
             const currentSelection = inst.value;
             if (isEqual(currentSelection, nextSelection)) {
@@ -68,25 +57,16 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
         return nextSelection;
       }
 
-      // We may be able to reuse the previous invocation's result.
       const prevSnapshot: Snapshot = memoizedSnapshot;
       const prevSelection: Selection = memoizedSelection;
 
       if (is(prevSnapshot, nextSnapshot)) {
-        // The snapshot is the same as last time. Reuse the previous selection.
         return prevSelection;
       }
 
-      // The snapshot has changed, so we need to compute a new selection.
       const nextSelection = selector(nextSnapshot);
 
-      // If a custom isEqual function is provided, use that to check if the data
-      // has changed. If it hasn't, return the previous selection. That signals
-      // to React that the selections are conceptually equal, and we can bail
-      // out of rendering.
       if (isEqual !== undefined && isEqual(prevSelection, nextSelection)) {
-        // The snapshot still has changed, so make sure to update to not keep
-        // old references alive
         memoizedSnapshot = nextSnapshot;
         return prevSelection;
       }
@@ -95,7 +75,6 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
       memoizedSelection = nextSelection;
       return nextSelection;
     };
-    // Assigning this to a constant so that Flow knows it can't change.
     const maybeGetServerSnapshot =
       getServerSnapshot === undefined ? null : getServerSnapshot;
     const getSnapshotWithSelector = () => memoizedSelector(getSnapshot());
@@ -113,9 +92,7 @@ export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
   );
 
   useEffect(() => {
-    // $FlowFixMe[incompatible-type] changing the variant using mutation isn't supported
     inst.hasValue = true;
-    // $FlowFixMe[incompatible-type]
     inst.value = value;
   }, [value]);
 

--- a/packages/xstate-store/src/useSyncExternalStoreWithSelector.ts
+++ b/packages/xstate-store/src/useSyncExternalStoreWithSelector.ts
@@ -1,0 +1,124 @@
+// Copied from https://github.com/facebook/react/blob/0a76aecbfa3d493c6b97998d0444f6505f5e5365/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js
+import * as React from 'react';
+const is = (a: any, b: any) => a === b;
+import { useSyncExternalStore } from 'react';
+
+// Intentionally not using named imports because Rollup uses dynamic dispatch
+// for CommonJS interop.
+const { useRef, useEffect, useMemo, useDebugValue } = React;
+
+// Same as useSyncExternalStore, but supports selector and isEqual arguments.
+export function useSyncExternalStoreWithSelector<Snapshot, Selection>(
+  subscribe: (arg: () => void) => () => void,
+  getSnapshot: () => Snapshot,
+  getServerSnapshot: void | null | (() => Snapshot),
+  selector: (snapshot: Snapshot) => Selection,
+  isEqual?: (a: Selection, b: Selection) => boolean
+): Selection {
+  // Use this to track the rendered snapshot.
+  const instRef = useRef<
+    | {
+        hasValue: true;
+        value: Selection;
+      }
+    | {
+        hasValue: false;
+        value: null;
+      }
+    | null
+  >(null);
+  let inst;
+  if (instRef.current === null) {
+    inst = {
+      hasValue: false as const,
+      value: null
+    };
+    instRef.current = inst;
+  } else {
+    inst = instRef.current;
+  }
+
+  const [getSelection, getServerSelection] = useMemo(() => {
+    // Track the memoized state using closure variables that are local to this
+    // memoized instance of a getSnapshot function. Intentionally not using a
+    // useRef hook, because that state would be shared across all concurrent
+    // copies of the hook/component.
+    let hasMemo = false;
+    let memoizedSnapshot: Snapshot;
+    let memoizedSelection: Selection;
+    const memoizedSelector = (nextSnapshot: Snapshot) => {
+      if (!hasMemo) {
+        // The first time the hook is called, there is no memoized result.
+        hasMemo = true;
+        memoizedSnapshot = nextSnapshot;
+        const nextSelection = selector(nextSnapshot);
+        if (isEqual !== undefined) {
+          // Even if the selector has changed, the currently rendered selection
+          // may be equal to the new selection. We should attempt to reuse the
+          // current value if possible, to preserve downstream memoizations.
+          if (inst.hasValue) {
+            const currentSelection = inst.value;
+            if (isEqual(currentSelection, nextSelection)) {
+              memoizedSelection = currentSelection;
+              return currentSelection;
+            }
+          }
+        }
+        memoizedSelection = nextSelection;
+        return nextSelection;
+      }
+
+      // We may be able to reuse the previous invocation's result.
+      const prevSnapshot: Snapshot = memoizedSnapshot;
+      const prevSelection: Selection = memoizedSelection;
+
+      if (is(prevSnapshot, nextSnapshot)) {
+        // The snapshot is the same as last time. Reuse the previous selection.
+        return prevSelection;
+      }
+
+      // The snapshot has changed, so we need to compute a new selection.
+      const nextSelection = selector(nextSnapshot);
+
+      // If a custom isEqual function is provided, use that to check if the data
+      // has changed. If it hasn't, return the previous selection. That signals
+      // to React that the selections are conceptually equal, and we can bail
+      // out of rendering.
+      if (isEqual !== undefined && isEqual(prevSelection, nextSelection)) {
+        // The snapshot still has changed, so make sure to update to not keep
+        // old references alive
+        memoizedSnapshot = nextSnapshot;
+        return prevSelection;
+      }
+
+      memoizedSnapshot = nextSnapshot;
+      memoizedSelection = nextSelection;
+      return nextSelection;
+    };
+    // Assigning this to a constant so that Flow knows it can't change.
+    const maybeGetServerSnapshot =
+      getServerSnapshot === undefined ? null : getServerSnapshot;
+    const getSnapshotWithSelector = () => memoizedSelector(getSnapshot());
+    const getServerSnapshotWithSelector =
+      maybeGetServerSnapshot === null
+        ? undefined
+        : () => memoizedSelector(maybeGetServerSnapshot());
+    return [getSnapshotWithSelector, getServerSnapshotWithSelector];
+  }, [getSnapshot, getServerSnapshot, selector, isEqual]);
+
+  const value = useSyncExternalStore(
+    subscribe,
+    getSelection,
+    getServerSelection
+  );
+
+  useEffect(() => {
+    // $FlowFixMe[incompatible-type] changing the variant using mutation isn't supported
+    inst.hasValue = true;
+    // $FlowFixMe[incompatible-type]
+    inst.value = value;
+  }, [value]);
+
+  useDebugValue(value);
+  return value;
+}

--- a/packages/xstate-store/test/react.test.tsx
+++ b/packages/xstate-store/test/react.test.tsx
@@ -267,7 +267,7 @@ it('useActorRef (@xstate/react) should work', () => {
   expect(countDiv.textContent).toEqual('1');
 });
 
-it.only('useSelector should not infinite loop', () => {
+it('useSelector should not infinite loop', () => {
   const store = createStore({
     context: {
       count: [1, 2, 3, 4]
@@ -276,6 +276,8 @@ it.only('useSelector should not infinite loop', () => {
   });
 
   const Counter = () => {
+    // Using .slice() creates a new array reference
+    // which previously caused an infinite loop
     const count = useSelector(store, (s) => s.context.count.slice());
 
     return (
@@ -285,7 +287,7 @@ it.only('useSelector should not infinite loop', () => {
           store.send({ type: 'inc' });
         }}
       >
-        {count}
+        {count.join(',')}
       </div>
     );
   };
@@ -294,9 +296,5 @@ it.only('useSelector should not infinite loop', () => {
 
   const countDiv = screen.getByTestId('count');
 
-  expect(countDiv.textContent).toEqual('0');
-
-  fireEvent.click(countDiv);
-
-  expect(countDiv.textContent).toEqual('1');
+  expect(countDiv.textContent).toEqual('1,2,3,4');
 });

--- a/packages/xstate-store/test/react.test.tsx
+++ b/packages/xstate-store/test/react.test.tsx
@@ -266,3 +266,37 @@ it('useActorRef (@xstate/react) should work', () => {
 
   expect(countDiv.textContent).toEqual('1');
 });
+
+it.only('useSelector should not infinite loop', () => {
+  const store = createStore({
+    context: {
+      count: [1, 2, 3, 4]
+    },
+    on: {}
+  });
+
+  const Counter = () => {
+    const count = useSelector(store, (s) => s.context.count.slice());
+
+    return (
+      <div
+        data-testid="count"
+        onClick={() => {
+          store.send({ type: 'inc' });
+        }}
+      >
+        {count}
+      </div>
+    );
+  };
+
+  render(<Counter />);
+
+  const countDiv = screen.getByTestId('count');
+
+  expect(countDiv.textContent).toEqual('0');
+
+  fireEvent.click(countDiv);
+
+  expect(countDiv.textContent).toEqual('1');
+});


### PR DESCRIPTION
The `useSelector(…)` hook will no longer result in an infinite loop when an object-like value is returned from the selector function.

cc. @TkDodo - I had to bring back in `useSyncExternalStoreWithSelector` (copy-pasted, no dependencies), but if you have any better ideas for solving this, I'm open to a simpler solution.