### PR TITLE
[@xstate/store] Fix `useAtom` to accept `ReadonlyAtom`

### DIFF
--- a/.changeset/fine-apes-switch.md
+++ b/.changeset/fine-apes-switch.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix the types for `useAtom` to accept `ReadonlyAtom` values.

--- a/.changeset/fine-apes-switch.md
+++ b/.changeset/fine-apes-switch.md
@@ -4,4 +4,3 @@
 
 Fix the types for `useAtom` to accept `ReadonlyAtom` values.
 
-See #5306

--- a/.changeset/fine-apes-switch.md
+++ b/.changeset/fine-apes-switch.md
@@ -3,3 +3,5 @@
 ---
 
 Fix the types for `useAtom` to accept `ReadonlyAtom` values.
+
+See #5306

--- a/packages/xstate-store/src/react.ts
+++ b/packages/xstate-store/src/react.ts
@@ -8,7 +8,7 @@ import {
   ExtractEvents,
   Readable,
   AnyAtom,
-  Atom
+  BaseAtom
 } from './types';
 import { createStore } from './store';
 
@@ -128,9 +128,9 @@ export const useStore: {
  * @param compare An optional function which compares the selected value to the
  *   previous value
  */
-export function useAtom<T>(atom: Atom<T>): T;
+export function useAtom<T>(atom: BaseAtom<T>): T;
 export function useAtom<T, S>(
-  atom: Atom<T>,
+  atom: BaseAtom<T>,
   selector: (snapshot: T) => S,
   compare?: (a: S, b: S) => boolean
 ): S;

--- a/packages/xstate-store/test/react.test.tsx
+++ b/packages/xstate-store/test/react.test.tsx
@@ -912,4 +912,20 @@ describe('useAtom', () => {
     });
     expect(getByTestId('count').textContent).toBe('2');
   });
+
+  // https://github.com/statelyai/xstate/issues/5306
+  it('should work with readonly atoms', () => {
+    const booleanTestAtom = createAtom(() => 13 > 12);
+
+    const TestComponent = () => {
+      const booleanValue = useAtom(booleanTestAtom);
+
+      expect(booleanValue).toBe(true);
+      expect(typeof booleanValue).toBe('boolean');
+
+      return <div>{booleanValue.toString()}</div>;
+    };
+
+    render(<TestComponent />);
+  });
 });

--- a/packages/xstate-store/test/react.test.tsx
+++ b/packages/xstate-store/test/react.test.tsx
@@ -13,7 +13,6 @@ import {
 } from '@xstate/react';
 import ReactDOM from 'react-dom';
 import { vi } from 'vitest';
-import { useEffect } from 'react';
 
 describe('useSelector', () => {
   it('useSelector should work', () => {
@@ -920,12 +919,15 @@ describe('useAtom', () => {
     const TestComponent = () => {
       const booleanValue = useAtom(booleanTestAtom);
 
-      expect(booleanValue).toBe(true);
-      expect(typeof booleanValue).toBe('boolean');
+      booleanValue satisfies boolean;
 
-      return <div>{booleanValue.toString()}</div>;
+      // @ts-expect-error
+      booleanValue satisfies number;
+
+      return <div data-testid="value">{booleanValue.toString()}</div>;
     };
 
     render(<TestComponent />);
+    expect(screen.getByTestId('value').textContent).toBe('true');
   });
 });


### PR DESCRIPTION
This PR fixes the types for `useAtom` to accept `ReadonlyAtom` values.

Fixes #5306 