### PR TITLE
fix(core): parallel top-level transitions preserve sibling region sub-state

### DIFF
--- a/.changeset/fix-parallel-top-level-transition-resets-siblings.md
+++ b/.changeset/fix-parallel-top-level-transition-resets-siblings.md
@@ -1,0 +1,28 @@
+---
+'xstate': patch
+---
+
+Fixed a bug where transitions defined directly on a parallel state (in its `on` property) that target a specific sub-region would incorrectly reset all other parallel regions to their initial sub-states.
+
+```ts
+const machine = createMachine({
+  id: 'parallelExample',
+  type: 'parallel',
+  on: {
+    ARCHIVE: { target: '#parallelExample.phase.archive' },
+    EDIT: { target: '#parallelExample.mode.edit' },
+  },
+  states: {
+    phase: { initial: 'inquiry', states: { inquiry: {}, archive: {} } },
+    mode: { initial: 'new', states: { new: {}, edit: {} } },
+  },
+});
+
+const actor = createActor(machine).start();
+actor.send({ type: 'EDIT' });
+// state is now { phase: 'inquiry', mode: 'edit' }
+
+actor.send({ type: 'ARCHIVE' });
+// was: { phase: 'archive', mode: 'new' }  ← mode incorrectly reset to initial
+// now: { phase: 'archive', mode: 'edit' } ← mode correctly preserved
+```

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -950,9 +950,40 @@ function computeExitSet(
         statesToExit.add(domain);
       }
 
-      for (const stateNode of stateNodeSet) {
-        if (isDescendant(stateNode, domain!)) {
-          statesToExit.add(stateNode);
+      const targetStates = getEffectiveTargetStates(t, historyValue);
+
+      // When the domain is a parallel state and the transition source is the
+      // domain itself (i.e. the transition is defined directly on the parallel
+      // state), only exit the regions that contain the transition's targets —
+      // unless any target IS the domain itself (e.g. a RESET to '#machineId'
+      // which must re-enter all regions from scratch). Sibling regions that
+      // are not targeted must not be exited so they can remain in their
+      // current sub-state rather than being reset to initial (issue #5214).
+      if (
+        domain?.type === 'parallel' &&
+        t.source === domain &&
+        targetStates.every((target) => target !== domain)
+      ) {
+        const affectedChildren = getChildren(domain).filter((child) =>
+          targetStates.some(
+            (target) => isDescendant(target, child) || target === child
+          )
+        );
+        for (const stateNode of stateNodeSet) {
+          if (
+            affectedChildren.some(
+              (child) =>
+                isDescendant(stateNode, child) || stateNode === child
+            )
+          ) {
+            statesToExit.add(stateNode);
+          }
+        }
+      } else {
+        for (const stateNode of stateNodeSet) {
+          if (isDescendant(stateNode, domain!)) {
+            statesToExit.add(stateNode);
+          }
         }
       }
     }
@@ -1289,7 +1320,12 @@ function computeEntrySet(
     const targetStates = getEffectiveTargetStates(t, historyValue);
     for (const s of targetStates) {
       const ancestors = getProperAncestors(s, domain);
-      if (domain?.type === 'parallel') {
+      // Only push the parallel domain into the ancestors list when the source
+      // of the transition is NOT the domain itself. When source === domain the
+      // transition is "scoped" to specific regions; pushing the domain would
+      // cause addAncestorStatesToEnter to reset all sibling parallel regions
+      // to their initial sub-states (see issue #5214).
+      if (domain?.type === 'parallel' && t.source !== domain) {
         ancestors.push(domain);
       }
       addAncestorStatesToEnter(

--- a/packages/core/test/parallel.test.ts
+++ b/packages/core/test/parallel.test.ts
@@ -1343,4 +1343,48 @@ describe('parallel states', () => {
 
     expect(flushTracked()).toEqual([]);
   });
+  // https://github.com/statelyai/xstate/issues/5214
+  it('transitions defined on a parallel state should not reset sibling regions to their initial sub-state', () => {
+    const machine = createMachine({
+      id: 'parallelExample',
+      type: 'parallel',
+      on: {
+        INQUIRY: { target: '#parallelExample.phase.inquiry' },
+        ARCHIVE: { target: '#parallelExample.phase.archive' },
+        EDIT: { target: '#parallelExample.mode.edit' },
+        NEW: { target: '#parallelExample.mode.new' }
+      },
+      states: {
+        phase: {
+          initial: 'inquiry',
+          states: {
+            inquiry: {},
+            archive: {}
+          }
+        },
+        mode: {
+          initial: 'new',
+          states: {
+            new: {},
+            edit: {}
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine);
+    actor.start();
+
+    // Move mode to 'edit' — phase should stay 'inquiry'
+    actor.send({ type: 'EDIT' });
+    expect(actor.getSnapshot().value).toEqual({ phase: 'inquiry', mode: 'edit' });
+
+    // Move phase to 'archive' — mode must NOT reset to its initial 'new'
+    actor.send({ type: 'ARCHIVE' });
+    expect(actor.getSnapshot().value).toEqual({ phase: 'archive', mode: 'edit' });
+
+    // Move mode to 'new' — phase must NOT reset to its initial 'inquiry'
+    actor.send({ type: 'NEW' });
+    expect(actor.getSnapshot().value).toEqual({ phase: 'archive', mode: 'new' });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #5214

## Bug

When a transition is defined directly on a parallel state (its `on` property) and targets a specific sub-region, all other parallel regions were being reset to their initial sub-states.

```ts
const machine = createMachine({
  id: 'parallelExample',
  type: 'parallel',
  on: {
    ARCHIVE: { target: '#parallelExample.phase.archive' },
    EDIT: { target: '#parallelExample.mode.edit' },
  },
  states: {
    phase: { initial: 'inquiry', states: { inquiry: {}, archive: {} } },
    mode: { initial: 'new', states: { new: {}, edit: {} } },
  },
});

const actor = createActor(machine).start();
actor.send({ type: 'EDIT' });
// { phase: 'inquiry', mode: 'edit' }

actor.send({ type: 'ARCHIVE' });
// Before fix: { phase: 'archive', mode: 'new' }  ← mode wrongly reset
// After fix:  { phase: 'archive', mode: 'edit' } ← mode preserved ✓
```

## Root Cause

In `computeExitSet`, when the transition domain is a parallel state, ALL active descendants of that domain were added to the exit set — including states in unrelated sibling regions.

In `computeEntrySet`, the domain (parallel state) was pushed into the ancestor list, which caused `addAncestorStatesToEnter` to call `addDescendantStatesToEnter` for every child of the parallel state not already targeted, resetting them to their initial sub-states.

## Fix

When the transition's **source IS the parallel domain** and **no target is the domain itself**:

1. **`computeExitSet`**: only adds states in the parallel regions that *contain* the transition targets to the exit set. Sibling regions are left untouched.
2. **`computeEntrySet`**: skips pushing the parallel domain into ancestors, so `addAncestorStatesToEnter` never resets sibling regions.

Cross-region transitions (source is a child state, not the domain) and full-reset transitions that target the domain node itself (e.g. `RESET: '#machineId'`) continue to work with the original behaviour.

## Verification

```
pnpm --filter xstate test
# Test Files  73 passed (73)
# Tests       1728 passed | 13 skipped | 1 todo (1742)
```

New regression test: *"transitions defined on a parallel state should not reset sibling regions to their initial sub-state"* in `packages/core/test/parallel.test.ts`.

> AI-assisted contribution.