### PR TITLE
[@xstate/store] Fix `createStoreHook` to use single store instance

### DIFF
--- a/.changeset/shiny-needles-drop.md
+++ b/.changeset/shiny-needles-drop.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix `createStoreHook` to create a single shared store instance across all components. Previously, the implementation was creating independent store instances, but now multiple components using the same hook will share state as expected.

--- a/packages/xstate-store/src/react.ts
+++ b/packages/xstate-store/src/react.ts
@@ -189,6 +189,8 @@ export function createStoreHook<
   >;
   type TSnapshot = StoreSnapshot<TContext>;
 
+  const store = createStore(definition);
+
   function useStoreHook(): [TSnapshot, TStore];
   function useStoreHook<T>(
     selector: (snapshot: TSnapshot) => T,
@@ -198,14 +200,6 @@ export function createStoreHook<
     selector?: (snapshot: TSnapshot) => T,
     compare: (a: T | undefined, b: T) => boolean = defaultCompare
   ) {
-    const storeRef = useRef<TStore | undefined>(undefined);
-
-    if (!storeRef.current) {
-      storeRef.current = createStore(definition);
-    }
-
-    const store = storeRef.current;
-
     // If no selector provided, return full snapshot
     if (!selector) {
       const snapshot = useSelector(store, identity, defaultCompare);

--- a/packages/xstate-store/test/react.test.tsx
+++ b/packages/xstate-store/test/react.test.tsx
@@ -1170,7 +1170,7 @@ describe('createStoreHook', () => {
     expect(screen.getByTestId('count').textContent).toBe('1');
   });
 
-  it('should work with multiple independent hook instances', () => {
+  it('should work with shared store instance across multiple hook calls', () => {
     const useCounterStore = createStoreHook({
       context: { count: 0 },
       on: {
@@ -1205,19 +1205,18 @@ describe('createStoreHook', () => {
       </>
     );
 
-    // Both should start at 0
+    // Both should start at 0 (shared state)
     expect(screen.getByTestId('count-1').textContent).toBe('0');
     expect(screen.getByTestId('count-2').textContent).toBe('0');
 
-    // Increment first counter only
+    // Increment first counter - both should update since they share the same store
     fireEvent.click(screen.getByTestId('inc-1'));
     expect(screen.getByTestId('count-1').textContent).toBe('1');
-    expect(screen.getByTestId('count-2').textContent).toBe('0'); // Should remain 0
+    expect(screen.getByTestId('count-2').textContent).toBe('1'); // Should also be 1
 
-    // Increment second counter twice
+    // Increment second counter - both should update since they share the same store
     fireEvent.click(screen.getByTestId('inc-2'));
-    fireEvent.click(screen.getByTestId('inc-2'));
-    expect(screen.getByTestId('count-1').textContent).toBe('1'); // Should remain 1
+    expect(screen.getByTestId('count-1').textContent).toBe('2'); // Should also be 2
     expect(screen.getByTestId('count-2').textContent).toBe('2');
   });
 


### PR DESCRIPTION
Fix `createStoreHook` to create a single shared store instance across all components. Previously, the implementation was creating independent store instances, but now multiple components using the same hook will share state as expected.