### PR TITLE
fix(core): enter parallel default configuration when targeting an unvisited history child

### DIFF
--- a/.changeset/wild-history-parallel.md
+++ b/.changeset/wild-history-parallel.md
@@ -1,0 +1,26 @@
+---
+'xstate': patch
+---
+
+Fixed a bug where targeting a history state that is a direct child of a `parallel` state would silently do nothing when that parallel state had not been visited yet and the history state had no default target. The machine now enters the parallel state's initial configuration, matching the behavior of history states inside compound states.
+
+```ts
+const machine = createMachine({
+  initial: 'off',
+  states: {
+    off: { on: { GO: 'on.hist' } },
+    on: {
+      type: 'parallel',
+      states: {
+        regA: { initial: 'a1', states: { a1: {}, a2: {} } },
+        regB: { initial: 'b1', states: { b1: {}, b2: {} } },
+        hist: { type: 'history', history: 'deep' }
+      }
+    }
+  }
+});
+
+const actor = createActor(machine).start();
+actor.send({ type: 'GO' });
+actor.getSnapshot().value; // { on: { regA: 'a1', regB: 'b1' } }
+```

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -512,6 +512,9 @@ function resolveHistoryDefaultTransition<
     stateNode.config.target
   );
   if (!normalizedTarget) {
+    if (stateNode.parent!.type === 'parallel') {
+      return { target: [stateNode.parent!] };
+    }
     return stateNode.parent!.initial;
   }
   return {

--- a/packages/core/test/history.test.ts
+++ b/packages/core/test/history.test.ts
@@ -295,6 +295,58 @@ describe('history states', () => {
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
+  it('should enter the parallel default configuration when a deep history state without a default target is targeted and its parent parallel state was never visited yet', () => {
+    const machine = createMachine({
+      initial: 'off',
+      states: {
+        off: {
+          on: { GO: 'on.hist' }
+        },
+        on: {
+          type: 'parallel',
+          states: {
+            regA: { initial: 'a1', states: { a1: {}, a2: {} } },
+            regB: { initial: 'b1', states: { b1: {}, b2: {} } },
+            hist: { type: 'history', history: 'deep' }
+          }
+        }
+      }
+    });
+
+    const actorRef = createActor(machine).start();
+    actorRef.send({ type: 'GO' });
+
+    expect(actorRef.getSnapshot().value).toEqual({
+      on: { regA: 'a1', regB: 'b1' }
+    });
+  });
+
+  it('should enter the parallel default configuration when a shallow history state without a default target is targeted and its parent parallel state was never visited yet', () => {
+    const machine = createMachine({
+      initial: 'off',
+      states: {
+        off: {
+          on: { GO: 'on.hist' }
+        },
+        on: {
+          type: 'parallel',
+          states: {
+            regA: { initial: 'a1', states: { a1: {}, a2: {} } },
+            regB: { initial: 'b1', states: { b1: {}, b2: {} } },
+            hist: { type: 'history', history: 'shallow' }
+          }
+        }
+      }
+    });
+
+    const actorRef = createActor(machine).start();
+    actorRef.send({ type: 'GO' });
+
+    expect(actorRef.getSnapshot().value).toEqual({
+      on: { regA: 'a1', regB: 'b1' }
+    });
+  });
+
   it('should not execute actions of the initial transition when a history state with a default target is targeted and its parent state was never visited yet', () => {
     const spy = vi.fn();
     const machine = createMachine({


### PR DESCRIPTION
Targeting a history state that is a direct child of a `parallel` state silently does nothing when that parallel state has not been visited yet and the history state has no default `target`. The machine stays in the source state instead of entering the parallel state's initial configuration, and no error is thrown.

```ts
const machine = createMachine({
  initial: 'off',
  states: {
    off: { on: { GO: 'on.hist' } },
    on: {
      type: 'parallel',
      states: {
        regA: { initial: 'a1', states: { a1: {}, a2: {} } },
        regB: { initial: 'b1', states: { b1: {}, b2: {} } },
        hist: { type: 'history', history: 'deep' }
      }
    }
  }
});

const actor = createActor(machine).start();
actor.send({ type: 'GO' });
actor.getSnapshot().value; // stays 'off'; expected { on: { regA: 'a1', regB: 'b1' } }
```

## Cause

In `resolveHistoryDefaultTransition` (`packages/core/src/stateUtils.ts`), a history node with no configured `target` returns `parent.initial`. For a compound parent that is the single initial child, so entry works. For a `parallel` parent there is no single initial child, so `parent.initial` produces a transition with `target: []`; the empty target set flows through the entry machinery and the transition no-ops. The compound case is already documented and tested ("should execute actions of the initial transition when a history state without a default target is targeted and its parent state was never visited yet"); the parallel case was missed.

## Fix

When the history node has no default target and its parent is a `parallel` state, return the parallel state itself as the target. The existing entry logic then enters every region at its initial state, which is the parallel state's initial configuration. Compound parents are unchanged.

## Testing

Added deep and shallow history variants to `packages/core/test/history.test.ts`. They fail on the current code (value stays `off`) and pass with the fix. `pnpm test:core` stays green (1746 passed) and `packages/core` typechecks clean. Changeset included.
