### PR TITLE
[@xstate/store] Add `useAtom(atom)` + fix vitest config

### DIFF
--- a/.changeset/fresh-mails-shake.md
+++ b/.changeset/fresh-mails-shake.md
@@ -1,0 +1,32 @@
+---
+'@xstate/store': minor
+---
+
+The `useAtom` hook is now available for reading the value of an atom or selecting a value from the atom.
+
+```tsx
+const atom = createAtom(0);
+
+const Component = () => {
+  const count = useAtom(atom);
+
+  return (
+    <>
+      <div onClick={() => atom.set((c) => c + 1)}>{count}</div>
+      <button onClick={() => atom.set(0)}>Reset</button>
+    </>
+  );
+};
+```
+
+With selectors:
+
+```tsx
+const atom = createAtom({ count: 0 });
+
+const Component = () => {
+  const count = useAtom(atom, (s) => s.count);
+
+  return <div>{count}</div>;
+};
+```

--- a/packages/xstate-store/src/react.ts
+++ b/packages/xstate-store/src/react.ts
@@ -8,7 +8,7 @@ import {
   ExtractEvents,
   Readable,
   AnyAtom,
-  SnapshotFromAtom
+  Atom
 } from './types';
 import { createStore } from './store';
 
@@ -128,19 +128,17 @@ export const useStore: {
  * @param compare An optional function which compares the selected value to the
  *   previous value
  */
-export function useAtom<TAtom extends AnyAtom>(
-  atom: TAtom
-): SnapshotFromAtom<TAtom>;
-export function useAtom<TAtom extends AnyAtom, T>(
-  atom: TAtom,
-  selector: (snapshot: SnapshotFromAtom<TAtom>) => T,
-  compare?: (a: T | undefined, b: T) => boolean
-): T;
-export function useAtom<TAtom extends AnyAtom, T>(
-  atom: TAtom,
+export function useAtom<T>(atom: Atom<T>): T;
+export function useAtom<T, S>(
+  atom: Atom<T>,
+  selector: (snapshot: T) => S,
+  compare?: (a: S, b: S) => boolean
+): S;
+export function useAtom(
+  atom: AnyAtom,
   selector = identity,
   compare = defaultCompare
-): T {
+) {
   const state = useSelector(atom, selector, compare);
 
   return state;

--- a/packages/xstate-store/src/react.ts
+++ b/packages/xstate-store/src/react.ts
@@ -6,12 +6,18 @@ import {
   StoreConfig,
   Store,
   ExtractEvents,
-  Readable
+  Readable,
+  AnyAtom,
+  SnapshotFromAtom
 } from './types';
 import { createStore } from './store';
 
 function defaultCompare<T>(a: T | undefined, b: T) {
   return a === b;
+}
+
+function identity<T>(snapshot: T): T {
+  return snapshot;
 }
 
 function useSelectorWithCompare<TStore extends Readable<any>, T>(
@@ -94,3 +100,48 @@ export const useStore: {
 
   return storeRef.current;
 };
+
+/**
+ * A React hook that subscribes to the `atom` and returns the current value of
+ * the atom.
+ *
+ * @example
+ *
+ * ```ts
+ * const atom = createAtom(0);
+ *
+ * const Component = () => {
+ *   const count = useAtom(atom);
+ *
+ *   return (
+ *     <div>
+ *       <div>{count}</div>
+ *       <button onClick={() => atom.set((c) => c + 1)}>Increment</button>
+ *     </div>
+ *   );
+ * };
+ * ```
+ *
+ * @param atom The atom, created from `createAtom(…)`
+ * @param selector An optional function which takes in the `snapshot` and
+ *   returns a selected value
+ * @param compare An optional function which compares the selected value to the
+ *   previous value
+ */
+export function useAtom<TAtom extends AnyAtom>(
+  atom: TAtom
+): SnapshotFromAtom<TAtom>;
+export function useAtom<TAtom extends AnyAtom, T>(
+  atom: TAtom,
+  selector: (snapshot: SnapshotFromAtom<TAtom>) => T,
+  compare?: (a: T | undefined, b: T) => boolean
+): T;
+export function useAtom<TAtom extends AnyAtom, T>(
+  atom: TAtom,
+  selector = identity,
+  compare = defaultCompare
+): T {
+  const state = useSelector(atom, selector, compare);
+
+  return state;
+}

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -178,6 +178,9 @@ export type SnapshotFromStore<TStore extends Store<any, any, any>> =
     ? StoreSnapshot<TContext>
     : never;
 
+export type SnapshotFromAtom<TAtom extends AnyAtom> =
+  TAtom extends Readable<infer T> ? T : never;
+
 /**
  * Extract the type of events from a `Store`.
  *

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -178,9 +178,6 @@ export type SnapshotFromStore<TStore extends Store<any, any, any>> =
     ? StoreSnapshot<TContext>
     : never;
 
-export type SnapshotFromAtom<TAtom extends AnyAtom> =
-  TAtom extends Readable<infer T> ? T : never;
-
 /**
  * Extract the type of events from a `Store`.
  *

--- a/packages/xstate-store/vitest.config.mts
+++ b/packages/xstate-store/vitest.config.mts
@@ -4,7 +4,7 @@ import { include as includeVue } from './vitest.config.vue.mts';
 
 export default defineProject({
   test: {
-    include: ['tests/**/*.test.{ts,tsx}'],
+    include: ['test/**/*.test.{ts,tsx}'],
     exclude: [...includeSolid, ...includeVue],
     globals: true,
     environment: 'happy-dom'


### PR DESCRIPTION
This PR adds the `useAtom` hook for reading the value of an atom or selecting a value from the atom.

It is meant for the common use-case where the entire value of the atom (usually granular data) is needed.

```tsx
const atom = createAtom(0);

const Component = () => {
  const count = useAtom(atom);

  return (
    <>
      <div onClick={() => atom.set((c) => c + 1)}>{count}</div>
      <button onClick={() => atom.set(0)}>Reset</button>
    </>
  );
};
```

With selectors:

```tsx
const atom = createAtom({ count: 0 });

const Component = () => {
  const count = useAtom(atom, (s) => s.count);

  return <div>{count}</div>;
};
```
