### PR TITLE
Exposes store transition utility and types

### DIFF
--- a/packages/xstate-store/src/index.ts
+++ b/packages/xstate-store/src/index.ts
@@ -3,7 +3,8 @@ export { fromStore } from './fromStore';
 export {
   createStore,
   createStoreWithProducer,
-  createStoreConfig
+  createStoreConfig,
+  createStoreTransition
 } from './store';
 export { createAtom, createAsyncAtom } from './atom';
 export type {
@@ -35,6 +36,9 @@ export type {
   AtomOptions,
   AnyAtom,
   ReadonlyAtom,
+  StoreLogic,
+  AnyStoreLogic,
+  AnyStoreConfig,
   EventFromStoreConfig,
   EmitsFromStoreConfig,
   ContextFromStoreConfig


### PR DESCRIPTION
This PR exposes additional utilities and types from the `xstate-store` package.

The new exports provide consumers with direct access to the `createStoreTransition` function and key store configuration types. This enhances flexibility and configurability, allowing for more advanced and custom store configurations to be built externally such as the currently stalled [persist utility](https://github.com/statelyai/xstate/blob/e3094b28ffae126686e3fe9ff9677ed54d092443/packages/xstate-store/src/persist.ts)

- Exports `createStoreTransition` utility function.
- Exports `StoreLogic`, `AnyStoreLogic`, and `AnyStoreConfig` types.

Additional context: [Discord thread](https://discord.com/channels/795785288994652170/1423268446379966524)