### PR TITLE
Merge actions and guards schema maps in extend()

### DIFF
--- a/.changeset/extend-merge-actions-guards.md
+++ b/.changeset/extend-merge-actions-guards.md
@@ -1,0 +1,47 @@
+---
+'xstate': major
+---
+
+`extend(...)` now merges `actions` and `guards` schema maps instead of replacing the base setup schemas. Previously, only `events`, `emitted`, and `children` were merged.
+
+```ts
+import { setup, types } from 'xstate';
+
+const machine = setup({
+  schemas: {
+    actions: {
+      track: { params: types<{ key: string }>() }
+    },
+    guards: {
+      hasAccess: { params: types<{ role: string }>() }
+    }
+  }
+})
+  .extend({
+    schemas: {
+      actions: {
+        notify: { params: types<{ message: string }>() }
+      },
+      guards: {
+        canReset: { params: types<{ reason: string }>() }
+      }
+    }
+  })
+  .createMachine({
+    // Both base and extended actions/guards are available
+    entry: ({ actions }, enq) => {
+      enq(actions.track({ key: 'init' }));
+      enq(actions.notify({ message: 'started' }));
+    },
+    on: {
+      RESET: ({ guards }) => {
+        if (
+          guards.hasAccess({ role: 'admin' }) &&
+          guards.canReset({ reason: 'manual' })
+        ) {
+          return { target: '.idle' };
+        }
+      }
+    }
+  });
+```

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -2127,6 +2127,8 @@ function mergeSchemas(
     ...left,
     ...right,
     events: mergeMaps(left?.events, right?.events),
+    actions: mergeMaps(left?.actions, right?.actions),
+    guards: mergeMaps(left?.guards, right?.guards),
     emitted: mergeMaps(left?.emitted, right?.emitted),
     children: mergeMaps(left?.children, right?.children)
   };

--- a/packages/core/test/setup.test.ts
+++ b/packages/core/test/setup.test.ts
@@ -35,6 +35,91 @@ describe('setup', () => {
     expect(setup().schemas).toEqual({});
   });
 
+  it('exposes extended schemas', () => {
+    const context = types<{ count: number }>();
+    const inc = types<{ value: number }>();
+    const reset = types<{}>();
+    const track = types<{ key: string }>();
+    const notify = types<{ message: string }>();
+    const hasAccess = types<{ role: string }>();
+    const canReset = types<{ reason: string }>();
+    const changed = types<{ value: number }>();
+    const notified = types<{ message: string }>();
+    const child = types<unknown>();
+    const sibling = types<unknown>();
+    const input = types<{ start: number }>();
+    const output = types<{ total: number }>();
+    const meta = types<{ label: string }>();
+    const tags = types<'active'>();
+
+    const s = setup({
+      schemas: {
+        context,
+        events: {
+          INC: inc
+        },
+        actions: {
+          track: {
+            params: track
+          }
+        },
+        guards: {
+          hasAccess: {
+            params: hasAccess
+          }
+        },
+        emitted: {
+          changed
+        },
+        input,
+        meta,
+        children: {
+          child
+        }
+      }
+    }).extend({
+      schemas: {
+        events: {
+          RESET: reset
+        },
+        actions: {
+          notify: {
+            params: notify
+          }
+        },
+        guards: {
+          canReset: {
+            params: canReset
+          }
+        },
+        emitted: {
+          notified
+        },
+        output,
+        tags,
+        children: {
+          sibling
+        }
+      }
+    });
+
+    expect(s.schemas.context).toBe(context);
+    expect(s.schemas.events.INC).toBe(inc);
+    expect(s.schemas.events.RESET).toBe(reset);
+    expect(s.schemas.actions.track.params).toBe(track);
+    expect(s.schemas.actions.notify.params).toBe(notify);
+    expect(s.schemas.guards.hasAccess.params).toBe(hasAccess);
+    expect(s.schemas.guards.canReset.params).toBe(canReset);
+    expect(s.schemas.emitted.changed).toBe(changed);
+    expect(s.schemas.emitted.notified).toBe(notified);
+    expect(s.schemas.input).toBe(input);
+    expect(s.schemas.output).toBe(output);
+    expect(s.schemas.meta).toBe(meta);
+    expect(s.schemas.tags).toBe(tags);
+    expect(s.schemas.children.child).toBe(child);
+    expect(s.schemas.children.sibling).toBe(sibling);
+  });
+
   it('extends implementations', () => {
     const calls: string[] = [];
 


### PR DESCRIPTION
Previously, `extend()` merged schema maps for `events`, `emitted`, and `children`, but replaced `actions` and `guards` entirely. As a result, extending with new action or guard schemas would discard the base ones.

Now, `actions` and `guards` are also included so that all five schema fields are shallow-merged.

```ts
import { setup, types } from 'xstate';

const baseDef = setup({
  schemas: {
    actions: {
      track: { params: types<{ key: string }>() }
    },
    guards: {
      hasAccess: { params: types<{ role: string }>() }
    }
  }
})


const extendedDef = baseDef.extend({
  schemas: {
    actions: {
      notify: { params: types<{ message: string }>() }
    },
    guards: {
      canReset: { params: types<{ reason: string }>() }
    }
  }
})

// Both base and extended actions/guards are available
const machine = extendedDef.createMachine({
  entry: ({ actions }, enq) => {
    enq(actions.track({ key: 'init' }));
    enq(actions.notify({ message: 'started' }));
  },
  on: {
    RESET: ({ guards }) => {
      if (
        guards.hasAccess({ role: 'admin' }) &&
        guards.canReset({ reason: 'manual' })
      ) {
        return { target: '.idle' };
      }
    }
  }
});
```
