### PR TITLE
[@xstate/store] `createStoreLogic` and selectors

### DIFF
--- a/.changeset/store-logic-selectors.md
+++ b/.changeset/store-logic-selectors.md
@@ -1,0 +1,26 @@
+---
+'@xstate/store': minor
+---
+
+Added `createStoreLogic` for reusable store definitions with input and `selectors` support for both `createStore` and `createStoreLogic`.
+
+```ts
+const counterLogic = createStoreLogic({
+  context: (input: { initialCount: number }) => ({
+    count: input.initialCount
+  }),
+  on: {
+    inc: (ctx) => ({ count: ctx.count + 1 })
+  },
+  selectors: {
+    doubled: (ctx) => ctx.count * 2
+  }
+});
+
+const counter1 = counterLogic.createStore({ initialCount: 42 });
+const counter2 = counterLogic.createStore({ initialCount: 0 });
+
+counter1.selectors.doubled.get(); // 84
+```
+
+Selectors are reactive `ReadonlyAtom`s (powered by `store.select()`), composable with `createAtom`, and preserved through `.with()` extensions.

--- a/packages/xstate-store/src/index.ts
+++ b/packages/xstate-store/src/index.ts
@@ -3,7 +3,8 @@ export { fromStore } from './fromStore';
 export {
   createStore,
   createStoreWithProducer,
-  createStoreConfig
+  createStoreConfig,
+  createStoreLogic
 } from './store';
 export { createAtom, createAsyncAtom } from './atom';
 export type {
@@ -39,5 +40,9 @@ export type {
   EventFromStoreConfig,
   EmitsFromStoreConfig,
   ContextFromStoreConfig,
-  StoreExtension
+  StoreExtension,
+  StoreSelectorsConfig,
+  ResolvedStoreSelectors,
+  StoreWithSelectors,
+  StoreLogicCreator
 } from './types';

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -57,7 +57,7 @@ function attachSelectors<
     );
   }
 
-  const originalWith = store.with.bind(store);
+  const originalWith = store.with;
   const storeWithSelectors = store as StoreWithSelectors<
     TContext,
     TEventPayloadMap,
@@ -315,7 +315,7 @@ export function createStore<
   TSelectors extends Record<string, (context: TContext) => any>
 >(
   definition: StoreConfig<TContext, TEventPayloadMap, TEmittedPayloadMap> & {
-    selectors: TSelectors & Record<string, (context: TContext) => any>;
+    selectors: TSelectors;
   }
 ): StoreWithSelectors<
   TContext,
