### PR TITLE
[core] Fix emit callback error crashing actor

### DIFF
--- a/.changeset/polite-bugs-lose.md
+++ b/.changeset/polite-bugs-lose.md
@@ -1,0 +1,12 @@
+---
+'xstate': patch
+---
+
+Fix: Emit callback errors no longer crash the actor
+
+```ts
+actor.on('event', () => {
+  // Will no longer crash the actor
+  throw new Error('oops');
+});
+```

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -200,7 +200,11 @@ export class Actor<TLogic extends AnyActorLogic>
           ...(wildcardListener ? wildcardListener.values() : [])
         ];
         for (const handler of allListeners) {
-          handler(emittedEvent);
+          try {
+            handler(emittedEvent);
+          } catch (err) {
+            reportUnhandledError(err);
+          }
         }
       },
       actionExecutor: (action) => {


### PR DESCRIPTION

Fix: Emit callback errors no longer crash the actor

```ts
actor.on('event', () => {
  // Will no longer crash the actor
  throw new Error('oops');
});
```
