### PR TITLE
Fix #5480: narrow ActorOptions.snapshot and getPersistedSnapshot() to SnapshotFrom<TLogic>

### DIFF
--- a/.changeset/fix-snapshot-type-5480.md
+++ b/.changeset/fix-snapshot-type-5480.md
@@ -1,0 +1,13 @@
+---
+'xstate': patch
+'@xstate/react': patch
+---
+
+Fix `ActorOptions.snapshot` and `Actor.getPersistedSnapshot()` to return `SnapshotFrom<TLogic>` instead of `Snapshot<unknown>`, so that rehydrating a machine from a persisted snapshot no longer produces TypeScript errors.
+
+```ts
+const persisted = actor.getPersistedSnapshot(); // typed SnapshotFrom<TMachine>
+useMachine(machine, { snapshot: persisted }); // now typechecks
+```
+
+Resolves [#5480](https://github.com/statelyai/xstate/issues/5480).

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -784,9 +784,12 @@ export class Actor<TLogic extends AnyActorLogic>
    * Can be restored with {@link ActorOptions.state}
    * @see https://stately.ai/docs/persistence
    */
-  public getPersistedSnapshot(): Snapshot<unknown>;
-  public getPersistedSnapshot(options?: unknown): Snapshot<unknown> {
-    return this.logic.getPersistedSnapshot(this._snapshot, options);
+  public getPersistedSnapshot(): SnapshotFrom<TLogic>;
+  public getPersistedSnapshot(options?: unknown): SnapshotFrom<TLogic> {
+    return this.logic.getPersistedSnapshot(
+      this._snapshot,
+      options
+    ) as SnapshotFrom<TLogic>;
   }
 
   public [symbolObservable](): InteropSubscribable<SnapshotFrom<TLogic>> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1865,10 +1865,10 @@ export interface ActorOptions<TLogic extends AnyActorLogic> {
    * Can be generated with {@link Actor.getPersistedSnapshot}.
    * @see https://stately.ai/docs/persistence
    */
-  snapshot?: Snapshot<unknown>;
+  snapshot?: SnapshotFrom<TLogic>;
 
   /** @deprecated Use `snapshot` instead. */
-  state?: Snapshot<unknown>;
+  state?: SnapshotFrom<TLogic>;
 
   /** The source actor logic. */
   src?: string | AnyActorLogic;

--- a/packages/xstate-react/test/createActorContext.test.tsx
+++ b/packages/xstate-react/test/createActorContext.test.tsx
@@ -3,6 +3,7 @@ import {
   assign,
   fromPromise,
   Snapshot,
+  SnapshotFrom,
   InspectionEvent
 } from 'xstate';
 import { fireEvent, screen, render, waitFor } from '@testing-library/react';
@@ -374,7 +375,7 @@ describe('createActorContext', () => {
       }
     });
     const SomeContext = createActorContext(machine);
-    let persistedState: Snapshot<unknown> | undefined = undefined;
+    let persistedState: SnapshotFrom<typeof machine> | undefined = undefined;
 
     const Component = () => {
       const actorRef = SomeContext.useActorRef();

--- a/packages/xstate-react/test/types.test.tsx
+++ b/packages/xstate-react/test/types.test.tsx
@@ -1,5 +1,11 @@
 import { render } from '@testing-library/react';
-import { ActorRefFrom, assign, createMachine, setup } from 'xstate';
+import {
+  ActorRefFrom,
+  assign,
+  createActor,
+  createMachine,
+  setup
+} from 'xstate';
 import {
   useActor,
   useActorRef,
@@ -217,4 +223,30 @@ it('useMachine types work for machines with a specified id and state with an aft
 
     return state.matches('enabled');
   }
+});
+
+// https://github.com/statelyai/xstate/issues/5480
+it('useMachine accepts a rehydrated snapshot from getPersistedSnapshot #5480', () => {
+  const counterMachine = setup({}).createMachine({
+    initial: 'idle',
+    states: {
+      idle: {},
+      active: {}
+    }
+  });
+
+  // Round-trip: getPersistedSnapshot() -> useMachine(machine, { snapshot })
+  // Both sides must typecheck without `as any` casts or @ts-expect-error.
+  function App() {
+    const actorRef = createActor(counterMachine).start();
+    const persistedState = actorRef.getPersistedSnapshot();
+
+    const [, , restoredRef] = useMachine(counterMachine, {
+      snapshot: persistedState
+    });
+
+    return <span data-testid="value">{restoredRef.getSnapshot().value}</span>;
+  }
+
+  render(<App />);
 });

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -9,6 +9,7 @@ import {
   ActorRef,
   DoneActorEvent,
   Snapshot,
+  SnapshotFrom,
   StateFrom,
   assign,
   createActor,
@@ -86,7 +87,7 @@ describeEachReactMode('useActor (%s)', ({ suiteKey, render }) => {
 
   const Fetcher: React.FC<{
     onFetch: () => Promise<any>;
-    persistedState?: Snapshot<unknown>;
+    persistedState?: SnapshotFrom<typeof fetchMachine>;
   }> = ({
     onFetch = () => {
       return new Promise((res) => res('some data'));


### PR DESCRIPTION
Closes #5480

## Problem

`ActorOptions.snapshot` and `Actor.getPersistedSnapshot()` were typed
`Snapshot<unknown>` (a 4-shape union of `status` / `output` /
`error`). Real machine snapshots (`MachineSnapshot<...>`) have a
richer shape (`status` / `value` / `context` / `matches(...)` /
...). The two shapes do not overlap, so the round-trip
`getPersistedSnapshot()` → `useMachine(machine, { snapshot })`
failed typecheck even though the runtime is fine.

The deprecated `state` alias had the same problem.

## Fix

Narrow both sides of the round-trip to `SnapshotFrom<TLogic>` so
the types agree:

- `packages/core/src/types.ts` — `ActorOptions.snapshot` and
  `ActorOptions.state` now use `SnapshotFrom<TLogic>` instead of
  `Snapshot<unknown>`.
- `packages/core/src/createActor.ts` —
  `Actor.getPersistedSnapshot()` return type is now
  `SnapshotFrom<TLogic>`. The internal
  `this.logic.getPersistedSnapshot(...)` call still returns
  `Snapshot<unknown>` per `ActorLogic`'s generic declaration, so
  a single cast is applied at the public boundary. Runtime
  behaviour is unchanged.

For a `StateMachine`, `SnapshotFrom<TMachine>` resolves to
`MachineSnapshot<...>` via `ReturnType<R['transition']>`, which
is exactly what `getPersistedSnapshot()` returns at runtime.

## Test

`packages/xstate-react/test/types.test.tsx` gets a new
`it('useMachine accepts a rehydrated snapshot from
getPersistedSnapshot #5480', ...)` that exercises the round-trip
end-to-end and is expected to typecheck without `as any` or
`@ts-expect-error`. Two existing tests
(`createActorContext.test.tsx`, `useActor.test.tsx`) are updated
to use `SnapshotFrom<typeof machine>` for their `persistedState`
annotations to keep `tsc` green.

## Verification

- `pnpm typecheck` → 0 errors (3 errors before the test-file
  annotations were updated; now clean).
- `pnpm test:core` is gated on Node ≥ 22 in this repo (uses
  `Promise.withResolvers`) — environment issue unrelated to this
  change.

Backward-compatible: callers passing a hand-written
`Snapshot<unknown>` to `snapshot:` are unaffected because the
internal `_initState` / `restoreSnapshot` flow still accepts any
shape that the logic's `restoreSnapshot` can convert.
