### PR TITLE
[@xstate/store] Expose store schemas

### DIFF
--- a/.changeset/short-pugs-bow.md
+++ b/.changeset/short-pugs-bow.md
@@ -1,0 +1,22 @@
+---
+'@xstate/store': minor
+---
+
+Expose `store.schemas` so integrations can read the store's context, event, and emitted event schemas at runtime.
+
+```ts
+const store = createStore({
+  schemas: {
+    context: z.object({ count: z.number() }),
+    events: {
+      inc: z.object({ by: z.number() })
+    }
+  },
+  context: { count: 0 },
+  on: {
+    inc: (context, event) => ({ count: context.count + event.by })
+  }
+});
+
+store.schemas?.events?.inc;
+```

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -246,6 +246,7 @@ function createStoreCore<
   let currentSnapshot: TSnapshot = initialSnapshot;
   const atom = createAtom<StoreSnapshot<TContext>>(currentSnapshot);
   const eventTypes = logic.eventTypes;
+  const schemas = logic.schemas;
 
   const emit = (ev: TEmitted) => {
     listeners?.get(ev.type)?.forEach((listener) => listener(ev));
@@ -360,6 +361,7 @@ function createStoreCore<
     transition(state, event) {
       return transition(state as TSnapshot, event);
     },
+    schemas,
     sessionId: uniqueId(),
     send,
     getSnapshot() {

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -193,6 +193,8 @@ export interface Store<
 > extends Subscribable<StoreSnapshot<TContext>>,
     InteropObservable<StoreSnapshot<TContext>>,
     Readable<StoreSnapshot<TContext>> {
+  /** Standard Schema definitions for this store, if provided. */
+  readonly schemas?: StoreSchemas<any, any, any>;
   send: (event: ExtractEvents<TEventPayloadMap>) => void;
   getSnapshot: () => StoreSnapshot<TContext>;
   /** Read the current snapshot as a `Readable` value. */

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -155,6 +155,43 @@ it('does not expose atom internals at runtime', () => {
   expect('_snapshot' in store).toBe(false);
 });
 
+it('exposes schemas at runtime', () => {
+  const schemas = {
+    context: z.object({ count: z.number() }),
+    events: {
+      inc: z.object({ by: z.number() })
+    },
+    emitted: {
+      increased: z.object({ by: z.number() })
+    }
+  };
+  const store = createStore({
+    schemas,
+    context: { count: 0 },
+    on: {
+      inc: (context, event, enq) => {
+        enq.emit.increased({ by: event.by });
+        return { count: context.count + event.by };
+      }
+    }
+  });
+
+  expect(store.schemas).toBe(schemas);
+});
+
+it('exposes schemas after extension', () => {
+  const schemas = {
+    context: z.object({ count: z.number() })
+  };
+  const store = createStore({
+    schemas,
+    context: { count: 0 },
+    on: {}
+  }).with(reset());
+
+  expect(store.schemas).toBe(schemas);
+});
+
 it('can be inspected', () => {
   const store = createStore({
     context: {

--- a/packages/xstate-store/test/types.test.tsx
+++ b/packages/xstate-store/test/types.test.tsx
@@ -1,5 +1,10 @@
 import { createActor } from 'xstate';
-import { createStore, createStoreLogic, fromStore } from '../src/index.ts';
+import {
+  createStore,
+  createStoreLogic,
+  fromStore,
+  type StoreSchemas
+} from '../src/index.ts';
 import { z } from 'zod';
 
 describe('emitted', () => {
@@ -372,10 +377,11 @@ describe('schemas', () => {
   });
 
   it('uses schema-declared context for snapshot typing', () => {
+    const schemas = {
+      context: z.object({ count: z.number(), label: z.string() })
+    };
     const store = createStore({
-      schemas: {
-        context: z.object({ count: z.number(), label: z.string() })
-      },
+      schemas,
       context: {
         count: 0,
         label: 'ready'
@@ -384,6 +390,7 @@ describe('schemas', () => {
     });
 
     store.getSnapshot().context.label satisfies string;
+    store.schemas satisfies StoreSchemas | undefined;
 
     // @ts-expect-error
     store.getSnapshot().context.label satisfies number;


### PR DESCRIPTION

Expose `store.schemas` so integrations can read the store's context, event, and emitted event schemas at runtime.

```ts
const store = createStore({
  schemas: {
    context: z.object({ count: z.number() }),
    events: {
      inc: z.object({ by: z.number() })
    }
  },
  context: { count: 0 },
  on: {
    inc: (context, event) => ({ count: context.count + event.by })
  }
});

store.schemas?.events?.inc;
```
