### PR TITLE
fix(core): Pass input from function-syntax transitions to entry actions

### DIFF
--- a/.changeset/fix-fn-transition-input.md
+++ b/.changeset/fix-fn-transition-input.md
@@ -1,0 +1,16 @@
+---
+'xstate': patch
+---
+
+Fix function-syntax transitions not passing `input` to target state entry actions.
+
+```ts
+on: {
+  FETCH: ({ context, event }) => ({
+    target: 'fetching',
+    input: { url: event.url, token: context.authToken }
+  });
+}
+```
+
+Previously, `input` returned from function-syntax transitions was silently ignored. Now it is correctly forwarded to the target state's `entry` action.

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1712,15 +1712,16 @@ export function getTransitionResult(
     const targets = res?.target
       ? resolveTarget(transition.source, toArray(res.target) as string[])
       : undefined;
-    // Resolve input for .to transitions
+
     const resolvedInput =
-      typeof transition.input === 'function'
+      res?.input ??
+      (typeof transition.input === 'function'
         ? transition.input({
             context: snapshot.context,
             event,
             output: getEventOutput(event)
           })
-        : transition.input;
+        : transition.input);
 
     return {
       targets: targets,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -555,6 +555,7 @@ export type TransitionConfigFunction<
   context?: Partial<_TCtx>;
   reenter?: boolean;
   meta?: TMeta;
+  input?: Record<string, unknown>;
 } | void;
 
 type TransitionFunctionArgs<

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -837,6 +837,49 @@ describe('setup', () => {
     expect(receivedInputs).toEqual([{ url: '/api/users', method: 'GET' }]);
   });
 
+  it('function-syntax transition should compute input from event and context', () => {
+    const receivedInputs: unknown[] = [];
+    const s = setup({
+      schemas: {
+        events: {
+          FETCH: types<{ url: string }>()
+        }
+      },
+      states: {
+        idle: {},
+        fetching: {
+          schemas: {
+            input: z.object({ url: z.string(), token: z.string() })
+          }
+        }
+      }
+    });
+
+    const machine = s.createMachine({
+      initial: 'idle',
+      context: { authToken: 'abc-123' },
+      states: {
+        idle: {
+          on: {
+            FETCH: ({ context, event }) => ({
+              target: 'fetching',
+              input: { url: event.url, token: context.authToken }
+            })
+          }
+        },
+        fetching: {
+          entry: ({ input }) => {
+            receivedInputs.push(input);
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'FETCH', url: '/api/users' });
+    expect(receivedInputs).toEqual([{ url: '/api/users', token: 'abc-123' }]);
+  });
+
   it('initial transition should accept input', () => {
     const entryInputs: unknown[] = [];
 


### PR DESCRIPTION
## Problem

When using function-syntax transitions that return an `input` property, the input was silently ignored — the target state's `entry` action received `input` as `undefined`.

**Object syntax (works):**
```ts
on: {
  FETCH: {
    target: 'fetching',
    input: ({ context, event }) => ({ url: event.url, token: context.authToken })
  }
}

fetching: {
  entry: ({ input }) => {
    console.log(input); // { url: '/api/users', token: 'abc-123' } ✅
  }
}
```

**Function syntax (broken):**
```ts
on: {
  FETCH: ({ context, event }) => ({
    target: 'fetching',
    input: { url: event.url, token: context.authToken }
  })
}

fetching: {
  entry: ({ input }) => {
    console.log(input); // undefined ❌
  }
}
```

The `input` returned by function-syntax transitions was never picked up — only the static `transition.input` from object-syntax was resolved.

## Fix

In `stateUtils.ts`, the resolved input now prefers `res?.input` (the value returned by the function-syntax transition) over the static `transition.input` fallback:

```ts
const resolvedInput = res?.input ??
  (typeof transition.input === 'function'
       ? transition.input({ context, event, output: getEventOutput(event) })
       : transition.input);
```

## Test plan

- [x] Added test: function-syntax transition computes `input` from event and context, and the target state's `entry` action receives it
- [x] Existing `stateInput` tests continue to pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5573" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->