### PR TITLE
[@xstate/store] Fix accidental dep in subscription

### DIFF
--- a/.changeset/quick-jeans-doubt.md
+++ b/.changeset/quick-jeans-doubt.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix `atom.subscribe()` callbacks tracking dependencies from `.get()` calls inside the callback (fixes #5509). Previously, calling `otherAtom.get()` inside a subscription callback would cause the callback to re-run whenever `otherAtom` changed, even if the subscribed atom's value didn't change.

--- a/packages/xstate-store/src/atom.ts
+++ b/packages/xstate-store/src/atom.ts
@@ -148,7 +148,13 @@ export function createAtom<T>(
         if (!observed.current) {
           observed.current = true;
         } else {
-          obs.next?.(atom._snapshot);
+          const prevSub = activeSub;
+          activeSub = undefined;
+          try {
+            obs.next?.(atom._snapshot);
+          } finally {
+            activeSub = prevSub;
+          }
         }
       });
 

--- a/packages/xstate-store/test/atom.test.ts
+++ b/packages/xstate-store/test/atom.test.ts
@@ -776,4 +776,41 @@ describe('async atoms', () => {
     expect(log2).toHaveBeenCalledTimes(1);
     expect(log2).toHaveBeenCalledWith({ status: 'done', data: 'multi-test' });
   });
+
+  it('subscribe callback should not track dependencies from .get() calls', () => {
+    const items = createAtom<number[]>([]);
+    const ids = createAtom(() => Array.from(items.get()).sort().join(','));
+    const log = vi.fn();
+
+    ids.subscribe(() => {
+      void items.get();
+      log();
+    });
+
+    items.set([1]);
+    items.set([1]);
+    items.set([1, 2]);
+    items.set([1, 2]);
+
+    expect(log).toHaveBeenCalledTimes(2);
+  });
+
+  it('subscribe callback should not track deps on non-computed atoms', () => {
+    const ids = createAtom('');
+    const items = createAtom<number[]>([]);
+    items.subscribe((value) => ids.set(Array.from(value).sort().join(',')));
+    const log = vi.fn();
+
+    ids.subscribe(() => {
+      void items.get();
+      log();
+    });
+
+    items.set([1]);
+    items.set([1]);
+    items.set([1, 2]);
+    items.set([1, 2]);
+
+    expect(log).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
Fix `atom.subscribe()` callbacks tracking dependencies from `.get()` calls inside the callback (fixes #5509). Previously, calling `otherAtom.get()` inside a subscription callback would cause the callback to re-run whenever `otherAtom` changed, even if the subscribed atom's value didn't change.