### PR TITLE
feat(core): Fix typed `trigger` on spawned actors (v6)

### DIFF
--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -26,6 +26,7 @@ let executingCustomAction: boolean = false;
 
 import type {
   ActorScope,
+  ActorTrigger,
   AnyActor,
   AnyActorLogic,
   EmittedFrom,
@@ -186,19 +187,7 @@ export class Actor<TLogic extends AnyActorLogic>
   /** The system to which this actor belongs. */
   public system: AnyActorSystem;
 
-  public trigger: {
-    [K in SendableEventFromLogic<TLogic>['type']]: {} extends Omit<
-      Extract<SendableEventFromLogic<TLogic>, { type: K }>,
-      'type'
-    >
-      ? () => void
-      : (
-          payload: Omit<
-            Extract<SendableEventFromLogic<TLogic>, { type: K }>,
-            'type'
-          >
-        ) => void;
-  };
+  public trigger: ActorTrigger<SendableEventFromLogic<TLogic>>;
 
   public src: string | AnyActorLogic;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1645,6 +1645,17 @@ export interface ActorRef<
   ) => Subscription;
 }
 
+type EventPayload<
+  TEvent extends EventObject,
+  TType extends TEvent['type']
+> = HomomorphicOmit<ExtractEvent<TEvent, TType>, 'type'>;
+
+export type ActorTrigger<TEvent extends EventObject> = {
+  [K in TEvent['type']]: {} extends EventPayload<TEvent, K>
+    ? () => void
+    : (payload: EventPayload<TEvent, K>) => void;
+};
+
 /**
  * Runtime-only actor capabilities.
  *
@@ -1656,7 +1667,8 @@ export interface ActorRef<
 export interface ActorRuntime<
   TSnapshot extends Snapshot<unknown>,
   TEvent extends EventObject,
-  _TEmitted extends EventObject = EventObject
+  _TEmitted extends EventObject = EventObject,
+  TSendEvent extends EventObject = TEvent
 > {
   /** The unique identifier for this actor relative to its parent. */
   id: string;
@@ -1678,7 +1690,7 @@ export interface ActorRuntime<
   /** @internal */
   _processingStatus: ProcessingStatus;
   src: string | AnyActorLogic;
