### PR TITLE
feat(core): allow `void` and `undefined` in event types (v6)

### DIFF
--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -50,13 +50,17 @@ export type InferEvents<
   [K in keyof TEventSchemaMap & string]: StandardSchemaV1.InferOutput<
     TEventSchemaMap[K]
   > extends infer O
-    ? unknown extends O
-      ? O & { type: K }
-      : string extends keyof O
-        ? [O[string]] extends [never]
+    ? [O] extends [never]
+      ? never
+      : unknown extends O
+        ? O & { type: K }
+        : [O] extends [void]
           ? { type: K }
-          : Required<O> & { type: K }
-        : Required<O> & { type: K }
+          : string extends keyof O
+            ? [O[string]] extends [never]
+              ? { type: K }
+              : Required<O> & { type: K }
+            : Required<O> & { type: K }
     : never;
 }>;
 

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -2582,6 +2582,61 @@ describe('invoke', () => {
     actor.send({ type: 'UPDATE' });
   });
 
+  it('should infer void and undefined event schemas as type-only events', () => {
+    const machine = setup({
+      schemas: {
+        events: {
+          SEND: types<void>(),
+          RESET: types<undefined>(),
+          UPDATE: types<{ value: string }>()
+        }
+      }
+    }).createMachine({});
+
+    const actor = createActor(machine).start();
+    const snapshot = actor.getSnapshot();
+
+    actor.send({ type: 'SEND' });
+    actor.send({ type: 'RESET' });
+    snapshot.can({ type: 'SEND' });
+    snapshot.can({ type: 'RESET' });
+
+    actor.send({ type: 'UPDATE', value: 'ok' });
+    snapshot.can({ type: 'UPDATE', value: 'ok' });
+    // @ts-expect-error
+    actor.send({ type: 'UPDATE' });
+    // @ts-expect-error
+    snapshot.can({ type: 'UPDATE' });
+
+    const emittedMachine = setup({
+      schemas: {
+        emitted: {
+          DONE: types<void>(),
+          CLEARED: types<undefined>(),
+          CHANGED: types<{ value: string }>()
+        }
+      }
+    }).createMachine({});
+
+    const emittedActor = createActor(emittedMachine);
+
+    emittedActor.on('DONE', (event) => {
+      event.type satisfies 'DONE';
+      // @ts-expect-error
+      event.value;
+    });
+    emittedActor.on('CLEARED', (event) => {
+      event.type satisfies 'CLEARED';
+      // @ts-expect-error
+      event.value;
+    });
+    emittedActor.on('CHANGED', (event) => {
+      event.value satisfies string;
+    });
+    // @ts-expect-error
+    emittedActor.on('UNKNOWN', () => {});
+  });
+
   it('should infer callback logic input from source schemas', () => {
     const logic = createCallbackLogic({
       schemas: {


### PR DESCRIPTION
## Summary
I noticed that using `void` collapsed the types causing issues with event types, which became `void & { type: "Export" }`, which collapses to `never`:
```ts
const exportBackupMachine = setup({
  schemas: {
    events: {
      Export: Schema.toStandardSchemaV1(Schema.Void) // 👈 `void` from `effect`
```

The above example broke a few API types (e.g. `snapshot.can`).

This PR fixes the types so that `void` and `undefined` are treated at "type-only" e.g. `{ type: "Export" }` instead of `void & { type: "Export" }`