### PR TITLE
Support generic sent event types (sendBack events) to callback-based actors

### DIFF
--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -186,7 +186,7 @@ export function fromCallback<
   TEvent extends EventObject,
   TInput = NonReducibleUnknown,
   TEmitted extends EventObject = EventObject,
-  TSentEvent extends EventObject = AnyEventObject
+  TSentEvent extends EventObject = EventObject
 >(
   callback: CallbackLogicFunction<TEvent, TSentEvent, TInput, TEmitted>
 ): CallbackActorLogic<TEvent, TInput, TEmitted, TSentEvent> {

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -27,13 +27,15 @@ export type CallbackSnapshot<TInput> = Snapshot<undefined> & {
 export type CallbackActorLogic<
   TEvent extends EventObject,
   TInput = NonReducibleUnknown,
-  TEmitted extends EventObject = EventObject
+  TEmitted extends EventObject = EventObject,
+  TSentEvent extends EventObject = AnyEventObject
 > = ActorLogic<
   CallbackSnapshot<TInput>,
   TEvent,
   TInput,
   AnyActorSystem,
-  TEmitted
+  TEmitted,
+  TSentEvent
 >;
 
 /**
@@ -183,11 +185,12 @@ export type CallbackLogicFunction<
 export function fromCallback<
   TEvent extends EventObject,
   TInput = NonReducibleUnknown,
-  TEmitted extends EventObject = EventObject
+  TEmitted extends EventObject = EventObject,
+  TSentEvent extends EventObject = AnyEventObject
 >(
-  callback: CallbackLogicFunction<TEvent, AnyEventObject, TInput, TEmitted>
-): CallbackActorLogic<TEvent, TInput, TEmitted> {
-  const logic: CallbackActorLogic<TEvent, TInput, TEmitted> = {
+  callback: CallbackLogicFunction<TEvent, TSentEvent, TInput, TEmitted>
+): CallbackActorLogic<TEvent, TInput, TEmitted, TSentEvent> {
+  const logic: CallbackActorLogic<TEvent, TInput, TEmitted, TSentEvent> = {
     config: callback,
     start: (state, actorScope) => {
       const { self, system, emit } = actorScope;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2211,7 +2211,7 @@ export interface ActorLogic<
   in TInput = NonReducibleUnknown,
   TSystem extends AnyActorSystem = AnyActorSystem,
   in out TEmitted extends EventObject = EventObject, // it's invariant because it's also aprt of `ActorScope["self"]["on"]`
-  in _TSentEvent extends EventObject = AnyEventObject // currently unused at this level, but used by `CallbackActorLogic`
+  _TSentEvent extends EventObject = AnyEventObject // currently unused at this level, but used by `CallbackActorLogic`
 > {
   /** The initial setup/configuration used to create the actor logic. */
   config?: unknown;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2210,7 +2210,8 @@ export interface ActorLogic<
   in out TEvent extends EventObject, // it's invariant because it's also part of `ActorScope["self"]["send"]`
   in TInput = NonReducibleUnknown,
   TSystem extends AnyActorSystem = AnyActorSystem,
-  in out TEmitted extends EventObject = EventObject // it's invariant because it's also aprt of `ActorScope["self"]["on"]`
+  in out TEmitted extends EventObject = EventObject, // it's invariant because it's also aprt of `ActorScope["self"]["on"]`
+  in _TSentEvent extends EventObject = AnyEventObject // currently unused at this level, but used by `CallbackActorLogic`
 > {
   /** The initial setup/configuration used to create the actor logic. */
   config?: unknown;


### PR DESCRIPTION
As mentioned in Discord, I don't think this is supported presently. With no typing, it's possible to place arbitrary events into the `sendBack` method. With this change (currently intended to be a suggestion; some things are broken), the types do work as I want them to in my use-cases so this seems to be on the right track.

One existing solution to this problem is to type the events like this:

```ts
export type SegmenterEvent =
  | {
      type: 'SEGMENT_CREATED';
      eventID: string;
      eventData: EventData;
    }
  | {
      type: 'SEGMENTER_FINISHED';
      segmenterID: string;
    }
  | {
      type: 'SEGMENTER_FAILED';
      segmenterID: string;
      error: unknown;
    };

export const segmenter = fromCallback(
  ({ input, sendBack }: { input: SegmenterInput; sendBack: (e: SegmenterEvent) => void }) => {
    const segmentEventData = async () => {
```

With this proposed change, the goal is to be able to type them like this:

```ts
export const segmenter = fromCallback<AnyEventObject, SegmenterInput, AnyEventObject, SegmenterEvent>(
  ({ input, sendBack }) => {
    const segmentEventData = async () => {
```

Both versions are quite verbose, but for callbacks with received, emitted, and sent events, it could be quite a bit cleaner.

Remaining:

- [ ] Determine if anyone else thinks this is a good idea
- [ ] Include changeset
- [ ] Figure out why typecheck is failing. It appears to be failing on main as well, but not sure if this is a caching/local issue of some sort. I'll look closer
- [ ] Review if the changes are made correctly, or only match my use case coincidentally while it might break others