### PR TITLE
feat(core): autocomplete for `schemas` fields (v6)

### DIFF
--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -2,28 +2,28 @@ import { StandardSchemaV1 } from './schema.types.ts';
 import { StateMachine } from './StateMachine.ts';
 import {
   AnyActorRef,
-  AnyEventObject,
   AnyStateNode,
-  Cast,
-  Compute,
-  EnqueueObject,
-  EventDescriptor,
   EventObject,
+  AnyEventObject,
+  EventDescriptor,
   ExtractEvent,
   MachineContext,
-  MetaObject,
   ProvidedActor,
   RoutableStateId,
   StateSchema,
   StateValue,
-  ToChildren
+  ToChildren,
+  MetaObject,
+  Cast,
+  Compute,
+  EnqueueObject
 } from './types.ts';
 import {
   DelayMapFromNames,
-  Implementations,
   InferChildren,
-  InferEvents,
+  Implementations,
   InferOutput,
+  InferEvents,
   Next_MachineConfig,
   Next_StateNodeConfig,
   WithDefault

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -2,28 +2,28 @@ import { StandardSchemaV1 } from './schema.types.ts';
 import { StateMachine } from './StateMachine.ts';
 import {
   AnyActorRef,
-  AnyStateNode,
-  EventObject,
   AnyEventObject,
+  AnyStateNode,
+  Cast,
+  Compute,
+  EnqueueObject,
   EventDescriptor,
+  EventObject,
   ExtractEvent,
   MachineContext,
+  MetaObject,
   ProvidedActor,
   RoutableStateId,
   StateSchema,
   StateValue,
-  ToChildren,
-  MetaObject,
-  Cast,
-  Compute,
-  EnqueueObject
+  ToChildren
 } from './types.ts';
 import {
   DelayMapFromNames,
-  InferChildren,
   Implementations,
-  InferOutput,
+  InferChildren,
   InferEvents,
+  InferOutput,
   Next_MachineConfig,
   Next_StateNodeConfig,
   WithDefault
@@ -37,7 +37,7 @@ type SetupConfig<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays']
 > = {
-  schemas?: TSchemas;
+  schemas?: TSchemas & SetupSchemas;
   states?: TStates;
   actions?: TActionMap;
   actors?: TActorMap;


### PR DESCRIPTION
## Summary
This allows the IDE to show autocomplete suggestions for `schemas` inside `setup`.

Before:
<img width="306" height="301" alt="スクリーンショット 2026-06-26 15 34 26" src="https://github.com/user-attachments/assets/5bd49e5e-8adc-4d86-a41c-f93629ddd047" />

After:
<img width="297" height="305" alt="スクリーンショット 2026-06-26 15 35 02" src="https://github.com/user-attachments/assets/d49ccf47-c8ea-4049-8950-82920447ec97" />
