### PR TITLE
[xstate/store] Fix types for emitting with no payload

### DIFF
--- a/.changeset/wild-shoes-eat.md
+++ b/.changeset/wild-shoes-eat.md
@@ -1,0 +1,21 @@
+---
+'@xstate/store': patch
+---
+
+The types for emitting events with no payload have been fixed so that the following code works:
+
+```ts
+const store = createStore({
+  emits: {
+    incremented: () => {}
+  },
+  on: {
+    inc: (ctx, ev, enq) => {
+      // No payload is expected
+      enq.emit.incremented();
+    }
+  }
+});
+```
+
+Previously, this would have been an error because the `incremented` event was expected to have a payload.

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -6,15 +6,13 @@ export type ExtractEvents<T extends EventPayloadMap> = Values<{
 
 export type Recipe<T, TReturn> = (state: T) => TReturn;
 
-type HasNoPayload<T extends EventObject> = { type: T['type'] } extends T
-  ? keyof T extends 'type'
-    ? true
-    : false
-  : false;
+type AllKeys<T> = T extends any ? keyof T : never;
 
 type EmitterFunction<TEmittedEvent extends EventObject> = (
-  ...args: HasNoPayload<TEmittedEvent> extends true
-    ? []
+  ...args: { type: TEmittedEvent['type'] } extends TEmittedEvent
+    ? AllKeys<TEmittedEvent> extends 'type'
+      ? []
+      : [DistributiveOmit<TEmittedEvent, 'type'>?]
     : [DistributiveOmit<TEmittedEvent, 'type'>]
 ) => void;
 

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -11,7 +11,7 @@ export type EnqueueObject<TEmittedEvent extends EventObject> = {
     [E in TEmittedEvent as E['type']]: IsEmptyObject<
       Omit<E, 'type'>
     > extends true
-      ? () => void
+      ? (_?: {}) => void
       : (payload: Omit<E, 'type'>) => void;
   };
   effect: (fn: () => void) => void;

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -8,7 +8,11 @@ export type Recipe<T, TReturn> = (state: T) => TReturn;
 
 export type EnqueueObject<TEmittedEvent extends EventObject> = {
   emit: {
-    [E in TEmittedEvent as E['type']]: (payload: Omit<E, 'type'>) => void;
+    [E in TEmittedEvent as E['type']]: IsEmptyObject<
+      Omit<E, 'type'>
+    > extends true
+      ? () => void
+      : (payload: Omit<E, 'type'>) => void;
   };
   effect: (fn: () => void) => void;
 };
@@ -89,7 +93,7 @@ export interface Store<
   on: <TEmittedType extends TEmitted['type']>(
     eventType: TEmittedType,
     emittedEventHandler: (
-      ev: Compute<TEmitted & { type: TEmittedType }>
+      emittedEvent: Compute<TEmitted & { type: TEmittedType }>
     ) => void
   ) => Subscription;
   /**

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -13,7 +13,6 @@ type HasNoPayload<T extends EventObject> = { type: T['type'] } extends T
   : false;
 
 type EmitterFunction<TEmittedEvent extends EventObject> = (
-  // payload: DistributiveOmit<TEmittedEvent, 'type'>
   ...args: HasNoPayload<TEmittedEvent> extends true
     ? []
     : [DistributiveOmit<TEmittedEvent, 'type'>]

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -6,11 +6,22 @@ export type ExtractEvents<T extends EventPayloadMap> = Values<{
 
 export type Recipe<T, TReturn> = (state: T) => TReturn;
 
+type HasNoPayload<T extends EventObject> = { type: T['type'] } extends T
+  ? keyof T extends 'type'
+    ? true
+    : false
+  : false;
+
+type EmitterFunction<TEmittedEvent extends EventObject> = (
+  // payload: DistributiveOmit<TEmittedEvent, 'type'>
+  ...args: HasNoPayload<TEmittedEvent> extends true
+    ? []
+    : [DistributiveOmit<TEmittedEvent, 'type'>]
+) => void;
+
 export type EnqueueObject<TEmittedEvent extends EventObject> = {
   emit: {
-    [E in TEmittedEvent as E['type']]: (
-      payload: DistributiveOmit<E, 'type'>
-    ) => void;
+    [E in TEmittedEvent as E['type']]: EmitterFunction<E>;
   };
   effect: (fn: () => void) => void;
 };

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -376,6 +376,26 @@ it('events can be emitted with no payload', () => {
   expect(spy).toHaveBeenCalledWith({ type: 'incremented' });
 });
 
+it('events can be emitted with optional payloads (type check)', () => {
+  createStore({
+    emits: {
+      optionalPayload: (_: { payload?: string }) => {}
+    },
+    context: {},
+    on: {
+      inc: (_ctx, _ev, enq) => {
+        enq.emit
+          // @ts-expect-error
+          .optionalPayload();
+
+        enq.emit.optionalPayload({ payload: 'hello' });
+
+        enq.emit.optionalPayload({});
+      }
+    }
+  });
+});
+
 it('effects can be enqueued', async () => {
   const store = createStore({
     context: {

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -356,10 +356,7 @@ it('events can be emitted with no payload', () => {
         enq.emit.incremented();
       },
       dec: (_ctx, _ev, enq) => {
-        enq.emit.decremented(
-          // @ts-expect-error
-          {}
-        );
+        enq.emit.decremented({});
       },
       hasPayload: (_ctx, _ev, enq) => {
         enq.emit

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -354,6 +354,10 @@ it('events can be emitted with no payload', () => {
     on: {
       inc: (_ctx, _ev, enq) => {
         enq.emit.incremented();
+        enq.emit.incremented(
+          // @ts-expect-error
+          'foo'
+        );
       },
       dec: (_ctx, _ev, enq) => {
         enq.emit.decremented(
@@ -384,13 +388,16 @@ it('events can be emitted with optional payloads (type check)', () => {
     context: {},
     on: {
       inc: (_ctx, _ev, enq) => {
-        enq.emit
-          // @ts-expect-error An object is still expected
-          .optionalPayload();
+        enq.emit.optionalPayload();
 
         enq.emit.optionalPayload({ payload: 'hello' });
 
         enq.emit.optionalPayload({});
+
+        enq.emit.optionalPayload(
+          // @ts-expect-error
+          'foo'
+        );
       }
     }
   });

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -356,11 +356,14 @@ it('events can be emitted with no payload', () => {
         enq.emit.incremented();
       },
       dec: (_ctx, _ev, enq) => {
-        enq.emit.decremented({});
+        enq.emit.decremented(
+          // @ts-expect-error No payload expected
+          {}
+        );
       },
       hasPayload: (_ctx, _ev, enq) => {
         enq.emit
-          // @ts-expect-error
+          // @ts-expect-error Payload expected
           .expectsPayload();
       }
     }
@@ -382,7 +385,7 @@ it('events can be emitted with optional payloads (type check)', () => {
     on: {
       inc: (_ctx, _ev, enq) => {
         enq.emit
-          // @ts-expect-error
+          // @ts-expect-error An object is still expected
           .optionalPayload();
 
         enq.emit.optionalPayload({ payload: 'hello' });


### PR DESCRIPTION
The types for emitting events with no payload have been fixed so that the following code works:

```ts
const store = createStore({
  emits: {
    incremented: () => {}
  },
  on: {
    inc: (ctx, ev, enq) => {
      // No payload is expected
      enq.emit.incremented();
    }
  }
});
```

Previously, this would have been an error because the `incremented` event was expected to have a payload.