### PR TITLE
docs: add missing https:// protocol to Stately Studio link

### DIFF
--- a/.changeset/lemon-pillows-fix.md
+++ b/.changeset/lemon-pillows-fix.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: add missing `https://` protocol to the Stately Studio link in the READMEs so it no longer resolves as a relative GitHub URL

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ donutStore.send({ type: 'changeFlavor', flavor: 'strawberry' });
 - Deploy to Stately Sky
 - Generate & modify machines with Stately AI
 
-<a href="stately.ai/registry/new?ref=github" title="Stately Studio">
+<a href="https://stately.ai/registry/new?ref=github" title="Stately Studio">
   <img src="https://github.com/statelyai/xstate/assets/1093738/74ed9cbc-b824-4ed7-a16d-f104947af8a7" alt="XState Viz" width="800" />
 </a>
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -164,7 +164,7 @@ toggleActor.send({ type: 'TOGGLE' });
 - Deploy to Stately Sky
 - Generate & modify machines with Stately AI
 
-<a href="stately.ai/registry/new?ref=github" title="Stately Studio">
+<a href="https://stately.ai/registry/new?ref=github" title="Stately Studio">
   <img src="https://github.com/statelyai/xstate/assets/1093738/74ed9cbc-b824-4ed7-a16d-f104947af8a7" alt="XState Viz" width="800" />
 </a>
 


### PR DESCRIPTION
## What

The "Stately Studio" call-to-action image link is missing its URL scheme in two READMEs:

```html
<a href="stately.ai/registry/new?ref=github" title="Stately Studio">
```

Without `https://`, browsers and GitHub treat it as a **relative** URL, so on the rendered README it resolves to `https://github.com/statelyai/xstate/blob/main/stately.ai/registry/new?ref=github` instead of the Stately registry. The same `packages/core/README.md` also ships as the `xstate` package page on npm.

The intended target is confirmed a few lines below in the same files, where the link is already written correctly:

```md
**[state.new](https://stately.ai/registry/new?ref=github)**
```

## Fix

Add the missing `https://` in:

- `README.md`
- `packages/core/README.md`

## Notes

- Docs-only change. I added an empty changeset (no version bump). Happy to switch it to a `patch` for `xstate` if you'd prefer the corrected link to ship to the npm package README on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)