### PR TITLE
fix(core): fall back to wildcard event descriptors when an exact descriptor's guard fails

### DIFF
--- a/.changeset/fix-exact-descriptor-wildcard-fallback.md
+++ b/.changeset/fix-exact-descriptor-wildcard-fallback.md
@@ -1,0 +1,7 @@
+---
+"xstate": patch
+---
+
+fix(core): fall back to wildcard event descriptors when an exact descriptor's guard fails
+
+When a state has both an exact event descriptor (e.g. `"foo.bar"`) and a matching wildcard descriptor (e.g. `"foo.*"`), transitions from the exact descriptor are now tried first; if all their guards fail, matching wildcard descriptor transitions are tried as fallback. Previously, the presence of an exact match would prevent any wildcard fallback from being considered, leaving the machine in its current state when the exact descriptor's guard failed.

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -213,16 +213,19 @@ export function getCandidates<TEvent extends EventObject>(
   stateNode: StateNode<any, TEvent>,
   receivedEventType: TEvent['type']
 ): Array<TransitionDefinition<any, TEvent>> {
-  const candidates =
-    stateNode.transitions.get(receivedEventType) ||
-    [...stateNode.transitions.keys()]
-      .filter((eventDescriptor) =>
+  const exactMatch = stateNode.transitions.get(receivedEventType);
+  const wildcardCandidates = [...stateNode.transitions.keys()]
+    .filter(
+      (eventDescriptor) =>
+        eventDescriptor !== receivedEventType &&
         matchesEventDescriptor(receivedEventType, eventDescriptor)
-      )
-      .sort((a, b) => b.length - a.length)
-      .flatMap((key) => stateNode.transitions.get(key)!);
+    )
+    .sort((a, b) => b.length - a.length)
+    .flatMap((key) => stateNode.transitions.get(key)!);
 
-  return candidates;
+  return exactMatch
+    ? [...exactMatch, ...wildcardCandidates]
+    : wildcardCandidates;
 }
 
 /** All delayed transitions from the config. */

--- a/packages/core/test/eventDescriptors.test.ts
+++ b/packages/core/test/eventDescriptors.test.ts
@@ -104,6 +104,29 @@ describe('event descriptors', () => {
     expect(service.getSnapshot().value).toBe('pass');
   });
 
+  it('should fall back to wildcard descriptor when exact descriptor guard fails', () => {
+    const machine = createMachine({
+      initial: 'A',
+      states: {
+        A: {
+          on: {
+            'foo.bar': {
+              guard: () => false,
+              target: 'fail'
+            },
+            'foo.*': 'pass'
+          }
+        },
+        fail: {},
+        pass: {}
+      }
+    });
+
+    const service = createActor(machine).start();
+    service.send({ type: 'foo.bar' });
+    expect(service.getSnapshot().value).toBe('pass');
+  });
+
   it('should NOT support non-tokenized wildcards', () => {
     const machine = createMachine({
       initial: 'start',


### PR DESCRIPTION
## Summary

When a state has both an exact event descriptor (e.g. `"foo.bar"`) and a matching wildcard descriptor (e.g. `"foo.*"`), transitions from the exact descriptor are tried first; if all their guards fail, matching wildcard descriptor transitions are now used as fallbacks.

### Bug

`getCandidates` in `stateUtils.ts` used a short-circuit `||` to return exact-match transitions early, preventing wildcard candidates from being included at all:

```ts
// Before — wildcardCandidates never built when exact match exists
const candidates =
  stateNode.transitions.get(receivedEventType) ||
  [...stateNode.transitions.keys()]
    .filter(d => matchesEventDescriptor(receivedEventType, d))
    .sort((a, b) => b.length - a.length)
    .flatMap(key => stateNode.transitions.get(key)!);
```

This meant that with:
```ts
on: {
  'foo.bar': { guard: () => false, target: 'fail' },
  'foo.*': 'pass'
}
```
Sending `{ type: 'foo.bar' }` would leave the machine in its current state instead of transitioning to `'pass'` via the wildcard fallback.

The existing behaviour for two wildcard descriptors already handled this correctly: `'foo.bar.*'` with a failing guard correctly falls back to `'foo.*'`. This fix makes exact descriptors consistent with that.

### Fix

Split the lookup into exact-match (priority) and wildcard candidates (fallback), then concatenate:

```ts
const exactMatch = stateNode.transitions.get(receivedEventType);
const wildcardCandidates = [...stateNode.transitions.keys()]
  .filter(d => d !== receivedEventType && matchesEventDescriptor(receivedEventType, d))
  .sort((a, b) => b.length - a.length)
  .flatMap(key => stateNode.transitions.get(key)!);
return exactMatch ? [...exactMatch, ...wildcardCandidates] : wildcardCandidates;
```

Exact-match transitions are still first in the array, preserving their priority when guards pass.

### Test

New test added to `test/eventDescriptors.test.ts`: *"should fall back to wildcard descriptor when exact descriptor guard fails"*. All 1739 existing tests continue to pass.

> AI-assisted contribution