### PR TITLE
[@xstate/store] Use `EventTarget` for store implementation

### DIFF
--- a/.changeset/tasty-ravens-prove.md
+++ b/.changeset/tasty-ravens-prove.md
@@ -1,0 +1,16 @@
+---
+'@xstate/store': minor
+---
+
+The store now extends EventTarget, allowing for native DOM event handling capabilities while maintaining the existing `.on()` API. This change:
+
+- Adds support for standard `.addEventListener(…)` and `.removeEventListener(…)` methods
+- Simplifies internal event handling by leveraging native `EventTarget` functionality
+- Maintains full backwards compatibility with existing `.on(…)` method
+
+```ts
+// ...
+store.addEventListener('incremented', (event) => {
+  console.log(event.detail);
+});
+```

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -82,7 +82,8 @@ export interface Store<
   TEvent extends EventObject,
   TEmitted extends EventObject
 > extends Subscribable<StoreSnapshot<TContext>>,
-    InteropObservable<StoreSnapshot<TContext>> {
+    InteropObservable<StoreSnapshot<TContext>>,
+    EventTarget {
   send: (event: TEvent) => void;
   getSnapshot: () => StoreSnapshot<TContext>;
   getInitialSnapshot: () => StoreSnapshot<TContext>;


### PR DESCRIPTION
This pull request refactors the store implementation to extend `EventTarget` for the event emitter implementation.