### PR TITLE
Add Svelte 5 to the allowed peer dependency range

### DIFF
--- a/.changeset/long-ravens-yell.md
+++ b/.changeset/long-ravens-yell.md
@@ -1,0 +1,5 @@
+---
+'@xstate/svelte': patch
+---
+
+Bump svelte version to include svelte 5

--- a/.changeset/long-ravens-yell.md
+++ b/.changeset/long-ravens-yell.md
@@ -2,4 +2,4 @@
 '@xstate/svelte': patch
 ---
 
-Bump svelte version to include svelte 5
+Add Svelte 5 to the allowed peer dependency range

--- a/packages/xstate-svelte/package.json
+++ b/packages/xstate-svelte/package.json
@@ -44,7 +44,7 @@
     "url": "https://github.com/statelyai/xstate/issues"
   },
   "peerDependencies": {
-    "svelte": "^3.24.1 || ^4",
+    "svelte": "^3.24.1 || ^4 || ^5",
     "xstate": "workspace:^"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Svelte 5 is "almost" entirely backwards compatible with svelte 4. Breaking changes can be found [here](https://svelte.dev/docs/svelte/v5-migration-guide#Breaking-changes-in-runes-mode). 

`@xstate/svelte` only uses `onDestroy`, `readable`, and `Readable` from svelte, which are backwards compatible.

