### PR TITLE
Introduce nix and just for reproducible CI locally

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ api/
 
 # pnpm
 .pnpm-lock.yaml
+
+# nix
+.direnv

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1736693123,
+        "narHash": "sha256-9lIfXCaBPwUA7FnfDnoH4gxxdOvXG78k6UlUw0+ZDxc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fdec2c2e68b7b7845d1ea4e0894c63143e3261b",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        nodeVersion = builtins.readFile ./.node-version;
+        majorNodeVersion = builtins.substring 0 2 nodeVersion;
+        node = pkgs."nodejs_${majorNodeVersion}";
+      in
+      {
+        devShell = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            just
+            node
+            node.pkgs.pnpm
+          ];
+        };
+      }
+    );
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,21 @@
+[private]
+default:
+	@ just --list --unsorted
+
+init:
+	test -d node_modules || pnpm install
+
+lint:
+	pnpm lint
+
+build:
+	pnpm build
+
+test:
+	pnpm typecheck
+	pnpm test
+
+ci: init build lint test
+	pnpm --filter @xstate/svelte svelte-check
+	pnpm knip
+	# ✅ PASSED

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged && jest -o"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
The goal is to allow dev to quickly become productive, and be able to execute exactly what is run during CI before they submit a PR.

- **Nix Integration:**
  - Added `.envrc` for direnv integration with `use flake` to load the Nix environment.
  - Introduced `flake.nix` and `flake.lock` to define and lock dependencies.
  - Updated `.gitignore` to include `.direnv`, which is generated by Direnv and Nix workflow.

- **Just Task Runner:**
  - Added `justfile` to define reproducible commands for tasks such as:
    - `init`: Installs node dependencies if `node_modules` does not exist.
    - `lint`: Runs linting on the codebase.
    - `build`: Compiles the project.
    - `test`: Typechecks and tests the project.
    - `ci`: Comprehensive task that runs `init`, `build`, `lint`, and `test` stages.

- **Updates to Pre-commit Hook:**
  - Modified the `pre-commit` hook in `package.json` to run `jest -o` along with `lint-staged`. This ensures that only changed files are tested during a commit, optimizing the commit workflow.