@@ -594,14 +594,15 @@ export function createStoreTransition<
  * const store = todoLogic.createStore();
  * ```
  */
+// Overload: with input + selectors
 export function createStoreLogic<
   TContext extends StoreContext,
   const TEventPayloadMap extends EventPayloadMap,
   TEmittedPayloadMap extends EventPayloadMap,
-  TInput = void,
-  TSelectors extends Record<string, (context: TContext) => any> = {}
+  TInput,
+  TSelectors extends Record<string, (context: TContext) => any>
 >(config: {
-  context: [TInput] extends [void] ? TContext : (input: TInput) => TContext;
+  context: (input: TInput) => TContext;
   on: {
     [K in keyof TEventPayloadMap & string]: StoreAssigner<
       TContext,
@@ -614,20 +615,108 @@ export function createStoreLogic<
       payload: TEmittedPayloadMap[K]
     ) => void;
   };
-  selectors?: TSelectors & Record<string, (context: TContext) => any>;
+  selectors: TSelectors;
 }): StoreLogicCreator<
   TContext,
   TEventPayloadMap,
   ExtractEvents<TEmittedPayloadMap>,
   TInput,
   TSelectors
-> {
+>;
+// Overload: with input, no selectors
+export function createStoreLogic<
+  TContext extends StoreContext,
+  const TEventPayloadMap extends EventPayloadMap,
+  TEmittedPayloadMap extends EventPayloadMap,
+  TInput
+>(config: {
+  context: (input: TInput) => TContext;
+  on: {
+    [K in keyof TEventPayloadMap & string]: StoreAssigner<
+      TContext,
+      { type: K } & TEventPayloadMap[K],
+      ExtractEvents<TEmittedPayloadMap>
+    >;
+  };
+  emits?: {
+    [K in keyof TEmittedPayloadMap & string]: (
+      payload: TEmittedPayloadMap[K]
+    ) => void;
+  };
+}): StoreLogicCreator<
+  TContext,
+  TEventPayloadMap,
+  ExtractEvents<TEmittedPayloadMap>,
+  TInput,
+  {}
+>;
+// Overload: static context + selectors
+export function createStoreLogic<
+  TContext extends StoreContext,
+  const TEventPayloadMap extends EventPayloadMap,
+  TEmittedPayloadMap extends EventPayloadMap,
+  TSelectors extends Record<string, (context: TContext) => any>
+>(config: {
+  context: TContext;
+  on: {
+    [K in keyof TEventPayloadMap & string]: StoreAssigner<
+      TContext,
+      { type: K } & TEventPayloadMap[K],
+      ExtractEvents<TEmittedPayloadMap>
+    >;
+  };
+  emits?: {
+    [K in keyof TEmittedPayloadMap & string]: (
+      payload: TEmittedPayloadMap[K]
+    ) => void;
+  };
+  selectors: TSelectors;
+}): StoreLogicCreator<
+  TContext,
+  TEventPayloadMap,
+  ExtractEvents<TEmittedPayloadMap>,
+  void,
+  TSelectors
+>;
+// Overload: static context, no selectors
+export function createStoreLogic<
+  TContext extends StoreContext,
+  const TEventPayloadMap extends EventPayloadMap,
+  TEmittedPayloadMap extends EventPayloadMap
+>(config: {
+  context: TContext;
+  on: {
+    [K in keyof TEventPayloadMap & string]: StoreAssigner<
+      TContext,
+      { type: K } & TEventPayloadMap[K],
+      ExtractEvents<TEmittedPayloadMap>
+    >;
+  };
+  emits?: {
+    [K in keyof TEmittedPayloadMap & string]: (
+      payload: TEmittedPayloadMap[K]
+    ) => void;
+  };
+}): StoreLogicCreator<
+  TContext,
+  TEventPayloadMap,
+  ExtractEvents<TEmittedPayloadMap>,
+  void,
+  {}
+>;
+// Implementation
+export function createStoreLogic(config: {
+  context: any;
+  on: any;
+  emits?: any;
+  selectors?: any;
+}): any {
   const { on, emits, selectors } = config;
 
-  const createStoreFn = (input?: TInput) => {
+  const createStoreFn = (input?: any) => {
     const context =
       typeof config.context === 'function'
-        ? (config.context as (input: TInput) => TContext)(input as TInput)
+        ? config.context(input)
         : config.context;
 
     const transition = createStoreTransition(on);
@@ -644,21 +733,13 @@ export function createStoreLogic<
     const store = createStoreCore(logic, emits);
 
     if (selectors && Object.keys(selectors).length > 0) {
-      return attachSelectors(store, selectors as any);
+      return attachSelectors(store, selectors);
     }
 
     return store;
   };
 
-  return {
-    createStore: createStoreFn
-  } as unknown as StoreLogicCreator<
-    TContext,
-    TEventPayloadMap,
-    ExtractEvents<TEmittedPayloadMap>,
-    TInput,
-    TSelectors
-  >;
+  return { createStore: createStoreFn };
 }
 
 /**

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -600,7 +600,7 @@ export function createStoreLogic<
   const TEventPayloadMap extends EventPayloadMap,
   TEmittedPayloadMap extends EventPayloadMap,
   TInput,
-  TSelectors extends Record<string, (context: TContext) => any>
+  TSelectors extends Record<string, (context: TContext) => unknown>
 >(config: {
   context: (input: TInput) => TContext;
   on: {
@@ -655,7 +655,7 @@ export function createStoreLogic<
   TContext extends StoreContext,
   const TEventPayloadMap extends EventPayloadMap,
   TEmittedPayloadMap extends EventPayloadMap,
-  TSelectors extends Record<string, (context: TContext) => any>
+  TSelectors extends Record<string, (context: TContext) => unknown>
 >(config: {
   context: TContext;
   on: {

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -21,7 +21,11 @@ import {
   StoreLogic,
   StoreTransition,
   AnyStoreLogic,
-  SpecificStoreConfig
+  SpecificStoreConfig,
+  StoreSelectorsConfig,
+  ResolvedStoreSelectors,
+  StoreWithSelectors,
+  StoreLogicCreator
 } from './types';
 
 const symbolObservable: typeof Symbol.observable = (() =>
@@ -32,6 +36,42 @@ const inspectionObservers = new WeakMap<
   Store<any, any, any>,
   Set<Observer<StoreInspectionEvent>>
 >();
+
+/**
+ * Attaches resolved selectors to a store instance and wraps `.with()` to
+ * preserve selectors through extensions.
+ */
+function attachSelectors<
+  TContext extends StoreContext,
+  TEventPayloadMap extends EventPayloadMap,
+  TEmitted extends EventObject,
+  TSelectors extends StoreSelectorsConfig<TContext>
+>(
+  store: Store<TContext, TEventPayloadMap, TEmitted>,
+  selectorsConfig: TSelectors
+): StoreWithSelectors<TContext, TEventPayloadMap, TEmitted, TSelectors> {
+  const selectors = {} as ResolvedStoreSelectors<TContext, TSelectors>;
+  for (const key of Object.keys(selectorsConfig) as (keyof TSelectors)[]) {
+    (selectors as any)[key] = store.select(
+      selectorsConfig[key] as Selector<TContext, any>
+    );
+  }
+
+  const originalWith = store.with.bind(store);
+  const storeWithSelectors = store as StoreWithSelectors<
+    TContext,
+    TEventPayloadMap,
+    TEmitted,
+    TSelectors
+  >;
+  storeWithSelectors.selectors = selectors;
+  storeWithSelectors.with = ((extension: any) => {
+    const extended = originalWith(extension);
+    return attachSelectors(extended, selectorsConfig);
+  }) as any;
+
+  return storeWithSelectors;
+}
 
 function createStoreCore<
   TContext extends StoreContext,
@@ -239,13 +279,50 @@ export type TransitionsFromEventPayloadMap<
  * // Logs { context: { count: 5, name: 'Ada' }, status: 'active', ... }
  * ```
  *
