### PR TITLE
fix(core): prevent transitions from final states in parallel regions

### DIFF
--- a/.changeset/fix-parallel-final-state.md
+++ b/.changeset/fix-parallel-final-state.md
@@ -1,0 +1,13 @@
+---
+'xstate': patch
+---
+
+Fix: parallel final states are now truly final
+
+A final state inside a parallel region could incorrectly allow outgoing
+transitions if transitions were defined on it. `StateNode.next()` now
+returns `undefined` immediately for any `final`-type state node,
+matching the SCXML specification that final states are terminal and
+cannot have outgoing transitions.
+
+Fixes #5460

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -376,6 +376,11 @@ export class StateNode<
     >,
     event: TEvent
   ): TransitionDefinition<TContext, TEvent>[] | undefined {
+    // Final states are terminal — they cannot have outgoing transitions.
+    if (this.type === 'final') {
+      return undefined;
+    }
+
     const eventType = event.type;
     const actions: UnknownAction[] = [];
 

--- a/packages/core/test/parallel.test.ts
+++ b/packages/core/test/parallel.test.ts
@@ -1343,4 +1343,50 @@ describe('parallel states', () => {
 
     expect(flushTracked()).toEqual([]);
   });
+
+  // https://github.com/statelyai/xstate/issues/5460
+  it('should not allow transitions from a final state inside a parallel region', () => {
+    const machine = createMachine({
+      id: 'test',
+      type: 'parallel',
+      states: {
+        first: {
+          initial: 'a',
+          states: {
+            a: {
+              on: { NEXT: 'done' }
+            },
+            done: {
+              type: 'final',
+              // @ts-expect-error intentionally invalid: testing runtime guard
+              on: { BACK: 'a' }
+            }
+          }
+        },
+        second: {
+          initial: 'x',
+          states: {
+            x: {
+              on: { MOVE: 'y' }
+            },
+            y: {}
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+
+    // Move first region to its final state
+    actor.send({ type: 'NEXT' });
+    expect(actor.getSnapshot().value).toEqual({ first: 'done', second: 'x' });
+
+    // Sending BACK (which is defined on the final state) must not transition away
+    actor.send({ type: 'BACK' });
+    expect(actor.getSnapshot().value).toEqual({ first: 'done', second: 'x' });
+
+    // Other region can still transition normally
+    actor.send({ type: 'MOVE' });
+    expect(actor.getSnapshot().value).toEqual({ first: 'done', second: 'y' });
+  });
 });


### PR DESCRIPTION
Closes #5460

## Root cause

`StateNode.next()` — the method that returns the enabled transition for a given event — did not check whether the node itself is of type `'final'`. A final state inside a parallel region therefore continued to process events if its config happened to include `on` entries (which is technically invalid per the spec, but the engine accepted them silently and acted on them). The machine could be yanked out of a terminal region and made to revisit earlier states, breaking the SCXML guarantee that final states are terminal.

**Example** (broken before this PR):

```ts
const machine = createMachine({
  type: 'parallel',
  states: {
    first: {
      initial: 'a',
      states: {
        a:    { on: { NEXT: 'done' } },
        done: { type: 'final', on: { BACK: 'a' } }  // invalid, but silently accepted
      }
    },
    second: { initial: 'x', states: { x: {} } }
  }
});

const actor = createActor(machine).start();
actor.send({ type: 'NEXT' });   // → { first: 'done', second: 'x' }
actor.send({ type: 'BACK' });   // BUG: { first: 'a', second: 'x' }  — final was exited!
```

## Fix

Add a single early-return guard at the top of `StateNode.next()`:

```ts
if (this.type === 'final') {
  return undefined;
}
```

This is the lowest-level, most defensive place to put the guard: regardless of what transitions are stored in the node's config, the engine will never select one for a final state.

## Test

Added `test/parallel.test.ts > should not allow transitions from a final state inside a parallel region` which:
1. Moves a parallel region to its final state.
2. Sends the event that is (incorrectly) defined as an outgoing transition on that final state.
3. Asserts the snapshot is unchanged — the final region must not move.
4. Asserts the other (non-final) region still transitions normally.

**Fail-without / pass-with confirmed** (`vitest run test/parallel.test.ts`):
- without fix: 1 failed | 28 passed
- with fix: 29 passed

Full core suite: 74 test files, 1 738 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)