### PR TITLE
ci: use a PAT for the changesets version step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,12 @@ jobs:
         uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           version: pnpm run version
+        env:
+          # Use a PAT instead of the default github.token: the ephemeral App
+          # installation token makes @changesets/changelog-github's GraphQL call
+          # to api.github.com truncate (ERR_STREAM_PREMATURE_CLOSE), failing
+          # changelog generation in the Version job.
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_PAT }}
 
   publish:
     name: Publish


### PR DESCRIPTION
## Problem

The **Version** job in `publish.yml` has been failing on every push since a changeset reappeared after the last release, with:

```
🦋  error FetchError: Invalid response body while trying to fetch
    https://api.github.com/graphql: Premature close
    at Gunzip.<anonymous> (.../node-fetch/lib/index.js:217:52)
    ... ERR_STREAM_PREMATURE_CLOSE
```

`changeset version` calls `@changesets/changelog-github`, which hits the GitHub GraphQL API to resolve PR/author info. That response truncates at the gzip layer **only on the runner** — it reproduces never locally.

## Diagnosis

- GitHub API is operational; the data fetches fine via other clients.
- A **valid token is present** in CI (the error is a transport-level truncation, not `Bad credentials` or the "create a token" message). `changesets/action` injects `github.token` into the version subprocess.
- The full `changeset version` command + the exact `getInfo` call succeed locally on **both Node 24 (CI's version) and Node 25**, with a personal token, every time.
- The breakage correlates with #5517 (workflow recreated) / #5527 (CI hardening). The one variable that can't be reproduced off-runner is the **token type**: CI uses the ephemeral `github.token` (a GitHub App installation token); locally a classic PAT works.

Switching the changesets step to a dedicated PAT is the standard remedy for `@changesets/get-github-info` GraphQL flakiness with the default token.

## Change

Add `env.GITHUB_TOKEN: ${{ secrets.CHANGESETS_PAT }}` to the "Create or update release pull request" step.

## ⚠️ Required before merge

Create a repo secret **`CHANGESETS_PAT`** — a classic PAT with `repo` + `read:user` scopes. Without the secret the token is empty and the step will fail with a clear "create a token" error.

## Note

This is the **leading hypothesis**, not a runner-verified fix (the App-token path can't be reproduced locally). The current release (`@xstate/store@4.2.1`) was already shipped by running `changeset version` locally and pushing, which sidesteps the changelog GraphQL call entirely.