### PR TITLE
[@xstate/store]  chore: add missing EventFromStoreConfig, EmitsFromStoreConfig, ContextFromStoreConfig types

### DIFF
--- a/.changeset/selfish-readers-sniff.md
+++ b/.changeset/selfish-readers-sniff.md
@@ -1,0 +1,5 @@
+---
+"@xstate/store": patch
+---
+
+chore: add missing EventFromStoreConfig, EmitsFromStoreConfig, ContextFromStoreConfig types from @xstate/store exports

--- a/packages/xstate-store/src/index.ts
+++ b/packages/xstate-store/src/index.ts
@@ -34,5 +34,8 @@ export type {
   Atom,
   AtomOptions,
   AnyAtom,
-  ReadonlyAtom
+  ReadonlyAtom,
+  EventFromStoreConfig,
+  EmitsFromStoreConfig,
+  ContextFromStoreConfig
 } from './types';


### PR DESCRIPTION
need these types in our repo 🙇🏽

https://github.com/statelyai/xstate/pull/5334

would be great too!