### PR TITLE
Get list of currently running actors in system

### DIFF
--- a/.changeset/nice-teeth-lead.md
+++ b/.changeset/nice-teeth-lead.md
@@ -1,0 +1,21 @@
+---
+'xstate': minor
+---
+
+Adds `system.getRunningActors` that returns a record of running actors within the system by their system id
+
+```ts
+const childMachine = createMachine({});
+const machine = createMachine({
+  // ...
+  invoke: [
+    {
+      src: childMachine,
+      systemId: 'test'
+    }
+  ]
+});
+const system = createActor(machine);
+
+system.getRunningActors(); // { test: ActorRefFrom<typeof childMachine> }
+```

--- a/.changeset/nice-teeth-lead.md
+++ b/.changeset/nice-teeth-lead.md
@@ -2,7 +2,7 @@
 'xstate': minor
 ---
 
-Adds `system.getRunningActors` that returns a record of running actors within the system by their system id
+Adds `system.getAll` that returns a record of running actors within the system by their system id
 
 ```ts
 const childMachine = createMachine({});
@@ -17,5 +17,5 @@ const machine = createMachine({
 });
 const system = createActor(machine);
 
-system.getRunningActors(); // { test: ActorRefFrom<typeof childMachine> }
+system.getAll(); // { test: ActorRefFrom<typeof childMachine> }
 ```

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -187,7 +187,8 @@ export function createSystem<T extends ActorSystemInfo>(
       }
     },
     get: (systemId) => {
-      return keyedActors.get(systemId) as T['actors'][any] | undefined
+      return keyedActors.get(systemId) as T['actors'][any] | undefined;
+    },
     getAll: () => {
       return Object.fromEntries(keyedActors.entries()) as Partial<T['actors']>;
     },

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -55,6 +55,7 @@ export interface ActorSystem<T extends ActorSystemInfo> {
   /** @internal */
   _set: <K extends keyof T['actors']>(key: K, actorRef: T['actors'][K]) => void;
   get: <K extends keyof T['actors']>(key: K) => T['actors'][K] | undefined;
+  getRunningActors: () => T['actors'];
 
   inspect: (
     observer:
@@ -187,6 +188,9 @@ export function createSystem<T extends ActorSystemInfo>(
     },
     get: (systemId) => {
       return keyedActors.get(systemId) as T['actors'][any];
+    },
+    getRunningActors: () => {
+      return Object.fromEntries(keyedActors.entries()) as T['actors'];
     },
     _set: (systemId, actorRef) => {
       const existing = keyedActors.get(systemId);

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -55,7 +55,7 @@ export interface ActorSystem<T extends ActorSystemInfo> {
   /** @internal */
   _set: <K extends keyof T['actors']>(key: K, actorRef: T['actors'][K]) => void;
   get: <K extends keyof T['actors']>(key: K) => T['actors'][K] | undefined;
-  getRunningActors: () => T['actors'];
+  getAll: () => T['actors'];
 
   inspect: (
     observer:
@@ -189,7 +189,7 @@ export function createSystem<T extends ActorSystemInfo>(
     get: (systemId) => {
       return keyedActors.get(systemId) as T['actors'][any];
     },
-    getRunningActors: () => {
+    getAll: () => {
       return Object.fromEntries(keyedActors.entries()) as T['actors'];
     },
     _set: (systemId, actorRef) => {

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -55,7 +55,7 @@ export interface ActorSystem<T extends ActorSystemInfo> {
   /** @internal */
   _set: <K extends keyof T['actors']>(key: K, actorRef: T['actors'][K]) => void;
   get: <K extends keyof T['actors']>(key: K) => T['actors'][K] | undefined;
-  getAll: () => T['actors'];
+  getAll: () => Partial<T['actors']>;
 
   inspect: (
     observer:
@@ -187,10 +187,9 @@ export function createSystem<T extends ActorSystemInfo>(
       }
     },
     get: (systemId) => {
-      return keyedActors.get(systemId) as T['actors'][any];
-    },
+      return keyedActors.get(systemId) as T['actors'][any] | undefined
     getAll: () => {
-      return Object.fromEntries(keyedActors.entries()) as T['actors'];
+      return Object.fromEntries(keyedActors.entries()) as Partial<T['actors']>;
     },
     _set: (systemId, actorRef) => {
       const existing = keyedActors.get(systemId);

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -547,4 +547,41 @@ describe('system', () => {
     const actor = createActor(machine, { systemId: 'test' });
     expect(actor.systemId).toBe('test');
   });
+
+  it('should give a list of runnings actors', () => {
+    const machine = createMachine({
+      id: 'root',
+      initial: 'happy path',
+      states: {
+        'happy path': {
+          entry: [spawnChild(createMachine({}), { systemId: 'child1' })],
+          invoke: [
+            {
+              src: createMachine({
+                id: 'machine'
+              }),
+              systemId: 'child2'
+            }
+          ],
+          on: {
+            stopChild1: 'sad path'
+          }
+        },
+        'sad path': {
+          entry: stopChild(({ system }) => system.get('child1'))
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+
+    expect(actor.system.getRunningActors()).toEqual({
+      child1: actor.system.get('child1'),
+      child2: actor.system.get('child2')
+    });
+
+    actor.send({ type: 'stopChild1' });
+
+    expect(actor.system.getRunningActors()).toEqual({});
+  });
 });

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -575,13 +575,13 @@ describe('system', () => {
 
     const actor = createActor(machine).start();
 
-    expect(actor.system.getRunningActors()).toEqual({
+    expect(actor.system.getAll()).toEqual({
       child1: actor.system.get('child1'),
       child2: actor.system.get('child2')
     });
 
     actor.send({ type: 'stopChild1' });
 
-    expect(actor.system.getRunningActors()).toEqual({});
+    expect(actor.system.getAll()).toEqual({});
   });
 });


### PR DESCRIPTION
This PR adds `system.getAll` that returns a record of running actors within the system by their system id.
This is very helpful for a tool to visualize active actors in a system given the system reference.