### PR TITLE
[@xstate/solid] Fix context mutation with new values nested in arrays

### DIFF
--- a/packages/xstate-solid/src/createImmutable.ts
+++ b/packages/xstate-solid/src/createImmutable.ts
@@ -53,6 +53,13 @@ const updateStore = <Path extends unknown[]>(
       const smallestSize = Math.min(prev.length, next.length);
       const largestSize = Math.max(next.length, prev.length);
 
+      // Update new or now undefined indexes
+      if (newIndices !== 0) {
+        for (let newEnd = smallestSize; newEnd <= largestSize - 1; newEnd++) {
+          set(...path, newEnd, deepClone(next[newEnd]));
+        }
+      }
+
       // Diff array
       for (let start = 0, end = largestSize - 1; start <= end; start++, end--) {
         diff(next[start], prev[start], [...path, start] as Path);
@@ -60,14 +67,9 @@ const updateStore = <Path extends unknown[]>(
         diff(next[end], prev[end], [...path, end] as Path);
       }
 
-      // Update new or now undefined indexes
-      if (newIndices !== 0) {
-        for (let newEnd = smallestSize; newEnd <= largestSize - 1; newEnd++) {
-          set(...path, newEnd, next[newEnd]);
-        }
-        if (prev.length > next.length) {
-          set(...path, 'length', next.length);
-        }
+      // Update length if it has changed
+      if (prev.length !== next.length) {
+        set(...path, 'length', next.length);
       }
     } else {
       // Update new values


### PR DESCRIPTION
Fix new array index value not being cloned before insertion into store - Fix #5099

* [`packages/xstate-solid/src/createImmutable.ts`](diffhunk://#diff-189122ca05a9c2d9e0559f05565de61a9b74b5c74be087a09f71dd6970a4b564R56-L71): Refactored the `updateStore` function to deep clone new elements in the array, ensuring immutability.

### Additions to test cases:

* [`packages/xstate-solid/test/useActor.test.tsx`](diffhunk://#diff-bd88a12ef25cb8c59659c67547866b04e5da5745f8e83c4accb6e98c0e73d16dR689-R814): Added a new test case to verify that moving objects between arrays does not mutate the context.