### PR TITLE
ci: pin Node to 24.16.0 (fix changesets ERR_STREAM_PREMATURE_CLOSE)

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -6,10 +6,14 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
 
-    - name: Use Node.js 24.x
+    - name: Use Node.js
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
-        node-version: 24.x
+        # Pinned: Node 24.17.0 regressed node-fetch@2's gzip handling, making
+        # @changesets/changelog-github's GraphQL call fail with
+        # ERR_STREAM_PREMATURE_CLOSE. 24.16.0 is the last known-good 24.x.
+        # https://github.com/changesets/changesets/issues/2115
+        node-version: 24.16.0
         cache: 'pnpm'
         registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
## Problem

The **Version** job in `publish.yml` fails whenever a changeset is present, during changelog generation:

```
🦋  error FetchError: Invalid response body while trying to fetch
    https://api.github.com/graphql: Premature close   (ERR_STREAM_PREMATURE_CLOSE)
    at Gunzip.<anonymous> (.../node-fetch/lib/index.js:217:52)
```

## Root cause — Node 24.17.0

`@changesets/changelog-github` → `@changesets/get-github-info` uses `node-fetch@2`, whose gzip handling regressed in **Node 24.17.0**. `ci-setup` requested the floating `node-version: 24.x`, which the runner resolved to **24.17.0**.

Reproduced locally against the exact `getInfo` call:

| Node | Result |
|---|---|
| 24.14.1 | ✅ |
| 24.16.0 | ✅ (6/6) |
| **24.17.0** | ❌ intermittent `ERR_STREAM_PREMATURE_CLOSE` |
| 25.9.0 | ✅ |
| 26.3.1 | ❌ (per upstream issue) |

Upstream: https://github.com/changesets/changesets/issues/2115

## Fix

Pin `ci-setup` to **24.16.0**, the last known-good 24.x. Exact pin (not `24.x`) so CI can't float back into a broken patch.

## Notes
- `@xstate/store@4.2.1` was already shipped manually (ran `changeset version` locally on good Node, pushed) to unblock — this prevents recurrence on the next changeset-bearing release.
- Bump deliberately once a fixed 24.x ships.