### PR TITLE
[@xstate/store] Fix synchronous updates to atom dependencies during a subscription callback

### DIFF
--- a/.changeset/sharp-aliens-hide.md
+++ b/.changeset/sharp-aliens-hide.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix computed `atom.subscribe()` callbacks not re-running after one of it's dependencies is synchronously updated inside the callback. Previously, calling `someDependency.set()` inside a subscription callback would prevent that subscription from being notified of future changes. This also affected store selector subscriptions which triggered an update to the store.

--- a/packages/xstate-store/src/atom.ts
+++ b/packages/xstate-store/src/atom.ts
@@ -155,6 +155,13 @@ export function createAtom<T>(
           } finally {
             activeSub = prevSub;
           }
+
+          // If the observer synchronously updates any of our deps we'll be
+          // marked as dirty preventing this effect from re-running. Request
+          // the value again to reconcile any dirty deps.
+          if (atom.flags & ReactiveFlags.Dirty) {
+            atom.get();
+          }
         }
       });
 

--- a/packages/xstate-store/test/atom.test.ts
+++ b/packages/xstate-store/test/atom.test.ts
@@ -103,6 +103,18 @@ it('allows updates to a computed dependency during a subscription callback', () 
   expect(atom.get().b).toBe(3);
 });
 
+it('does not loop when updating a computed dependency which affects an atoms own state', () => {
+  const count = createAtom(0);
+  const a = createAtom(() => count.get());
+
+  a.subscribe(() => count.set((val) => val + 1));
+
+  count.set((val) => val + 1);
+
+  expect(a.get()).toBe(2);
+  expect(count.get()).toBe(2);
+});
+
 it('works with a mix of atoms and stores', () => {
   const countAtom = createAtom(0);
   const store = createStore({

--- a/packages/xstate-store/test/atom.test.ts
+++ b/packages/xstate-store/test/atom.test.ts
@@ -88,6 +88,21 @@ it('can create a combined atom (get API)', () => {
   numAtom.set(5);
 });
 
+it('allows updates to a computed dependency during a subscription callback', () => {
+  const atom = createAtom({ a: 0, b: 0 });
+
+  const a = createAtom(() => atom.get().a);
+  a.subscribe(() => atom.set((ctx) => ({ ...ctx, b: ctx.a })));
+
+  atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));
+  atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));
+  atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));
+
+  expect(a.get()).toBe(3);
+  expect(atom.get().a).toBe(3);
+  expect(atom.get().b).toBe(3);
+});
+
 it('works with a mix of atoms and stores', () => {
   const countAtom = createAtom(0);
   const store = createStore({
@@ -233,6 +248,26 @@ it('works with selectors', () => {
   store.trigger.increment();
 
   expect(combinedAtom.get()).toBe(2);
+});
+
+it('allows sending events to the store during a selector subscription', () => {
+  const store = createStore({
+    context: { a: 0, b: 0 },
+    on: {
+      a: (context) => ({ ...context, a: context.a + 1 }),
+      b: (context) => ({ ...context, b: context.b + 1 })
+    }
+  });
+
+  const a = store.select((context) => context.a);
+  a.subscribe(() => store.trigger.b());
+
+  store.trigger.a();
+  store.trigger.a();
+  store.trigger.a();
+
+  expect(store.get().context.a).toBe(3);
+  expect(store.get().context.b).toBe(3);
 });
 
 it('works with selectors (get API)', () => {


### PR DESCRIPTION
Fix computed `atom.subscribe()` callbacks not re-running after one of it's dependencies is synchronously updated inside the callback. Previously, calling `someDependency.set()` inside a subscription callback would prevent that subscription from being notified of future changes. This also affected store selector subscriptions which triggered an update to the store (b/c they're also just computed atoms).

---

I ran into this when triggering an update to a store from a selector subscription that tracked cursor position and recorded (possibly) hovered items separately. I probably should've been using store events to trigger the secondary update but was trying to prototype things rather quickly

I found some workarounds while working on the fix:

1. Update the dependent atom asynchronously using `queueMicrotask`
```js
let atom = createAtom(() => count.get() * 2)

atom.subscribe(() => {
  queueMicrotask(() => count.set(v => v + 1))
})
```

2. Manually call `atom.get()` *inside* the subscription callback after updating the dependent atom
```js
let atom = createAtom(() => count.get() * 2)

atom.subscribe(() => {
  count.set(v => v + 1)
  atom.get()
})
```

This is what the fix does internally _if_ the atom ends up dirty after the observer is notified.

3. Subscribe to the atom again
```js
let atom = createAtom(() => count.get() * 2)

atom.subscribe(() => {
  count.set(v => v + 1)
})

atom.subscribe(() => { /* do nothing */ })
```

The extra subscription causes `atom.get()` to get called again which cleans up after the first one's updates.