+ * @example
+ *
+ * ```ts
+ * // With selectors
+ * const store = createStore({
+ *   context: { count: 0 },
+ *   on: {
+ *     inc: (ctx) => ({ count: ctx.count + 1 })
+ *   },
+ *   selectors: {
+ *     doubled: (ctx) => ctx.count * 2
+ *   }
+ * });
+ *
+ * store.selectors.doubled.get(); // 0
+ * store.trigger.inc();
+ * store.selectors.doubled.get(); // 2
+ * ```
+ *
  * @param config - The store configuration object
  * @param config.context - The initial state of the store
  * @param config.on - An object mapping event types to transition functions
  * @param config.emits - An object mapping emitted event types to handlers
+ * @param config.selectors - An object mapping selector names to selector
+ *   functions that derive values from context. Each selector becomes a reactive
+ *   `ReadonlyAtom` on `store.selectors`.
  * @returns A store instance with methods to send events and subscribe to state
  *   changes
  */
+export function createStore<
+  TContext extends StoreContext,
+  const TEventPayloadMap extends EventPayloadMap,
+  TEmittedPayloadMap extends EventPayloadMap,
+  TSelectors extends Record<string, (context: TContext) => any>
+>(
+  definition: StoreConfig<TContext, TEventPayloadMap, TEmittedPayloadMap> & {
+    selectors: TSelectors & Record<string, (context: TContext) => any>;
+  }
+): StoreWithSelectors<
+  TContext,
+  TEventPayloadMap,
+  ExtractEvents<TEmittedPayloadMap>,
+  TSelectors
+>;
 export function createStore<
   TContext extends StoreContext,
   const TEventPayloadMap extends EventPayloadMap,
