### PR TITLE
[@xstate/store] Add store effect trigger

### DIFF
--- a/.changeset/effect-enqueue.md
+++ b/.changeset/effect-enqueue.md
@@ -1,0 +1,35 @@
+---
+'@xstate/store': minor
+---
+
+Effects enqueued via `enq.effect(...)` now receive an enqueue object with `trigger`, `send`, and `getSnapshot`, so you can dispatch events back into the store after async work and read the latest state — without needing a reference to the store. This is especially useful with `createStoreLogic(...)`, where the store is created per-instance and there's no store to close over.
+
+```ts
+const storeLogic = createStoreLogic({
+  context: () => ({ foo: null, loading: false }),
+  on: {
+    fetchFoo: (context, event, enq) => {
+      enq.effect(({ trigger }) => {
+        myApi.requestFoo().then((response) => trigger.gotFoo({ response }));
+      });
+      return { ...context, loading: true };
+    },
+    gotFoo: (context, event) => ({
+      ...context,
+      foo: event.response,
+      loading: false
+    })
+  }
+});
+```
+
+Use `trigger` for fully-typed dispatch; `send` is a loosely-typed escape hatch for dynamically-constructed events. After an `await`, the `context` argument is stale — use `getSnapshot()` to read the current state:
+
+```ts
+enq.effect(async ({ getSnapshot, trigger }) => {
+  await someAsyncWork();
+  if (getSnapshot().context.loading) {
+    trigger.done();
+  }
+});
+```

--- a/packages/xstate-store/src/fromStore.ts
+++ b/packages/xstate-store/src/fromStore.ts
@@ -45,6 +45,7 @@ type InferredFromStoreTransitions<
     context: NoInfer<ResolveStoreContext<TContext, TContextSchema>>,
     event: any,
     enq: EnqueueObject<
+      ResolveStoreContext<TContext, TContextSchema>,
       FromStoreEmittedEvents<TEmittedPayloadMap, TEmittedSchemaMap>,
       InferredEventPayloadMap<TTransitions>
     >
