### PR TITLE
[@xstate/store] React `createStoreHook(…)` helper

### DIFF
--- a/.changeset/twenty-bars-relate.md
+++ b/.changeset/twenty-bars-relate.md
@@ -1,0 +1,24 @@
+---
+'@xstate/store': minor
+---
+
+Add `createStoreHook(…)` function for React. Creates a store hook that returns `[selectedValue, store]` instead of managing store instances manually.
+
+```tsx
+const useCountStore = createStoreHook({
+  context: { count: 0 },
+  on: {
+    inc: (ctx, event: { by: number }) => ({
+      ...ctx,
+      count: ctx.count + event.by
+    })
+  }
+});
+
+// Usage
+const [count, store] = useCountStore((s) => s.context.count);
+store.trigger.inc({ by: 3 });
+
+// Usage (no selector)
+const [snapshot, store] = useCountStore();
+```

--- a/packages/xstate-store/src/react.ts
+++ b/packages/xstate-store/src/react.ts
@@ -9,8 +9,7 @@ import {
   Readable,
   AnyAtom,
   BaseAtom,
-  StoreSnapshot,
-  SnapshotFromStore
+  StoreSnapshot
 } from './types';
 import { createStore } from './store';
 

--- a/packages/xstate-store/test/react.test.tsx
+++ b/packages/xstate-store/test/react.test.tsx
@@ -954,24 +954,24 @@ describe('createStoreHook', () => {
     });
 
     const Counter = () => {
-      const [count, triggers] = useCountStore((s) => s.context.count);
+      const [count, store] = useCountStore((s) => s.context.count);
 
       return (
         <div>
           <div data-testid="count">{count}</div>
           <button
             data-testid="increment"
-            onClick={() => triggers.inc({ by: 1 })}
+            onClick={() => store.trigger.inc({ by: 1 })}
           >
             +1
           </button>
           <button
             data-testid="increment-5"
-            onClick={() => triggers.inc({ by: 5 })}
+            onClick={() => store.trigger.inc({ by: 5 })}
           >
             +5
           </button>
-          <button data-testid="reset" onClick={() => triggers.reset()}>
+          <button data-testid="reset" onClick={() => store.trigger.reset()}>
             Reset
           </button>
         </div>
@@ -1014,18 +1014,18 @@ describe('createStoreHook', () => {
     });
 
     const Component = () => {
-      const [snapshot, triggers] = useFullStore();
+      const [snapshot, store] = useFullStore();
 
       return (
         <div>
           <div data-testid="name">{snapshot.context.name}</div>
           <div data-testid="count">{snapshot.context.count}</div>
           <div data-testid="status">{snapshot.status}</div>
-          <button onClick={() => triggers.inc()}>Increment</button>
+          <button onClick={() => store.trigger.inc()}>Increment</button>
           <input
             data-testid="name-input"
             value={snapshot.context.name}
-            onChange={(e) => triggers.setName({ name: e.target.value })}
+            onChange={(e) => store.trigger.setName({ name: e.target.value })}
           />
         </div>
       );
@@ -1065,7 +1065,7 @@ describe('createStoreHook', () => {
     const OptimizedComponent = () => {
       renderCount++;
       // Only re-render if count changes (custom comparison)
-      const [count, triggers] = useOptimizedStore(
+      const [count, store] = useOptimizedStore(
         (s) => s.context.count,
         (a, b) => a === b
       );
@@ -1073,12 +1073,12 @@ describe('createStoreHook', () => {
       return (
         <div>
           <div data-testid="count">{count}</div>
-          <button data-testid="inc-count" onClick={() => triggers.inc()}>
+          <button data-testid="inc-count" onClick={() => store.trigger.inc()}>
             Inc Count
           </button>
           <button
             data-testid="change-name"
-            onClick={() => triggers.setName({ name: 'Changed' })}
+            onClick={() => store.trigger.setName({ name: 'Changed' })}
           >
             Change Name
           </button>
@@ -1112,15 +1112,15 @@ describe('createStoreHook', () => {
     });
 
     const Component = () => {
-      const [count, triggers] = useTestStore((s) => s.context.count);
+      const [count, store] = useTestStore((s) => s.context.count);
 
-      // Capture the triggers object to check stability
-      storeInstances.push(triggers);
+      // Capture the store object to check stability
+      storeInstances.push(store);
 
       return (
         <div>
           <div data-testid="count">{count}</div>
-          <button onClick={() => triggers.inc()}>Increment</button>
+          <button onClick={() => store.trigger.inc()}>Increment</button>
         </div>
       );
     };
@@ -1158,12 +1158,12 @@ describe('createStoreHook', () => {
     });
 
     const Component = () => {
-      const [count, triggers] = useEmittingStore((s) => s.context.count);
+      const [count, store] = useEmittingStore((s) => s.context.count);
 
       return (
         <div>
           <div data-testid="count">{count}</div>
-          <button onClick={() => triggers.inc()}>Increment</button>
+          <button onClick={() => store.trigger.inc()}>Increment</button>
         </div>
       );
     };
@@ -1185,11 +1185,11 @@ describe('createStoreHook', () => {
     });
 
     const Counter1 = () => {
-      const [count, triggers] = useCounterStore((s) => s.context.count);
+      const [count, store] = useCounterStore((s) => s.context.count);
       return (
         <div>
           <div data-testid="count-1">{count}</div>
-          <button data-testid="inc-1" onClick={() => triggers.inc()}>
+          <button data-testid="inc-1" onClick={() => store.trigger.inc()}>
             +
           </button>
         </div>
@@ -1197,11 +1197,11 @@ describe('createStoreHook', () => {
     };
 
     const Counter2 = () => {
-      const [count, triggers] = useCounterStore((s) => s.context.count);
+      const [count, store] = useCounterStore((s) => s.context.count);
       return (
         <div>
           <div data-testid="count-2">{count}</div>
-          <button data-testid="inc-2" onClick={() => triggers.inc()}>
+          <button data-testid="inc-2" onClick={() => store.trigger.inc()}>
             +
           </button>
         </div>
@@ -1255,19 +1255,19 @@ describe('createStoreHook', () => {
     });
 
     const TypedComponent = () => {
-      const [state, triggers] = useTypedStore();
+      const [state, store] = useTypedStore();
 
       // Test that triggers have correct types
       return (
         <div>
           <div data-testid="count">{state.context.count}</div>
           <div data-testid="name">{state.context.name}</div>
-          <button onClick={() => triggers.increment({ by: 5 })}>+5</button>
-          <button onClick={() => triggers.decrement({ by: 2 })}>-2</button>
-          <button onClick={() => triggers.setName({ name: 'updated' })}>
+          <button onClick={() => store.trigger.increment({ by: 5 })}>+5</button>
+          <button onClick={() => store.trigger.decrement({ by: 2 })}>-2</button>
+          <button onClick={() => store.trigger.setName({ name: 'updated' })}>
             Set Name
           </button>
-          <button onClick={() => triggers.reset()}>Reset</button>
+          <button onClick={() => store.trigger.reset()}>Reset</button>
         </div>
       );
     };
@@ -1277,7 +1277,6 @@ describe('createStoreHook', () => {
     expect(screen.getByTestId('count').textContent).toBe('0');
     expect(screen.getByTestId('name').textContent).toBe('test');
 
-    // Test all trigger methods work correctly
     fireEvent.click(screen.getByText('+5'));
     expect(screen.getByTestId('count').textContent).toBe('5');
 
@@ -1318,12 +1317,12 @@ describe('createStoreHook', () => {
     });
 
     const UserComponent = () => {
-      const [userName, triggers] = useComplexStore((s) => s.context.user.name);
+      const [userName, store] = useComplexStore((s) => s.context.user.name);
 
       return (
         <div>
           <div data-testid="user-name">{userName}</div>
-          <button onClick={() => triggers.updateUser({ name: 'Jane' })}>
+          <button onClick={() => store.trigger.updateUser({ name: 'Jane' })}>
             Update Name
           </button>
         </div>
@@ -1331,27 +1330,27 @@ describe('createStoreHook', () => {
     };
 
     const ThemeComponent = () => {
-      const [theme, triggers] = useComplexStore(
-        (s) => s.context.settings.theme
-      );
+      const [theme, store] = useComplexStore((s) => s.context.settings.theme);
 
       return (
         <div>
           <div data-testid="theme">{theme}</div>
-          <button onClick={() => triggers.toggleTheme()}>Toggle Theme</button>
+          <button onClick={() => store.trigger.toggleTheme()}>
+            Toggle Theme
+          </button>
         </div>
       );
     };
 
     const ItemsComponent = () => {
-      const [itemCount, triggers] = useComplexStore(
-        (s) => s.context.items.length
-      );
+      const [itemCount, store] = useComplexStore((s) => s.context.items.length);
 
       return (
         <div>
           <div data-testid="item-count">{itemCount}</div>
-          <button onClick={() => triggers.addItem({ item: Math.random() })}>
+          <button
+            onClick={() => store.trigger.addItem({ item: Math.random() })}
+          >
             Add Item
           </button>
         </div>

--- a/packages/xstate-store/test/react.test.tsx
+++ b/packages/xstate-store/test/react.test.tsx
@@ -3,7 +3,8 @@ import {
   createStore,
   fromStore,
   createStoreConfig,
-  createAtom
+  createAtom,
+  AnyStore
 } from '../src/index.ts';
 import {
   useSelector,
@@ -1073,15 +1074,11 @@ describe('createStoreHook', () => {
       return (
         <div>
           <div data-testid="count">{count}</div>
-          <button data-testid="inc-count" onClick={() => store.trigger.inc()}>
-            Inc Count
-          </button>
+          <button data-testid="inc-count" onClick={() => store.trigger.inc()} />
           <button
             data-testid="change-name"
             onClick={() => store.trigger.setName({ name: 'Changed' })}
-          >
-            Change Name
-          </button>
+          />
         </div>
       );
     };
@@ -1102,7 +1099,7 @@ describe('createStoreHook', () => {
   });
 
   it('should maintain stable store instances across renders', () => {
-    const storeInstances: any[] = [];
+    const storeInstances: Set<AnyStore> = new Set();
 
     const useTestStore = createStoreHook({
       context: { count: 0 },
@@ -1115,7 +1112,7 @@ describe('createStoreHook', () => {
       const [count, store] = useTestStore((s) => s.context.count);
 
       // Capture the store object to check stability
-      storeInstances.push(store);
+      storeInstances.add(store);
 
       return (
         <div>
@@ -1132,10 +1129,7 @@ describe('createStoreHook', () => {
     fireEvent.click(screen.getByRole('button'));
 
     // All trigger objects should be the same reference (stable)
-    expect(storeInstances.length).toBeGreaterThan(1);
-    expect(
-      storeInstances.every((instance) => instance === storeInstances[0])
-    ).toBe(true);
+    expect(storeInstances.size).toBe(1);
   });
 
   it('should handle emitted events', () => {
@@ -1163,7 +1157,7 @@ describe('createStoreHook', () => {
       return (
         <div>
           <div data-testid="count">{count}</div>
-          <button onClick={() => store.trigger.inc()}>Increment</button>
+          <button onClick={() => store.trigger.inc()} />
         </div>
       );
     };
@@ -1189,9 +1183,7 @@ describe('createStoreHook', () => {
       return (
         <div>
           <div data-testid="count-1">{count}</div>
-          <button data-testid="inc-1" onClick={() => store.trigger.inc()}>
-            +
-          </button>
+          <button data-testid="inc-1" onClick={() => store.trigger.inc()} />
         </div>
       );
     };
@@ -1201,9 +1193,7 @@ describe('createStoreHook', () => {
       return (
         <div>
           <div data-testid="count-2">{count}</div>
-          <button data-testid="inc-2" onClick={() => store.trigger.inc()}>
-            +
-          </button>
+          <button data-testid="inc-2" onClick={() => store.trigger.inc()} />
         </div>
       );
     };
@@ -1262,12 +1252,19 @@ describe('createStoreHook', () => {
         <div>
           <div data-testid="count">{state.context.count}</div>
           <div data-testid="name">{state.context.name}</div>
-          <button onClick={() => store.trigger.increment({ by: 5 })}>+5</button>
-          <button onClick={() => store.trigger.decrement({ by: 2 })}>-2</button>
-          <button onClick={() => store.trigger.setName({ name: 'updated' })}>
-            Set Name
-          </button>
-          <button onClick={() => store.trigger.reset()}>Reset</button>
+          <button
+            data-testid="increment"
+            onClick={() => store.trigger.increment({ by: 5 })}
+          />
+          <button
+            data-testid="decrement"
+            onClick={() => store.trigger.decrement({ by: 2 })}
+          />
+          <button
+            data-testid="set-name"
+            onClick={() => store.trigger.setName({ name: 'updated' })}
+          />
+          <button data-testid="reset" onClick={() => store.trigger.reset()} />
         </div>
       );
     };
@@ -1277,16 +1274,16 @@ describe('createStoreHook', () => {
     expect(screen.getByTestId('count').textContent).toBe('0');
     expect(screen.getByTestId('name').textContent).toBe('test');
 
-    fireEvent.click(screen.getByText('+5'));
+    fireEvent.click(screen.getByTestId('increment'));
     expect(screen.getByTestId('count').textContent).toBe('5');
 
-    fireEvent.click(screen.getByText('-2'));
+    fireEvent.click(screen.getByTestId('decrement'));
     expect(screen.getByTestId('count').textContent).toBe('3');
 
-    fireEvent.click(screen.getByText('Set Name'));
+    fireEvent.click(screen.getByTestId('set-name'));
     expect(screen.getByTestId('name').textContent).toBe('updated');
 
-    fireEvent.click(screen.getByText('Reset'));
+    fireEvent.click(screen.getByTestId('reset'));
     expect(screen.getByTestId('count').textContent).toBe('0');
   });
 
@@ -1322,9 +1319,10 @@ describe('createStoreHook', () => {
       return (
         <div>
           <div data-testid="user-name">{userName}</div>
-          <button onClick={() => store.trigger.updateUser({ name: 'Jane' })}>
-            Update Name
-          </button>
+          <button
+            data-testid="update-name"
+            onClick={() => store.trigger.updateUser({ name: 'Jane' })}
+          />
         </div>
       );
     };
@@ -1335,9 +1333,10 @@ describe('createStoreHook', () => {
       return (
         <div>
           <div data-testid="theme">{theme}</div>
-          <button onClick={() => store.trigger.toggleTheme()}>
-            Toggle Theme
-          </button>
+          <button
+            data-testid="toggle-theme"
+            onClick={() => store.trigger.toggleTheme()}
+          />
         </div>
       );
     };
@@ -1349,10 +1348,9 @@ describe('createStoreHook', () => {
         <div>
           <div data-testid="item-count">{itemCount}</div>
           <button
+            data-testid="add-item"
             onClick={() => store.trigger.addItem({ item: Math.random() })}
-          >
-            Add Item
-          </button>
+          />
         </div>
       );
     };
@@ -1371,15 +1369,15 @@ describe('createStoreHook', () => {
     expect(screen.getByTestId('item-count').textContent).toBe('3');
 
     // Update user name
-    fireEvent.click(screen.getByText('Update Name'));
+    fireEvent.click(screen.getByTestId('update-name'));
     expect(screen.getByTestId('user-name').textContent).toBe('Jane');
 
     // Toggle theme
-    fireEvent.click(screen.getByText('Toggle Theme'));
+    fireEvent.click(screen.getByTestId('toggle-theme'));
     expect(screen.getByTestId('theme').textContent).toBe('light');
 
     // Add item
-    fireEvent.click(screen.getByText('Add Item'));
+    fireEvent.click(screen.getByTestId('add-item'));
     expect(screen.getByTestId('item-count').textContent).toBe('4');
   });
 });


### PR DESCRIPTION
From #5298

Add `createStoreHook(…)` function for React. Creates a store hook that returns `[selectedValue, store]` instead of managing store instances manually.

```tsx
const useCountStore = createStoreHook({
  context: { count: 0 },
  on: {
    inc: (ctx, event: { by: number }) => ({
      ...ctx,
      count: ctx.count + event.by
    })
  }
});

// Usage
const [count, store] = useCountStore((s) => s.context.count);
store.trigger.inc({ by: 3 });

// Usage (no selector)
const [snapshot, store] = useCountStore();
```
