### PR TITLE
infered typehint for state machine properties 'on' and 'initial'

### DIFF
--- a/.changeset/many-tips-sit.md
+++ b/.changeset/many-tips-sit.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Added a new flag 'scriptType' to state machine which provides different levels of typehint for states 'initial' and 'on' properties.

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -1,5 +1,10 @@
 import { StateMachine } from './StateMachine.ts';
-import { ResolvedStateMachineTypes, TODO } from './types.ts';
+import {
+  ResolvedStateMachineTypes,
+  StatesConfig,
+  StrictType,
+  TODO
+} from './types.ts';
 import {
   AnyActorRef,
   EventObject,
@@ -84,6 +89,8 @@ export function createMachine<
   TOutput extends NonReducibleUnknown,
   TEmitted extends EventObject,
   TMeta extends MetaObject,
+  TStates extends Record<string, any>,
+  TStrictType extends StrictType,
   // it's important to have at least one default type parameter here
   // it allows us to benefit from contextual type instantiation as it makes us to pass the hasInferenceCandidatesOrDefault check in the compiler
   // we should be able to remove this when we start inferring TConfig, with it we'll always have an inference candidate
@@ -115,8 +122,13 @@ export function createMachine<
     TInput,
     TOutput,
     TEmitted,
-    TMeta
-  >,
+    TMeta,
+    TStates,
+    Extract<keyof TStates, string>,
+    TStrictType
+  > & {
+      strictType?: TStrictType;
+    },
   implementations?: InternalMachineImplementations<
     ResolvedStateMachineTypes<
       TContext,


### PR DESCRIPTION
Added a new flag 'scriptType' to state machine which provides different levels of typehint for states 'initial' and 'on' properties.

`strictType` can be:
- `"strict"` : add type-hints and errors if types do not match, this will break some features eg spreading vars into the machine,
- `"loose"` : adds type-hint but does not give errors when keys dont exist, as far as i know this keeps all compatibility, 
- `undefined` : no type-hint, the default behaviour if you do not provide a `strictType` param

I wasn't too sure how states inside states should work, so i made it scoped to the nested state you are currently on.