### PR TITLE
feat(core): Fix `matches` type narrowing (v6)

### DIFF
--- a/.changeset/clean-snapshot-matches.md
+++ b/.changeset/clean-snapshot-matches.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Fix `snapshot.matches(...)` narrowing so repeated checks like `snapshot.matches('loaded') || snapshot.matches('failed')` compile correctly.
+Fix `snapshot.matches(...)` narrowing so repeated checks like `snapshot.matches('loaded') || snapshot.matches('failed')` compile correctly, and make `StateFrom<typeof machine>` preserve the machine's concrete state value.

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -11,6 +11,7 @@ import type {
   MachineContext,
   StateConfig,
   StateValue,
+  StateValueMap,
   AnyActorRef,
   Snapshot,
   MetaObject,
@@ -44,10 +45,12 @@ type MatchingObjectStateValue<
     [K in keyof TTestStateValue]: K extends keyof TStateValue
       ? NonNullable<TStateValue[K]> extends StateValue
         ? NonNullable<TTestStateValue[K]> extends StateValue
-          ? MatchingStateValue<
-              NonNullable<TStateValue[K]>,
-              NonNullable<TTestStateValue[K]>
-            > extends never
+          ? [
+              MatchingStateValue<
+                NonNullable<TStateValue[K]>,
+                NonNullable<TTestStateValue[K]>
+              >
+            ] extends [never]
             ? false
             : true
           : false
@@ -55,7 +58,14 @@ type MatchingObjectStateValue<
       : false;
   }>
     ? never
-    : TStateValue;
+    : {
+        [K in keyof TStateValue]: K extends keyof TTestStateValue
+          ? MatchingStateValue<
+              NonNullable<TStateValue[K]>,
+              NonNullable<TTestStateValue[K]>
+            >
+          : TStateValue[K];
+      };
 
 type MatchingStateValue<
   TStateValue extends StateValue,
@@ -64,30 +74,21 @@ type MatchingStateValue<
   ? TStateValue
   : string extends TTestStateValue
     ? TStateValue
-    : TTestStateValue extends string
-      ? TStateValue extends TTestStateValue
-        ? TStateValue
-        : TStateValue extends Record<string, unknown>
-          ? TTestStateValue extends keyof TStateValue
-            ? TStateValue
+    : TStateValue extends unknown
+      ? TTestStateValue extends string
+        ? TStateValue extends string
+          ? TTestStateValue extends TStateValue
+            ? TTestStateValue
+            : Extract<TStateValue, TTestStateValue>
+          : TStateValue extends Record<string, unknown>
+            ? TStateValue & Record<TTestStateValue, StateValue | undefined>
+            : never
+        : TTestStateValue extends Record<string, unknown>
+          ? TStateValue extends Record<string, unknown>
+            ? MatchingObjectStateValue<TStateValue, TTestStateValue>
             : never
           : never
-      : TTestStateValue extends Record<string, unknown>
-        ? TStateValue extends Record<string, unknown>
-          ? MatchingObjectStateValue<TStateValue, TTestStateValue>
-          : never
-        : never;
-
-type NarrowStateValue<TStateValue extends StateValue> =
-  StateValue extends TStateValue
-    ? never
-    : string extends TStateValue
-      ? never
-      : TStateValue extends Record<string, unknown>
-        ? string extends keyof TStateValue
-          ? never
-          : TStateValue
-        : TStateValue;
+      : never;
 
 let emptyCanActor: AnyActor | undefined;
 let emptyCanActorScope: AnyActorScope | undefined;
@@ -171,8 +172,22 @@ interface MachineSnapshotBase<
    *
    * @param partialStateValue
    */
