### PR TITLE
ci: add CVE Lite dependency audit workflow

### DIFF
--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -1,0 +1,37 @@
+name: CVE Lite dependency audit
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly on Monday at 06:00 UTC - catches new advisories between pushes
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  scan:
+    name: Scan dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Scan for vulnerabilities
+        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        with:
+          fail-on: high
+          sarif: 'true'
+
+      - name: Upload SARIF to Code Scanning
+        if: always() && hashFiles('*.sarif') != ''
+        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
+        with:
+          sarif_file: cve-lite-*.sarif
+          category: cve-lite

--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Scan for vulnerabilities
-        uses: OWASP/cve-lite-cli@2eed959b8641042472d2810444393b88d5454e62 # v1
+        uses: OWASP/cve-lite-cli@99b7b0dcd4c687116890515dbfa8f955871776cc # v1
         with:
           fail-on: high
           sarif: 'true'

--- a/.github/workflows/cve-lite.yml
+++ b/.github/workflows/cve-lite.yml
@@ -30,8 +30,9 @@ jobs:
           sarif: 'true'
 
       - name: Upload SARIF to Code Scanning
-        if: always() && hashFiles('*.sarif') != ''
+        if: always()
+        continue-on-error: true
         uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
         with:
-          sarif_file: cve-lite-*.sarif
+          sarif_file: .
           category: cve-lite


### PR DESCRIPTION
This PR adds a CVE Lite CLI dependency audit workflow to XState's CI pipeline.

A scan of the current `pnpm-lock.yaml` found **6 critical-severity** and **35 high-severity** advisories, including 10 direct dependencies with available fixes:

**Direct critical-severity finding:**
- `happy-dom@14.x` / `vitest@2.x` - sandbox escape via prototype pollution (GHSA-x77j-w7hc-8mgr) - fix: `pnpm add happy-dom@20.8.9 vitest@4.1.0`

**Direct high-severity findings:**
- `ws@7.x` in `xstate-inspect` - DoS via crafted HTTP upgrade request (GHSA-3h5q-q39x-f9x2) - fix: `pnpm add --filter ./packages/xstate-inspect ws@8.21.0`
- `@angular/core`, `@angular/common`, `@angular/compiler` - outdated Angular versions with known CVEs - fix: `pnpm add -D --filter ./packages/xstate-store-angular @angular/common@20.0.0 @angular/compiler@20.0.0 @angular/core@20.0.0`
- `preact@10.x` - XSS via crafted input - fix: `pnpm add -D --filter ./packages/xstate-store-preact preact@10.28.2`

The workflow runs on push, pull request, and weekly schedule. Findings are uploaded to GitHub's Security tab as SARIF.

**Tool:** [CVE Lite CLI](https://github.com/OWASP/cve-lite-cli) is an OWASP Lab Project. It reads the lockfile locally, queries the OSV database, and produces actionable fix commands with resolved safe versions.
