### PR TITLE
Fix Jest config and launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
       "type": "node",
       "request": "launch",
       "name": "Jest Current File",
-      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
       "args": ["${file}", "--config", "jest.config.js", "--no-cache"],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
@@ -17,7 +17,7 @@
       "type": "node",
       "request": "launch",
       "name": "Jest Current File (no timeout)",
-      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
       "args": [
         "${file}",
         "--config",

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ const { constants } = require('jest-config');
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {
   prettierPath: null,
-  setupFilesAfterEnv: ['@xstate-repo/jest-utils/setup'],
+  setupFilesAfterEnv: ['<rootDir>/scripts/jest-utils/setup'],
   transform: {
     [constants.DEFAULT_JS_PATTERN]: 'babel-jest',
     '^.+\\.vue$': '@vue/vue3-jest',


### PR DESCRIPTION
Fixes this error when trying to hit <kbd>F5</kbd> to debug a test:

> basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
>           ^^^^^^^
> SyntaxError: missing ) after argument list