### PR TITLE
Persist state input on machine snapshots

### DIFF
--- a/.changeset/persist-state-input.md
+++ b/.changeset/persist-state-input.md
@@ -1,0 +1,33 @@
+---
+'xstate': patch
+---
+
+State `input` attached to a state now survives `getPersistedSnapshot()` → restore. Previously the input was dropped on persistence, so a restored actor lost the input for its active states (read via `snapshot.getInputs()`).
+
+```ts
+const machine = setup({
+  states: {
+    loading: {
+      schemas: { input: z.object({ userId: z.string() }) }
+    }
+  }
+}).createMachine({
+  initial: 'idle',
+  states: {
+    idle: {
+      on: { LOAD: { target: 'loading', input: { userId: 'u1' } } }
+    },
+    loading: {}
+  }
+});
+
+const actor = createActor(machine).start();
+actor.send({ type: 'LOAD' });
+
+const persisted = actor.getPersistedSnapshot();
+const restored = createActor(machine, { snapshot: persisted }).start();
+
+restored.getSnapshot().getInputs(); // { '(machine).loading': { userId: 'u1' } }
+```
+
+The persisted snapshot only includes a `stateInputs` field when at least one active state has an input, so machines that don't use state input persist to an unchanged snapshot.

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -580,6 +580,10 @@ export function getPersistedSnapshot<
     historyValue: serializeHistoryValue(jsonValues.historyValue)
   };
 
+  if (_stateInputs && Object.keys(_stateInputs).length > 0) {
+    persisted.stateInputs = _stateInputs;
+  }
+
   if (machine.version !== undefined) {
     persisted.version = machine.version;
   }

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -1066,7 +1066,8 @@ export class StateMachine<
         children,
         _nodes: nodes,
         value: snapshotData.value,
-        historyValue: revivedHistoryValue
+        historyValue: revivedHistoryValue,
+        _stateInputs: snapshotData.stateInputs ?? {}
       },
       this
     ) as MachineSnapshot<

