### PR TITLE
[@xstate/store] Fix event type overwriting

### DIFF
--- a/.changeset/kind-regions-mate.md
+++ b/.changeset/kind-regions-mate.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+- Fix: `trigger` methods now work when passed directly as event handlers, even for events with no payload. Before, the React `event.type` would overwrite the intended event type.

--- a/.changeset/kind-regions-mate.md
+++ b/.changeset/kind-regions-mate.md
@@ -2,4 +2,4 @@
 '@xstate/store': patch
 ---
 
-- Fix: `trigger` methods now work when passed directly as event handlers, even for events with no payload. Before, the React `event.type` would overwrite the intended event type.
+Fix: `trigger` methods now work when passed directly as event handlers, even for events with no payload. Before, the React `event.type` would overwrite the intended event type.

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -185,8 +185,8 @@ function createStoreCore<
       get: (_, eventType: string) => {
         return (payload: any) => {
           store.send({
-            type: eventType,
-            ...payload
+            ...payload,
+            type: eventType
           });
         };
       }

--- a/packages/xstate-store/test/react.test.tsx
+++ b/packages/xstate-store/test/react.test.tsx
@@ -1379,4 +1379,29 @@ describe('createStoreHook', () => {
     fireEvent.click(screen.getByTestId('add-item'));
     expect(screen.getByTestId('item-count').textContent).toBe('4');
   });
+
+  it('trigger methods that do not take args should work when passed directly into event handlers', () => {
+    const useTriggerStore = createStoreHook({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ ...ctx, count: ctx.count + 1 })
+      }
+    });
+
+    const Component = () => {
+      const [count, store] = useTriggerStore((s) => s.context.count);
+      return (
+        <div>
+          <div data-testid="count">{count}</div>
+          {/* Before, event.type would overwrite { type: 'inc' } */}
+          <button onClick={store.trigger.inc} />
+        </div>
+      );
+    };
+
+    render(<Component />);
+
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByTestId('count').textContent).toBe('1');
+  });
 });


### PR DESCRIPTION
- Fix: `trigger` methods now work when passed directly as event handlers, even for events with no payload. Before, the React `event.type` would overwrite the intended event type.
