### PR TITLE
[core] Add `actor.inspect(…)`

### DIFF
--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -45,6 +45,7 @@ import {
   Subscription
 } from './types.ts';
 import { toObserver } from './utils.ts';
+import { InspectionEvent } from './inspection.ts';
 
 export const $$ACTOR_TYPE = 1;
 
@@ -788,6 +789,18 @@ export class Actor<TLogic extends AnyActorLogic>
       );
     }
     return this._snapshot;
+  }
+
+  /**
+   * Subscribes to [inspection events](https://stately.ai/docs/inspection) from
+   * the actor.
+   */
+  public inspect(
+    observer:
+      | Observer<InspectionEvent>
+      | ((inspectionEvent: InspectionEvent) => void)
+  ): Subscription {
+    return this.system.inspect(observer);
   }
 }
 

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -1149,4 +1149,21 @@ describe('inspect', () => {
 
     expect(events.length).toEqual(0);
   });
+
+  it('actor.inspect(…) can inspect actors', () => {
+    const actor = createActor(createMachine({}));
+    const events: InspectionEvent[] = [];
+
+    actor.start();
+
+    actor.inspect((ev) => {
+      events.push(ev);
+    });
+
+    expect(events).toHaveLength(0);
+
+    actor.send({ type: 'someEvent' });
+
+    expect(events).toHaveLength(3);
+  });
 });


### PR DESCRIPTION
I often find myself wanting to inspect an actor that already exists, hence this PR