### PR TITLE
Add getter api to @xstate/store in main

### DIFF
--- a/.changeset/fresh-keys-enjoy.md
+++ b/.changeset/fresh-keys-enjoy.md
@@ -20,17 +20,17 @@ const store = createStore({
 });
 
 // Getters are available on store snapshots
-var snapshot = store.getSnapshot();
-assert.equal(snapshot.doubled, 4);
-assert.equal(snapshot.squared, 4);
-assert.equal(snapshot.sum, 8);
+var getters = store.getSnapshot().getters;
+assert.equal(getters.doubled, 4);
+assert.equal(getters.squared, 4);
+assert.equal(getters.sum, 8);
 
 // Automatically update when context changes
 store.send({ type: 'inc' });
-var snapshot = store.getSnapshot();
-assert.equal(snapshot.doubled, 6);
-assert.equal(snapshot.squared, 36);
-assert.equal(snapshot.sum, 42);
+var getters = store.getSnapshot().getters;
+assert.equal(getters.doubled, 6);
+assert.equal(getters.squared, 36);
+assert.equal(getters.sum, 42);
 ```
 
 Key features:

--- a/.changeset/fresh-keys-enjoy.md
+++ b/.changeset/fresh-keys-enjoy.md
@@ -1,0 +1,42 @@
+---
+'@xstate/store': minor
+---
+
+Added store getters API for computed values derived from context:
+
+```ts
+const store = createStore({
+  context: { count: 2 },
+  getters: {
+    doubled: (ctx) => ctx.count * 2,
+    squared: (ctx) => ctx.count ** 2,
+    // Can depend on other getters (types can not be inferred, due to circular references)
+    sum: (ctx, getters: { doubled: number; squared: number }) =>
+      getters.doubled + getters.squared
+  },
+  on: {
+    inc: (ctx) => ({ count: ctx.count + 1 })
+  }
+});
+
+// Getters are available on store snapshots
+var snapshot = store.getSnapshot();
+assert.equal(snapshot.doubled, 4);
+assert.equal(snapshot.squared, 4);
+assert.equal(snapshot.sum, 8);
+
+// Automatically update when context changes
+store.send({ type: 'inc' });
+var snapshot = store.getSnapshot();
+assert.equal(snapshot.doubled, 6);
+assert.equal(snapshot.squared, 36);
+assert.equal(snapshot.sum, 42);
+```
+
+Key features:
+
+- Getters recalculate automatically when context changes
+- Included in inspection snapshots
+- Can depend on other getters via proxy
+- Works with Immer producer API
+- Full type safety for computed values

--- a/packages/xstate-store/src/fromStore.ts
+++ b/packages/xstate-store/src/fromStore.ts
@@ -77,7 +77,7 @@ export function fromStore<
       const newSnapshot = {
         ...snapshot,
         context: newContext,
-        ...computeGetters(newContext, getters)
+        getters: computeGetters(newContext, getters)
       } as StoreSnapshot<TContext, TGetters>;
 
       for (const effect of effects) {
@@ -101,7 +101,7 @@ export function fromStore<
         context,
         output: undefined,
         error: undefined,
-        ...computeGetters(context, getters)
+        getters: computeGetters(context, getters)
       } satisfies StoreSnapshot<TContext, TGetters>;
     },
     getPersistedSnapshot: (s) => s,

--- a/packages/xstate-store/src/fromStore.ts
+++ b/packages/xstate-store/src/fromStore.ts
@@ -1,21 +1,28 @@
 import { ActorLogic } from 'xstate';
-import { createStoreTransition, TransitionsFromEventPayloadMap } from './store';
+import { createStoreTransition, computeGetters } from './store';
 import {
   EventPayloadMap,
   StoreContext,
-  Snapshot,
   StoreSnapshot,
   EventObject,
   ExtractEvents,
-  StoreAssigner
+  StoreAssigner,
+  StoreGetters
 } from './types';
 
 type StoreLogic<
   TContext extends StoreContext,
   TEvent extends EventObject,
   TInput,
-  TEmitted extends EventObject
-> = ActorLogic<StoreSnapshot<TContext>, TEvent, TInput, any, TEmitted>;
+  TEmitted extends EventObject,
+  TGetters extends Record<string, (context: TContext, getters: any) => any> = {}
+> = ActorLogic<
+  StoreSnapshot<TContext, TGetters>,
+  TEvent,
+  TInput,
+  any,
+  TEmitted
+>;
 
 /**
  * An actor logic creator which creates store [actor
@@ -26,13 +33,15 @@ type StoreLogic<
  *   that returns context based on input, or the context itself
  * @param config.on An object defining the transitions for different event types
  * @param config.emits Optional object to define emitted event handlers
+ * @param config.getters Optional object to define store getters
  * @returns An actor logic creator function that creates store actor logic
  */
 export function fromStore<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap,
   TInput,
-  TEmitted extends EventPayloadMap
+  TEmitted extends EventPayloadMap,
+  TGetters extends Record<string, (context: TContext, getters: any) => any> = {}
 >(config: {
   context: ((input: TInput) => TContext) | TContext;
   on: {
@@ -47,47 +56,55 @@ export function fromStore<
       payload: { type: K } & TEmitted[K]
     ) => void;
   };
+  getters?: StoreGetters<TContext, TGetters>;
 }): StoreLogic<
   TContext,
   ExtractEvents<TEventPayloadMap>,
   TInput,
-  ExtractEvents<TEmitted>
+  ExtractEvents<TEmitted>,
+  TGetters
 > {
-  const initialContext: ((input: TInput) => TContext) | TContext =
-    config.context;
-  const transitionsObj: TransitionsFromEventPayloadMap<
-    TEventPayloadMap,
-    NoInfer<TContext>,
-    EventObject
-  > = config.on;
+  const initialContext = config.context;
+  const transitionsObj = config.on;
+  const getters = config.getters;
 
   const transition = createStoreTransition(transitionsObj);
+
   return {
     transition: (snapshot, event, actorScope) => {
-      const [nextSnapshot, effects] = transition(snapshot, event);
+      const [newContext, effects] = transition(snapshot.context, event);
+
+      const newSnapshot = {
+        ...snapshot,
+        context: newContext,
+        ...computeGetters(newContext, getters)
+      } as StoreSnapshot<TContext, TGetters>;
 
       for (const effect of effects) {
         if (typeof effect === 'function') {
           effect();
         } else {
-          actorScope.emit(effect as ExtractEvents<TEmitted>);
+          actorScope.emit(effect);
         }
       }
 
-      return nextSnapshot;
+      return newSnapshot;
     },
     getInitialSnapshot: (_, input: TInput) => {
+      const context =
+        typeof initialContext === 'function'
+          ? initialContext(input)
+          : initialContext;
+
       return {
         status: 'active',
-        context:
-          typeof initialContext === 'function'
-            ? initialContext(input)
-            : initialContext,
+        context,
         output: undefined,
-        error: undefined
-      } satisfies StoreSnapshot<TContext>;
+        error: undefined,
+        ...computeGetters(context, getters)
+      } satisfies StoreSnapshot<TContext, TGetters>;
     },
-    getPersistedSnapshot: (s: StoreSnapshot<TContext>) => s,
-    restoreSnapshot: (s: Snapshot<unknown>) => s as StoreSnapshot<TContext>
+    getPersistedSnapshot: (s) => s,
+    restoreSnapshot: (s) => s as StoreSnapshot<TContext, TGetters>
   };
 }

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -5,6 +5,7 @@ import {
   ExtractEvents,
   InteropSubscribable,
   Observer,
+  Producer,
   Recipe,
   Store,
   StoreAssigner,
@@ -12,7 +13,9 @@ import {
   StoreEffect,
   StoreInspectionEvent,
   StoreProducerAssigner,
-  StoreSnapshot
+  StoreSnapshot,
+  StoreGetters,
+  ResolvedGetters
 } from './types';
 
 const symbolObservable: typeof Symbol.observable = (() =>
@@ -58,31 +61,30 @@ const inspectionObservers = new WeakMap<
 function createStoreCore<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap,
-  TEmitted extends EventObject
+  TGetters extends Record<string, (context: TContext, getters: any) => any>,
+  TEmitted extends EventObject = EventObject
 >(
   initialContext: TContext,
-  transitions: {
-    [K in keyof TEventPayloadMap & string]: StoreAssigner<
-      NoInfer<TContext>,
-      { type: K } & TEventPayloadMap[K],
-      TEmitted
-    >;
-  },
-  producer?: (
-    context: NoInfer<TContext>,
-    recipe: (context: NoInfer<TContext>) => void
-  ) => NoInfer<TContext>
-): Store<TContext, ExtractEvents<TEventPayloadMap>, TEmitted> {
+  transitions: TransitionsFromEventPayloadMap<
+    TEventPayloadMap,
+    TContext,
+    TEmitted
+  >,
+  getters?: TGetters,
+  producer?: Producer<TContext>
+): Store<TContext, ExtractEvents<TEventPayloadMap>, TEmitted, TGetters> {
   type StoreEvent = ExtractEvents<TEventPayloadMap>;
-  let observers: Set<Observer<StoreSnapshot<TContext>>> | undefined;
+  let observers: Set<Observer<StoreSnapshot<TContext, TGetters>>> | undefined;
   let listeners: Map<TEmitted['type'], Set<any>> | undefined;
-  const initialSnapshot: StoreSnapshot<TContext> = {
+
+  const initialSnapshot: StoreSnapshot<TContext, TGetters> = {
     context: initialContext,
     status: 'active',
     output: undefined,
-    error: undefined
+    error: undefined,
+    ...computeGetters(initialContext, getters)
   };
-  let currentSnapshot: StoreSnapshot<TContext> = initialSnapshot;
+  let currentSnapshot: StoreSnapshot<TContext, TGetters> = initialSnapshot;
 
   const emit = (ev: TEmitted) => {
     if (!listeners) {
@@ -98,8 +100,13 @@ function createStoreCore<
   const transition = createStoreTransition(transitions, producer);
 
   function receive(event: StoreEvent) {
-    let effects: StoreEffect<TEmitted>[];
-    [currentSnapshot, effects] = transition(currentSnapshot, event);
+    const [newContext, effects] = transition(currentSnapshot.context, event);
+
+    currentSnapshot = {
+      ...currentSnapshot,
+      context: newContext,
+      ...computeGetters(newContext, getters)
+    } as StoreSnapshot<TContext, TGetters>;
 
     inspectionObservers.get(store)?.forEach((observer) => {
       observer.next?.({
@@ -122,7 +129,7 @@ function createStoreCore<
     }
   }
 
-  const store: Store<TContext, StoreEvent, TEmitted> = {
+  const store: Store<TContext, StoreEvent, TEmitted, TGetters> = {
     on(emittedEventType, handler) {
       if (!listeners) {
         listeners = new Map();
@@ -171,7 +178,9 @@ function createStoreCore<
         }
       };
     },
-    [symbolObservable](): InteropSubscribable<StoreSnapshot<TContext>> {
+    [symbolObservable](): InteropSubscribable<
+      StoreSnapshot<TContext, TGetters>
+    > {
       return this;
     },
     inspect: (observerOrFn) => {
@@ -202,7 +211,12 @@ function createStoreCore<
         }
       };
     },
-    trigger: new Proxy({} as Store<TContext, StoreEvent, TEmitted>['trigger'], {
+    trigger: {} as any
+  };
+
+  (store as any).trigger = new Proxy(
+    {} as Store<TContext, StoreEvent, TEmitted>['trigger'],
+    {
       get: (_, eventType: string) => {
         return (payload: any) => {
           store.send({
@@ -211,8 +225,8 @@ function createStoreCore<
           });
         };
       }
-    })
-  };
+    }
+  );
 
   return store;
 }
@@ -234,7 +248,8 @@ export type TransitionsFromEventPayloadMap<
 type CreateStoreParameterTypes<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap,
-  TEmitted extends EventPayloadMap
+  TEmitted extends EventPayloadMap,
+  TGetters extends Record<string, any> = {}
 > = [
   definition: {
     context: TContext;
@@ -248,14 +263,21 @@ type CreateStoreParameterTypes<
         ExtractEvents<TEmitted>
       >;
     };
+    getters?: StoreGetters<TContext, TGetters>;
   }
 ];
 
 type CreateStoreReturnType<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap,
-  TEmitted extends EventPayloadMap
-> = Store<TContext, ExtractEvents<TEventPayloadMap>, ExtractEvents<TEmitted>>;
+  TEmitted extends EventPayloadMap,
+  TGetters extends Record<string, any> = {}
+> = Store<
+  TContext,
+  ExtractEvents<TEventPayloadMap>,
+  ExtractEvents<TEmitted>,
+  TGetters
+>;
 
 /**
  * Creates a **store** that has its own internal state and can be sent events
@@ -290,15 +312,17 @@ type CreateStoreReturnType<
 function _createStore<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap,
-  TEmitted extends EventPayloadMap
+  TEmitted extends EventPayloadMap,
+  TGetters extends Record<string, any> = {}
 >(
-  ...[{ context, on }]: CreateStoreParameterTypes<
+  ...[{ context, on, getters }]: CreateStoreParameterTypes<
     TContext,
     TEventPayloadMap,
-    TEmitted
+    TEmitted,
+    TGetters
   >
-): CreateStoreReturnType<TContext, TEventPayloadMap, TEmitted> {
-  return createStoreCore(context, on);
+): CreateStoreReturnType<TContext, TEventPayloadMap, TEmitted, TGetters> {
+  return createStoreCore(context, on, getters);
 }
 
 export const createStore: {
@@ -308,17 +332,29 @@ export const createStore: {
   <
     TContext extends StoreContext,
     TEventPayloadMap extends EventPayloadMap,
-    TEmitted extends EventPayloadMap
+    TEmitted extends EventPayloadMap,
+    TGetters extends Record<string, any> = {}
   >(
-    ...args: CreateStoreParameterTypes<TContext, TEventPayloadMap, TEmitted>
-  ): CreateStoreReturnType<TContext, TEventPayloadMap, TEmitted>;
+    ...args: CreateStoreParameterTypes<
+      TContext,
+      TEventPayloadMap,
+      TEmitted,
+      TGetters
+    >
+  ): CreateStoreReturnType<TContext, TEventPayloadMap, TEmitted, TGetters>;
   <
     TContext extends StoreContext,
     TEventPayloadMap extends EventPayloadMap,
-    TEmitted extends EventPayloadMap
+    TEmitted extends EventPayloadMap,
+    TGetters extends Record<string, any> = {}
   >(
-    ...args: CreateStoreParameterTypes<TContext, TEventPayloadMap, TEmitted>
-  ): CreateStoreReturnType<TContext, TEventPayloadMap, TEmitted>;
+    ...args: CreateStoreParameterTypes<
+      TContext,
+      TEventPayloadMap,
+      TEmitted,
+      TGetters
+    >
+  ): CreateStoreReturnType<TContext, TEventPayloadMap, TEmitted, TGetters>;
 } = _createStore;
 
 /**
@@ -350,11 +386,10 @@ export const createStore: {
 export function createStoreWithProducer<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap,
-  TEmittedPayloadMap extends EventPayloadMap
+  TEmittedPayloadMap extends EventPayloadMap,
+  TGetters extends Record<string, any> = {}
 >(
-  producer: NoInfer<
-    (context: TContext, recipe: (context: TContext) => void) => TContext
-  >,
+  producer: NoInfer<Producer<TContext>>,
   config: {
     context: TContext;
     on: {
@@ -364,13 +399,15 @@ export function createStoreWithProducer<
         enqueue: EnqueueObject<ExtractEvents<TEmittedPayloadMap>>
       ) => void;
     };
+    getters?: StoreGetters<TContext, TGetters>;
   }
 ): Store<
   TContext,
   ExtractEvents<TEventPayloadMap>,
-  ExtractEvents<TEmittedPayloadMap>
+  ExtractEvents<TEmittedPayloadMap>,
+  TGetters
 > {
-  return createStoreCore(config.context, config.on, producer);
+  return createStoreCore(config.context, config.on, config.getters, producer);
 }
 
 declare global {
@@ -401,17 +438,13 @@ export function createStoreTransition<
       TEmitted
     >;
   },
-  producer?: (
-    context: TContext,
-    recipe: (context: TContext) => void
-  ) => TContext
+  producer?: Producer<TContext>
 ) {
   return (
-    snapshot: StoreSnapshot<TContext>,
+    currentContext: TContext,
     event: ExtractEvents<TEventPayloadMap>
-  ): [StoreSnapshot<TContext>, StoreEffect<TEmitted>[]] => {
+  ): [TContext, StoreEffect<TEmitted>[]] => {
     type StoreEvent = ExtractEvents<TEventPayloadMap>;
-    let currentContext = snapshot.context;
     const assigner = transitions?.[event.type as StoreEvent['type']];
     const effects: StoreEffect<TEmitted>[] = [];
 
@@ -432,7 +465,7 @@ export function createStoreTransition<
     };
 
     if (!assigner) {
-      return [snapshot, effects];
+      return [currentContext, effects];
     }
 
     if (typeof assigner === 'function') {
@@ -471,7 +504,7 @@ export function createStoreTransition<
       currentContext = Object.assign({}, currentContext, partialUpdate);
     }
 
-    return [{ ...snapshot, context: currentContext }, effects];
+    return [currentContext, effects];
   };
 }
 
@@ -483,3 +516,28 @@ export function createStoreTransition<
 function uniqueId() {
   return Math.random().toString(36).slice(6);
 }
+
+const computeGetters = <
+  TContext extends StoreContext,
+  TGetters extends Record<string, (context: TContext, getters: any) => any>
+>(
+  context: TContext,
+  getters?: TGetters
+): ResolvedGetters<TGetters> => {
+  const computed = {} as ResolvedGetters<TGetters>;
+
+  if (!getters) return computed;
+
+  Object.entries(getters).forEach(([key, fn]) => {
+    computed[key as keyof TGetters] = fn(
+      context,
+      new Proxy(computed, {
+        get(target, prop) {
+          return target[prop as keyof typeof target];
+        }
+      })
+    );
+  });
+
+  return computed;
+};

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -517,7 +517,7 @@ function uniqueId() {
   return Math.random().toString(36).slice(6);
 }
 
-const computeGetters = <
+export const computeGetters = <
   TContext extends StoreContext,
   TGetters extends Record<string, (context: TContext, getters: any) => any>
 >(

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -231,7 +231,7 @@ function createStoreCore<
   return store;
 }
 
-export type TransitionsFromEventPayloadMap<
+type TransitionsFromEventPayloadMap<
   TEventPayloadMap extends EventPayloadMap,
   TContext extends StoreContext,
   TEmitted extends EventObject

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -82,7 +82,7 @@ function createStoreCore<
     status: 'active',
     output: undefined,
     error: undefined,
-    ...computeGetters(initialContext, getters)
+    getters: computeGetters(initialContext, getters)
   };
   let currentSnapshot: StoreSnapshot<TContext, TGetters> = initialSnapshot;
 
@@ -105,7 +105,7 @@ function createStoreCore<
     currentSnapshot = {
       ...currentSnapshot,
       context: newContext,
-      ...computeGetters(newContext, getters)
+      getters: computeGetters(newContext, getters)
     } as StoreSnapshot<TContext, TGetters>;
 
     inspectionObservers.get(store)?.forEach((observer) => {

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -123,11 +123,8 @@ export type AnyStore = Store<any, any, any>;
 
 export type Compute<A> = { [K in keyof A]: A[K] };
 
-export type SnapshotFromStore<
-  TStore extends Store<any, any, any>,
-  TGetters extends Record<string, (context: any, getters: any) => any>
-> =
-  TStore extends Store<infer TContext, any, any, TGetters>
+export type SnapshotFromStore<TStore extends Store<any, any, any, any>> =
+  TStore extends Store<infer TContext, any, any, infer TGetters>
     ? StoreSnapshot<TContext, TGetters>
     : never;
 

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -58,7 +58,8 @@ export type StoreSnapshot<
   TGetters extends Record<string, (context: TContext, getters: any) => any>
 > = Snapshot<unknown> & {
   context: TContext;
-} & ResolvedGetters<TGetters>;
+  getters: StoreGetters<TContext, TGetters>;
+};
 
 /**
  * An actor-like object that:

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -544,12 +544,12 @@ describe('getters', () => {
       }
     });
 
-    expect(store.getSnapshot().doubled).toBe(4);
-    expect(store.getSnapshot().squared).toBe(4);
+    expect(store.getSnapshot().getters.doubled).toBe(4);
+    expect(store.getSnapshot().getters.squared).toBe(4);
 
     store.send({ type: 'inc' });
-    expect(store.getSnapshot().doubled).toBe(6);
-    expect(store.getSnapshot().squared).toBe(9);
+    expect(store.getSnapshot().getters.doubled).toBe(6);
+    expect(store.getSnapshot().getters.squared).toBe(9);
   });
 
   it('handles getter dependencies', () => {
@@ -567,10 +567,10 @@ describe('getters', () => {
       }
     });
 
-    expect(store.getSnapshot().total).toBeCloseTo(22); // 20 + 2 = 22
+    expect(store.getSnapshot().getters.total).toBeCloseTo(22); // 20 + 2 = 22
 
     store.send({ type: 'updatePrice', value: 20 });
-    expect(store.getSnapshot().total).toBeCloseTo(44); // 40 + 4 = 44
+    expect(store.getSnapshot().getters.total).toBeCloseTo(44); // 40 + 4 = 44
   });
 
   it('updates getters when context changes', () => {
@@ -587,10 +587,10 @@ describe('getters', () => {
       }
     });
 
-    expect(store.getSnapshot().hasItems).toBe(false);
+    expect(store.getSnapshot().getters.hasItems).toBe(false);
 
     store.send({ type: 'addItem', item: 'test' });
-    expect(store.getSnapshot().hasItems).toBe(true);
+    expect(store.getSnapshot().getters.hasItems).toBe(true);
   });
 
   it('works with immer producer', () => {
@@ -608,12 +608,12 @@ describe('getters', () => {
       }
     });
 
-    expect(store.getSnapshot().sum).toBe(3);
-    expect(store.getSnapshot().product).toBe(2);
+    expect(store.getSnapshot().getters.sum).toBe(3);
+    expect(store.getSnapshot().getters.product).toBe(2);
 
     store.send({ type: 'update', a: 3 });
-    expect(store.getSnapshot().sum).toBe(5);
-    expect(store.getSnapshot().product).toBe(6);
+    expect(store.getSnapshot().getters.sum).toBe(5);
+    expect(store.getSnapshot().getters.product).toBe(6);
   });
 
   it('includes getters in inspection snapshots', () => {
@@ -638,9 +638,18 @@ describe('getters', () => {
     store.send({ type: 'increment' });
 
     expect(snapshots).toEqual([
-      expect.objectContaining({ context: { value: 5 }, squared: 25 }),
-      expect.objectContaining({ context: { value: 6 }, squared: 36 }),
-      expect.objectContaining({ context: { value: 7 }, squared: 49 })
+      expect.objectContaining({
+        context: { value: 5 },
+        getters: { squared: 25 }
+      }),
+      expect.objectContaining({
+        context: { value: 6 },
+        getters: { squared: 36 }
+      }),
+      expect.objectContaining({
+        context: { value: 7 },
+        getters: { squared: 49 }
+      })
     ]);
   });
 });


### PR DESCRIPTION
https://github.com/statelyai/xstate/pull/5184

Added store getters API for computed values derived from context:

```ts
const store = createStore({
  context: { count: 2 },
  getters: {
    doubled: (ctx) => ctx.count * 2,
    squared: (ctx) => ctx.count ** 2,
    // Can depend on other getters (types can not be inferred, due to circular references)
    sum: (ctx, getters: { doubled: number; squared: number }) =>
      getters.doubled + getters.squared
  },
  on: {
    inc: (ctx) => ({ count: ctx.count + 1 })
  }
});