@@ -269,8 +346,12 @@ export function createStore<
   TEmitted
 >;
 export function createStore(
-  definitionOrLogic: StoreConfig<any, any, any> | AnyStoreLogic
-) {
+  definitionOrLogic:
+    | (StoreConfig<any, any, any> & {
+        selectors?: Record<string, (context: any) => any>;
+      })
+    | AnyStoreLogic
+): any {
   if ('transition' in definitionOrLogic) {
     return createStoreCore(definitionOrLogic);
   }
@@ -285,7 +366,13 @@ export function createStore(
     }),
     transition
   } satisfies AnyStoreLogic;
-  return createStoreCore(logic, definitionOrLogic.emits);
+  const store = createStoreCore(logic, definitionOrLogic.emits);
+
+  if (definitionOrLogic.selectors) {
+    return attachSelectors(store, definitionOrLogic.selectors);
+  }
+
+  return store;
 }
 
 function _createStoreConfig<
@@ -458,6 +545,120 @@ export function createStoreTransition<
       effects
     ];
   };
+}
+
+/**
+ * Creates a reusable store logic definition that can be instantiated multiple
+ * times with different inputs.
+ *
+ * @example
+ *
+ * ```ts
+ * const counterLogic = createStoreLogic({
+ *   context: (input: { initialCount: number }) => ({
+ *     count: input.initialCount
+ *   }),
+ *   on: {
+ *     inc: (ctx) => ({ count: ctx.count + 1 }),
+ *     dec: (ctx) => ({ count: ctx.count - 1 })
+ *   },
+ *   selectors: {
+ *     doubled: (ctx) => ctx.count * 2,
+ *     isPositive: (ctx) => ctx.count > 0
+ *   }
+ * });
+ *
+ * const counter1 = counterLogic.createStore({ initialCount: 42 });
+ * const counter2 = counterLogic.createStore({ initialCount: 0 });
+ *
+ * counter1.selectors.doubled.get(); // 84
+ * counter2.selectors.doubled.get(); // 0
+ * ```
+ *
+ * @example
+ *
+ * ```ts
+ * // Without input
+ * const todoLogic = createStoreLogic({
+ *   context: { todos: [] as string[] },
+ *   on: {
+ *     add: (ctx, ev: { text: string }) => ({
+ *       todos: [...ctx.todos, ev.text]
+ *     })
+ *   },
+ *   selectors: {
+ *     count: (ctx) => ctx.todos.length
+ *   }
+ * });
+ *
+ * const store = todoLogic.createStore();
+ * ```
+ */
+export function createStoreLogic<
+  TContext extends StoreContext,
+  const TEventPayloadMap extends EventPayloadMap,
+  TEmittedPayloadMap extends EventPayloadMap,
+  TInput = void,
+  TSelectors extends Record<string, (context: TContext) => any> = {}
+>(config: {
+  context: [TInput] extends [void] ? TContext : (input: TInput) => TContext;
+  on: {
+    [K in keyof TEventPayloadMap & string]: StoreAssigner<
+      TContext,
+      { type: K } & TEventPayloadMap[K],
+      ExtractEvents<TEmittedPayloadMap>
+    >;
+  };
+  emits?: {
+    [K in keyof TEmittedPayloadMap & string]: (
+      payload: TEmittedPayloadMap[K]
+    ) => void;
+  };
+  selectors?: TSelectors & Record<string, (context: TContext) => any>;
+}): StoreLogicCreator<
+  TContext,
+  TEventPayloadMap,
+  ExtractEvents<TEmittedPayloadMap>,
+  TInput,
+  TSelectors
+> {
+  const { on, emits, selectors } = config;
+
+  const createStoreFn = (input?: TInput) => {
+    const context =
+      typeof config.context === 'function'
+        ? (config.context as (input: TInput) => TContext)(input as TInput)
+        : config.context;
+
+    const transition = createStoreTransition(on);
+    const logic: AnyStoreLogic = {
+      getInitialSnapshot: () => ({
+        status: 'active' as const,
+        context,
+        output: undefined,
+        error: undefined
+      }),
+      transition
+    } satisfies AnyStoreLogic;
+
+    const store = createStoreCore(logic, emits);
+
+    if (selectors && Object.keys(selectors).length > 0) {
+      return attachSelectors(store, selectors as any);
+    }
+
+    return store;
+  };
+
+  return {
+    createStore: createStoreFn
+  } as unknown as StoreLogicCreator<
+    TContext,
+    TEventPayloadMap,
+    ExtractEvents<TEmittedPayloadMap>,
+    TInput,
+    TSelectors
+  >;
 }
 
 /**

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -312,7 +312,7 @@ export function createStore<
   TContext extends StoreContext,
   const TEventPayloadMap extends EventPayloadMap,
   TEmittedPayloadMap extends EventPayloadMap,
-  TSelectors extends Record<string, (context: TContext) => any>
+  TSelectors extends Record<string, (context: TContext) => unknown>
 >(
   definition: StoreConfig<TContext, TEventPayloadMap, TEmittedPayloadMap> & {
     selectors: TSelectors & Record<string, (context: TContext) => any>;

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -491,6 +491,56 @@ export type StoreExtension<
   TEmitted
 >;
 
+// Selectors
+export type StoreSelectorsConfig<TContext extends StoreContext> = Record<
+  string,
+  Selector<TContext, any>
+>;
+
+export type ResolvedStoreSelectors<
+  TContext extends StoreContext,
+  TSelectors extends Record<string, (context: TContext) => any>
+> = {
+  [K in keyof TSelectors]: Selection<ReturnType<TSelectors[K]>>;
+};
+
+export type StoreWithSelectors<
+  TContext extends StoreContext,
+  TEventPayloadMap extends EventPayloadMap,
+  TEmitted extends EventObject,
+  TSelectors extends Record<string, (context: TContext) => any>
+> = Omit<Store<TContext, TEventPayloadMap, TEmitted>, 'with'> & {
+  selectors: ResolvedStoreSelectors<TContext, TSelectors>;
+  with<TNewEventPayloadMap extends EventPayloadMap>(
+    extension: StoreExtension<
+      TContext,
+      TEventPayloadMap,
+      TNewEventPayloadMap,
+      TEmitted
+    >
+  ): StoreWithSelectors<
+    TContext,
+    TEventPayloadMap & TNewEventPayloadMap,
+    TEmitted,
+    TSelectors
+  >;
+};
+
+export interface StoreLogicCreator<
+  TContext extends StoreContext,
+  TEventPayloadMap extends EventPayloadMap,
+  TEmitted extends EventObject,
+  TInput,
+  TSelectors extends Record<string, (context: TContext) => any>
+> {
+  /** Creates a new store instance from this logic definition. */
+  createStore: [TInput] extends [void]
+    ? () => StoreWithSelectors<TContext, TEventPayloadMap, TEmitted, TSelectors>
+    : (
+        input: TInput
+      ) => StoreWithSelectors<TContext, TEventPayloadMap, TEmitted, TSelectors>;
+}
+
 export type AnyStoreConfig = StoreConfig<any, any, any>;
 export type EventFromStoreConfig<TStore extends AnyStoreConfig> =
   TStore extends StoreConfig<any, infer TEventPayloadMap, any>

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -499,7 +499,7 @@ export type StoreSelectorsConfig<TContext extends StoreContext> = Record<
 
 export type ResolvedStoreSelectors<
   TContext extends StoreContext,
