### PR TITLE
[xstate/store] Ensure that atoms are unsubscribed when no longer read

### DIFF
--- a/.changeset/grumpy-countries-serve.md
+++ b/.changeset/grumpy-countries-serve.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fixed a bug where conditional atoms were not properly unsubscribed when no longer needed.

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -370,6 +370,8 @@ export interface Atom<T> extends Subscribable<T>, Readable<T> {
   set(value: T): void;
 }
 
+export type AnyAtom = Atom<any>;
+
 /**
  * An atom that is read-only and cannot be set.
  *


### PR DESCRIPTION
Fixed a bug where conditional atoms were not properly unsubscribed when no longer needed.

Fixes #5234 