### PR TITLE
[@xstate/store] Fix distributive event payload types

### DIFF
--- a/.changeset/long-moons-trade.md
+++ b/.changeset/long-moons-trade.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix type inference for discriminated union event types in the `trigger` object. Previously, using `Omit` with union types would incorrectly combine event types, breaking type inference for discriminated unions. This has been fixed by introducing a `DistributiveOmit` type that correctly preserves the relationship between discriminated properties.

--- a/.changeset/long-moons-trade.md
+++ b/.changeset/long-moons-trade.md
@@ -2,4 +2,4 @@
 '@xstate/store': patch
 ---
 
-Fix type inference for discriminated union event types in the `trigger` object. Previously, using `Omit` with union types would incorrectly combine event types, breaking type inference for discriminated unions. This has been fixed by introducing a `DistributiveOmit` type that correctly preserves the relationship between discriminated properties.
+Fix type inference for discriminated union event types in the `trigger` and the `emit` object. Previously, using `Omit` with union types would incorrectly combine event types, breaking type inference for discriminated unions. This has been fixed by introducing a `DistributiveOmit` type that correctly preserves the relationship between discriminated properties.

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -8,7 +8,9 @@ export type Recipe<T, TReturn> = (state: T) => TReturn;
 
 export type EnqueueObject<TEmittedEvent extends EventObject> = {
   emit: {
-    [E in TEmittedEvent as E['type']]: (payload: Omit<E, 'type'>) => void;
+    [E in TEmittedEvent as E['type']]: (
+      payload: DistributiveOmit<E, 'type'>
+    ) => void;
   };
   effect: (fn: () => void) => void;
 };

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -109,10 +109,10 @@ export interface Store<
    */
   trigger: {
     [E in TEvent as E['type'] & string]: IsEmptyObject<
-      Omit<E, 'type'>
+      DistributiveOmit<E, 'type'>
     > extends true
-      ? () => Omit<E, 'type'>
-      : (eventPayload: Omit<E, 'type'>) => void;
+      ? () => DistributiveOmit<E, 'type'>
+      : (eventPayload: DistributiveOmit<E, 'type'>) => void;
   };
   select<TSelected>(
     selector: Selector<TContext, TSelected>,
@@ -384,3 +384,8 @@ export type AnyAtom = Atom<any>;
  * ```
  */
 export interface ReadonlyAtom<T> extends Readable<T> {}
+
+/** A version of `Omit` that works with distributive types. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends any
+  ? Omit<T, K>
+  : never;

--- a/packages/xstate-store/test/types.test.tsx
+++ b/packages/xstate-store/test/types.test.tsx
@@ -88,6 +88,31 @@ describe('emitted', () => {
       (ev) => {}
     );
   });
+
+  it('works with a discriminated union event payload', () => {
+    createStore({
+      context: {},
+      emits: {
+        log: (
+          _:
+            | { level: 'warn'; message: string }
+            | { level: 'error'; error: string }
+        ) => {}
+      },
+      on: {
+        log: (ctx, _ev, enq) => {
+          enq.emit.log({ level: 'warn', message: 'hmm' });
+          enq.emit.log({ level: 'error', error: 'uh oh' });
+          enq.emit.log({
+            level: 'error',
+            // @ts-expect-error
+            message: 'foo'
+          });
+          return ctx;
+        }
+      }
+    });
+  });
 });
 
 describe('trigger', () => {

--- a/packages/xstate-store/test/types.test.tsx
+++ b/packages/xstate-store/test/types.test.tsx
@@ -89,3 +89,30 @@ describe('emitted', () => {
     );
   });
 });
+
+describe('trigger', () => {
+  it('works with a distributive event payload', () => {
+    const store = createStore({
+      context: {},
+      on: {
+        log: (
+          ctx,
+          _ev:
+            | { level: 'warn'; message: string }
+            | { level: 'error'; error: string }
+        ) => {
+          return ctx;
+        }
+      }
+    });
+
+    store.trigger.log({ level: 'warn', message: 'hmm' });
+    store.trigger.log({ level: 'error', error: 'uh oh' });
+
+    store.trigger.log({
+      level: 'error',
+      // @ts-expect-error
+      message: 'foo'
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes type inference for discriminated union event types in the `trigger` and `emit` object. Previously, using `Omit` with union types would incorrectly combine event types, breaking type inference for discriminated unions. This has been fixed by introducing a `DistributiveOmit` type that correctly preserves the relationship between discriminated properties.