-  TSelectors extends Record<string, (context: TContext) => any>
+  TSelectors extends Record<string, (context: TContext) => unknown>
 > = {
   [K in keyof TSelectors]: Selection<ReturnType<TSelectors[K]>>;
 };
@@ -508,7 +508,7 @@ export type StoreWithSelectors<
   TContext extends StoreContext,
   TEventPayloadMap extends EventPayloadMap,
   TEmitted extends EventObject,
-  TSelectors extends Record<string, (context: TContext) => any>
+  TSelectors extends Record<string, (context: TContext) => unknown>
 > = Omit<Store<TContext, TEventPayloadMap, TEmitted>, 'with'> & {
   selectors: ResolvedStoreSelectors<TContext, TSelectors>;
   with<TNewEventPayloadMap extends EventPayloadMap>(
@@ -531,7 +531,7 @@ export interface StoreLogicCreator<
   TEventPayloadMap extends EventPayloadMap,
   TEmitted extends EventObject,
   TInput,
-  TSelectors extends Record<string, (context: TContext) => any>
+  TSelectors extends Record<string, (context: TContext) => unknown>
 > {
   /** Creates a new store instance from this logic definition. */
   createStore: [TInput] extends [void]

--- a/packages/xstate-store/test/storeLogic.test.ts
+++ b/packages/xstate-store/test/storeLogic.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect } from 'vitest';
+import { createStore, createStoreLogic, createAtom } from '../src/index.ts';
+import { reset } from '../src/reset.ts';
+
+describe('createStoreLogic', () => {
+  it('creates multiple store instances from the same logic', () => {
+    const counterLogic = createStoreLogic({
+      context: (input: { initialCount: number }) => ({
+        count: input.initialCount
+      }),
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 }),
+        dec: (ctx) => ({ count: ctx.count - 1 })
+      }
+    });
+
+    const store1 = counterLogic.createStore({ initialCount: 42 });
+    const store2 = counterLogic.createStore({ initialCount: 0 });
+
+    expect(store1.getSnapshot().context.count).toBe(42);
+    expect(store2.getSnapshot().context.count).toBe(0);
+
+    store1.trigger.inc();
+    expect(store1.getSnapshot().context.count).toBe(43);
+    expect(store2.getSnapshot().context.count).toBe(0);
+  });
+
+  it('supports selectors that return reactive atoms', () => {
+    const counterLogic = createStoreLogic({
+      context: (input: { initialCount: number }) => ({
+        count: input.initialCount
+      }),
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      },
+      selectors: {
+        doubled: (ctx) => ctx.count * 2,
+        isPositive: (ctx) => ctx.count > 0
+      }
+    });
+
+    const store = counterLogic.createStore({ initialCount: 5 });
+
+    expect(store.selectors.doubled.get()).toBe(10);
+    expect(store.selectors.isPositive.get()).toBe(true);
+
+    store.trigger.inc();
+    expect(store.selectors.doubled.get()).toBe(12);
+  });
+
+  it('each instance gets independent selectors', () => {
+    const counterLogic = createStoreLogic({
+      context: (input: { initialCount: number }) => ({
+        count: input.initialCount
+      }),
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      },
+      selectors: {
+        doubled: (ctx) => ctx.count * 2
+      }
+    });
+
+    const store1 = counterLogic.createStore({ initialCount: 10 });
+    const store2 = counterLogic.createStore({ initialCount: 20 });
+
+    expect(store1.selectors.doubled.get()).toBe(20);
+    expect(store2.selectors.doubled.get()).toBe(40);
+
+    store1.trigger.inc();
+    expect(store1.selectors.doubled.get()).toBe(22);
+    expect(store2.selectors.doubled.get()).toBe(40);
+  });
+
+  it('works without input (static context)', () => {
+    const todoLogic = createStoreLogic({
+      context: { todos: [] as string[] },
+      on: {
+        add: (ctx, ev: { text: string }) => ({
+          todos: [...ctx.todos, ev.text]
+        })
+      },
+      selectors: {
+        count: (ctx) => ctx.todos.length,
+        isEmpty: (ctx) => ctx.todos.length === 0
+      }
+    });
+
+    const store = todoLogic.createStore();
+
+    expect(store.selectors.count.get()).toBe(0);
+    expect(store.selectors.isEmpty.get()).toBe(true);
+
+    store.trigger.add({ text: 'hello' });
+    expect(store.selectors.count.get()).toBe(1);
+    expect(store.selectors.isEmpty.get()).toBe(false);
+  });
+
+  it('works without selectors', () => {
+    const logic = createStoreLogic({
+      context: (input: { n: number }) => ({ count: input.n }),
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      }
+    });
+
+    const store = logic.createStore({ n: 5 });
+    expect(store.getSnapshot().context.count).toBe(5);
+    store.trigger.inc();
+    expect(store.getSnapshot().context.count).toBe(6);
+  });
+
+  it('.with() preserves selectors', () => {
+    const counterLogic = createStoreLogic({
+      context: (input: { initialCount: number }) => ({
+        count: input.initialCount
+      }),
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      },
+      selectors: {
+        doubled: (ctx) => ctx.count * 2
+      }
+    });
+
+    const store = counterLogic.createStore({ initialCount: 10 }).with(reset());
+
+    expect(store.selectors.doubled.get()).toBe(20);
+
+    store.trigger.inc();
+    expect(store.selectors.doubled.get()).toBe(22);
+
+    store.trigger.reset();
+    expect(store.selectors.doubled.get()).toBe(20);
+  });
+
+  it('selectors are subscribable atoms', () => {
+    const counterLogic = createStoreLogic({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      },
+      selectors: {
+        doubled: (ctx) => ctx.count * 2
+      }
+    });
+
+    const store = counterLogic.createStore();
+    const values: number[] = [];
+
+    store.selectors.doubled.subscribe((v) => values.push(v));
+
+    store.trigger.inc();
+    store.trigger.inc();
+    store.trigger.inc();
+
+    expect(values).toEqual([2, 4, 6]);
+  });
+
+  it('selectors can be composed with createAtom', () => {
+    const counterLogic = createStoreLogic({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      },
+      selectors: {
+        doubled: (ctx) => ctx.count * 2,
+        tripled: (ctx) => ctx.count * 3
+      }
+    });
+
+    const store = counterLogic.createStore();
+
+    const sum = createAtom(
+      () => store.selectors.doubled.get() + store.selectors.tripled.get()
+    );
+
+    expect(sum.get()).toBe(0);
+
+    store.trigger.inc();
+    expect(sum.get()).toBe(5); // 2 + 3
+  });
+
+  it('supports emits', () => {
+    const logic = createStoreLogic({
+      context: { count: 0 },
+      on: {
+        inc: (
+          ctx: { count: number },
+          _ev: {},
+          enq: {
+            emit: { changed: (p: { count: number }) => void };
+            effect: (fn: () => void) => void;
+          }
+        ) => {
+          enq.emit.changed({ count: ctx.count + 1 });
+          return { count: ctx.count + 1 };
+        }
+      },
+      emits: {
+        changed: (_payload: { count: number }) => {}
+      },
+      selectors: {
+        doubled: (ctx) => ctx.count * 2
+      }
+    });
+
+    const store = logic.createStore();
+    const emitted: any[] = [];
+
+    store.on('changed', (ev) => emitted.push(ev));
+    store.trigger.inc();
+
+    expect(emitted).toEqual([{ type: 'changed', count: 1 }]);
+    expect(store.selectors.doubled.get()).toBe(2);
+  });
+
+  it('stores are fully independent (no shared state)', () => {
+    const logic = createStoreLogic({
+      context: { items: [] as string[] },
+      on: {
+        add: (ctx, ev: { item: string }) => ({
+          items: [...ctx.items, ev.item]
+        })
+      }
+    });
+
+    const store1 = logic.createStore();
+    const store2 = logic.createStore();
+
+    store1.trigger.add({ item: 'a' });
+    store2.trigger.add({ item: 'x' });
+    store2.trigger.add({ item: 'y' });
+
+    expect(store1.getSnapshot().context.items).toEqual(['a']);
+    expect(store2.getSnapshot().context.items).toEqual(['x', 'y']);
+  });
+});
+
+describe('createStore with selectors', () => {
+  it('supports selectors config', () => {
+    const store = createStore({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      },
+      selectors: {
+        doubled: (ctx) => ctx.count * 2,
+        isEven: (ctx) => ctx.count % 2 === 0
+      }
+    });
+
+    expect(store.selectors.doubled.get()).toBe(0);
+    expect(store.selectors.isEven.get()).toBe(true);
+
+    store.trigger.inc();
+    expect(store.selectors.doubled.get()).toBe(2);
+    expect(store.selectors.isEven.get()).toBe(false);
+  });
+
+  it('.with() preserves selectors', () => {
+    const store = createStore({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      },
+      selectors: {
+        doubled: (ctx) => ctx.count * 2
+      }
+    }).with(reset());
+
+    store.trigger.inc();
+    store.trigger.inc();
+    expect(store.selectors.doubled.get()).toBe(4);
+
+    store.trigger.reset();
+    expect(store.selectors.doubled.get()).toBe(0);
+  });
+
+  it('selectors are reactive atoms', () => {
+    const store = createStore({
+      context: { name: 'Ada', age: 30 },
+      on: {
+        setName: (ctx, ev: { name: string }) => ({ ...ctx, name: ev.name }),
+        birthday: (ctx) => ({ ...ctx, age: ctx.age + 1 })
+      },
+      selectors: {
+        greeting: (ctx) => `Hello, ${ctx.name}!`,
+        isAdult: (ctx) => ctx.age >= 18
+      }
+    });
+
+    const greetings: string[] = [];
+    store.selectors.greeting.subscribe((v) => greetings.push(v));
+
+    store.trigger.setName({ name: 'Grace' });
+    expect(greetings).toEqual(['Hello, Grace!']);
+    expect(store.selectors.isAdult.get()).toBe(true);
+  });
+
+  it('works without selectors (backward compatible)', () => {
+    const store = createStore({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      }
+    });
+
+    // Should still work as a normal store
+    store.trigger.inc();
+    expect(store.getSnapshot().context.count).toBe(1);
+
+    // select() still works
+    const doubled = store.select((ctx) => ctx.count * 2);
+    expect(doubled.get()).toBe(2);
+  });
+});


### PR DESCRIPTION
Added `createStoreLogic` for reusable store definitions with input and `selectors` support for both `createStore` and `createStoreLogic`.

```ts
const counterLogic = createStoreLogic({
  context: (input: { initialCount: number }) => ({
    count: input.initialCount
  }),
  on: {
    inc: (ctx) => ({ count: ctx.count + 1 })
  },
  selectors: {
    doubled: (ctx) => ctx.count * 2
  }
});

const counter1 = counterLogic.createStore({ initialCount: 42 });
const counter2 = counterLogic.createStore({ initialCount: 0 });

counter1.selectors.doubled.get(); // 84
```

Selectors are reactive `ReadonlyAtom`s (powered by `store.select()`), composable with `createAtom`, and preserved through `.with()` extensions.
