### PR TITLE
[@xstate/store] Improves async effect types

### DIFF
--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -94,7 +94,7 @@ function createStoreCore<
 
     for (const effect of effects) {
       if (typeof effect === 'function') {
-        effect();
+        void effect();
       } else {
         // handle the inherent effect first
         emits?.[effect.type]?.(effect);

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -22,7 +22,7 @@ export type EnqueueObject<TEmittedEvent extends EventObject> = {
   emit: {
     [E in TEmittedEvent as E['type']]: EmitterFunction<E>;
   };
-  effect: (fn: () => void) => void;
+  effect: (fn: () => void | Promise<void>) => void;
 };
 
 export type StoreEffect<TEmitted extends EventObject> = (() => void) | TEmitted;

--- a/packages/xstate-store/test/types.test.tsx
+++ b/packages/xstate-store/test/types.test.tsx
@@ -141,3 +141,35 @@ describe('trigger', () => {
     });
   });
 });
+
+describe('enqueue effects', () => {
+  it('can enqueue only sync and async functions', () => {
+    const store = createStore({
+      context: { count: 0 },
+      on: {
+        increment: (ctx, _, enq) => {
+          // @ts-expect-error
+          enq.effect({ answer: 84 });
+
+          enq.effect(() => {
+            store.send({ type: 'decrement' });
+          });
+
+          enq.effect(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            store.send({ type: 'decrement' });
+          });
+
+          return {
+            ...ctx,
+            count: ctx.count + 1
+          };
+        },
+        decrement: (ctx) => ({
+          ...ctx,
+          count: ctx.count - 1
+        })
+      }
+    });
+  });
+});


### PR DESCRIPTION
Just minor type improvements. Nothing changed in the behavior or APIs.

More details can be found in this [discussion](https://github.com/statelyai/xstate/discussions/5377).