### PR TITLE
Pass state input to timeout, onTimeout, after and event handlers

### DIFF
--- a/.changeset/timeout-receives-input.md
+++ b/.changeset/timeout-receives-input.md
@@ -1,0 +1,37 @@
+---
+'xstate': patch
+---
+
+State input is now available in `on`, `after`, `timeout`, and `onTimeout` handlers (previously only `entry`/`exit` received it).
+
+```ts
+const machine = setup({
+  states: {
+    active: {
+      schemas: { input: z.object({ duration: z.number() }) }
+    }
+  }
+}).createMachine({
+  initial: 'idle',
+  states: {
+    idle: {
+      on: {
+        activate: ({ event }) => ({
+          target: 'active',
+          input: { duration: event.duration }
+        })
+      }
+    },
+    active: {
+      timeout: ({ input }) => input.duration,
+      onTimeout: ({ input }) => ({ target: 'idle' }),
+      after: {
+        1000: ({ input }) => ({ target: 'idle' })
+      },
+      on: {
+        ping: ({ input }, enq) => {}
+      }
+    }
+  }
+});
+```

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -923,7 +923,8 @@ type StateNodeConfigWithNestedInput<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TSystemRegistry
+      TSystemRegistry,
+      StateInput<TStateSchema>
     >;
     always?: StateTransitionConfigOrTarget<
       TSiblingStateSchemas,
@@ -938,7 +939,8 @@ type StateNodeConfigWithNestedInput<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TSystemRegistry
+      TSystemRegistry,
+      StateInput<TStateSchema>
     >;
     invoke?: SingleOrArray<
       SetupInvokeConfig<
@@ -969,7 +971,8 @@ type StateNodeConfigWithNestedInput<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TSystemRegistry
+      TSystemRegistry,
+      StateInput<TStateSchema>
     >;
   },
   TStateSchema['states'] extends Record<string, SetupStateSchema>
@@ -1024,7 +1027,8 @@ type StateTransitions<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TInput = undefined
 > = {
   [K in EventDescriptor<TEvent>]?: StateTransitionConfigOrTarget<
     TStateSchemas,
@@ -1039,7 +1043,8 @@ type StateTransitions<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TSystemRegistry
+    TSystemRegistry,
+    TInput
   >;
 };
 
@@ -1167,7 +1172,8 @@ type StateTransitionConfigOrTarget<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TInput = undefined
 > =
   | undefined
   | StateTransitionObjectConfig<
@@ -1196,7 +1202,8 @@ type StateTransitionConfigOrTarget<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TSystemRegistry
+      TSystemRegistry,
+      TInput
     >;
 
 type StateTransitionObjectConfig<
