### PR TITLE
fix(core): prevent 'systemId already exists' error in pure transition functions

### DIFF
--- a/.changeset/fix-pure-transition-systemid.md
+++ b/.changeset/fix-pure-transition-systemid.md
@@ -1,0 +1,26 @@
+---
+'xstate': patch
+---
+
+Fixed `initialTransition` (and `transition`) throwing `"Actor with system ID '...' already exists"` when the machine contains an `invoke` with a `systemId`.
+
+**Root cause:** `createInertActorScope` used `createActor(logic)` internally, which eagerly ran `getInitialSnapshot` during construction and registered any `systemId`-carrying child actors in the system. When the caller then ran `getInitialSnapshot` (or `transition`) via the returned scope, the same system was reused, causing the duplicate-registration error.
+
+**Fix:** After creating the internal actor, `createInertActorScope` now replaces the actor's system reference with a freshly-created system. Child actors spawned by the subsequent caller-driven `getInitialSnapshot` / `transition` invocation therefore register into a clean system with no pre-existing entries.
+
+```ts
+const machine = createMachine({
+  initial: 'idle',
+  states: {
+    idle: {
+      invoke: {
+        src: fromPromise(async () => 42),
+        systemId: 'myActor'  // previously caused: "Actor with system ID 'myActor' already exists"
+      }
+    }
+  }
+});
+
+// Now works correctly — returns [snapshot, actions] without throwing
+const [snapshot, actions] = initialTransition(machine);
+```

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -1,4 +1,5 @@
 import { createActor } from './createActor.ts';
+import { createSystem } from './system.ts';
 import {
   ActorScope,
   AnyActorLogic,
@@ -14,6 +15,18 @@ export function createInertActorScope<T extends AnyActorLogic>(
   actorLogic: T
 ): AnyActorScope {
   const self = createActor(actorLogic as AnyActorLogic);
+  // The Actor constructor eagerly calls `getInitialSnapshot` during `_initState`,
+  // which can register child actors with `systemId` in `self.system`.
+  // Replace `self.system` with a fresh system so that child actors spawned by
+  // the *caller's* explicit `getInitialSnapshot` / `transition` call register
+  // into a clean system and do not collide with those from the eager
+  // construction call.  This is what makes `initialTransition(machine)` safe
+  // even when invoked actors carry a `systemId`.
+  const freshSystem = createSystem(self, {
+    clock: self.system._clock,
+    logger: self.system._logger
+  });
+  (self as any).system = freshSystem;
   const inertActorScope: ActorScope<
     SnapshotFrom<T>,
     EventFromLogic<T>,
@@ -26,7 +39,7 @@ export function createInertActorScope<T extends AnyActorLogic>(
     logger: () => {},
     sessionId: '',
     stopChild: () => {},
-    system: self.system,
+    system: freshSystem,
     emit: () => {},
     actionExecutor: () => {}
   };

--- a/packages/core/test/issue5454.test.ts
+++ b/packages/core/test/issue5454.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createMachine,
+  initialTransition,
+  transition,
+  fromPromise,
+  fromTransition
+} from '../src';
+
+/**
+ * Regression tests for: Bug #5454
+ * `initialTransition` fails when invoke has `systemId`
+ *
+ * Root cause: `createInertActorScope` called `createActor(logic)` which
+ * eagerly ran `getInitialSnapshot` and registered child actors with `systemId`
+ * in the system. Then `initialTransition` called `getInitialSnapshot` again on
+ * the same system, causing "Actor with system ID '...' already exists".
+ */
+describe('initialTransition / transition with invoke systemId (issue #5454)', () => {
+  it('does not throw when the initial state has an invoke with systemId', () => {
+    const machine = createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          invoke: {
+            src: fromPromise(async () => 42),
+            systemId: 'myActor'
+          }
+        }
+      }
+    });
+
+    expect(() => initialTransition(machine)).not.toThrow();
+  });
+
+  it('returns the correct initial snapshot when invoke has systemId', () => {
+    const machine = createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          invoke: {
+            src: fromPromise(async () => 42),
+            systemId: 'myActor'
+          }
+        }
+      }
+    });
+
+    const [snapshot, actions] = initialTransition(machine);
+    expect(snapshot.value).toBe('idle');
+    expect(actions).toHaveLength(1); // the spawnChild action for the invoke
+  });
+
+  it('is idempotent: repeated calls do not throw', () => {
+    const machine = createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          invoke: {
+            src: fromPromise(async () => 42),
+            systemId: 'myActor'
+          }
+        }
+      }
+    });
+
+    expect(() => {
+      initialTransition(machine);
+      initialTransition(machine);
+      initialTransition(machine);
+    }).not.toThrow();
+  });
+
+  it('transition() does not throw when the target state has an invoke with systemId', () => {
+    const countMachine = fromTransition(
+      (s, e) => (e.type === 'INC' ? s + 1 : s),
+      0
+    );
+
+    const machine = createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: { START: 'running' }
+        },
+        running: {
+          invoke: {
+            src: countMachine,
+            systemId: 'counter'
+          }
+        }
+      }
+    });
+
+    const [initial] = initialTransition(machine);
+
+    expect(() => transition(machine, initial, { type: 'START' })).not.toThrow();
+  });
+
+  it('works with multiple invokes each having a distinct systemId', () => {
+    const machine = createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          invoke: [
+            {
+              src: fromPromise(async () => 1),
+              systemId: 'actorOne'
+            },
+            {
+              src: fromPromise(async () => 2),
+              systemId: 'actorTwo'
+            }
+          ]
+        }
+      }
+    });
+
+    expect(() => initialTransition(machine)).not.toThrow();
+    const [snapshot] = initialTransition(machine);
+    expect(snapshot.value).toBe('idle');
+  });
+});


### PR DESCRIPTION
Closes #5454

## Bug

`initialTransition(machine)` (and `transition()`) throws `"Actor with system ID 'myActor' already exists"` when the machine has an `invoke` with a `systemId`:

```ts
const machine = createMachine({
  initial: 'idle',
  states: {
    idle: {
      invoke: {
        src: fromPromise(async () => 42),
        systemId: 'myActor'   // ← causes the throw
      }
    }
  }
});

initialTransition(machine);  // Error: Actor with system ID 'myActor' already exists
```

## Root cause

`createInertActorScope` called `createActor(logic)` which eagerly ran `getInitialSnapshot` during the Actor constructor (`_initState`). This registered any `systemId`-carrying child actors in the newly-created `self.system`. When `initialTransition` then called `logic.getInitialSnapshot(actorScope, ...)` with `actorScope.system === self.system`, `resolveSpawn` tried to register a *new* child actor for the same `systemId` in the same system → collision.

## Fix

After constructing the inert actor in `createInertActorScope`, replace `self.system` with a fresh `createSystem(...)`. Child actors spawned by the caller's explicit `getInitialSnapshot` / `transition` invocation register into this clean system with no pre-existing keyed entries, so repeated or back-to-back calls no longer collide.

## Verification

New regression test in `packages/core/test/issue5454.test.ts` (5 cases, RED → GREEN):
- single `initialTransition` with `systemId` invoke
- correct snapshot value returned
- idempotent: three consecutive calls do not throw
- `transition()` to a state with a `systemId` invoke does not throw
- multiple invokes with distinct `systemId`s work

Full core test suite: **1732 passed, 0 failed** (`pnpm vitest run packages/core/test/`)