### PR TITLE
docs: add missing https:// protocol to Stately Studio link

### DIFF
--- a/.changeset/tasty-pandas-open.md
+++ b/.changeset/tasty-pandas-open.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Add missing https:// protocol to the Stately Studio link in the README

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ donutStore.send({ type: 'changeFlavor', flavor: 'strawberry' });
 - Deploy to Stately Sky
 - Generate & modify machines with Stately AI
 
-<a href="stately.ai/registry/new?ref=github" title="Stately Studio">
+<a href="https://stately.ai/registry/new?ref=github" title="Stately Studio">
   <img src="https://github.com/statelyai/xstate/assets/1093738/74ed9cbc-b824-4ed7-a16d-f104947af8a7" alt="XState Viz" width="800" />
 </a>
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -164,7 +164,7 @@ toggleActor.send({ type: 'TOGGLE' });
 - Deploy to Stately Sky
 - Generate & modify machines with Stately AI
 
-<a href="stately.ai/registry/new?ref=github" title="Stately Studio">
+<a href="https://stately.ai/registry/new?ref=github" title="Stately Studio">
   <img src="https://github.com/statelyai/xstate/assets/1093738/74ed9cbc-b824-4ed7-a16d-f104947af8a7" alt="XState Viz" width="800" />
 </a>
 


### PR DESCRIPTION
## Problem

The "Stately Studio" call-to-action link is missing its URL scheme in two READMEs:

```html
<a href="stately.ai/registry/new?ref=github" title="Stately Studio">
```

Without `https://`, GitHub (and the npm `xstate` package page) renders it as a
**relative** URL, resolving to
`github.com/statelyai/xstate/blob/main/stately.ai/registry/new?ref=github`
instead of the Stately registry.

The intended target is confirmed a few lines below, where the same link is
already written correctly:

```md
**[state.new](https://stately.ai/registry/new?ref=github)**
```

## Fix

Add the missing `https://` in `README.md` and `packages/core/README.md`.