### PR TITLE
[@xstate/store] Refactor store logic to improve context updates and snapshot handling

### DIFF
--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -7,7 +7,6 @@ import {
   ExtractEvents,
   InteropSubscribable,
   Observer,
-  Recipe,
   Store,
   StoreAssigner,
   StoreContext,
@@ -27,20 +26,6 @@ import {
 const symbolObservable: typeof Symbol.observable = (() =>
   (typeof Symbol === 'function' && Symbol.observable) ||
   '@@observable')() as any;
-
-/**
- * Updates a context object using a recipe function.
- *
- * @param context - The current context
- * @param recipe - A function that describes how to update the context
- * @returns The updated context
- */
-function setter<TContext extends StoreContext>(
-  context: TContext,
-  recipe: Recipe<TContext, TContext>
-): TContext {
-  return recipe(context);
-}
 
 const inspectionObservers = new WeakMap<
   Store<any, any, any>,
@@ -76,20 +61,25 @@ function createStoreCore<
   const transition = logic.transition;
 
   function receive(event: StoreEvent) {
-    let effects: StoreEffect<TEmitted>[];
-    [currentSnapshot, effects] = transition(currentSnapshot, event);
+    const [nextSnapshot, effects] = transition(currentSnapshot, event);
+
+    if (nextSnapshot === currentSnapshot && !effects.length) {
+      return;
+    }
+
+    currentSnapshot = nextSnapshot;
 
     inspectionObservers.get(store)?.forEach((observer) => {
       observer.next?.({
         type: '@xstate.snapshot',
         event,
-        snapshot: currentSnapshot,
+        snapshot: nextSnapshot,
         actorRef: store,
         rootId: store.sessionId
       });
     });
 
-    atom.set(currentSnapshot);
+    atom.set(nextSnapshot);
 
     for (const effect of effects) {
       if (typeof effect === 'function') {
@@ -423,7 +413,7 @@ export function createStoreTransition<
     event: ExtractEvents<TEventPayloadMap>
   ): [StoreSnapshot<TContext>, StoreEffect<TEmitted>[]] => {
     type StoreEvent = ExtractEvents<TEventPayloadMap>;
-    let currentContext = snapshot.context;
+    const currentContext = snapshot.context;
     const assigner = transitions?.[event.type as StoreEvent['type']];
     const effects: StoreEffect<TEmitted>[] = [];
 
@@ -447,43 +437,22 @@ export function createStoreTransition<
       return [snapshot, effects];
     }
 
-    if (typeof assigner === 'function') {
-      currentContext = producer
-        ? producer(currentContext, (draftContext) =>
-            (assigner as StoreProducerAssigner<TContext, StoreEvent, TEmitted>)(
-              draftContext,
-              event,
-              enqueue
-            )
+    const nextContext = producer
+      ? producer(currentContext, (draftContext) =>
+          (assigner as StoreProducerAssigner<TContext, StoreEvent, TEmitted>)(
+            draftContext,
+            event,
+            enqueue
           )
-        : setter(currentContext, (draftContext) =>
-            Object.assign(
-              {},
-              currentContext,
-              assigner?.(
-                draftContext,
-                event as any, // TODO: help me
-                enqueue
-              )
-            )
-          );
-    } else {
-      const partialUpdate: Record<string, unknown> = {};
-      for (const key of Object.keys(assigner)) {
-        const propAssignment = assigner[key];
-        partialUpdate[key] =
-          typeof propAssignment === 'function'
-            ? (propAssignment as StoreAssigner<TContext, StoreEvent, TEmitted>)(
-                currentContext,
-                event,
-                enqueue
-              )
-            : propAssignment;
-      }
-      currentContext = Object.assign({}, currentContext, partialUpdate);
-    }
+        )
+      : (assigner(currentContext, event as any, enqueue) ?? currentContext);
 
-    return [{ ...snapshot, context: currentContext }, effects];
+    return [
+      nextContext === currentContext
+        ? snapshot
+        : { ...snapshot, context: nextContext },
+      effects
+    ];
   };
 }
 

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -447,6 +447,43 @@ it('effects can be enqueued', async () => {
   expect(store.getSnapshot().context.count).toEqual(0);
 });
 
+it('effect-only transitions should execute effects', () => {
+  const spy = vi.fn();
+  const store = createStore({
+    context: { count: 0 },
+    on: {
+      justEffect: (ctx, _, enq) => {
+        enq.effect(spy);
+      }
+    }
+  });
+
+  store.trigger.justEffect();
+
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+
+it('emits-only transitions should emit events', () => {
+  const spy = vi.fn();
+  const store = createStore({
+    context: { count: 0 },
+    emits: {
+      emitted: () => {}
+    },
+    on: {
+      justEmit: (ctx, _, enq) => {
+        enq.emit.emitted();
+      }
+    }
+  });
+
+  store.on('emitted', spy);
+
+  store.trigger.justEmit();
+
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+
 describe('store.trigger', () => {
   it('should allow triggering events with a fluent API', () => {
     const store = createStore({
@@ -764,6 +801,45 @@ it('can be created with a logic object', () => {
 
   // @ts-expect-error
   store.getSnapshot().context.count satisfies string;
+});
+
+it('should not trigger update if the snapshot is the same', () => {
+  const store = createStore({
+    context: { count: 0 },
+    on: {
+      doNothing: (ctx) => ctx
+    }
+  });
+
+  const spy = vi.fn();
+  store.subscribe(spy);
+
+  store.trigger.doNothing();
+  store.trigger.doNothing();
+
+  expect(spy).toHaveBeenCalledTimes(0);
+});
+
+it('should not trigger update if the snapshot is the same even if there are effects', () => {
+  const store = createStore({
+    context: { count: 0 },
+    on: {
+      doNothing: (ctx, _, enq) => {
+        enq.effect(() => {
+          // …
+        });
+        return ctx;
+      }
+    }
+  });
+
+  const spy = vi.fn();
+  store.subscribe(spy);
+
+  store.trigger.doNothing();
+  store.trigger.doNothing();
+
+  expect(spy).toHaveBeenCalledTimes(0);
 });
 
 describe('types', () => {


### PR DESCRIPTION
- Removed unused setter function and associated recipe parameter.
- Updated transition logic to prevent unnecessary updates when the snapshot remains unchanged.
- Enhanced tests to verify behavior of effect-only and emit-only transitions, ensuring no updates trigger when the snapshot is the same.