### PR TITLE
fix(core): resolve children snapshot union pollution for typed invoke ids

### DIFF
--- a/.changeset/upset-pants-wear.md
+++ b/.changeset/upset-pants-wear.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+fix(core): resolve children snapshot union pollution for typed invoke

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -79,6 +79,37 @@ type ToStateSchema<TSchema extends StateSchema> = {
 type RequiredSetupKeys<TChildrenMap> =
   IsNever<keyof TChildrenMap> extends true ? never : 'actors';
 
+// Extract { [invokeId]: src } mappings from a machine config's invoke entries.
+// This allows createMachine to infer TChildrenMap from the invoke config
+// when types.children is not explicitly provided.
+type ExtractInvokeEntry<T> = T extends {
+  id: infer TId extends string;
+  src: infer TSrc extends string;
+}
+  ? { [K in TId]: TSrc }
+  : {};
+
+type ExtractInvokeChildren<T> = T extends readonly (infer E)[]
+  ? UnionToIntersection<ExtractInvokeEntry<E>>
+  : ExtractInvokeEntry<T>;
+
+type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (
+  x: infer I
+) => void
+  ? I
+  : never;
+
+type ExtractConfigChildren<TConfig> = TConfig extends {
+  invoke: infer TInvoke;
+}
+  ? ExtractInvokeChildren<TInvoke>
+  : {};
+
+type MergeChildrenMap<
+  TExplicit extends Record<string, string>,
+  TInferred extends Record<string, string>
+> = IsNever<keyof TExplicit> extends true ? TInferred : TExplicit;
+
 export type SetupReturn<
   TContext extends MachineContext,
   TEvent extends AnyEventObject,
@@ -247,6 +278,10 @@ export type SetupReturn<
       TOutput,
       TEmitted,
       TMeta
+    >,
+    TResolvedChildren extends Record<string, string> = MergeChildrenMap<
+      TChildrenMap,
+      Cast<ExtractConfigChildren<TConfig>, Record<string, string>>
     >
   >(
     config: TConfig
@@ -260,10 +295,10 @@ export type SetupReturn<
             to: RoutableStateId<TConfig>;
           }),
     Cast<
-      ToChildren<ToProvidedActor<TChildrenMap, TActors>>,
+      ToChildren<ToProvidedActor<TResolvedChildren, TActors>>,
       Record<string, AnyActorRef | undefined>
     >,
-    ToProvidedActor<TChildrenMap, TActors>,
+    ToProvidedActor<TResolvedChildren, TActors>,
     ToParameterizedObject<TActions>,
     ToParameterizedObject<TGuards>,
     TDelay,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2546,6 +2546,15 @@ type ToConcreteChildren<TActor extends ProvidedActor> = {
   >;
 };
 
+// Actors that don't have literal string IDs — these are the only ones
+// that should appear in the index signature fallback, since actors with
+// literal IDs are already covered by ToConcreteChildren.
+type NonConcreteActors<TActor extends ProvidedActor> = TActor extends any
+  ? ExtractLiteralString<TActor['id']> extends never
+    ? TActor
+    : never
+  : never;
+
 export type ToChildren<TActor extends ProvidedActor> =
   // only proceed further if all configured `src`s are literal strings
   string extends TActor['src']