@@ -1355,7 +1362,8 @@ type StateTransitionFunction<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TInput = undefined
 > = (
   args: {
     context: TContext;
@@ -1369,6 +1377,7 @@ type StateTransitionFunction<
     actorSources: TActorMap;
     guards: TGuardMap;
     delays: TDelayMap;
+    input: TInput;
   } & OutputArg<TExpressionEvent>,
   enq: EnqueueObject<TEvent, TEmitted, TSystemRegistry>
 ) => StateTransitionResult<

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -79,6 +79,7 @@ function resolveDelay(
     context: MachineContext;
     event: EventObject;
     stateNode: AnyStateNode;
+    input?: Record<string, unknown>;
   }
 ) {
   if (typeof delay === 'function') {
@@ -91,6 +92,10 @@ function resolveDelay(
   }
 
   return configuredDelay;
+}
+
+function getStateInput(snapshot: AnyMachineSnapshot, stateNodeId: string) {
+  return snapshot._stateInputs?.[stateNodeId];
 }
 
 export function isAtomicStateNode(stateNode: AnyStateNode) {
@@ -272,6 +277,7 @@ function scheduleDelayedEvent(
     context: MachineContext;
     event: EventObject;
     delays: Record<string, any>;
+    input?: Record<string, unknown>;
   }) => any
 ) {
   const eventType = event.type;
@@ -382,7 +388,8 @@ export function getDelayedTransitions(
       resolveDelay(delay, fromDelaysMap ? x.delays : {}, {
         context: x.context,
         event: x.event,
-        stateNode
+        stateNode,
+        input: x.input
       })
     );
     for (const transition of toTransitionConfigArray(transitions as any)) {
@@ -1157,7 +1164,7 @@ function microstep(
       }
 
       for (const exitStateNode of statesToExit) {
-        const stateInput = currentSnapshot._stateInputs?.[exitStateNode.id];
+        const stateInput = getStateInput(currentSnapshot, exitStateNode.id);
 
         const [exitActions, nextContext, internalEvents] = exitStateNode.exit
           ? getStateActionsAndContext(
@@ -1677,7 +1684,7 @@ function microstep(
 
       nextStateNodesToExit.forEach((stateNode) => {
         if (stateNode.exit) {
-          const stateInput = nextState._stateInputs?.[stateNode.id];
+          const stateInput = getStateInput(nextState, stateNode.id);
           const [exitActions, , nextInternalEvents] = getStateActionsAndContext(
             stateNode.exit,
             nextState.context,
@@ -1759,7 +1766,8 @@ export function getTransitionResult(
     actions: snapshot.machine.implementations.actions,
     actorSources: snapshot.machine.implementations.actorSources,
     guards: snapshot.machine.implementations.guards,
-    delays: snapshot.machine.implementations.delays
+    delays: snapshot.machine.implementations.delays,
+    input: getStateInput(snapshot, transition.source.id)
   };
 
   if (transition.to) {
@@ -1994,7 +2002,8 @@ export function hasEffect(
       event,
       snapshot,
       self,
-      snapshot.machine.implementations
+      snapshot.machine.implementations,
+      transition.source.id
     );
   }
 
@@ -2007,7 +2016,8 @@ function transitionToHasEffect(
   event: EventObject,
   snapshot: AnyMachineSnapshot,
   self: AnyActor,
-  implementations: AnyMachineSnapshot['machine']['implementations']
+  implementations: AnyMachineSnapshot['machine']['implementations'],
+  sourceId: string
 ) {
   let hasEffect = false;
   let res;
@@ -2032,7 +2042,8 @@ function transitionToHasEffect(
         actions: implementations.actions,
         actorSources: implementations.actorSources,
         guards: implementations.guards,
-        delays: implementations.delays
+        delays: implementations.delays,
+        input: getStateInput(snapshot, sourceId)
       },
       createEnqueueObject(
         {
@@ -2153,7 +2164,8 @@ export function evaluateCandidate(
       event,
       snapshot,
       self,
-      stateNode.machine.implementations
+      stateNode.machine.implementations,
+      candidate.source.id
     );
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -575,6 +575,7 @@ export type TransitionConfigFunction<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TMeta extends MetaObject,
+  TInput = undefined,
   _TCtx extends MachineContext = [TContext] extends [never] ? any : TContext
 > = (
   args: TransitionFunctionArgs<
@@ -585,7 +586,7 @@ export type TransitionConfigFunction<
     TActorMap,
     TGuardMap,
     TDelayMap
-  >,
+  > & { input: TInput },
   enq: EnqueueObject<TEvent, TEmitted>
 ) => {
   target?: string | string[];
@@ -2540,6 +2541,8 @@ export type StateSchema = {
   exit?: unknown;
   onDone?: unknown;
   onError?: unknown;
+  timeout?: unknown;
+  onTimeout?: unknown;
   after?: unknown;
   always?: unknown;
   choice?: unknown;

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -769,6 +769,7 @@ type Next_ChoiceArgs<
     TGuardMap,
     TDelayMap,
     MetaObject,
+    undefined, // TInput
     _TCtx
   >
 >[0];
@@ -1047,7 +1048,8 @@ interface Next_RegularStateNodeConfig<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TMeta
+      TMeta,
+      TInput
     >;
   };
   /**
@@ -1135,7 +1137,8 @@ interface Next_RegularStateNodeConfig<
           TActorMap,
           TGuardMap,
           TDelayMap,
-          TMeta
+          TMeta,
+          TInput
         >;
   };
 
@@ -1155,6 +1158,7 @@ interface Next_RegularStateNodeConfig<
         context: TContext;
         event: TEvent;
         stateNode: AnyStateNode;
+        input: TInput;
       }) => number);
   /** Transition taken when `timeout` expires. Required when `timeout` is set. */
   onTimeout?: Next_TransitionConfigOrTarget<
@@ -1166,7 +1170,8 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TMeta,
+    TInput
   >;
 
   /**
@@ -1230,7 +1235,8 @@ export type Next_TransitionConfigOrTarget<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TMeta extends MetaObject
+  TMeta extends MetaObject,
+  TInput = undefined
 > =
   | undefined
   | {
@@ -1263,7 +1269,8 @@ export type Next_TransitionConfigOrTarget<
         TActorMap,
         TGuardMap,
         TDelayMap,
-        TMeta
+        TMeta,
+        TInput
       >;
       context?:
         | TransitionContextPatch<TContext>
@@ -1292,7 +1299,8 @@ export type Next_TransitionConfigOrTarget<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TMeta
+      TMeta,
+      TInput
     >;
 
 export type WithDefault<T, Default> = IsNever<T> extends true ? Default : T;
@@ -1320,16 +1328,12 @@ type DelayNamesFromConfig<TConfig> = TConfig extends {
   ? Extract<keyof TDelays, string>
   : string;
 
+// Checks only `after` keys (and nested `states`): a bad `after` key is accepted
+// structurally, so it needs validation here. A bad `timeout` string is already
+// rejected by the `timeout?:` field type, so it needs no branch.
 type InvalidDelayReferences<TConfig, TDelays extends string> =
   | (TConfig extends { after: infer TAfter }
       ? Exclude<Extract<keyof TAfter, string>, TDelays>
-      : never)
-  | (TConfig extends { timeout: infer TTimeout }
-      ? TTimeout extends string
-        ? TTimeout extends TDelays
-          ? never
-          : TTimeout
-        : never
       : never)
   | (TConfig extends { states: infer TStates }
       ? TStates extends Record<string, unknown>

--- a/packages/core/test/timeout.test.ts
+++ b/packages/core/test/timeout.test.ts
@@ -1,4 +1,5 @@
-import { createActor, createMachine } from '../src';
+import z from 'zod';
+import { createActor, createMachine, setup } from '../src';
 import { createAsyncLogic, TimeoutError } from '../src/actors/promise.ts';
 
 afterEach(() => {
@@ -219,6 +220,173 @@ describe('state-level timeout', () => {
         }
       })
     ).toThrow(/onTimeout/);
+  });
+
+  it('passes state input to entry, exit, on, timeout, onTimeout, and after', () => {
+    vi.useFakeTimers();
+
+    const entrySpy = vi.fn();
+    const exitSpy = vi.fn();
+    const timeoutSpy = vi.fn();
+    const onTimeoutSpy = vi.fn();
+    const onPingSpy = vi.fn();
+    const afterSpy = vi.fn();
+    const machine = setup({
+      schemas: {
+        events: {
+          activate: z.object({
+            duration: z.number()
+          }),
+          ping: z.object({})
+        }
+      },
+      states: {
+        idle: {},
+        active: {
+          schemas: {
+            input: z.object({
+              duration: z.number()
+            })
+          }
+        }
+      }
+    }).createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            activate: ({ event }) => ({
+              target: 'active',
+              input: {
+                duration: event.duration
+              }
+            })
+          }
+        },
+        active: {
+          entry: ({ input }, enq) => {
+            enq(entrySpy, input.duration);
+          },
+          exit: ({ input }, enq) => {
+            enq(exitSpy, input.duration);
+          },
+          timeout: ({ input }) => {
+            timeoutSpy(input.duration);
+
+            return input.duration;
+          },
+          onTimeout: ({ input }, enq) => {
+            enq(onTimeoutSpy, input.duration);
+
+            return {
+              target: 'idle'
+            };
+          },
+          on: {
+            ping: ({ input }, enq) => {
+              onPingSpy(input.duration);
+            }
+          },
+          after: {
+            1000: ({ input }) => {
+              afterSpy(input.duration);
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+
+    actor.send({ type: 'activate', duration: 500 });
+
+    expect(actor.getSnapshot().value).toBe('active');
+    expect(entrySpy).toHaveBeenCalledWith(500);
+    // timeout resolves eagerly on entry; onTimeout waits for the delay
+    expect(timeoutSpy).toHaveBeenCalledWith(500);
+    expect(onTimeoutSpy).not.toHaveBeenCalled();
+
+    // on handler receives state input
+    actor.send({ type: 'ping' });
+    expect(onPingSpy).toHaveBeenCalledWith(500);
+
+    vi.advanceTimersByTime(500);
+    expect(actor.getSnapshot().value).toBe('idle');
+    expect(onTimeoutSpy).toHaveBeenCalledWith(500);
+    expect(exitSpy).toHaveBeenCalledWith(500);
+    // after fires after timeout since timeout (500ms) < after (1000ms)
+    expect(afterSpy).not.toHaveBeenCalled();
+
+    // re-enter active with longer duration so after fires first
+    actor.send({ type: 'activate', duration: 2000 });
+    expect(actor.getSnapshot().value).toBe('active');
+
+    vi.advanceTimersByTime(1000);
+    expect(afterSpy).toHaveBeenCalledWith(2000);
+  });
+
+  it('passes the correct state input to nested states', () => {
+    const parentSpy = vi.fn();
+    const childSpy = vi.fn();
+
+    const machine = setup({
+      schemas: {
+        events: {
+          ping: z.object({})
+        }
+      },
+      states: {
+        parent: {
+          schemas: {
+            input: z.object({
+              label: z.literal('parent')
+            })
+          },
+          states: {
+            child: {
+              schemas: {
+                input: z.object({
+                  label: z.literal('child')
+                })
+              }
+            }
+          }
+        }
+      }
+    }).createMachine({
+      initial: {
+        target: 'parent',
+        input: { label: 'parent' }
+      },
+      states: {
+        parent: {
+          initial: {
+            target: 'child',
+            input: { label: 'child' }
+          },
+          on: {
+            ping: ({ input }) => {
+              parentSpy(input.label);
+            }
+          },
+          states: {
+            child: {
+              on: {
+                ping: ({ input }) => {
+                  childSpy(input.label);
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'ping' });
+
+    expect(childSpy).toHaveBeenCalledWith('child');
+    expect(parentSpy).toHaveBeenCalledWith('parent');
   });
 });
 


### PR DESCRIPTION
State input is already available in a state's `entry` and `exit` actions. 
This PR makes it available in event handlers, `after`, `timeout`, and `onTimeout` as well.

```js
const machine = setup({
  states: {
    active: {
      schemas: { input: z.object({ duration: z.number() }) }
    }
  }
}).createMachine({
  initial: 'idle',
  states: {
    idle: {
      on: {
        activate: ({ event }) => ({
          target: 'active',
          input: { duration: event.duration }
        })
      }
    },
    active: {
      timeout: ({ input }) => input.duration,
      onTimeout: ({ input }) => ({ target: 'idle' }),
      after: {
        1000: ({ input }) => ({ target: 'idle' })
      },
      on: {
        ping: ({ input }, enq) => {}
      }
    }
  }
});
```