### PR TITLE
[@xstate/store] Fix synchronous updates through nested atom dependencies and subscriptions

### DIFF
--- a/.changeset/tame-trams-serve.md
+++ b/.changeset/tame-trams-serve.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix synchronous subscribe callbacks still not re-running if a subscription triggers another one through multiple levels of computed atoms.

--- a/packages/xstate-store/src/atom.ts
+++ b/packages/xstate-store/src/atom.ts
@@ -159,7 +159,7 @@ export function createAtom<T>(
           // If the observer synchronously updates any of our deps we'll be
           // marked as dirty preventing this effect from re-running. Request
           // the value again to reconcile any dirty deps.
-          if (atom.flags & ReactiveFlags.Dirty) {
+          if (atom.flags & (ReactiveFlags.Dirty | ReactiveFlags.Pending)) {
             atom.get();
           }
         }

--- a/packages/xstate-store/src/atom.ts
+++ b/packages/xstate-store/src/atom.ts
@@ -159,9 +159,7 @@ export function createAtom<T>(
           // If the observer synchronously updates any of our deps we'll be
           // marked as dirty preventing this effect from re-running. Request
           // the value again to reconcile any dirty deps.
-          if (atom.flags & (ReactiveFlags.Dirty | ReactiveFlags.Pending)) {
-            atom.get();
-          }
+          atom.get();
         }
       });
 

--- a/packages/xstate-store/test/atom.test.ts
+++ b/packages/xstate-store/test/atom.test.ts
@@ -89,18 +89,27 @@ it('can create a combined atom (get API)', () => {
 });
 
 it('allows updates to a computed dependency during a subscription callback', () => {
-  const atom = createAtom({ a: 0, b: 0 });
+  const atom = createAtom({ a: 0, b: 0, c: 0 });
 
-  const a = createAtom(() => atom.get().a);
-  a.subscribe(() => atom.set((ctx) => ({ ...ctx, b: ctx.a })));
+  const a0 = createAtom(() => atom.get().a);
+  const a1 = createAtom(() => a0.get());
+  a1.subscribe(() => atom.set((ctx) => ({ ...ctx, b: ctx.a })));
+
+  const b0 = createAtom(() => atom.get().b);
+  const b1 = createAtom(() => b0.get());
+  b1.subscribe(() => atom.set((ctx) => ({ ...ctx, c: ctx.b })));
 
   atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));
   atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));
   atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));
 
-  expect(a.get()).toBe(3);
+  expect(a0.get()).toBe(3);
+  expect(a1.get()).toBe(3);
+  expect(b0.get()).toBe(3);
+  expect(b1.get()).toBe(3);
   expect(atom.get().a).toBe(3);
   expect(atom.get().b).toBe(3);
+  expect(atom.get().c).toBe(3);
 });
 
 it('does not loop when updating a computed dependency which affects an atoms own state', () => {


### PR DESCRIPTION
Fix synchronous subscribe callbacks still not re-running if a subscription triggers another one through multiple levels of computed atoms.

---

Turns out checking for the `dirty` state wasn't enough — I needed to check for the pending state as well.

Essentially the following test currently fails but now passes after this PR:
```js
it('allows updates to a computed dependency during a subscription callback', () => {
  const atom = createAtom({ a: 0, b: 0, c: 0 });

  const a0 = createAtom(() => atom.get().a);
  const a1 = createAtom(() => a0.get());
  a1.subscribe(() => atom.set((ctx) => ({ ...ctx, b: ctx.a })));

  const b0 = createAtom(() => atom.get().b);
  const b1 = createAtom(() => b0.get());
  b1.subscribe(() => atom.set((ctx) => ({ ...ctx, c: ctx.b })));

  atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));
  atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));
  atom.set((ctx) => ({ ...ctx, a: ctx.a + 1 }));

  expect(a0.get()).toBe(3);
  expect(a1.get()).toBe(3);
  expect(b0.get()).toBe(3);
  expect(b1.get()).toBe(3);
  expect(atom.get().a).toBe(3);
  expect(atom.get().b).toBe(3);
  expect(atom.get().c).toBe(3);
});
```

This happens because b1's subscription callback runs *during* a1's subscription callback (which the previous PR handled) but the state of the atom is different in this particular case.