--- a/packages/core/test/stateInput.persistence.test.ts
+++ b/packages/core/test/stateInput.persistence.test.ts
@@ -1,0 +1,187 @@
+import z from 'zod';
+import { createActor, setup } from '../src/index.ts';
+
+describe('persisting state input', () => {
+  describe('getPersistedSnapshot() output shape', () => {
+    it('emits a flat `stateInputs` map keyed by node id across a deep hierarchy, omitting input-less nodes', () => {
+      const machine = setup({
+        states: {
+          level1: {
+            schemas: {
+              input: z.object({ l1: z.string() })
+            },
+            states: {
+              level2: {
+                schemas: {
+                  input: z.object({ l2: z.string() })
+                },
+                states: {
+                  level3: {
+                    schemas: {
+                      input: z.object({ l3: z.string() })
+                    },
+                    states: {
+                      // active but has no input -> must be absent from the map
+                      level4: {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }).createMachine({
+        initial: { target: 'level1', input: { l1: 'a' } },
+        states: {
+          level1: {
+            initial: { target: 'level2', input: { l2: 'b' } },
+            states: {
+              level2: {
+                initial: { target: 'level3', input: { l3: 'c' } },
+                states: {
+                  level3: {
+                    initial: 'level4',
+                    states: {
+                      level4: {}
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      });
+
+      const actor = createActor(machine).start();
+      const persisted = actor.getPersistedSnapshot() as any;
+
+      expect(persisted).toHaveProperty('stateInputs');
+
+      expect(persisted.stateInputs).toEqual({
+        '(machine).level1': { l1: 'a' },
+        '(machine).level1.level2': { l2: 'b' },
+        '(machine).level1.level2.level3': { l3: 'c' }
+      });
+    });
+  });
+
+  describe('round-trip (persist -> restore)', () => {
+    it('state input survives persist -> JSON round-trip -> restore', () => {
+      // parent input is set by an event, child input by a nested initial
+      // transition — both active nodes' inputs must survive the round-trip.
+      const machine = setup({
+        states: {
+          idle: {},
+          parent: {
+            schemas: {
+              input: z.object({ parentId: z.string() })
+            },
+            states: {
+              child: {
+                schemas: {
+                  input: z.object({ childId: z.number() })
+                }
+              }
+            }
+          }
+        }
+      }).createMachine({
+        initial: 'idle',
+        states: {
+          idle: {
+            on: {
+              LOAD: { target: 'parent', input: { parentId: 'p1' } }
+            }
+          },
+          parent: {
+            initial: { target: 'child', input: { childId: 42 } },
+            states: {
+              child: {}
+            }
+          }
+        }
+      });
+
+      const actor = createActor(machine).start();
+      actor.send({ type: 'LOAD' });
+
+      const persisted = JSON.parse(
+        JSON.stringify(actor.getPersistedSnapshot())
+      );
+      actor.stop();
+
+      const restored = createActor(machine, { snapshot: persisted }).start();
+
+      expect(restored.getSnapshot().getInputs()).toMatchObject({
+        '(machine).parent': { parentId: 'p1' },
+        '(machine).parent.child': { childId: 42 }
+      });
+    });
+
+    it('invoked child: input is persisted nested under the parent, then restored into the child', () => {
+      const child = setup({
+        states: {
+          idle: {},
+          loading: {
+            schemas: {
+              input: z.object({ childId: z.string() })
+            }
+          }
+        }
+      }).createMachine({
+        initial: 'idle',
+        states: {
+          idle: {
+            on: {
+              GO: { target: 'loading', input: { childId: 'child-1' } }
+            }
+          },
+          loading: {}
+        }
+      });
+
+      // A persistable invoked child must use a string `src` resolved against
+      // `actorSources` — an inline actor cannot be persisted.
+      const parent = setup({
+        actorSources: { child }
+      }).createMachine({
+        initial: 'active',
+        states: {
+          active: {
+            invoke: { src: 'child', id: 'myChild' }
+          }
+        }
+      });
+
+      const actor = createActor(parent).start();
+      const childActor = actor.getSnapshot().children.myChild!;
+      childActor.send({ type: 'GO' });
+
+      expect(childActor.getSnapshot().getInputs()['(machine).loading']).toEqual(
+        {
+          childId: 'child-1'
+        }
+      );
+
+      const persisted = JSON.parse(
+        JSON.stringify(actor.getPersistedSnapshot())
+      );
+
+      // Parent state has no input of its own -> no top-level map.
+      expect(persisted.stateInputs).toBeUndefined();
+      // Child input is persisted nested inside the child's own snapshot.
+      expect(persisted.children.myChild.snapshot.stateInputs).toEqual({
+        '(machine).loading': { childId: 'child-1' }
+      });
+
+      actor.stop();
+
+      const restored = createActor(parent, { snapshot: persisted }).start();
+      const restoredChild = restored.getSnapshot().children.myChild!;
+
+      expect(
+        restoredChild.getSnapshot().getInputs()['(machine).loading']
+      ).toEqual({ childId: 'child-1' });
+    });
+  });
+});


### PR DESCRIPTION
### Problem

State inputs are lost when persisting and restoring an actor. Calling `getPersistedSnapshot()` and then restoring with `createActor(machine, { snapshot })` silently drops the input for all active states:

```ts
const persisted = actor.getPersistedSnapshot();
const restored = createActor(machine, { snapshot: persisted }).start();

// Before persistence:
actor.getSnapshot().getInputs();
// => { '(machine).loading': { userId: 'u1' } }

// After restore (bug — input is lost):
restored.getSnapshot().getInputs();
// => {}
```

### What this PR changes

The persisted snapshot now includes a `stateInputs` field that captures the input for every active state. On restore, these inputs are rehydrated so `getInputs()` returns exactly what it did before persistence.

This also works for invoked children — each child's `stateInputs` is persisted nested inside its own snapshot under `children[id].snapshot.stateInputs`.

When no state in the machine uses input, the `stateInputs` field is omitted from the snapshot entirely (similar to how `version` is only included when set), so machines that don't use state input produce an unchanged snapshot.

### Example

```ts
const machine = setup({
  states: {
    loading: {
      schemas: { input: z.object({ userId: z.string() }) }
    }
  }
}).createMachine({
  initial: 'idle',
  states: {
    idle: {
      on: { LOAD: { target: 'loading', input: { userId: 'u1' } } }
    },
    loading: {}
  }
});

const actor = createActor(machine).start();
actor.send({ type: 'LOAD' });

const persisted = actor.getPersistedSnapshot();
const restored = createActor(machine, { snapshot: persisted }).start();

// Currently: {} — the input is lost on restore
// With this PR: { '(machine).loading': { userId: 'u1' } }
restored.getSnapshot().getInputs();
```

### Shape of the persisted snapshot

The `stateInputs` field is a flat map keyed by state node id. Even in a nested hierarchy, all inputs are stored at the same level:

```json
{
  "value": { "parent": { "child": {} } },
  "context": {},
  "stateInputs": {
    "(machine).parent": { "parentId": "p1" },
    "(machine).parent.child": { "childId": 42 }
  }
}
```

For invoked children, the child's inputs live inside the child's own nested snapshot:

```json
{
  "value": { "active": {} },
  "children": {
    "myChild": {
      "snapshot": {
        "value": { "loading": {} },
        "stateInputs": {
          "(machine).loading": { "childId": "child-1" }
        }
      }
    }
  }
}
```