-  trigger: any;
+  trigger: ActorTrigger<TSendEvent>;
   select<TSelected>(
     selector: (snapshot: TSnapshot) => TSelected,
     equalityFn?: (a: TSelected, b: TSelected) => boolean
@@ -1697,7 +1709,7 @@ export interface ActorInstance<
   TEvent extends EventObject,
   TEmitted extends EventObject = EventObject,
   TSendEvent extends EventObject = TEvent
-> extends ActorRuntime<TSnapshot, TEvent, TEmitted>,
+> extends ActorRuntime<TSnapshot, TEvent, TEmitted, TSendEvent>,
     ActorRef<TSnapshot, TEvent, TEmitted, TSendEvent> {}
 
 /**
@@ -1712,7 +1724,7 @@ export type ActorSelf<
   TEvent extends EventObject,
   TEmitted extends EventObject = EventObject,
   TSendEvent extends EventObject = TEvent
-> = ActorRuntime<TSnapshot, TEvent, TEmitted> &
+> = ActorRuntime<TSnapshot, TEvent, TEmitted, TSendEvent> &
   ActorRef<TSnapshot, TEvent, TEmitted, TSendEvent>;
 
 // TODO: in v6, this should only accept AnyActorLogic, like ActorRefFromLogic

--- a/packages/core/test/spawn.types.test.ts
+++ b/packages/core/test/spawn.types.test.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { createMachine } from '../src';
+import {
+  createLogic,
+  createMachine,
+  type ActorRefFromLogic,
+  type Spawner
+} from '../src';
 
 describe('spawn inside machine', () => {
   it('input is required when defined in actor', () => {
@@ -57,6 +62,72 @@ describe('spawn inside machine', () => {
             })
           }
         }
+      }
+    });
+  });
+
+  it('preserves typed trigger API on spawned actors', () => {
+    const childMachine = createMachine({
+      schemas: {
+        events: {
+          PING: z.object({
+            value: z.string()
+          }),
+          RESET: z.object({})
+        }
+      }
+    });
+    const optionalPayloadLogic = createLogic<
+      {},
+      unknown,
+      { type: 'SEARCH'; query?: string } | { type: 'SAVE'; value: string }
+    >({
+      context: {},
+      run: () => {}
+    });
+
+    function _expectTypedSpawner(spawn: Spawner) {
+      const childRef = spawn(childMachine);
+      const optionalPayloadRef = spawn(optionalPayloadLogic);
+
+      childRef.trigger.PING({ value: 'ok' });
+      childRef.trigger.RESET();
+      optionalPayloadRef.trigger.SEARCH();
+      optionalPayloadRef.trigger.SAVE({ value: 'ok' });
+
+      // @ts-expect-error payload event requires a payload
+      childRef.trigger.PING();
+      // @ts-expect-error invalid payload
+      childRef.trigger.PING({ value: 42 });
+      // @ts-expect-error type-only event does not accept a payload
+      childRef.trigger.RESET({});
+      // @ts-expect-error required payload event still requires a payload
+      optionalPayloadRef.trigger.SAVE();
+
+      const actorRef: ActorRefFromLogic<typeof childMachine> = childRef;
+      // @ts-expect-error ActorRef is the narrow public interface
+      actorRef.trigger.PING({ value: 'ok' });
+    }
+    void _expectTypedSpawner;
+
+    createMachine({
+      entry: (_, enq) => {
+        const childRef = enq.spawn(childMachine);
+        const optionalPayloadRef = enq.spawn(optionalPayloadLogic);
+
+        childRef.trigger.PING({ value: 'ok' });
+        childRef.trigger.RESET();
+        optionalPayloadRef.trigger.SEARCH();
+        optionalPayloadRef.trigger.SAVE({ value: 'ok' });
+
+        // @ts-expect-error payload event requires a payload
+        childRef.trigger.PING();
+        // @ts-expect-error invalid payload
+        childRef.trigger.PING({ value: 42 });
+        // @ts-expect-error type-only event does not accept a payload
+        childRef.trigger.RESET({});
+        // @ts-expect-error required payload event still requires a payload
+        optionalPayloadRef.trigger.SAVE();
       }
     });
   });

--- a/packages/xstate-react/test/useSelector.test.tsx
+++ b/packages/xstate-react/test/useSelector.test.tsx
@@ -3,13 +3,16 @@ import * as React from 'react';
 import {
   ActorRef,
   ActorRefFrom,
+  ActorFromLogic,
   AnyMachineSnapshot,
   createLogic,
   createAsyncLogic,
   createActor,
   StateFrom,
   LogicSnapshot,
-  createMachine
+  createMachine,
+  setup,
+  types
 } from 'xstate';
 import {
   shallowEqual,
@@ -387,6 +390,100 @@ describeEachReactMode('useSelector (%s)', ({ suiteKey, render }) => {
     expect(countEl.textContent).toEqual('0');
     fireEvent.click(buttonEl);
     expect(countEl.textContent).toEqual('1');
+  });
+
+  it('can call trigger on a spawned actor passed to a child component', () => {
+    const todoMachine = setup({
+      schemas: {
+        context: types<{
+          label: string;
+          done: boolean;
+        }>(),
+        events: {
+          rename: types<{ value: string }>(),
+          toggle: types<{}>()
+        }
+      }
+    }).createMachine({
+      context: {
+        label: 'Draft',
+        done: false
+      },
+      on: {
+        rename: ({ context, event }) => ({
+          context: {
+            ...context,
+            label: event.value
+          }
+        }),
+        toggle: ({ context }) => ({
+          context: {
+            ...context,
+            done: !context.done
+          }
+        })
+      }
+    });
+
+    type TodoActor = ActorFromLogic<typeof todoMachine>;
+
+    const parentMachine = setup({
+      schemas: {
+        context: types<{
+          todo: TodoActor | undefined;
+        }>()
+      },
+      actorSources: {
+        todo: todoMachine
+      }
+    }).createMachine({
+      context: {
+        todo: undefined
+      },
+      entry: ({ actorSources }, enq) => ({
+        context: {
+          todo: enq.spawn(actorSources.todo)
+        }
+      })
+    });
+
+    function Parent() {
+      const [state] = useMachine(parentMachine);
+      const todo = state.context.todo;
+
+      if (!todo) {
+        return null;
+      }
+
+      return <TodoItem actor={todo} />;
+    }
+
+    function TodoItem({ actor }: { actor: TodoActor }) {
+      const todo = useSelector(actor, (state) => state.context);
+
+      return (
+        <>
+          <div data-testid="label">{todo.label}</div>
+          <div data-testid="done">{String(todo.done)}</div>
+          <button
+            data-testid="rename"
+            onClick={() => actor.trigger.rename({ value: 'Buy milk' })}
+          />
+          <button data-testid="toggle" onClick={() => actor.trigger.toggle()} />
+        </>
+      );
+    }
+
+    render(<Parent />);
+
+    expect(screen.getByTestId('label').textContent).toBe('Draft');
+    expect(screen.getByTestId('done').textContent).toBe('false');
+
+    fireEvent.click(screen.getByTestId('rename'));
+    expect(screen.getByTestId('label').textContent).toBe('Buy milk');
+
+    fireEvent.click(screen.getByTestId('toggle'));
+    expect(screen.getByTestId('done').textContent).toBe('true');
   });
 
   it('should immediately render snapshot of initially spawned custom actor', () => {


### PR DESCRIPTION
## Summary
`trigger` was not strongly typed inside a spawned child actor, which prevented to use it when the actor was passed as parameter with `ActorFromLogic`.

This changes fixes that, so that the below example works:
```tsx
import { setup, types, type ActorFromLogic } from 'xstate';
import { useMachine } from '@xstate/react';

const todoMachine = setup({
  schemas: {
    events: {
      rename: types<{ value: string }>(),
      toggle: types<{}>()
    }
  }
}).createMachine({});

type TodoActor = ActorFromLogic<typeof todoMachine>;

const parentMachine = setup({
  schemas: {
    context: types<{
      todo: TodoActor | undefined;
    }>()
  },
  actorSources: {
    todo: todoMachine
  }
}).createMachine({
  context: {
    todo: undefined
  },
  entry: ({ actorSources }, enq) => ({
    context: {
      // Spawned child actor
      todo: enq.spawn(actorSources.todo)
    }
  })
});

function Parent() {
  const [snapshot] = useMachine(parentMachine);
  const todo = snapshot.context.todo;

  if (!todo) {
    return null;
  }

  // Pass the child actor with `ActorFromLogic`
  return <TodoItem actor={todo} />;
}

// The `trigger` API is still intact
function TodoItem({ actor }: { actor: TodoActor }) {
  actor.trigger.rename({ value: 'Buy milk' });
  actor.trigger.toggle();

  // @ts-expect-error rename requires a string payload
  actor.trigger.rename({ value: 123 });

  // @ts-expect-error toggle does not accept a payload
  actor.trigger.toggle({ value: true });

  return null;
}
```