### PR TITLE
Fix missing build step in publish workflow

### DIFF
--- a/.changeset/fix-publish-build.md
+++ b/.changeset/fix-publish-build.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Fix broken exports caused by missing build step in the publish workflow.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,6 +47,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/ci-setup
 
+      - name: Build
+        run: pnpm build
+
       - name: Publish to npm
         # https://github.com/changesets/action
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0


### PR DESCRIPTION
## Summary
- The `publish` job in the CI workflow was missing `pnpm build`, causing packages to be published with dev stubs instead of built artifacts
- This broke `@xstate/store` v3.17.4 exports (#5517 split version/publish into separate jobs but omitted the build step from publish)

Fixes #5520

## Test plan
- [x] Verify the publish workflow runs `pnpm build` before `pnpm run release`