### PR TITLE
[@xstate/store] Add support for generics 

### DIFF
--- a/.changeset/full-signs-give.md
+++ b/.changeset/full-signs-give.md
@@ -1,0 +1,39 @@
+---
+'@xstate/store': patch
+---
+
+The `createStore` function now supports explicit generic type parameters for better type control when needed. This allows you to specify the exact types for context, events, and emitted events instead of relying solely on type inference if desired.
+
+```ts
+type CoffeeContext = {
+  beans: number;
+  cups: number;
+};
+
+type CoffeeEvents = { type: 'addBeans'; amount: number } | { type: 'brewCup' };
+
+type CoffeeEmitted =
+  | { type: 'beansAdded'; amount: number }
+  | { type: 'cupBrewed' };
+
+const coffeeStore = createStore<CoffeeContext, CoffeeEvents, CoffeeEmitted>({
+  context: {
+    beans: 0,
+    cups: 0
+  },
+  on: {
+    addBeans: (ctx, event, enq) => {
+      enq.emit.beansAdded({ amount: event.amount });
+      return { ...ctx, beans: ctx.beans + event.amount };
+    },
+    brewCup: (ctx, _, enq) => {
+      if (ctx.beans > 0) {
+        enq.emit.cupBrewed();
+        return { ...ctx, beans: ctx.beans - 1, cups: ctx.cups + 1 };
+      }
+
+      return ctx;
+    }
+  }
+});
+```

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -21,7 +21,8 @@ import {
   InternalBaseAtom,
   StoreLogic,
   StoreTransition,
-  AnyStoreLogic
+  AnyStoreLogic,
+  SpecificStoreConfig
 } from './types';
 
 const symbolObservable: typeof Symbol.observable = (() =>
@@ -263,14 +264,17 @@ export function createStore<
 export function createStore<
   TContext extends StoreContext,
   TEvent extends EventObject,
-  TEmittedPayloadMap extends EventPayloadMap
+  TEmitted extends EventObject
 >(
-  logic: StoreLogic<
-    StoreSnapshot<TContext>,
-    TEvent,
-    ExtractEvents<TEmittedPayloadMap>
-  >
-): Store<TContext, TEvent, ExtractEvents<TEmittedPayloadMap>>;
+  definition: SpecificStoreConfig<TContext, TEvent, TEmitted>
+): Store<TContext, TEvent, TEmitted>;
+export function createStore<
+  TContext extends StoreContext,
+  TEvent extends EventObject,
+  TEmitted extends EventObject
+>(
+  logic: StoreLogic<StoreSnapshot<TContext>, TEvent, TEmitted>
+): Store<TContext, TEvent, TEmitted>;
 export function createStore(
   definitionOrLogic: StoreConfig<any, any, any> | AnyStoreLogic
 ) {

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -173,6 +173,24 @@ export type StoreConfig<
   };
 };
 
+export type SpecificStoreConfig<
+  TContext extends StoreContext,
+  TEvent extends EventObject,
+  TEmitted extends EventObject
+> = {
+  context: TContext;
+  emits?: {
+    [K in TEmitted['type']]: (payload: TEmitted & { type: K }) => void;
+  };
+  on: {
+    [K in TEvent['type']]: StoreAssigner<
+      TContext,
+      { type: K } & TEvent,
+      TEmitted
+    >;
+  };
+};
+
 type IsEmptyObject<T> = T extends Record<string, never> ? true : false;
 
 export type AnyStore = Store<any, any, any>;

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -180,14 +180,10 @@ export type SpecificStoreConfig<
 > = {
   context: TContext;
   emits?: {
-    [K in TEmitted['type']]: (payload: TEmitted & { type: K }) => void;
+    [E in TEmitted as E['type']]: (payload: E) => void;
   };
   on: {
-    [K in TEvent['type']]: StoreAssigner<
-      TContext,
-      { type: K } & TEvent,
-      TEmitted
-    >;
+    [E in TEvent as E['type']]: StoreAssigner<TContext, E, TEmitted>;
   };
 };
 


### PR DESCRIPTION
The `createStore` function now supports explicit generic type parameters for better type control when needed. This allows you to specify the exact types for context, events, and emitted events instead of relying solely on type inference if desired.

```ts
type CoffeeContext = {
  beans: number;
  cups: number;
};

type CoffeeEvents = { type: 'addBeans'; amount: number } | { type: 'brewCup' };

type CoffeeEmitted =
  | { type: 'beansAdded'; amount: number }
  | { type: 'cupBrewed' };

const coffeeStore = createStore<CoffeeContext, CoffeeEvents, CoffeeEmitted>({
  context: {
    beans: 0,
    cups: 0
  },
  on: {
    addBeans: (ctx, event, enq) => {
      enq.emit.beansAdded({ amount: event.amount });
      return { ...ctx, beans: ctx.beans + event.amount };
    },
    brewCup: (ctx, _, enq) => {
      if (ctx.beans > 0) {
        enq.emit.cupBrewed();
        return { ...ctx, beans: ctx.beans - 1, cups: ctx.cups + 1 };
      }

      return ctx;
    }
  }
});
```
