### PR TITLE
[@xstate/store] Allow partial store context updates

### DIFF
--- a/.changeset/fresh-context-patches.md
+++ b/.changeset/fresh-context-patches.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': minor
+---
+
+Store transitions may now return partial context updates. For discriminated union contexts, returned updates must still satisfy the context type when applied.

--- a/packages/xstate-store/src/fromStore.ts
+++ b/packages/xstate-store/src/fromStore.ts
@@ -14,6 +14,7 @@ import {
   InferSchemaPayloadMap,
   ResolveStoreContext,
   ResolveStoreEmittedPayloadMap,
+  StoreContextUpdate,
   StoreSchemas,
   StandardSchemaMap
 } from './types.ts';
@@ -49,7 +50,7 @@ type InferredFromStoreTransitions<
       FromStoreEmittedEvents<TEmittedPayloadMap, TEmittedSchemaMap>,
       InferredEventPayloadMap<TTransitions>
     >
-  ) => ResolveStoreContext<TContext, TContextSchema> | void
+  ) => StoreContextUpdate<ResolveStoreContext<TContext, TContextSchema>> | void
 >;
 
 type InferredEventPayloadMap<

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -16,6 +16,7 @@ import {
   StoreConfig,
   StoreEffect,
   StoreEffectEnqueue,
+  StoreContextUpdate,
   StoreInspectionEvent,
   StoreProducerAssigner,
   StoreSnapshot,
@@ -799,7 +800,7 @@ export function createStoreTransition<
       const currentContext = currentSnapshot.context;
       const assigner = transitions?.[currentEvent.type as StoreEvent['type']];
       let producerAssignerResult: unknown;
-      let assignerResult: TContext | void = undefined;
+      let assignerResult: StoreContextUpdate<TContext> | void = undefined;
       const effectsLength = effects.length;
 
       if (!assigner) {
@@ -833,13 +834,15 @@ export function createStoreTransition<
               enqueue
             )) === undefined
           ? currentContext
-          : assignerResult;
+          : assignerResult === currentContext
+            ? currentContext
+            : { ...currentContext, ...assignerResult };
 
-      if (isPromiseLike(producer ? producerAssignerResult : nextContext)) {
+      if (isPromiseLike(producer ? producerAssignerResult : assignerResult)) {
         ignorePromiseRejection(
           (producer
             ? producerAssignerResult
-            : nextContext) as PromiseLike<unknown>
+            : assignerResult) as PromiseLike<unknown>
         );
         throw new Error(UNSUPPORTED_ASYNC_TRANSITION_ERROR);
       }

--- a/packages/xstate-store/src/types.ts
+++ b/packages/xstate-store/src/types.ts
@@ -158,6 +158,71 @@ export type StoreEffect<TEmitted extends EventObject> =
   | ((enq?: StoreEffectEnqueue<any, any>) => void)
   | TEmitted;
 
+export type StoreContextUpdate<TContext extends StoreContext> =
+  IsAny<TContext> extends true
+    ? TContext
+    : IsUnion<TContext> extends true
+      ? StoreUnionContextUpdate<TContext>
+      : Partial<TContext>;
+
+type StoreUnionContextUpdate<
+  TContext extends StoreContext,
+  TFullContext extends StoreContext = TContext
+> =
+  | TFullContext
+  | Partial<Pick<TFullContext, SafeStoreContextUpdateKeys<TFullContext>>>
+  | (TContext extends any
+      ? StoreContextPatchForVariant<TFullContext, TContext>
+      : never);
+
+type StoreContextPatchForVariant<
+  TFullContext extends StoreContext,
+  TVariant extends StoreContext
+> = Compute<
+  Partial<TVariant> &
+    Pick<
+      TVariant,
+      Extract<
+        RequiredStoreContextUpdateKeys<TFullContext, TVariant>,
+        keyof TVariant
+      >
+    >
+>;
+
+type RequiredStoreContextUpdateKeys<TContext, TTargetContext> = {
+  [K in keyof TTargetContext]-?: K extends keyof TContext
+    ? [TContext[K]] extends [TTargetContext[K]]
+      ? never
+      : K
+    : K;
+}[keyof TTargetContext];
+
+type SafeStoreContextUpdateKeys<
+  TContext extends StoreContext,
+  TFullContext extends StoreContext = TContext
+> = {
+  [K in keyof TContext & keyof TFullContext]-?: false extends (
+    TContext extends any
+      ? Compute<Omit<TContext, K> & Pick<TFullContext, K>> extends TFullContext
+        ? true
+        : false
+      : never
+  )
+    ? never
+    : K;
+}[keyof TContext & keyof TFullContext];
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type IsUnion<T, U = T> =
+  IsAny<T> extends true
+    ? false
+    : T extends any
+      ? [U] extends [T]
+        ? false
+        : true
+      : false;
+
 export type StoreAssigner<
   TContext extends StoreContext,
   TEvent extends EventObject,
@@ -167,7 +232,7 @@ export type StoreAssigner<
   context: TContext,
   event: TEvent,
   enq: EnqueueObject<TContext, TEmitted, TEventPayloadMap>
-) => TContext | void;
+) => StoreContextUpdate<TContext> | void;
 
 export type StoreProducerAssigner<
   TContext extends StoreContext,

--- a/packages/xstate-store/test/store.test.ts
+++ b/packages/xstate-store/test/store.test.ts
@@ -45,7 +45,6 @@ it('can update context', () => {
     context: { count: 0, greeting: 'hello' },
     on: {
       inc: (ctx) => ({
-        ...ctx,
         count: ctx.count + 1
       }),
       updateBoth: () => ({

--- a/packages/xstate-store/test/types.test.tsx
+++ b/packages/xstate-store/test/types.test.tsx
@@ -294,6 +294,51 @@ describe('can', () => {
   });
 });
 
+describe('context updates', () => {
+  it('allows partial context updates for object context', () => {
+    createStore({
+      context: { count: 0, greeting: 'hello' },
+      on: {
+        inc: (ctx) => ({
+          count: ctx.count + 1
+        })
+      }
+    });
+  });
+
+  it('requires discriminated union updates to satisfy the context type', () => {
+    type User = { id: string };
+    type Context =
+      | { status: 'loading'; user: null; count: number }
+      | { status: 'loaded'; user: User; count: number };
+
+    createStore<Context, { load: {}; increment: {} }>({
+      context: { status: 'loading', user: null, count: 0 },
+      on: {
+        load: () =>
+          // @ts-expect-error missing user for the loaded context
+          ({
+            status: 'loaded'
+          }),
+        // OK
+        increment: (ctx) => ({
+          count: ctx.count + 1
+        })
+      }
+    });
+
+    createStore<Context, { load: {} }>({
+      context: { status: 'loading', user: null, count: 0 },
+      on: {
+        load: () => ({
+          status: 'loaded',
+          user: { id: '1' }
+        })
+      }
+    });
+  });
+});
+
 describe('logic selectors', () => {
   it('infers selected values from a store', () => {
     const store = createStore({


### PR DESCRIPTION
Store transitions may now return partial context updates. For discriminated union contexts, returned updates must still satisfy the context type when applied.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5578" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->