### PR TITLE
Add peer dependency support for React 19

### DIFF
--- a/packages/xstate-react/package.json
+++ b/packages/xstate-react/package.json
@@ -54,7 +54,7 @@
     "url": "https://github.com/statelyai/xstate/issues"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "xstate": "workspace:^"
   },
   "peerDependenciesMeta": {

--- a/packages/xstate-store/package.json
+++ b/packages/xstate-store/package.json
@@ -69,7 +69,7 @@
     "xstate": "workspace:^"
   },
   "peerDependencies": {
-    "react": "^18.2.0",
+    "react": "^18.2.0 || ^19.0.0",
     "solid-js": "^1.7.6"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
This pull request updates the peer dependencies for React in two packages to ensure compatibility with React 19.0.0.

Updates to peer dependencies:

* [`packages/xstate-react/package.json`](diffhunk://#diff-e2045f48d48173fc0962dba9e836d62d8046c5f095a7af48e431bf2c081b5ec3L57-R57): Updated the `react` peer dependency to include version 19.0.0.
* [`packages/xstate-store/package.json`](diffhunk://#diff-8c37e346e3f76adcc61d764d32015b9c707852f4f59a38658126019254abec0dL72-R72): Updated the `react` peer dependency to include version 19.0.0.

---

A couple things we'll have to keep in mind for React 19:

- Render count in strict mode may be different (e.g. `5` instead of `6`)
- The way we are testing errors will change: https://react.dev/blog/2024/04/25/react-19#error-handling