-  matches<const TTestStateValue extends StateValue>(
-    partialStateValue: TTestStateValue & NarrowStateValue<TTestStateValue>
+  matches<const TTestStateValue extends string>(
+    partialStateValue: TTestStateValue,
+    ...args: string extends TTestStateValue ? [never] : []
+  ): this is MachineSnapshot<
+    StateContextFromStateValue<TStateSchema, TContext, TTestStateValue>,
+    TEvent,
+    TChildren,
+    MatchingStateValue<TStateValue, TTestStateValue>,
+    TTag,
+    _TOutput,
+    TMeta,
+    TStateSchema
+  >;
+  matches<const TTestStateValue extends StateValueMap>(
+    partialStateValue: TTestStateValue,
+    ...args: string extends keyof TTestStateValue ? [never] : []
   ): this is MachineSnapshot<
     StateContextFromStateValue<TStateSchema, TContext, TTestStateValue>,
     TEvent,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1222,10 +1222,142 @@ export type AnyHistoryValue = HistoryValue;
 export type StateFrom<
   T extends AnyStateMachine | ((...args: any[]) => AnyStateMachine)
 > = T extends AnyStateMachine
-  ? SnapshotFrom<T>
+  ? StateSnapshotFromMachine<T>
   : T extends (...args: any[]) => AnyStateMachine
-    ? SnapshotFrom<ReturnType<T>>
+    ? StateSnapshotFromMachine<ReturnType<T>>
     : never;
+
+type StateValueFromStateSchema<T extends StateSchema> = StateSchema extends T
+  ? StateValue
+  : ToStateValue<T> extends infer TStateValue
+    ? TStateValue extends StateValue
+      ? TStateValue
+      : StateValue
+    : StateValue;
+
+type MatchingStateValueForStateFrom<
+  TStateValue extends StateValue,
+  TTestStateValue extends StateValue
+> = TStateValue extends unknown
+  ? TTestStateValue extends string
+    ? TStateValue extends string
+      ? TTestStateValue extends TStateValue
+        ? TTestStateValue
+        : Extract<TStateValue, TTestStateValue>
+      : TStateValue extends StateValueMap
+        ? TStateValue & Record<TTestStateValue, StateValue | undefined>
+        : never
+    : TTestStateValue extends StateValueMap
+      ? TStateValue extends StateValueMap
+        ? MatchingStateValueMapForStateFrom<TStateValue, TTestStateValue>
+        : never
+      : never
+  : never;
+
+type MatchingStateValueMapForStateFrom<
+  TStateValue extends StateValueMap,
+  TTestStateValue extends StateValueMap
+> = false extends {
+  [K in keyof TTestStateValue & string]: K extends keyof TStateValue
+    ? IsNever<
+        MatchingStateValueForStateFrom<
+          NonNullable<TStateValue[K]>,
+          NonNullable<TTestStateValue[K]>
+        >
+      > extends true
+      ? false
+      : true
+    : false;
+}[keyof TTestStateValue & string]
+  ? never
+  : {
+      [K in keyof TStateValue]: K extends keyof TTestStateValue
+        ? MatchingStateValueForStateFrom<
+            NonNullable<TStateValue[K]>,
+            NonNullable<TTestStateValue[K]>
+          >
+        : TStateValue[K];
+    };
+
+type StateSnapshotFromStateValue<
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  TChildren extends Record<string, AnyActorRef | undefined>,
+  TStateValue extends StateValue,
+  TTag extends string,
+  TOutput,
+  TMeta extends MetaObject,
+  TStateSchema extends StateSchema,
+  TAllStateValue extends StateValue = TStateValue
+> = TStateValue extends unknown
+  ? Omit<
+      MachineSnapshot<
+        StateContextFromStateValue<TStateSchema, TContext, TStateValue>,
+        TEvent,
+        TChildren,
+        TStateValue,
+        TTag,
+        TOutput,
+        TMeta,
+        TStateSchema
+      >,
+      'matches'
+    > & {
+      matches<const TTestStateValue extends string>(
+        partialStateValue: TTestStateValue,
+        ...args: string extends TTestStateValue ? [never] : []
+      ): this is StateSnapshotFromStateValue<
+        StateContextFromStateValue<TStateSchema, TContext, TTestStateValue>,
+        TEvent,
+        TChildren,
+        MatchingStateValueForStateFrom<TAllStateValue, TTestStateValue>,
+        TTag,
+        TOutput,
+        TMeta,
+        TStateSchema,
+        TAllStateValue
+      >;
+      matches<const TTestStateValue extends StateValueMap>(
+        partialStateValue: TTestStateValue,
+        ...args: string extends keyof TTestStateValue ? [never] : []
+      ): this is StateSnapshotFromStateValue<
+        StateContextFromStateValue<TStateSchema, TContext, TTestStateValue>,
+        TEvent,
+        TChildren,
+        MatchingStateValueForStateFrom<TAllStateValue, TTestStateValue>,
+        TTag,
+        TOutput,
+        TMeta,
+        TStateSchema,
+        TAllStateValue
+      >;
+      matches(partialStateValue: StateValue): boolean;
+    }
+  : never;
+
+type StateSnapshotFromMachine<T extends AnyStateMachine> =
+  SnapshotFrom<T> extends MachineSnapshot<
+    infer TContext,
+    infer TEvent,
+    infer TChildren,
+    infer _TStateValue,
+    infer TTag,
+    infer TOutput,
+    infer TMeta,
+    infer TStateSchema
+  >
+    ? StateSnapshotFromStateValue<
+        TContext,
+        TEvent,
+        TChildren,
+        StateValueFromStateSchema<TStateSchema>,
+        TTag,
+        TOutput,
+        TMeta,
+        TStateSchema,
+        StateValueFromStateSchema<TStateSchema>
+      >
+    : SnapshotFrom<T>;
 
 export interface DoneActorEvent<TOutput = unknown, TId extends string = string>
   extends EventObject {
@@ -2519,7 +2651,7 @@ type _GroupStateKeys<
     ? [never, never]
     : T extends { type: 'parallel' }
       ? [S, never]
-      : 'states' extends keyof T['states'][S]
+      : T['states'][S] extends { states: Record<string, StateSchema> }
         ? [S, never]
         : [never, S]
   : never;

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1,6 +1,8 @@
 import z from 'zod';
 import { setup, createActor, types } from '../src/index.ts';
 import type {
+  IsAny,
+  StateFrom,
   StateContextFromStateValue,
   StateSchemaFrom
 } from '../src/types.ts';
@@ -1299,6 +1301,113 @@ describe('setup', () => {
       // @ts-expect-error - matched success context should not be nullable
       snapshot.context.user satisfies null;
     }
+    expect(true).toBe(true);
+  });
+
+  it('snapshot matches should allow chained checks for states sharing the same context', () => {
+    const sameContextMachine = setup({
+      states: {
+        Loading: {},
+        InvalidRoute: {},
+        Ready: {
+          schemas: {
+            context: types<{ data: 'value' }>()
+          }
+        }
+      }
+    }).createMachine({
+      initial: 'Loading',
+      states: {
+        Loading: {},
+        InvalidRoute: {},
+        Ready: {}
+      }
+    });
+
+    type SameContextSnapshot = StateFrom<typeof sameContextMachine>;
+    type SameContextValue = SameContextSnapshot['value'];
+    false satisfies IsAny<SameContextValue>;
+    'Ready' satisfies SameContextValue;
+    // @ts-expect-error - unknown states should not be part of this machine's state value
+    'Other' satisfies SameContextValue;
+
+    function chainedSameContext(snapshot: SameContextSnapshot) {
+      if (snapshot.matches('Loading') || snapshot.matches('InvalidRoute')) {
+        return true;
+      }
+
+      snapshot.value satisfies 'Ready';
+      type Data = typeof snapshot.context.data;
+      false satisfies IsAny<Data>;
+      snapshot.context.data satisfies 'value';
+
+      return snapshot.context.data;
+    }
+
+    chainedSameContext(
+      sameContextMachine.resolveState({
+        value: 'Ready',
+        context: { data: 'value' }
+      }) as SameContextSnapshot
+    );
+    expect(true).toBe(true);
+  });
+
+  it('snapshot matches should narrow context for nested state values', () => {
+    const nestedMachine = setup({
+      states: {
+        Flow: {
+          states: {
+            Loading: {},
+            InvalidRoute: {},
+            Ready: {
+              schemas: {
+                context: types<{ data: 'nested-value' }>()
+              }
+            }
+          }
+        }
+      }
+    }).createMachine({
+      initial: 'Flow',
+      states: {
+        Flow: {
+          initial: 'Loading',
+          states: {
+            Loading: {},
+            InvalidRoute: {},
+            Ready: {}
+          }
+        }
+      }
+    });
+
+    type NestedSnapshot = StateFrom<typeof nestedMachine>;
+    type NestedValue = NestedSnapshot['value'];
+    false satisfies IsAny<NestedValue>;
+    ({ Flow: 'Ready' }) satisfies NestedValue;
+    // @ts-expect-error - unknown nested states should not be part of this machine's state value
+    ({ Flow: 'Other' }) satisfies NestedValue;
+
+    function nestedReady(snapshot: NestedSnapshot) {
+      if (snapshot.matches({ Flow: 'Ready' })) {
+        snapshot.value satisfies { Flow: 'Ready' };
+        type Data = typeof snapshot.context.data;
+        false satisfies IsAny<Data>;
+        snapshot.context.data satisfies 'nested-value';
+
+        return snapshot.context.data;
+      }
+
+      return true;
+    }
+
+    nestedReady(
+      nestedMachine.resolveState({
+        value: { Flow: 'Ready' },
+        context: { data: 'nested-value' }
+      }) as NestedSnapshot
+    );
     expect(true).toBe(true);
   });
 

--- a/packages/xstate-react/test/useActor.test.tsx
+++ b/packages/xstate-react/test/useActor.test.tsx
@@ -7,7 +7,7 @@ import {
   Actor,
   ActorRef,
   Snapshot,
-  StateFrom,
+  SnapshotFrom,
   createActor,
   createMachine
 } from 'xstate';
@@ -829,7 +829,7 @@ describeEachReactMode('useActor (%s)', ({ suiteKey, render }) => {
     const persistedState = JSON.stringify(actorRef.getPersistedSnapshot());
     actorRef.stop();
 
-    let currentState: StateFrom<typeof testMachine>;
+    let currentState: SnapshotFrom<typeof testMachine>;
 
     const Test = () => {
       const [state, send] = useActor(testMachine, {

--- a/packages/xstate-react/test/useSelector.test.tsx
+++ b/packages/xstate-react/test/useSelector.test.tsx
@@ -8,7 +8,7 @@ import {
   createLogic,
   createAsyncLogic,
   createActor,
-  StateFrom,
+  SnapshotFrom,
   LogicSnapshot,
   createMachine,
   setup,
@@ -362,7 +362,7 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
         childActor: spawn(childMachine)
       })
     });
-    const selector = (state: StateFrom<typeof childMachine>) =>
+    const selector = (state: SnapshotFrom<typeof childMachine>) =>
       state.context.count;
 
     const App = () => {

--- a/packages/xstate-solid/test/selector.test.tsx
+++ b/packages/xstate-solid/test/selector.test.tsx
@@ -4,7 +4,7 @@ import { fireEvent, render, screen } from '@solidjs/testing-library';
 import {
   ActorRefFrom,
   AnyMachineSnapshot,
-  StateFrom,
+  SnapshotFrom,
   createMachine
 } from 'xstate';
 import { useActorRef, useMachine, fromActorRef } from '../src/index.ts';
@@ -36,8 +36,8 @@ describe('usage of selectors with reactive service state', () => {
       const service = useActorRef(machine);
       const serviceState = from(service);
 
-      const selector = (state: StateFrom<typeof machine> | undefined) =>
-        (state as any)?.context.count;
+      const selector = (state: SnapshotFrom<typeof machine> | undefined) =>
+        state?.context.count;
       rerenders++;
 
       return (


### PR DESCRIPTION
## Summary
Previously chaning `matches` would sometimes make the value type collapse. Furthermore, the types were not narrowing the state-specific `context`:
```ts
const sameContextMachine = setup({
  states: {
    Loading: {},
    InvalidRoute: {},
    Ready: {
      schemas: {
        context: types<{ data: 'value' }>()
      }
    }
  }
}).createMachine({
  initial: 'Loading',
  states: {
    Loading: {},
    InvalidRoute: {},
    Ready: {}
  }
});

function chainedSameContext(snapshot: SameContextSnapshot) {
  // Error on `InvalidRoute` typing
  if (snapshot.matches('Loading') || snapshot.matches('InvalidRoute')) {
    return true;
  }
  
  // `data` typed as `any`
  return snapshot.context.data;
}
```

With this new change, both those issues are fixed.
