### PR TITLE
[@xstate/store] Fix `createAsyncAtom` propagation

### DIFF
--- a/.changeset/dirty-donuts-clean.md
+++ b/.changeset/dirty-donuts-clean.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix: `createAsyncAtom` does not propagate status updates after promise resolves

--- a/.changeset/dirty-donuts-clean.md
+++ b/.changeset/dirty-donuts-clean.md
@@ -2,4 +2,4 @@
 '@xstate/store': patch
 ---
 
-Fix: `createAsyncAtom` does not propagate status updates after promise resolves
+Fix: `createAsyncAtom` now properly propagates status updates after promise resolves/rejects.

--- a/packages/xstate-store/src/atom.ts
+++ b/packages/xstate-store/src/atom.ts
@@ -68,10 +68,24 @@ export function createAsyncAtom<T>(
   const atom = createAtom<AsyncAtomState<T>>(() => {
     getValue().then(
       (data) => {
-        atom._update({ status: 'done', data });
+        if (atom._update({ status: 'done', data })) {
+          const subs = atom._subs;
+          if (subs !== undefined) {
+            propagate(subs);
+            shallowPropagate(subs);
+            flush();
+          }
+        }
       },
       (error) => {
-        atom._update({ status: 'error', error });
+        if (atom._update({ status: 'error', error })) {
+          const subs = atom._subs;
+          if (subs !== undefined) {
+            propagate(subs);
+            shallowPropagate(subs);
+            flush();
+          }
+        }
       }
     );
 

--- a/packages/xstate-store/test/atom.test.ts
+++ b/packages/xstate-store/test/atom.test.ts
@@ -699,4 +699,90 @@ describe('async atoms', () => {
 
     expect('set' in atom).toBe(false);
   });
+
+  it('should notify subscribers when async operation completes successfully', async () => {
+    const log = vi.fn();
+    const atom = createAsyncAtom(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return 'test-value';
+    });
+
+    atom.subscribe(log);
+
+    expect(atom.get()).toEqual({ status: 'pending' });
+    expect(log).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith({ status: 'done', data: 'test-value' });
+    expect(atom.get()).toEqual({ status: 'done', data: 'test-value' });
+  });
+
+  it('should notify subscribers when async operation fails', async () => {
+    const log = vi.fn();
+    const error = new Error('test error');
+    const atom = createAsyncAtom(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      throw error;
+    });
+
+    atom.subscribe(log);
+
+    expect(atom.get()).toEqual({ status: 'pending' });
+    expect(log).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(log).toHaveBeenCalledTimes(1);
+    expect(log).toHaveBeenCalledWith({ status: 'error', error });
+    expect(atom.get()).toEqual({ status: 'error', error });
+  });
+
+  it('should notify multiple subscribers when async operation completes', async () => {
+    const log1 = vi.fn();
+    const log2 = vi.fn();
+    const atom = createAsyncAtom(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return 'multi-test';
+    });
+
+    atom.subscribe(log1);
+    atom.subscribe(log2);
+
+    expect(atom.get()).toEqual({ status: 'pending' });
+    expect(log1).not.toHaveBeenCalled();
+    expect(log2).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(log1).toHaveBeenCalledTimes(1);
+    expect(log1).toHaveBeenCalledWith({ status: 'done', data: 'multi-test' });
+    expect(log2).toHaveBeenCalledTimes(1);
+    expect(log2).toHaveBeenCalledWith({ status: 'done', data: 'multi-test' });
+  });
+
+  it('should work with the exact example from the bug report', async () => {
+    const alertSpy = vi.fn();
+    const originalAlert = global.alert;
+    global.alert = alertSpy;
+
+    try {
+      const atom = createAsyncAtom(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+        return 'value';
+      });
+
+      atom.subscribe((snapshot) => {
+        if (snapshot.status === 'done') alertSpy(snapshot.data);
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(alertSpy).toHaveBeenCalledTimes(1);
+      expect(alertSpy).toHaveBeenCalledWith('value');
+    } finally {
+      global.alert = originalAlert;
+    }
+  });
 });

--- a/packages/xstate-store/test/atom.test.ts
+++ b/packages/xstate-store/test/atom.test.ts
@@ -761,28 +761,4 @@ describe('async atoms', () => {
     expect(log2).toHaveBeenCalledTimes(1);
     expect(log2).toHaveBeenCalledWith({ status: 'done', data: 'multi-test' });
   });
-
-  it('should work with the exact example from the bug report', async () => {
-    const alertSpy = vi.fn();
-    const originalAlert = global.alert;
-    global.alert = alertSpy;
-
-    try {
-      const atom = createAsyncAtom(async () => {
-        await new Promise((r) => setTimeout(r, 10));
-        return 'value';
-      });
-
-      atom.subscribe((snapshot) => {
-        if (snapshot.status === 'done') alertSpy(snapshot.data);
-      });
-
-      await new Promise((resolve) => setTimeout(resolve, 20));
-
-      expect(alertSpy).toHaveBeenCalledTimes(1);
-      expect(alertSpy).toHaveBeenCalledWith('value');
-    } finally {
-      global.alert = originalAlert;
-    }
-  });
 });


### PR DESCRIPTION
Fix: `createAsyncAtom` now properly propagates status updates after promise resolves/rejects.

Fixes #5327