@@ -2557,16 +2566,16 @@ export type ToChildren<TActor extends ProvidedActor> =
         ToConcreteChildren<TActor> &
           {
             include: {
-              [id: string]: TActor extends any
-                ? ActorRefFromLogic<TActor['logic']> | undefined
-                : never;
+              [id: string]: NonConcreteActors<TActor> extends never
+                ? AnyActorRef | undefined
+                : NonConcreteActors<TActor> extends any
+                  ?
+                      | ActorRefFromLogic<NonConcreteActors<TActor>['logic']>
+                      | undefined
+                  : never;
             };
             exclude: unknown;
-          }[undefined extends TActor['id'] // if not all actors have literal string IDs then we need to create an index signature containing all possible actor types
-            ? 'include'
-            : string extends TActor['id']
-              ? 'include'
-              : 'exclude']
+          }[NonConcreteActors<TActor> extends never ? 'exclude' : 'include']
       >;
 
 export type StateSchema = {

--- a/packages/core/test/setup.types.test.ts
+++ b/packages/core/test/setup.types.test.ts
@@ -1398,12 +1398,9 @@ describe('setup()', () => {
     counterActor satisfies ActorRefFrom<typeof child1> | undefined;
 
     const someActor = createActor(machine).getSnapshot().children.someChild;
-    // @ts-expect-error
     someActor satisfies ActorRefFrom<typeof child2> | undefined;
-    someActor satisfies
-      | ActorRefFrom<typeof child1>
-      | ActorRefFrom<typeof child2>
-      | undefined;
+    // @ts-expect-error - someChild can only be child2 (child1 has a literal id)
+    someActor satisfies ActorRefFrom<typeof child1> | undefined;
   });
 
   it('should type the snapshot state value of a stateless machine as an empty object', () => {

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -2634,12 +2634,77 @@ describe('state.children without setup', () => {
     counterActor satisfies ActorRefFrom<typeof child1> | undefined;
 
     const someActor = createActor(machine).getSnapshot().children.someChild;
-    // @ts-expect-error
     someActor satisfies ActorRefFrom<typeof child2> | undefined;
-    someActor satisfies
-      | ActorRefFrom<typeof child1>
-      | ActorRefFrom<typeof child2>
-      | undefined;
+    // @ts-expect-error - someChild can only be child2 (child1 has a literal id)
+    someActor satisfies ActorRefFrom<typeof child1> | undefined;
+  });
+});
+
+describe('state.children with setup and multiple invoke', () => {
+  it('should type children by their specific actor when using setup with an invoke array', () => {
+    const authLogic = setup({
+      types: {
+        context: {} as { token: string | null },
+        events: {} as { type: 'auth.logout' }
+      },
+      actors: {
+        authState: fromPromise(async () => ({ token: 'tok' }))
+      }
+    }).createMachine({
+      id: 'auth',
+      context: { token: null },
+      initial: 'idle',
+      invoke: {
+        src: 'authState',
+        onDone: {
+          actions: assign({ token: ({ event }) => event.output.token })
+        }
+      },
+      states: { idle: {} }
+    });
+
+    const telemetryLogic = setup({
+      types: {
+        context: {} as { store: string | null },
+        events: {} as { type: 'telemetry.start' }
+      },
+      actors: {
+        checkConsent: fromPromise(async () => ({ status: 'granted' }))
+      }
+    }).createMachine({
+      id: 'telemetry',
+      context: { store: null },
+      initial: 'idle',
+      states: { idle: {} }
+    });
+
+    const rootMachine = setup({
+      types: {
+        context: {} as { value: number }
+      },
+      actors: {
+        auth: authLogic,
+        telemetry: telemetryLogic
+      }
+    }).createMachine({
+      context: { value: 0 },
+      invoke: [
+        { id: 'auth', systemId: 'auth', src: 'auth' },
+        { id: 'telemetry', systemId: 'telemetry', src: 'telemetry' }
+      ]
+    });
+
+    const snapshot = createActor(rootMachine).getSnapshot();
+
+    const authChild = snapshot.children.auth;
+    authChild!.getSnapshot().context.token satisfies string | null;
+    // @ts-expect-error - token is string | null, not number
+    authChild!.getSnapshot().context.token satisfies number;
+
+    const telemetryChild = snapshot.children.telemetry;
+    telemetryChild!.getSnapshot().context.store satisfies string | null;
+    // @ts-expect-error - store is string | null, not number
+    telemetryChild!.getSnapshot().context.store satisfies number;
   });
 });
 


### PR DESCRIPTION
### Summary

When using `setup()` with multiple invoked child actors, accessing `snapshot.children.specificId` returns a union of all actor contexts instead of the specific child's context. This makes typed child actor access impossible without runtime narrowing.

**Root cause:** Two issues compound:

1. `ToChildren`'s index signature includes actors that already have literal ids in `ToConcreteChildren`, polluting specific keys via TypeScript's intersection behaviour
2. `setup().createMachine()` doesn't infer invoke `id` → `src` mappings from the config, so all actors default to `id: string | undefined`

**Fix:**

- `NonConcreteActors` (types.ts) — excludes actors with literal ids from the index signature
- `ExtractConfigChildren` (setup.ts) — infers `{ [invokeId]: src }` from the `const` machine config, removing the need for manual `types.children`

### Related issues

* closes #5515 
* closes #5181
