### PR TITLE
[@xstate/vue] Run actor during setup, not mounted.

### DIFF
--- a/packages/xstate-vue/src/useActorRef.ts
+++ b/packages/xstate-vue/src/useActorRef.ts
@@ -35,12 +35,12 @@ export function useActorRef<TLogic extends AnyActorLogic>(
   const actorRef = createActor(actorLogic, options);
 
   let sub: Subscription;
-  onMounted(() => {
-    if (observerOrListener) {
-      sub = actorRef.subscribe(toObserver(observerOrListener));
-    }
-    actorRef.start();
-  });
+
+  if (observerOrListener) {
+    sub = actorRef.subscribe(toObserver(observerOrListener));
+  }
+
+  actorRef.start();
 
   onBeforeUnmount(() => {
     actorRef.stop();


### PR DESCRIPTION
I started migrating the chat logic in a Vue application using XState. After some time, I encountered an issue where the actor does not work during the execution of the `setup` hook. This makes it impossible to set any initial state based on external data. Here's a simplified example for context:

```ts
const { send, snapshot } = useActor({
  // ...
  context: {
    after: null,
    before: null,
  },
  // ...more logic
  states: {
    idle: {
      on: {
        JUMP_TO_CURSOR: {
          target: 'loadingAroundTop',
          actions: assign({
            after: ({ event }) => event.cursor,
            before: null,
          }),
        },
      }
    }
  }
});

const { data: conversation } = await useFetchConversation({
  variables: () => ({
    id: route.params.id,
  }),
});

if (conversation.value.lastSeenMessageCursor) {
  send({
    type: 'JUMP_TO_CURSOR',
    cursor: conversation.value.lastSeenMessageCursor,
  });
} else {
  send({
    type: 'INIT_WITHOUT_CURSOR',
  });
}

const { data: messagesData } = await useFetchConversationMessages({
  variables: () => ({
    // Variables depend on machine context
    after: snapshot.value.context.after,
    before: snapshot.value.context.before,
  }),
});
```

**Expected behavior:**

```ts
console.log(snapshot.value.value); // 'loadingAroundTop'
console.log(snapshot.value.context.after); // <cursor>
console.log(snapshot.value.context.before); // null
```

**Actual behavior:**

```ts
console.log(snapshot.value.value); // 'idle'
console.log(snapshot.value.context.after); // null
console.log(snapshot.value.context.before); // null
```

After looking into the hook implementation, I realized the problem is that the actor is only started inside the `onMounted()` hook. This creates an unnecessary limitation because:

* It makes the actor unusable during SSR;
* It prevents reusing logic immediately in the `setup()` function;
* And it forces awkward workarounds just to interact with machine state early.

I don't see any strong reason for delaying `.start()` until `onMounted()`. I also found an issue mentioning the same limitation: https://github.com/statelyai/xstate/issues/3786#issuecomment-1424871839. Actor start was moved to onMounted in this commit https://github.com/statelyai/xstate/pull/4288/commits/bfc9f74a426784fe2d7a512f800a00a4c0f12fed