@@ -263,13 +264,33 @@ export function fromStore(config: {
     transition: (snapshot, event, actorScope) => {
       const [nextSnapshot, effects] = transition(snapshot, event);
 
+      // The actor only commits `nextSnapshot` after this function returns, so
+      // synchronous effects must read it directly; effects that run later
+      // (after an `await`) read the latest committed snapshot from the actor.
+      // This matches `createStore`, where `currentSnapshot` is updated before
+      // effects run.
+      let committed = false;
+      const effectEnqueue = {
+        send: (event: EventObject) => actorScope.self.send(event),
+        trigger: new Proxy({} as any, {
+          get: (_, eventType: string) => {
+            return (payload: any) =>
+              actorScope.self.send({ type: eventType, ...payload });
+          }
+        }),
+        getSnapshot: () =>
+          committed ? actorScope.self.getSnapshot() : nextSnapshot
+      };
+
       for (const effect of effects) {
         if (typeof effect === 'function') {
-          effect();
+          effect(effectEnqueue);
         } else {
           actorScope.emit(effect);
         }
       }
+
+      committed = true;
 
       return nextSnapshot;
     },

--- a/packages/xstate-store/src/index.ts
+++ b/packages/xstate-store/src/index.ts
@@ -20,6 +20,7 @@ export type {
   ResolveStoreEventPayloadMap,
   ResolveStoreEmittedPayloadMap,
   StoreEffect,
+  StoreEffectEnqueue,
   TriggerObject,
   CanObject,
   StoreAssigner,

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -283,10 +283,11 @@ function createStoreCore<
     atom.set(nextSnapshot);
     notifyInspection(event, nextSnapshot);
 
+    let committed = false;
     const effectEnqueue = {
       trigger,
       send,
-      getSnapshot: () => currentSnapshot
+      getSnapshot: () => (committed ? currentSnapshot : nextSnapshot)
     } as StoreEffectEnqueue<any, any>;
 
     for (const effect of effects) {
@@ -296,6 +297,8 @@ function createStoreCore<
         emit(effect);
       }
     }
+
+    committed = true;
   }
 
   const trigger =

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -15,6 +15,7 @@ import {
   StoreContext,
   StoreConfig,
   StoreEffect,
+  StoreEffectEnqueue,
   StoreInspectionEvent,
   StoreProducerAssigner,
   StoreSnapshot,
@@ -89,7 +90,7 @@ function toEvent(eventType: string, payload: any) {
 function createEnqueueObject<TEmitted extends EventObject>(
   effects: StoreEffect<TEmitted>[],
   trigger?: (event: EventObject) => void
-): EnqueueObject<TEmitted, any> {
+): EnqueueObject<any, TEmitted, any> {
   return {
     emit: new Proxy({} as any, {
       get: (_, eventType: string) => {
@@ -106,7 +107,7 @@ function createEnqueueObject<TEmitted extends EventObject>(
       }
     }),
     effect: (fn) => {
-      effects.push(fn);
+      effects.push(fn as StoreEffect<TEmitted>);
     }
   };
 }
@@ -282,9 +283,15 @@ function createStoreCore<
     atom.set(nextSnapshot);
     notifyInspection(event, nextSnapshot);
 
+    const effectEnqueue = {
+      trigger,
+      send,
+      getSnapshot: () => currentSnapshot
+    } as StoreEffectEnqueue<any, any>;
+
     for (const effect of effects) {
       if (typeof effect === 'function') {
-        effect();
+        effect(effectEnqueue);
       } else {
         emit(effect);
       }

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -125,11 +125,11 @@ export type CanObject<TEventPayloadMap extends EventPayloadMap> = {
  * useful with `createStoreLogic(...)` where there is no store reference to
  * close over.
  *
- * Use `trigger` for fully-typed dispatch (e.g. `enq.trigger.gotFoo({ ... })`);
- * `send` is a loosely-typed escape hatch for dynamically-constructed events.
- * `getSnapshot()` returns the current snapshot at the time the effect runs,
- * which is the correct way to read fresh context after an `await` (the
- * `context` argument to the transition is stale by then).
+ * Use `trigger` for event-specific dispatch; `send` accepts the same event
+ * objects as `store.send(...)`. `getSnapshot()` returns the current snapshot at
+ * the time the effect runs, which is the correct way to read fresh context
+ * after an `await` (the `context` argument to the transition is stale by
+ * then).
  */
 export type StoreEffectEnqueue<
   TContext extends StoreContext = StoreContext,

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -118,7 +118,30 @@ export type CanObject<TEventPayloadMap extends EventPayloadMap> = {
     : CanFunction<EventFromPayload<K, TEventPayloadMap[K]>>;
 };
 
+/**
+ * The object passed to an effect function enqueued via `enq.effect(...)`. It
+ * allows effects to send events back into the store (e.g. after an async
+ * operation resolves) and read the latest store state, which is especially
+ * useful with `createStoreLogic(...)` where there is no store reference to
+ * close over.
+ *
+ * Use `trigger` for fully-typed dispatch (e.g. `enq.trigger.gotFoo({ ... })`);
+ * `send` is a loosely-typed escape hatch for dynamically-constructed events.
+ * `getSnapshot()` returns the current snapshot at the time the effect runs,
+ * which is the correct way to read fresh context after an `await` (the
+ * `context` argument to the transition is stale by then).
+ */
+export type StoreEffectEnqueue<
+  TContext extends StoreContext = StoreContext,
+  TEventPayloadMap extends EventPayloadMap = {}
+> = {
+  trigger: TriggerObject<TEventPayloadMap>;
+  send: (event: EventObject) => void;
+  getSnapshot: () => StoreSnapshot<TContext>;
+};
+
 export type EnqueueObject<
+  TContext extends StoreContext,
   TEmittedEvent extends EventObject,
   TEventPayloadMap extends EventPayloadMap = {}
 > = {
@@ -126,10 +149,14 @@ export type EnqueueObject<
     [E in TEmittedEvent as E['type']]: EmitterFunction<E>;
   };
   trigger: TriggerObject<TEventPayloadMap>;
-  effect: (fn: () => void) => void;
+  effect: (
+    fn: (enq: StoreEffectEnqueue<TContext, TEventPayloadMap>) => void
+  ) => void;
 };
 
-export type StoreEffect<TEmitted extends EventObject> = (() => void) | TEmitted;
+export type StoreEffect<TEmitted extends EventObject> =
+  | ((enq?: StoreEffectEnqueue<any, any>) => void)
+  | TEmitted;
 
 export type StoreAssigner<
   TContext extends StoreContext,
@@ -139,7 +166,7 @@ export type StoreAssigner<
 > = (
   context: TContext,
   event: TEvent,
-  enq: EnqueueObject<TEmitted, TEventPayloadMap>
+  enq: EnqueueObject<TContext, TEmitted, TEventPayloadMap>
 ) => TContext | void;
 
 export type StoreProducerAssigner<
@@ -150,7 +177,7 @@ export type StoreProducerAssigner<
 > = (
   context: TContext,
   event: TEvent,
-  enq: EnqueueObject<TEmitted, TEventPayloadMap>
+  enq: EnqueueObject<TContext, TEmitted, TEventPayloadMap>
 ) => void;
 
 export type Snapshot<TOutput> =

--- a/packages/xstate-store/test/fromStore.test.ts
+++ b/packages/xstate-store/test/fromStore.test.ts
@@ -1,5 +1,6 @@
 import { createActor } from 'xstate';
 import { fromStore } from '../src/index.ts';
+import type { StoreEffectEnqueue } from '../src/index.ts';
 import { z } from 'zod';
 
 describe('fromStore', () => {
@@ -61,5 +62,56 @@ describe('fromStore', () => {
     expect(actor.getSnapshot().context.count).toEqual(50);
     expect(spy).toHaveBeenCalledTimes(1);
     expect(spy).toHaveBeenCalledWith({ type: 'increased', upBy: 8 });
+  });
+
+  it('enq.getSnapshot() in a sync effect reflects the post-transition state (matches createStore)', () => {
+    let seen: number | undefined;
+
+    const storeLogic = fromStore({
+      context: (_: void) => ({ count: 0 }),
+      on: {
+        inc: (ctx, _, enq) => {
+          enq.effect(
+            ({ getSnapshot }: StoreEffectEnqueue<{ count: number }>) => {
+              seen = getSnapshot().context.count;
+            }
+          );
+          return { ...ctx, count: ctx.count + 1 };
+        }
+      }
+    });
+
+    const actor = createActor(storeLogic).start();
+    actor.send({ type: 'inc' });
+
+    expect(seen).toEqual(1);
+  });
+
+  it('enq.getSnapshot() in an async effect reflects the latest committed state', async () => {
+    let seen: number | undefined;
+
+    const storeLogic = fromStore({
+      context: (_: void) => ({ count: 0 }),
+      on: {
+        start: (ctx, _, enq) => {
+          enq.effect(
+            async ({ getSnapshot }: StoreEffectEnqueue<{ count: number }>) => {
+              await new Promise((resolve) => setTimeout(resolve, 5));
+              seen = getSnapshot().context.count;
+            }
+          );
+          return { ...ctx, count: ctx.count + 1 };
+        },
+        bump: (ctx) => ({ count: ctx.count + 10 })
+      }
+    });
+
+    const actor = createActor(storeLogic).start();
+    actor.send({ type: 'start' }); // count -> 1
+    actor.send({ type: 'bump' }); // count -> 11 before the async effect resumes
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(seen).toEqual(11);
   });
 });

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -757,6 +757,30 @@ it('effects can read fresh state after awaiting via enq.getSnapshot()', async ()
   expect(seen).toEqual([11]);
 });
 
+it('sync effects read the current transition snapshot via enq.getSnapshot()', () => {
+  const seen: number[] = [];
+  const store = createStore({
+    context: { count: 0 },
+    on: {
+      start: (ctx, _, enq) => {
+        enq.effect(({ trigger }) => {
+          trigger.bump();
+        });
+        enq.effect(({ getSnapshot }) => {
+          seen.push(getSnapshot().context.count);
+        });
+        return { count: ctx.count + 1 };
+      },
+      bump: (ctx) => ({ count: ctx.count + 10 })
+    }
+  });
+
+  store.trigger.start();
+
+  expect(seen).toEqual([1]);
+  expect(store.getSnapshot().context.count).toEqual(11);
+});
+
 it('effects can use enq.send to dispatch events', async () => {
   const store = createStore({
     context: { count: 0 },

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -706,6 +706,77 @@ it('async effects can be enqueued', async () => {
   expect(store.getSnapshot().context.count).toEqual(0);
 });
 
+it('effects receive an enqueue object to trigger events (no closure needed)', async () => {
+  const logic = createStoreLogic({
+    context: () => ({ count: 0, status: 'idle' }),
+    on: {
+      inc: (ctx, _, enq) => {
+        enq.effect(async ({ trigger }) => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          trigger.done();
+        });
+        return { ...ctx, status: 'loading' };
+      },
+      done: (ctx) => ({ count: ctx.count + 1, status: 'done' })
+    }
+  });
+
+  const store = logic.createStore();
+
+  store.trigger.inc();
+  expect(store.getSnapshot().context).toEqual({ count: 0, status: 'loading' });
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  expect(store.getSnapshot().context).toEqual({ count: 1, status: 'done' });
+});
+
+it('effects can read fresh state after awaiting via enq.getSnapshot()', async () => {
+  const seen: number[] = [];
+  const store = createStore({
+    context: { count: 0 },
+    on: {
+      start: (ctx, _, enq) => {
+        enq.effect(async ({ getSnapshot, trigger }) => {
+          // `ctx` is stale by now; getSnapshot() reflects the bump below
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          seen.push(getSnapshot().context.count);
+          trigger.done();
+        });
+        return { ...ctx, count: ctx.count + 1 };
+      },
+      bump: (ctx) => ({ count: ctx.count + 10 }),
+      done: (ctx) => ctx
+    }
+  });
+
+  store.trigger.start(); // count -> 1
+  store.trigger.bump(); // count -> 11 (after effect was enqueued, before it runs)
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  expect(seen).toEqual([11]);
+});
+
+it('effects can use enq.send to dispatch events', async () => {
+  const store = createStore({
+    context: { count: 0 },
+    on: {
+      inc: (ctx, _, enq) => {
+        enq.effect(({ send }) => {
+          send({ type: 'dec' });
+        });
+        return { ...ctx, count: ctx.count + 1 };
+      },
+      dec: (ctx) => ({ ...ctx, count: ctx.count - 1 })
+    }
+  });
+
+  store.trigger.inc();
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  expect(store.getSnapshot().context.count).toEqual(0);
+});
+
 it('rejects async handlers in createStoreTransition(...)', () => {
   const store = createStore({
     context: { count: 0 },


### PR DESCRIPTION

Effects enqueued via `enq.effect(...)` now receive an enqueue object with `trigger`, `send`, and `getSnapshot`, so you can dispatch events back into the store after async work and read the latest state without needing a reference to the store. This is especially useful with `createStoreLogic(...)`, where the store is created per-instance and there's no store to close over.

```ts
const storeLogic = createStoreLogic({
  context: () => ({ foo: null, loading: false }),
  on: {
    fetchFoo: (context, event, enq) => {
      enq.effect(({ trigger }) => {
        myApi.requestFoo().then((response) => trigger.gotFoo({ response }));
      });
      return { ...context, loading: true };
    },
    gotFoo: (context, event) => ({
      ...context,
      foo: event.response,
      loading: false
    })
  }
});
```

