### PR TITLE
Expose `schemas` on machine defintion

### DIFF
--- a/.changeset/setup-return-schemas.md
+++ b/.changeset/setup-return-schemas.md
@@ -1,0 +1,25 @@
+---
+'xstate': minor
+---
+
+`setup(...)` now exposes the schemas defined in its configuration, making them accessible for external use.
+
+```ts
+import { setup, types } from 'xstate';
+
+const s = setup({
+  schemas: {
+    context: types<{ count: number }>(),
+    events: {
+      inc: types<{ by: number }>()
+    },
+    emitted: {
+      changed: types<{ value: number }>()
+    }
+  }
+});
+
+s.schemas.context;
+s.schemas.events.inc;
+s.schemas.emitted.changed;
+```

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1789,6 +1789,9 @@ export interface SetupReturn<
 
   /** State input schemas from setup config */
   states: TStates;
+
+  /** Schemas from setup config */
+  schemas: TSchemas;
 }
 
 type SetupConfigSchemas<TConfig> = TConfig extends { schemas?: infer TSchemas }
@@ -1987,7 +1990,8 @@ export function setup<
     createStateConfig(...args: unknown[]) {
       return args.length > 1 ? args[1] : args[0];
     },
-    states
+    states,
+    schemas: schemas ?? ({} as TSchemas)
   };
 }
 

--- a/packages/core/test/setup.test.ts
+++ b/packages/core/test/setup.test.ts
@@ -1,6 +1,40 @@
-import { createActor, setup } from '../src/index.ts';
+import { createActor, setup, types } from '../src/index.ts';
 
 describe('setup', () => {
+  it('exposes schemas', () => {
+    const schemas = {
+      context: types<{ count: number }>(),
+      events: {
+        INC: types<{ value: number }>()
+      },
+      actions: {
+        track: {
+          params: types<{ key: string }>()
+        }
+      },
+      guards: {
+        hasAccess: {
+          params: types<{ role: string }>()
+        }
+      },
+      emitted: {
+        changed: types<{ value: number }>()
+      },
+      input: types<{ start: number }>(),
+      output: types<{ total: number }>(),
+      meta: types<{ label: string }>(),
+      tags: types<'active'>(),
+      children: {
+        child: types<unknown>()
+      }
+    };
+
+    const s = setup({ schemas });
+
+    expect(s.schemas).toBe(schemas);
+    expect(setup().schemas).toEqual({});
+  });
+
   it('extends implementations', () => {
     const calls: string[] = [];
 

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -758,6 +758,64 @@ it('should expose non-context schemas on machine', () => {
   machine.schemas?.events?.inc satisfies StandardSchemaV1 | undefined;
 });
 
+it('should expose schemas on setup return', () => {
+  const s = setup({
+    schemas: {
+      context: z.object({
+        count: z.number()
+      }),
+      events: {
+        inc: z.object({
+          by: z.number()
+        })
+      },
+      actions: {
+        track: {
+          params: z.object({
+            key: z.string()
+          })
+        }
+      },
+      guards: {
+        hasAccess: {
+          params: z.object({
+            role: z.string()
+          })
+        }
+      },
+      emitted: {
+        changed: z.object({
+          value: z.number()
+        })
+      },
+      input: z.object({
+        start: z.number()
+      }),
+      output: z.object({
+        total: z.number()
+      }),
+      meta: z.object({
+        label: z.string()
+      }),
+      tags: z.literal('active'),
+      children: {
+        child: z.custom<AnyActorRef>()
+      }
+    }
+  });
+
+  s.schemas.context satisfies StandardSchemaV1;
+  s.schemas.events.inc satisfies StandardSchemaV1;
+  s.schemas.actions.track.params satisfies StandardSchemaV1;
+  s.schemas.guards.hasAccess.params satisfies StandardSchemaV1;
+  s.schemas.emitted.changed satisfies StandardSchemaV1;
+  s.schemas.input satisfies StandardSchemaV1;
+  s.schemas.output satisfies StandardSchemaV1;
+  s.schemas.meta satisfies StandardSchemaV1;
+  s.schemas.tags satisfies StandardSchemaV1;
+  s.schemas.children.child satisfies StandardSchemaV1;
+});
+
 describe('states', () => {
   it('should accept a state handling subset of events as part of the whole config handling superset of those events', () => {
     const italicState = {


### PR DESCRIPTION
Schemas passed to `setup()` are consumed internally for type inference but aren't accessible at runtime. 
External tooling could benefit from reading schemas directly from the machine definition as well. 

This PR adds a schemas property to the definition returned by setup(), so they can be read at runtime.

```ts
import { setup, types } from 'xstate';

const def = setup({
  schemas: {
    context: types<{ count: number }>(),
    events: {
      inc: types<{ by: number }>()
    },
    emitted: {
      changed: types<{ value: number }>()
    }
  }
});


def.schemas.context;
def.schemas.events.inc;
def.schemas.emitted.changed;
```

