### PR TITLE
Require input on transitions targeting states with an input schema

### DIFF
--- a/.changeset/require-input-on-transitions.md
+++ b/.changeset/require-input-on-transitions.md
@@ -27,6 +27,6 @@ const machine = setup({
 
 This is a breaking type change: machines that transition to an input-declaring sibling without providing `input` will no longer type-check — add the required `input`.
 
-A self-transition without `reenter: true` does not re-enter its target, so `input` stays **optional** there — the state keeps its current input and providing a new value has no effect (at runtime it is ignored and a development-only warning is logged, since previously it was stored but never applied). Add `reenter: true` to actually re-enter the state and apply the new input; re-entering self-transitions require `input` just like transitions to other input-schema states.
+A self-transition without `reenter: true` does not re-enter its target, so `input` stays **optional** there — the state keeps its current input and providing a new value has no effect (at runtime the new value is ignored). Add `reenter: true` to actually re-enter the state and apply the new input; re-entering self-transitions require `input` just like transitions to other input-schema states.
 
 Enforcement applies to direct sibling-key targets. Targets via `#id`, relative `.child`, or arrays (`{ target: [...] }`) are not correlated to a schema at the type level, so `input` stays optional there. Input schemas with no required fields still require an explicit `input` (e.g. `input: {}`).

--- a/.changeset/require-input-on-transitions.md
+++ b/.changeset/require-input-on-transitions.md
@@ -27,6 +27,6 @@ const machine = setup({
 
 This is a breaking type change: machines that transition to an input-declaring sibling without providing `input` will no longer type-check — add the required `input`.
 
-A self-transition without `reenter: true` does not re-enter its target, so `input` stays **optional** there — the state keeps its current input and providing a new value has no effect (at runtime the new value is ignored). Add `reenter: true` to actually re-enter the state and apply the new input; re-entering self-transitions require `input` just like transitions to other input-schema states.
+The requirement is uniform: a self-transition to an input-schema state requires `input` just like any other transition. Note that without `reenter: true` a self-transition does not re-enter its target, so the provided `input` is ignored at runtime — the state keeps its current input. Add `reenter: true` to actually re-enter the state and apply the new input.
 
 Enforcement applies to direct sibling-key targets. Targets via `#id`, relative `.child`, or arrays (`{ target: [...] }`) are not correlated to a schema at the type level, so `input` stays optional there. Input schemas with no required fields still require an explicit `input` (e.g. `input: {}`).

--- a/.changeset/require-input-on-transitions.md
+++ b/.changeset/require-input-on-transitions.md
@@ -1,0 +1,32 @@
+---
+'xstate': minor
+---
+
+Transitions that target a state declaring `schemas.input` now **require** an `input` property, enforced at the type level. This applies to `on`, `always`, `after`, `onTimeout`, `onDone`, `onError`, invoke handlers, and the object form of `initial`.
+
+```ts
+const machine = setup({
+  states: {
+    loading: {
+      schemas: { input: z.object({ userId: z.string() }) }
+    }
+  }
+}).createMachine({
+  initial: 'idle',
+  states: {
+    idle: {
+      on: {
+        // Before: LOAD: { target: 'loading' }  — now a type error
+        LOAD: { target: 'loading', input: { userId: 'user-1' } }
+      }
+    },
+    loading: {}
+  }
+});
+```
+
+This is a breaking type change: machines that transition to an input-declaring sibling without providing `input` will no longer type-check — add the required `input`.
+
+At runtime, if `input` is provided on a transition whose target is not actually re-entered — for example a self-transition without `reenter: true` — the input is now ignored (previously it was stored but never applied) and a development-only warning is logged. Add `reenter: true` to re-enter the state and apply the input.
+
+Enforcement applies to direct sibling-key targets. Targets via `#id`, relative `.child`, or arrays (`{ target: [...] }`) are not correlated to a schema at the type level, so `input` stays optional there. Input schemas with no required fields still require an explicit `input` (e.g. `input: {}`).

--- a/.changeset/require-input-on-transitions.md
+++ b/.changeset/require-input-on-transitions.md
@@ -24,9 +24,3 @@ const machine = setup({
   }
 });
 ```
-
-This is a breaking type change: machines that transition to an input-declaring sibling without providing `input` will no longer type-check — add the required `input`.
-
-The requirement is uniform: a self-transition to an input-schema state requires `input` just like any other transition. Note that without `reenter: true` a self-transition does not re-enter its target, so the provided `input` is ignored at runtime — the state keeps its current input. Add `reenter: true` to actually re-enter the state and apply the new input.
-
-Enforcement applies to direct sibling-key targets. Targets via `#id`, relative `.child`, or arrays (`{ target: [...] }`) are not correlated to a schema at the type level, so `input` stays optional there. Input schemas with no required fields still require an explicit `input` (e.g. `input: {}`).

--- a/.changeset/require-input-on-transitions.md
+++ b/.changeset/require-input-on-transitions.md
@@ -27,6 +27,6 @@ const machine = setup({
 
 This is a breaking type change: machines that transition to an input-declaring sibling without providing `input` will no longer type-check — add the required `input`.
 
-At runtime, if `input` is provided on a transition whose target is not actually re-entered — for example a self-transition without `reenter: true` — the input is now ignored (previously it was stored but never applied) and a development-only warning is logged. Add `reenter: true` to re-enter the state and apply the input.
+A self-transition without `reenter: true` does not re-enter its target, so `input` stays **optional** there — the state keeps its current input and providing a new value has no effect (at runtime it is ignored and a development-only warning is logged, since previously it was stored but never applied). Add `reenter: true` to actually re-enter the state and apply the new input; re-entering self-transitions require `input` just like transitions to other input-schema states.
 
 Enforcement applies to direct sibling-key targets. Targets via `#id`, relative `.child`, or arrays (`{ target: [...] }`) are not correlated to a schema at the type level, so `input` stays optional there. Input schemas with no required fields still require an explicit `input` (e.g. `input: {}`).

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -854,8 +854,7 @@ type StatesWithInput<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TSystemRegistry,
-    K
+    TSystemRegistry
   >;
 };
 
@@ -876,8 +875,7 @@ type StateNodeConfigWithNestedInput<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry,
-  TSelfKey extends string = never
+  TSystemRegistry extends SystemRegistry
 > = WithNestedStates<
   Omit<
     Next_StateNodeConfig<
@@ -934,8 +932,7 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>,
-      TSelfKey
+      StateInput<TStateSchema>
     >;
     always?: StateTransitionConfigOrTarget<
       TSiblingStateSchemas,
@@ -951,8 +948,7 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>,
-      TSelfKey
+      StateInput<TStateSchema>
     >;
     invoke?: SingleOrArray<
       SetupInvokeConfig<
@@ -967,8 +963,7 @@ type StateNodeConfigWithNestedInput<
         TActorMap,
         TGuardMap,
         TDelayMap,
-        TSystemRegistry,
-        TSelfKey
+        TSystemRegistry
       >
     >;
     onDone?: StateTransitionConfigOrTarget<
@@ -985,8 +980,7 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>,
-      TSelfKey
+      StateInput<TStateSchema>
     >;
     onError?: StateTransitionConfigOrTarget<
       TSiblingStateSchemas,
@@ -1002,8 +996,7 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>,
-      TSelfKey
+      StateInput<TStateSchema>
     >;
     onTimeout?: StateTransitionConfigOrTarget<
       TSiblingStateSchemas,
@@ -1019,8 +1012,7 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>,
-      TSelfKey
+      StateInput<TStateSchema>
     >;
     after?: {
       [K in NoInfer<TDelays> | number]?: StateTransitionConfigOrTarget<
@@ -1037,8 +1029,7 @@ type StateNodeConfigWithNestedInput<
         TGuardMap,
         TDelayMap,
         TSystemRegistry,
-        StateInput<TStateSchema>,
-        TSelfKey
+        StateInput<TStateSchema>
       >;
     };
   },
@@ -1095,8 +1086,7 @@ type StateTransitions<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined,
-  TSelfKey extends string = never
+  TInput = undefined
 > = {
   [K in EventDescriptor<TEvent>]?: StateTransitionConfigOrTarget<
     TStateSchemas,
@@ -1112,8 +1102,7 @@ type StateTransitions<
     TGuardMap,
     TDelayMap,
     TSystemRegistry,
-    TInput,
-    TSelfKey
+    TInput
   >;
 };
 
@@ -1145,8 +1134,7 @@ type SetupInvokeConfig<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry,
-  TSelfKey extends string = never
+  TSystemRegistry extends SystemRegistry
 > =
   Next_InvokeConfig<
     TContext,
@@ -1179,8 +1167,7 @@ type SetupInvokeConfig<
             TGuardMap,
             TDelayMap,
             TSystemRegistry,
-            undefined,
-            TSelfKey
+            undefined
           >;
           onError?: StateTransitionConfigOrTarget<
             TStateSchemas,
@@ -1196,8 +1183,7 @@ type SetupInvokeConfig<
             TGuardMap,
             TDelayMap,
             TSystemRegistry,
-            undefined,
-            TSelfKey
+            undefined
           >;
           onSnapshot?: StateTransitionConfigOrTarget<
             TStateSchemas,
@@ -1213,8 +1199,7 @@ type SetupInvokeConfig<
             TGuardMap,
             TDelayMap,
             TSystemRegistry,
-            undefined,
-            TSelfKey
+            undefined
           >;
           onTimeout?: StateTransitionConfigOrTarget<
             TStateSchemas,
@@ -1230,8 +1215,7 @@ type SetupInvokeConfig<
             TGuardMap,
             TDelayMap,
             TSystemRegistry,
-            undefined,
-            TSelfKey
+            undefined
           >;
         }
       : never
@@ -1251,8 +1235,7 @@ type StateTransitionConfigOrTarget<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined,
-  TSelfKey extends string = never
+  TInput = undefined
 > =
   | undefined
   | StateTransitionObjectConfig<
@@ -1266,8 +1249,7 @@ type StateTransitionConfigOrTarget<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TSystemRegistry,
-      TSelfKey
+      TSystemRegistry
     >
   | StateTransitionFunction<
       TStateSchemas,
@@ -1283,8 +1265,7 @@ type StateTransitionConfigOrTarget<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      TInput,
-      TSelfKey
+      TInput
     >;
 
 type StateTransitionObjectConfig<
@@ -1298,8 +1279,7 @@ type StateTransitionObjectConfig<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry,
-  TSelfKey extends string = never
+  TSystemRegistry extends SystemRegistry
 > =
   | (StateTransitionResult<
       TStateSchemas,
@@ -1313,8 +1293,7 @@ type StateTransitionObjectConfig<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      true,
-      TSelfKey
+      true
     > & {
       description?: string;
     })
@@ -1446,8 +1425,7 @@ type StateTransitionFunction<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined,
-  TSelfKey extends string = never
+  TInput = undefined
 > = (
   args: {
     context: TContext;
@@ -1476,8 +1454,7 @@ type StateTransitionFunction<
   TGuardMap,
   TDelayMap,
   TSystemRegistry,
-  false,
-  TSelfKey
+  false
 > | void;
 
 /** A function that computes a transition target's `input` from the event. */
@@ -1489,36 +1466,27 @@ type TransitionInputFn<
 ) => StateInput<TSchema>;
 
 /**
- * The `input`/`reenter` requirement for one transition target:
+ * The `input` requirement for one transition target:
  *
  * - No input schema → `input` optional
- * - Cross-target → `input` required
- * - Self-target → `input` required only when re-entering (`reenter: true`);
- *   without reenter it is relaxed to optional (the runtime drops it anyway).
+ * - Has input schema → `input` required
+ *
+ * The requirement is uniform across self- and cross-transitions. A self-
+ * transition without `reenter` still requires `input`, but the runtime drops it
+ * because the target is not re-entered.
  */
 type TransitionInputRequirement<
   TSchema extends SetupStateSchema,
-  TContext extends MachineContext,
-  TIsSelf extends boolean
+  TContext extends MachineContext
 > = [StateInput<TSchema>] extends [undefined]
   ? {
       reenter?: boolean;
       input?: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
     }
-  : TIsSelf extends true
-    ?
-        | {
-            reenter?: false;
-            input?: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
-          }
-        | {
-            reenter: boolean;
-            input: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
-          }
-    : {
-        reenter?: boolean;
-        input: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
-      };
+  : {
+      reenter?: boolean;
+      input: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
+    };
 
 type StateTransitionResult<
   TStateSchemas extends Record<string, SetupStateSchema>,
@@ -1532,8 +1500,7 @@ type StateTransitionResult<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TSystemRegistry extends SystemRegistry,
-  TAllowContextMapper extends boolean,
-  TSelfKey extends string = never
+  TAllowContextMapper extends boolean
 > =
   | {
       target?: never;
@@ -1558,11 +1525,7 @@ type StateTransitionResult<
       [K in keyof TStateSchemas & string]: {
         target: K;
         meta?: TMeta;
-      } & TransitionInputRequirement<
-        TStateSchemas[K],
-        TContext,
-        K extends TSelfKey ? true : false
-      > &
+      } & TransitionInputRequirement<TStateSchemas[K], TContext> &
         ([TContextShape] extends [
           StateContextShape<TStateSchemas[K], TContextShape>
         ]

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1480,7 +1480,6 @@ type StateTransitionFunction<
   TSelfKey
 > | void;
 
-/** The `input` value (or input-computing function) accepted by a transition. */
 type TransitionInputValue<
   TSchema extends SetupStateSchema,
   TContext extends MachineContext
@@ -1494,15 +1493,9 @@ type TransitionInputValue<
     ) => StateInput<TSchema>);
 
 /**
- * The `input`/`reenter` requirement for a single transition target.
- *
- * - No input schema → `input` is always optional.
- * - A cross-target with an input schema → `input` is always required.
- * - A self-target with an input schema → `input` is only applied (and therefore
- *   required) when the state is re-entered. Without `reenter: true` the target
- *   is not re-entered, so `input` is dropped at runtime (see the runtime
- *   backstop) and is relaxed to optional here to avoid forcing the user to
- *   write a value the runtime ignores.
+ * A self-target without `reenter: true` relaxes `input` to optional: the
+ * runtime drops it anyway (see the runtime backstop), so requiring it would
+ * force the user to write a value that gets ignored.
  */
 type TransitionInputRequirement<
   TSchema extends SetupStateSchema,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1457,7 +1457,6 @@ type StateTransitionFunction<
   false
 > | void;
 
-/** A function that computes a transition target's `input` from the event. */
 type TransitionInputFn<
   TSchema extends SetupStateSchema,
   TContext extends MachineContext
@@ -1465,16 +1464,6 @@ type TransitionInputFn<
   args: { context: TContext; event: EventObject } & OutputArg<EventObject>
 ) => StateInput<TSchema>;
 
-/**
- * The `input` requirement for one transition target:
- *
- * - No input schema → `input` optional
- * - Has input schema → `input` required
- *
- * The requirement is uniform across self- and cross-transitions. A self-
- * transition without `reenter` still requires `input`, but the runtime drops it
- * because the target is not re-entered.
- */
 type TransitionInputRequirement<
   TSchema extends SetupStateSchema,
   TContext extends MachineContext
@@ -1609,7 +1598,6 @@ type RequiredContextKeys<TCurrentContext, TTargetContext> = {
     : K;
 }[keyof TTargetContext];
 
-/** A function that computes an initial target's `input` from the event. */
 type InitialInputFn<
   TSchema extends SetupStateSchema,
   TContext extends MachineContext,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -27,6 +27,7 @@ import {
   DoneActorEvent,
   DoneStateEvent,
   ErrorActorEvent,
+  ErrorEvent,
   SystemRegistry,
   RegistryKeyForLogic,
   ActorOptions,
@@ -894,7 +895,14 @@ type StateNodeConfigWithNestedInput<
       Record<string, unknown>,
       TSystemRegistry
     >,
-    'on' | 'always' | 'initial' | 'invoke' | 'onDone'
+    | 'on'
+    | 'always'
+    | 'initial'
+    | 'invoke'
+    | 'onDone'
+    | 'after'
+    | 'onError'
+    | 'onTimeout'
   > & {
     initial?: TStateSchema['states'] extends Record<string, SetupStateSchema>
       ?
@@ -974,6 +982,56 @@ type StateNodeConfigWithNestedInput<
       TSystemRegistry,
       StateInput<TStateSchema>
     >;
+    onError?: StateTransitionConfigOrTarget<
+      TSiblingStateSchemas,
+      StateContext<TStateSchema, TContext>,
+      StateContextShape<TStateSchema, TContextShape>,
+      ErrorEvent,
+      TEvent,
+      TEmitted,
+      TChildren,
+      TMeta,
+      TActionMap,
+      TActorMap,
+      TGuardMap,
+      TDelayMap,
+      TSystemRegistry,
+      StateInput<TStateSchema>
+    >;
+    onTimeout?: StateTransitionConfigOrTarget<
+      TSiblingStateSchemas,
+      StateContext<TStateSchema, TContext>,
+      StateContextShape<TStateSchema, TContextShape>,
+      TEvent,
+      TEvent,
+      TEmitted,
+      TChildren,
+      TMeta,
+      TActionMap,
+      TActorMap,
+      TGuardMap,
+      TDelayMap,
+      TSystemRegistry,
+      StateInput<TStateSchema>
+    >;
+    after?: {
+      [K in NoInfer<TDelays> | number]?: StateTransitionConfigOrTarget<
+        TSiblingStateSchemas,
+        StateContext<TStateSchema, TContext>,
+        StateContextShape<TStateSchema, TContextShape>,
+        TEvent,
+        TEvent,
+        TEmitted,
+        TChildren,
+        TMeta,
+        TActionMap,
+        TActorMap,
+        TGuardMap,
+        TDelayMap,
+        TSystemRegistry,
+        StateInput<TStateSchema>
+      >;
+    };
   },
   TStateSchema['states'] extends Record<string, SetupStateSchema>
     ? StatesWithInput<
@@ -1433,49 +1491,62 @@ type StateTransitionResult<
         target: K;
         reenter?: boolean;
         meta?: TMeta;
-        input?:
-          | StateInput<TStateSchemas[K]>
-          | ((
-              args: {
-                context: TContext;
-                event: EventObject;
-              } & OutputArg<EventObject>
-            ) => StateInput<TStateSchemas[K]>);
-      } & ([TContextShape] extends [
-        StateContextShape<TStateSchemas[K], TContextShape>
-      ]
+      } & ([StateInput<TStateSchemas[K]>] extends [undefined]
         ? {
-            context?: StateTransitionContext<
-              TAllowContextMapper,
-              TContext,
-              TContextShape,
-              StateContextShape<TStateSchemas[K], TContextShape>,
-              StateContext<TStateSchemas[K], TContext>,
-              TExpressionEvent,
-              TChildren,
-              TActionMap,
-              TActorMap,
-              TGuardMap,
-              TDelayMap,
-              TSystemRegistry
-            >;
+            input?:
+              | StateInput<TStateSchemas[K]>
+              | ((
+                  args: {
+                    context: TContext;
+                    event: EventObject;
+                  } & OutputArg<EventObject>
+                ) => StateInput<TStateSchemas[K]>);
           }
         : {
-            context: StateTransitionContext<
-              TAllowContextMapper,
-              TContext,
-              TContextShape,
-              StateContextShape<TStateSchemas[K], TContextShape>,
-              StateContext<TStateSchemas[K], TContext>,
-              TExpressionEvent,
-              TChildren,
-              TActionMap,
-              TActorMap,
-              TGuardMap,
-              TDelayMap,
-              TSystemRegistry
-            >;
-          });
+            input:
+              | StateInput<TStateSchemas[K]>
+              | ((
+                  args: {
+                    context: TContext;
+                    event: EventObject;
+                  } & OutputArg<EventObject>
+                ) => StateInput<TStateSchemas[K]>);
+          }) &
+        ([TContextShape] extends [
+          StateContextShape<TStateSchemas[K], TContextShape>
+        ]
+          ? {
+              context?: StateTransitionContext<
+                TAllowContextMapper,
+                TContext,
+                TContextShape,
+                StateContextShape<TStateSchemas[K], TContextShape>,
+                StateContext<TStateSchemas[K], TContext>,
+                TExpressionEvent,
+                TChildren,
+                TActionMap,
+                TActorMap,
+                TGuardMap,
+                TDelayMap,
+                TSystemRegistry
+              >;
+            }
+          : {
+              context: StateTransitionContext<
+                TAllowContextMapper,
+                TContext,
+                TContextShape,
+                StateContextShape<TStateSchemas[K], TContextShape>,
+                StateContext<TStateSchemas[K], TContext>,
+                TExpressionEvent,
+                TChildren,
+                TActionMap,
+                TActorMap,
+                TGuardMap,
+                TDelayMap,
+                TSystemRegistry
+              >;
+            });
     }[keyof TStateSchemas & string]
   | {
       target: Exclude<
@@ -1532,13 +1603,23 @@ type InitialTransitionWithInput<
 > = {
   [K in keyof TStateSchemas & string]: {
     target: K;
-    input?:
-      | StateInput<TStateSchemas[K]>
-      | ((args: {
-          context: TContext;
-          event: TEvent;
-        }) => StateInput<TStateSchemas[K]>);
-  };
+  } & ([StateInput<TStateSchemas[K]>] extends [undefined]
+    ? {
+        input?:
+          | StateInput<TStateSchemas[K]>
+          | ((args: {
+              context: TContext;
+              event: TEvent;
+            }) => StateInput<TStateSchemas[K]>);
+      }
+    : {
+        input:
+          | StateInput<TStateSchemas[K]>
+          | ((args: {
+              context: TContext;
+              event: TEvent;
+            }) => StateInput<TStateSchemas[K]>);
+      });
 }[keyof TStateSchemas & string];
 
 /** Return type of setup() */

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -854,7 +854,8 @@ type StatesWithInput<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TSystemRegistry
+    TSystemRegistry,
+    K
   >;
 };
 
@@ -875,7 +876,8 @@ type StateNodeConfigWithNestedInput<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TSelfKey extends string = never
 > = WithNestedStates<
   Omit<
     Next_StateNodeConfig<
@@ -932,7 +934,8 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>
+      StateInput<TStateSchema>,
+      TSelfKey
     >;
     always?: StateTransitionConfigOrTarget<
       TSiblingStateSchemas,
@@ -948,7 +951,8 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>
+      StateInput<TStateSchema>,
+      TSelfKey
     >;
     invoke?: SingleOrArray<
       SetupInvokeConfig<
@@ -963,7 +967,8 @@ type StateNodeConfigWithNestedInput<
         TActorMap,
         TGuardMap,
         TDelayMap,
-        TSystemRegistry
+        TSystemRegistry,
+        TSelfKey
       >
     >;
     onDone?: StateTransitionConfigOrTarget<
@@ -980,7 +985,8 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>
+      StateInput<TStateSchema>,
+      TSelfKey
     >;
     onError?: StateTransitionConfigOrTarget<
       TSiblingStateSchemas,
@@ -996,7 +1002,8 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>
+      StateInput<TStateSchema>,
+      TSelfKey
     >;
     onTimeout?: StateTransitionConfigOrTarget<
       TSiblingStateSchemas,
@@ -1012,7 +1019,8 @@ type StateNodeConfigWithNestedInput<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      StateInput<TStateSchema>
+      StateInput<TStateSchema>,
+      TSelfKey
     >;
     after?: {
       [K in NoInfer<TDelays> | number]?: StateTransitionConfigOrTarget<
@@ -1029,7 +1037,8 @@ type StateNodeConfigWithNestedInput<
         TGuardMap,
         TDelayMap,
         TSystemRegistry,
-        StateInput<TStateSchema>
+        StateInput<TStateSchema>,
+        TSelfKey
       >;
     };
   },
@@ -1086,7 +1095,8 @@ type StateTransitions<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined
+  TInput = undefined,
+  TSelfKey extends string = never
 > = {
   [K in EventDescriptor<TEvent>]?: StateTransitionConfigOrTarget<
     TStateSchemas,
@@ -1102,7 +1112,8 @@ type StateTransitions<
     TGuardMap,
     TDelayMap,
     TSystemRegistry,
-    TInput
+    TInput,
+    TSelfKey
   >;
 };
 
@@ -1134,7 +1145,8 @@ type SetupInvokeConfig<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TSelfKey extends string = never
 > =
   Next_InvokeConfig<
     TContext,
@@ -1166,7 +1178,9 @@ type SetupInvokeConfig<
             TActorMap,
             TGuardMap,
             TDelayMap,
-            TSystemRegistry
+            TSystemRegistry,
+            undefined,
+            TSelfKey
           >;
           onError?: StateTransitionConfigOrTarget<
             TStateSchemas,
@@ -1181,7 +1195,9 @@ type SetupInvokeConfig<
             TActorMap,
             TGuardMap,
             TDelayMap,
-            TSystemRegistry
+            TSystemRegistry,
+            undefined,
+            TSelfKey
           >;
           onSnapshot?: StateTransitionConfigOrTarget<
             TStateSchemas,
@@ -1196,7 +1212,9 @@ type SetupInvokeConfig<
             TActorMap,
             TGuardMap,
             TDelayMap,
-            TSystemRegistry
+            TSystemRegistry,
+            undefined,
+            TSelfKey
           >;
           onTimeout?: StateTransitionConfigOrTarget<
             TStateSchemas,
@@ -1211,7 +1229,9 @@ type SetupInvokeConfig<
             TActorMap,
             TGuardMap,
             TDelayMap,
-            TSystemRegistry
+            TSystemRegistry,
+            undefined,
+            TSelfKey
           >;
         }
       : never
@@ -1231,7 +1251,8 @@ type StateTransitionConfigOrTarget<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined
+  TInput = undefined,
+  TSelfKey extends string = never
 > =
   | undefined
   | StateTransitionObjectConfig<
@@ -1245,7 +1266,8 @@ type StateTransitionConfigOrTarget<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TSystemRegistry
+      TSystemRegistry,
+      TSelfKey
     >
   | StateTransitionFunction<
       TStateSchemas,
@@ -1261,7 +1283,8 @@ type StateTransitionConfigOrTarget<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      TInput
+      TInput,
+      TSelfKey
     >;
 
 type StateTransitionObjectConfig<
@@ -1275,7 +1298,8 @@ type StateTransitionObjectConfig<
   TActorMap extends Implementations['actorSources'],
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TSelfKey extends string = never
 > =
   | (StateTransitionResult<
       TStateSchemas,
@@ -1289,7 +1313,8 @@ type StateTransitionObjectConfig<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      true
+      true,
+      TSelfKey
     > & {
       description?: string;
     })
@@ -1421,7 +1446,8 @@ type StateTransitionFunction<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined
+  TInput = undefined,
+  TSelfKey extends string = never
 > = (
   args: {
     context: TContext;
@@ -1450,8 +1476,45 @@ type StateTransitionFunction<
   TGuardMap,
   TDelayMap,
   TSystemRegistry,
-  false
+  false,
+  TSelfKey
 > | void;
+
+/** The `input` value (or input-computing function) accepted by a transition. */
+type TransitionInputValue<
+  TSchema extends SetupStateSchema,
+  TContext extends MachineContext
+> =
+  | StateInput<TSchema>
+  | ((
+      args: {
+        context: TContext;
+        event: EventObject;
+      } & OutputArg<EventObject>
+    ) => StateInput<TSchema>);
+
+/**
+ * The `input`/`reenter` requirement for a single transition target.
+ *
+ * - No input schema → `input` is always optional.
+ * - A cross-target with an input schema → `input` is always required.
+ * - A self-target with an input schema → `input` is only applied (and therefore
+ *   required) when the state is re-entered. Without `reenter: true` the target
+ *   is not re-entered, so `input` is dropped at runtime (see the runtime
+ *   backstop) and is relaxed to optional here to avoid forcing the user to
+ *   write a value the runtime ignores.
+ */
+type TransitionInputRequirement<
+  TSchema extends SetupStateSchema,
+  TContext extends MachineContext,
+  TIsSelf extends boolean
+> = [StateInput<TSchema>] extends [undefined]
+  ? { reenter?: boolean; input?: TransitionInputValue<TSchema, TContext> }
+  : TIsSelf extends true
+    ?
+        | { reenter?: false; input?: TransitionInputValue<TSchema, TContext> }
+        | { reenter: boolean; input: TransitionInputValue<TSchema, TContext> }
+    : { reenter?: boolean; input: TransitionInputValue<TSchema, TContext> };
 
 type StateTransitionResult<
   TStateSchemas extends Record<string, SetupStateSchema>,
@@ -1465,7 +1528,8 @@ type StateTransitionResult<
   TGuardMap extends Implementations['guards'],
   TDelayMap extends Implementations['delays'],
   TSystemRegistry extends SystemRegistry,
-  TAllowContextMapper extends boolean
+  TAllowContextMapper extends boolean,
+  TSelfKey extends string = never
 > =
   | {
       target?: never;
@@ -1489,29 +1553,12 @@ type StateTransitionResult<
   | {
       [K in keyof TStateSchemas & string]: {
         target: K;
-        reenter?: boolean;
         meta?: TMeta;
-      } & ([StateInput<TStateSchemas[K]>] extends [undefined]
-        ? {
-            input?:
-              | StateInput<TStateSchemas[K]>
-              | ((
-                  args: {
-                    context: TContext;
-                    event: EventObject;
-                  } & OutputArg<EventObject>
-                ) => StateInput<TStateSchemas[K]>);
-          }
-        : {
-            input:
-              | StateInput<TStateSchemas[K]>
-              | ((
-                  args: {
-                    context: TContext;
-                    event: EventObject;
-                  } & OutputArg<EventObject>
-                ) => StateInput<TStateSchemas[K]>);
-          }) &
+      } & TransitionInputRequirement<
+        TStateSchemas[K],
+        TContext,
+        K extends TSelfKey ? true : false
+      > &
         ([TContextShape] extends [
           StateContextShape<TStateSchemas[K], TContextShape>
         ]

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1480,34 +1480,45 @@ type StateTransitionFunction<
   TSelfKey
 > | void;
 
-type TransitionInputValue<
+/** A function that computes a transition target's `input` from the event. */
+type TransitionInputFn<
   TSchema extends SetupStateSchema,
   TContext extends MachineContext
-> =
-  | StateInput<TSchema>
-  | ((
-      args: {
-        context: TContext;
-        event: EventObject;
-      } & OutputArg<EventObject>
-    ) => StateInput<TSchema>);
+> = (
+  args: { context: TContext; event: EventObject } & OutputArg<EventObject>
+) => StateInput<TSchema>;
 
 /**
- * A self-target without `reenter: true` relaxes `input` to optional: the
- * runtime drops it anyway (see the runtime backstop), so requiring it would
- * force the user to write a value that gets ignored.
+ * The `input`/`reenter` requirement for one transition target:
+ *
+ * - No input schema → `input` optional
+ * - Cross-target → `input` required
+ * - Self-target → `input` required only when re-entering (`reenter: true`);
+ *   without reenter it is relaxed to optional (the runtime drops it anyway).
  */
 type TransitionInputRequirement<
   TSchema extends SetupStateSchema,
   TContext extends MachineContext,
   TIsSelf extends boolean
 > = [StateInput<TSchema>] extends [undefined]
-  ? { reenter?: boolean; input?: TransitionInputValue<TSchema, TContext> }
+  ? {
+      reenter?: boolean;
+      input?: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
+    }
   : TIsSelf extends true
     ?
-        | { reenter?: false; input?: TransitionInputValue<TSchema, TContext> }
-        | { reenter: boolean; input: TransitionInputValue<TSchema, TContext> }
-    : { reenter?: boolean; input: TransitionInputValue<TSchema, TContext> };
+        | {
+            reenter?: false;
+            input?: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
+          }
+        | {
+            reenter: boolean;
+            input: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
+          }
+    : {
+        reenter?: boolean;
+        input: StateInput<TSchema> | TransitionInputFn<TSchema, TContext>;
+      };
 
 type StateTransitionResult<
   TStateSchemas extends Record<string, SetupStateSchema>,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1646,6 +1646,13 @@ type RequiredContextKeys<TCurrentContext, TTargetContext> = {
     : K;
 }[keyof TTargetContext];
 
+/** A function that computes an initial target's `input` from the event. */
+type InitialInputFn<
+  TSchema extends SetupStateSchema,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = (args: { context: TContext; event: TEvent }) => StateInput<TSchema>;
+
 /** Initial transition with typed input based on target state */
 type InitialTransitionWithInput<
   TStateSchemas extends Record<string, SetupStateSchema>,
@@ -1658,18 +1665,12 @@ type InitialTransitionWithInput<
     ? {
         input?:
           | StateInput<TStateSchemas[K]>
-          | ((args: {
-              context: TContext;
-              event: TEvent;
-            }) => StateInput<TStateSchemas[K]>);
+          | InitialInputFn<TStateSchemas[K], TContext, TEvent>;
       }
     : {
         input:
           | StateInput<TStateSchemas[K]>
-          | ((args: {
-              context: TContext;
-              event: TEvent;
-            }) => StateInput<TStateSchemas[K]>);
+          | InitialInputFn<TStateSchemas[K], TContext, TEvent>;
       });
 }[keyof TStateSchemas & string];
 

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1446,8 +1446,22 @@ function microstep(
         );
         if (input && targets) {
           for (const targetNode of targets) {
-            stateInputMap[targetNode.id] = input;
-            stateInputsChanged = true;
+            // Only store the input for targets that are actually being
+            // (re)entered — i.e. present in the computed entry set. Otherwise the
+            // input would be stored but never consumed, since the target's entry
+            // actions never fire (e.g. a self-transition without `reenter: true`,
+            // or a transition whose target is a history node).
+            if (statesToEnter.has(targetNode)) {
+              stateInputMap[targetNode.id] = input;
+              stateInputsChanged = true;
+            } else if (isDevelopment) {
+              console.warn(
+                `Input provided on a transition to state "${targetNode.id}" is ignored ` +
+                  `because "${targetNode.id}" is not being (re)entered by this transition ` +
+                  `(for example, a self-transition without \`reenter: true\`). Add ` +
+                  `\`reenter: true\` to re-enter the state and apply the input.`
+              );
+            }
           }
         }
       }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1452,10 +1452,6 @@ function microstep(
             if (statesToEnter.has(targetNode)) {
               stateInputMap[targetNode.id] = input;
               stateInputsChanged = true;
-            } else if (isDevelopment) {
-              console.warn(
-                `Ignored \`input\` for state "${targetNode.id}" because it is not being (re)entered. Add \`reenter: true\` to re-enter and apply it.`
-              );
             }
           }
         }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1446,20 +1446,15 @@ function microstep(
         );
         if (input && targets) {
           for (const targetNode of targets) {
-            // Only store the input for targets that are actually being
-            // (re)entered — i.e. present in the computed entry set. Otherwise the
-            // input would be stored but never consumed, since the target's entry
-            // actions never fire (e.g. a self-transition without `reenter: true`,
-            // or a transition whose target is a history node).
+            // Only store input for a target that's actually being (re)entered;
+            // otherwise the input would never be consumed (its entry actions
+            // never fire).
             if (statesToEnter.has(targetNode)) {
               stateInputMap[targetNode.id] = input;
               stateInputsChanged = true;
             } else if (isDevelopment) {
               console.warn(
-                `Input provided on a transition to state "${targetNode.id}" is ignored ` +
-                  `because "${targetNode.id}" is not being (re)entered by this transition ` +
-                  `(for example, a self-transition without \`reenter: true\`). Add ` +
-                  `\`reenter: true\` to re-enter the state and apply the input.`
+                `Ignored \`input\` for state "${targetNode.id}" because it is not being (re)entered. Add \`reenter: true\` to re-enter and apply it.`
               );
             }
           }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1445,14 +1445,10 @@ function microstep(
           { resolveActions: false }
         );
         if (input && targets) {
-          for (const targetNode of targets) {
-            // Only store input for a target that's actually being (re)entered;
-            // otherwise the input would never be consumed (its entry actions
-            // never fire).
-            if (statesToEnter.has(targetNode)) {
-              stateInputMap[targetNode.id] = input;
-              stateInputsChanged = true;
-            }
+          const enteredTargets = targets.filter((t) => statesToEnter.has(t));
+          for (const targetNode of enteredTargets) {
+            stateInputMap[targetNode.id] = input;
+            stateInputsChanged = true;
           }
         }
       }

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -2001,6 +2001,13 @@ describe('setup', () => {
 });
 
 describe('required input on transitions', () => {
+  // Restore console.warn (and any other) spies after every test so a spy
+  // installed by a runtime test can't leak into a later test if an assertion
+  // throws before that test's manual restore runs.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   // Each negative (@ts-expect-error) case is paired with a positive twin identical
   // except for `input`; the twin compiling clean proves the error is caused
   // specifically by the missing input, not something unrelated.
@@ -2686,5 +2693,338 @@ describe('required input on transitions', () => {
     });
 
     expect(true).toBe(true);
+  });
+
+  // --- Runtime backstop (Change D) ---
+  // Input on a transition whose target is NOT actually being (re)entered — the
+  // classic case being a self-transition without `reenter: true` — would be
+  // silently stored but never consumed. Detect that: emit a dev warning and do
+  // NOT store the ignored input. These are real machine-execution tests.
+
+  it('self-transition without `reenter` ignores provided input and warns', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const s = setup({
+      states: {
+        active: {
+          schemas: {
+            input: z.object({ count: z.number() })
+          }
+        }
+      }
+    });
+
+    const entryInputs: unknown[] = [];
+    const machine = s.createMachine({
+      initial: {
+        target: 'active',
+        input: { count: 1 }
+      },
+      states: {
+        active: {
+          entry: ({ input }) => {
+            entryInputs.push(input);
+          },
+          on: {
+            // Self-transition WITHOUT reenter, carrying a DISTINCT input value.
+            PING: {
+              target: 'active',
+              input: { count: 2 }
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+
+    // Baseline: initial input applied, entry fired exactly once.
+    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
+      count: 1
+    });
+    expect(entryInputs).toEqual([{ count: 1 }]);
+
+    actor.send({ type: 'PING' });
+
+    // The provided { count: 2 } is ignored: a warning fires naming the state
+    // and telling the user how to fix it...
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain('(machine).active');
+    expect(warnSpy.mock.calls[0][0]).toContain('reenter: true');
+
+    // ...the stored input is UNCHANGED (still the original { count: 1 }),
+    // proving the ignored { count: 2 } was never stored...
+    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
+      count: 1
+    });
+
+    // ...and entry did not re-fire (no reenter).
+    expect(entryInputs).toEqual([{ count: 1 }]);
+
+    warnSpy.mockRestore();
+  });
+
+  it('self-transition with `reenter: true` applies the new input and does not warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const s = setup({
+      states: {
+        active: {
+          schemas: {
+            input: z.object({ count: z.number() })
+          }
+        }
+      }
+    });
+
+    const entryInputs: unknown[] = [];
+    const machine = s.createMachine({
+      initial: {
+        target: 'active',
+        input: { count: 1 }
+      },
+      states: {
+        active: {
+          entry: ({ input }) => {
+            entryInputs.push(input);
+          },
+          on: {
+            // Self-transition WITH reenter: the state IS re-entered.
+            PING: {
+              target: 'active',
+              reenter: true,
+              input: { count: 2 }
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    expect(entryInputs).toEqual([{ count: 1 }]);
+
+    actor.send({ type: 'PING' });
+
+    // The guard does not over-suppress: no warning fires...
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // ...entry re-fired and saw the NEW input...
+    expect(entryInputs).toEqual([{ count: 1 }, { count: 2 }]);
+
+    // ...and the stored input is updated to the new value.
+    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
+      count: 2
+    });
+
+    warnSpy.mockRestore();
+  });
+
+  it('normal transition to a different target applies input and does not warn', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const s = setup({
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    const entryInputs: unknown[] = [];
+    const machine = s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            LOAD: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            }
+          }
+        },
+        loading: {
+          entry: ({ input }) => {
+            entryInputs.push(input);
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'LOAD' });
+
+    // The common case is unaffected: no warning...
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    // ...entry saw the input...
+    expect(entryInputs).toEqual([{ userId: 'user-1' }]);
+
+    // ...and it was stored.
+    expect(actor.getSnapshot().getInputs()['(machine).loading']).toEqual({
+      userId: 'user-1'
+    });
+
+    warnSpy.mockRestore();
+  });
+
+  // Runtime backstop (Change D) at the COMPOUND seam. The parent is itself a
+  // compound state WITH an input schema, and the self-transition targets the
+  // parent. Distinct input values (`pv: 1` vs `pv: 2`) make this non-vacuous:
+  // whether the provided `{ pv: 2 }` is applied hinges solely on whether the
+  // parent is actually re-entered. Without `reenter` the parent stays active
+  // (not in the entry set), so its input is dropped and the dev warning fires;
+  // with `reenter: true` the parent is re-entered, so its input is applied and
+  // no warning fires. (The compound child re-enters via the default-entry path
+  // in both cases — a separate code path — and never triggers the warning.)
+  it('compound self-transition applies parent input only when the parent is re-entered', () => {
+    const s = setup({
+      states: {
+        parent: {
+          schemas: {
+            input: z.object({ pv: z.number() })
+          },
+          states: {
+            child: {}
+          }
+        }
+      }
+    });
+
+    // --- Case A: self-transition to the compound parent WITHOUT `reenter`. ---
+    // The parent stays active (not re-entered), so the provided `{ pv: 2 }` is
+    // ignored, the original `{ pv: 1 }` is retained, and the warning fires.
+    {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const parentEntries: unknown[] = [];
+      const childEntries: string[] = [];
+
+      const machine = s.createMachine({
+        initial: {
+          target: 'parent',
+          input: { pv: 1 }
+        },
+        states: {
+          parent: {
+            initial: 'child',
+            entry: ({ input }) => {
+              parentEntries.push(input);
+            },
+            on: {
+              // Compound self-transition WITHOUT reenter, carrying a DISTINCT input.
+              PING: {
+                target: 'parent',
+                input: { pv: 2 }
+              }
+            },
+            states: {
+              child: {
+                entry: () => {
+                  childEntries.push('child');
+                }
+              }
+            }
+          }
+        }
+      });
+
+      const actor = createActor(machine).start();
+
+      // Baseline: the parent's own initial input `{ pv: 1 }` reached its entry
+      // and was stored.
+      expect(parentEntries).toEqual([{ pv: 1 }]);
+      expect(childEntries).toEqual(['child']);
+      expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+        pv: 1
+      });
+
+      actor.send({ type: 'PING' });
+
+      // The parent is NOT re-entered → the provided `{ pv: 2 }` is ignored: the
+      // warning fires once, naming the state and how to fix it...
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('ignored');
+      expect(warnSpy.mock.calls[0][0]).toContain('(machine).parent');
+      expect(warnSpy.mock.calls[0][0]).toContain('reenter: true');
+
+      // ...the parent's entry did NOT re-fire and its stored input stays the
+      // original `{ pv: 1 }`, proving the ignored `{ pv: 2 }` was never stored...
+      expect(parentEntries).toEqual([{ pv: 1 }]);
+      expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+        pv: 1
+      });
+
+      // ...while the compound child still re-entered via the default-entry path
+      // (a separate code path that never triggers the warning).
+      expect(childEntries).toEqual(['child', 'child']);
+
+      warnSpy.mockRestore();
+    }
+
+    // --- Case B: self-transition to the compound parent WITH `reenter: true`. ---
+    // The parent IS re-entered, so the provided `{ pv: 2 }` is applied (entry
+    // re-fires) and stored; no warning fires.
+    {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const parentEntries: unknown[] = [];
+      const childEntries: string[] = [];
+
+      const machine = s.createMachine({
+        initial: {
+          target: 'parent',
+          input: { pv: 1 }
+        },
+        states: {
+          parent: {
+            initial: 'child',
+            entry: ({ input }) => {
+              parentEntries.push(input);
+            },
+            on: {
+              // Compound self-transition WITH reenter, carrying a DISTINCT input.
+              PING: {
+                target: 'parent',
+                reenter: true,
+                input: { pv: 2 }
+              }
+            },
+            states: {
+              child: {
+                entry: () => {
+                  childEntries.push('child');
+                }
+              }
+            }
+          }
+        }
+      });
+
+      const actor = createActor(machine).start();
+      expect(parentEntries).toEqual([{ pv: 1 }]);
+      expect(childEntries).toEqual(['child']);
+      expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+        pv: 1
+      });
+
+      actor.send({ type: 'PING' });
+
+      // The parent IS re-entered → no warning fires...
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      // ...its entry re-fires and sees the NEW input `{ pv: 2 }`...
+      expect(parentEntries).toEqual([{ pv: 1 }, { pv: 2 }]);
+
+      // ...the stored input is updated to `{ pv: 2 }`...
+      expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+        pv: 2
+      });
+
+      // ...and the child re-entered again as well.
+      expect(childEntries).toEqual(['child', 'child']);
+
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1999,3 +1999,692 @@ describe('setup', () => {
     expect(true).toBe(true);
   });
 });
+
+describe('required input on transitions', () => {
+  // Each negative (@ts-expect-error) case is paired with a positive twin identical
+  // except for `input`; the twin compiling clean proves the error is caused
+  // specifically by the missing input, not something unrelated.
+  it('`on` transition to an input-schema sibling requires input', () => {
+    const s = setup({
+      schemas: {
+        events: {
+          LOAD: z.object({})
+        }
+      },
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: omitting `input` on a transition to an input-schema sibling errors.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            // @ts-expect-error - target `loading` declares schemas.input, so input is required
+            LOAD: {
+              target: 'loading'
+            }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: identical except it supplies a valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            LOAD: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('`on` transition rejects a wrong-shaped input', () => {
+    const s = setup({
+      schemas: {
+        events: {
+          LOAD: z.object({})
+        }
+      },
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: `userId` must be a string, not a number.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            // @ts-expect-error - loading input requires userId: string, not number
+            LOAD: {
+              target: 'loading',
+              input: { userId: 123 }
+            }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: correct input shape — must compile clean.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            LOAD: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('function-syntax transition return requires input', () => {
+    const s = setup({
+      schemas: {
+        events: {
+          LOAD: z.object({})
+        }
+      },
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: function-syntax return omitting `input` errors.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            // @ts-expect-error - returned transition to `loading` requires input
+            LOAD: () => ({
+              target: 'loading'
+            })
+          }
+        },
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: function-syntax return supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            LOAD: () => ({
+              target: 'loading',
+              input: { userId: 'user-1' }
+            })
+          }
+        },
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('`always` transition requires input', () => {
+    const s = setup({
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: eventless `always` transition omitting `input` errors.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          // @ts-expect-error - always target `loading` requires input
+          always: {
+            target: 'loading'
+          }
+        },
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: `always` supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          always: {
+            target: 'loading',
+            input: { userId: 'user-1' }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('`after` delayed transition requires input', () => {
+    const s = setup({
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: delayed `after` transition omitting `input` errors.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          after: {
+            // @ts-expect-error - after target `loading` requires input
+            1000: {
+              target: 'loading'
+            }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: `after` supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          after: {
+            1000: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('state-level `onTimeout` transition requires input', () => {
+    const s = setup({
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: `onTimeout` transition omitting `input` errors.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          timeout: 1000,
+          // @ts-expect-error - onTimeout target `loading` requires input
+          onTimeout: {
+            target: 'loading'
+          }
+        },
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: `onTimeout` supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          timeout: 1000,
+          onTimeout: {
+            target: 'loading',
+            input: { userId: 'user-1' }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('state-level `onDone` transition requires input', () => {
+    const s = setup({
+      states: {
+        work: {
+          states: {
+            step: {}
+          }
+        },
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: `onDone` transition omitting `input` errors.
+    s.createMachine({
+      initial: 'work',
+      states: {
+        work: {
+          initial: 'step',
+          states: {
+            step: { type: 'final' }
+          },
+          // @ts-expect-error - onDone target `loading` requires input
+          onDone: {
+            target: 'loading'
+          }
+        },
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: `onDone` supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'work',
+      states: {
+        work: {
+          initial: 'step',
+          states: {
+            step: { type: 'final' }
+          },
+          onDone: {
+            target: 'loading',
+            input: { userId: 'user-1' }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('state-level `onError` transition requires input', () => {
+    const s = setup({
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: `onError` transition omitting `input` errors.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          // @ts-expect-error - onError target `loading` requires input
+          onError: {
+            target: 'loading'
+          }
+        },
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: `onError` supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          onError: {
+            target: 'loading',
+            input: { userId: 'user-1' }
+          }
+        },
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('object-form `initial` to an input-schema target requires input', () => {
+    const s = setup({
+      states: {
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: object-form `initial` omitting `input` errors.
+    s.createMachine({
+      // @ts-expect-error - initial target `loading` requires input
+      initial: {
+        target: 'loading'
+      },
+      states: {
+        loading: {}
+      }
+    });
+
+    // POSITIVE TWIN: object-form `initial` supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: {
+        target: 'loading',
+        input: { userId: 'user-1' }
+      },
+      states: {
+        loading: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('out-of-scope and no-schema targets keep input optional', () => {
+    const s = setup({
+      schemas: {
+        events: {
+          GO: z.object({})
+        }
+      },
+      states: {
+        idle: {},
+        loading: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      }
+    });
+
+    // Guard: a bare sibling target to `loading` IS enforced here — proving that
+    // `createStateConfig` applies the required-input rule, so the out-of-scope
+    // positives below are non-vacuous.
+    s.createStateConfig({
+      on: {
+        // @ts-expect-error - bare sibling target `loading` requires input
+        GO: {
+          target: 'loading'
+        }
+      }
+    });
+
+    // `#id` target: type system can't correlate to a schema, so input stays optional.
+    s.createStateConfig({
+      on: {
+        GO: {
+          target: '#loading'
+        }
+      }
+    });
+
+    // `.child` relative target: input stays optional.
+    s.createStateConfig({
+      on: {
+        GO: {
+          target: '.child'
+        }
+      }
+    });
+
+    // array/parallel target: bypasses the per-target union, so input stays optional
+    // (documented escape hatch).
+    s.createStateConfig({
+      on: {
+        GO: {
+          target: ['loading']
+        }
+      }
+    });
+
+    // no-schema sibling target: `idle` declares no input schema, so input stays optional.
+    s.createStateConfig({
+      on: {
+        GO: {
+          target: 'idle'
+        }
+      }
+    });
+
+    // no-target transition: pure context/effect transition, unaffected.
+    s.createStateConfig({
+      on: {
+        GO: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('all-optional / empty input schemas still require input', () => {
+    const s = setup({
+      schemas: {
+        events: {
+          LOAD: z.object({})
+        }
+      },
+      states: {
+        idle: {},
+        // empty schema -> output is `{}` (not `undefined`)
+        empty: {
+          schemas: {
+            input: z.object({})
+          }
+        },
+        // all-optional schema -> output is `{ userId?: string }` (not `undefined`)
+        allOptional: {
+          schemas: {
+            input: z.object({ userId: z.string().optional() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: even an empty-object input schema requires `input`.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            // @ts-expect-error - empty-object input schema still requires input
+            LOAD: {
+              target: 'empty'
+            }
+          }
+        },
+        empty: {},
+        allOptional: {}
+      }
+    });
+
+    // NEGATIVE: an all-optional input schema still requires `input`.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            // @ts-expect-error - all-optional input schema still requires input
+            LOAD: {
+              target: 'allOptional'
+            }
+          }
+        },
+        empty: {},
+        allOptional: {}
+      }
+    });
+
+    // POSITIVE TWINS: supplying `input` (even `{}`) compiles clean.
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            LOAD: {
+              target: 'empty',
+              input: {}
+            }
+          }
+        },
+        empty: {},
+        allOptional: {}
+      }
+    });
+
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            LOAD: {
+              target: 'allOptional',
+              input: {}
+            }
+          }
+        },
+        empty: {},
+        allOptional: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('invoke `onDone`/`onError` transition to an input-schema sibling requires input', () => {
+    const s = setup({
+      states: {
+        loading: {},
+        loaded: {
+          schemas: {
+            input: z.object({ userId: z.string() })
+          }
+        }
+      },
+      actorSources: {
+        load: createAsyncLogic({
+          run: async () => 'Done' as const
+        })
+      }
+    });
+
+    // NEGATIVE: invoke `onDone` targeting an input-schema sibling omits `input`.
+    s.createMachine({
+      initial: 'loading',
+      states: {
+        loading: {
+          // @ts-expect-error - onDone target `loaded` requires input
+          invoke: {
+            src: 'load',
+            onDone: {
+              target: 'loaded'
+            }
+          }
+        },
+        loaded: {}
+      }
+    });
+
+    // POSITIVE TWIN: invoke `onDone` supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'loading',
+      states: {
+        loading: {
+          invoke: {
+            src: 'load',
+            onDone: {
+              target: 'loaded',
+              input: { userId: 'user-1' }
+            }
+          }
+        },
+        loaded: {}
+      }
+    });
+
+    // NEGATIVE: invoke `onError` targeting an input-schema sibling omits `input`.
+    s.createMachine({
+      initial: 'loading',
+      states: {
+        loading: {
+          // @ts-expect-error - onError target `loaded` requires input
+          invoke: {
+            src: 'load',
+            onError: {
+              target: 'loaded'
+            }
+          }
+        },
+        loaded: {}
+      }
+    });
+
+    // POSITIVE TWIN: invoke `onError` supplying valid `input` — must compile clean.
+    s.createMachine({
+      initial: 'loading',
+      states: {
+        loading: {
+          invoke: {
+            src: 'load',
+            onError: {
+              target: 'loaded',
+              input: { userId: 'user-1' }
+            }
+          }
+        },
+        loaded: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+});

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1971,11 +1971,12 @@ describe('required input on transitions', () => {
   // Each negative (@ts-expect-error) case is paired with a positive twin identical
   // except for `input`; the twin compiling clean proves the error is caused
   // specifically by the missing input, not something unrelated.
-  it('`on` transition to an input-schema sibling requires input', () => {
+  it('`on` transitions (object and function syntax) require a correctly-shaped input', () => {
     const s = setup({
       schemas: {
         events: {
-          LOAD: z.object({})
+          LOAD: z.object({}),
+          LOAD_FN: z.object({})
         }
       },
       states: {
@@ -1996,45 +1997,14 @@ describe('required input on transitions', () => {
             // @ts-expect-error - target `loading` declares schemas.input, so input is required
             LOAD: {
               target: 'loading'
-            }
+            },
+            // @ts-expect-error - returned transition to `loading` requires input
+            LOAD_FN: () => ({
+              target: 'loading'
+            })
           }
         },
         loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            LOAD: {
-              target: 'loading',
-              input: { userId: 'user-1' }
-            }
-          }
-        },
-        loading: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('`on` transition rejects a wrong-shaped input', () => {
-    const s = setup({
-      schemas: {
-        events: {
-          LOAD: z.object({})
-        }
-      },
-      states: {
-        idle: {},
-        loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
       }
     });
 
@@ -2062,54 +2032,8 @@ describe('required input on transitions', () => {
             LOAD: {
               target: 'loading',
               input: { userId: 'user-1' }
-            }
-          }
-        },
-        loading: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('function-syntax transition return requires input', () => {
-    const s = setup({
-      schemas: {
-        events: {
-          LOAD: z.object({})
-        }
-      },
-      states: {
-        idle: {},
-        loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            // @ts-expect-error - returned transition to `loading` requires input
-            LOAD: () => ({
-              target: 'loading'
-            })
-          }
-        },
-        loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            LOAD: () => ({
+            },
+            LOAD_FN: () => ({
               target: 'loading',
               input: { userId: 'user-1' }
             })
@@ -2122,10 +2046,16 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
-  it('`always` transition requires input', () => {
+  it('state-level `always`/`after`/`onTimeout`/`onDone`/`onError` transitions require input', () => {
     const s = setup({
       states: {
         idle: {},
+        pending: {},
+        work: {
+          states: {
+            step: {}
+          }
+        },
         loading: {
           schemas: {
             input: z.object({ userId: z.string() })
@@ -2143,133 +2073,23 @@ describe('required input on transitions', () => {
             target: 'loading'
           }
         },
-        loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          always: {
-            target: 'loading',
-            input: { userId: 'user-1' }
-          }
-        },
-        loading: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('`after` delayed transition requires input', () => {
-    const s = setup({
-      states: {
-        idle: {},
-        loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
+        pending: {
           after: {
             // @ts-expect-error - after target `loading` requires input
             1000: {
               target: 'loading'
             }
-          }
-        },
-        loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          after: {
-            1000: {
-              target: 'loading',
-              input: { userId: 'user-1' }
-            }
-          }
-        },
-        loading: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('state-level `onTimeout` transition requires input', () => {
-    const s = setup({
-      states: {
-        idle: {},
-        loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
+          },
           timeout: 1000,
           // @ts-expect-error - onTimeout target `loading` requires input
           onTimeout: {
             target: 'loading'
+          },
+          // @ts-expect-error - onError target `loading` requires input
+          onError: {
+            target: 'loading'
           }
         },
-        loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          timeout: 1000,
-          onTimeout: {
-            target: 'loading',
-            input: { userId: 'user-1' }
-          }
-        },
-        loading: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('state-level `onDone` transition requires input', () => {
-    const s = setup({
-      states: {
-        work: {
-          states: {
-            step: {}
-          }
-        },
-        loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: 'work',
-      states: {
         work: {
           initial: 'step',
           states: {
@@ -2285,55 +2105,37 @@ describe('required input on transitions', () => {
     });
 
     s.createMachine({
-      initial: 'work',
+      initial: 'idle',
       states: {
+        idle: {
+          always: {
+            target: 'loading',
+            input: { userId: 'user-1' }
+          }
+        },
+        pending: {
+          after: {
+            1000: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            }
+          },
+          timeout: 1000,
+          onTimeout: {
+            target: 'loading',
+            input: { userId: 'user-1' }
+          },
+          onError: {
+            target: 'loading',
+            input: { userId: 'user-1' }
+          }
+        },
         work: {
           initial: 'step',
           states: {
             step: { type: 'final' }
           },
           onDone: {
-            target: 'loading',
-            input: { userId: 'user-1' }
-          }
-        },
-        loading: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('state-level `onError` transition requires input', () => {
-    const s = setup({
-      states: {
-        idle: {},
-        loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          // @ts-expect-error - onError target `loading` requires input
-          onError: {
-            target: 'loading'
-          }
-        },
-        loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          onError: {
             target: 'loading',
             input: { userId: 'user-1' }
           }
@@ -2623,11 +2425,12 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
-  it('self-transition to an input-schema target requires input (uniform rule)', () => {
+  it('self-transition to an input-schema target requires input (uniform rule, with or without reenter)', () => {
     const s = setup({
       schemas: {
         events: {
           PING: z.object({}),
+          PING_REENTER: z.object({}),
           GO: z.object({})
         }
       },
@@ -2654,6 +2457,11 @@ describe('required input on transitions', () => {
             PING: {
               target: 'active'
             },
+            // @ts-expect-error - reenter:true re-enters `active`, so input is required
+            PING_REENTER: {
+              target: 'active',
+              reenter: true
+            },
             // @ts-expect-error - target `other` declares schemas.input, so input is required
             GO: {
               target: 'other'
@@ -2664,7 +2472,7 @@ describe('required input on transitions', () => {
       }
     });
 
-    // Supplying input satisfies the requirement for both self and cross targets.
+    // Supplying input satisfies the requirement for self, reentering, and cross targets.
     s.createMachine({
       initial: { target: 'active', input: { count: 1 } },
       states: {
@@ -2674,6 +2482,11 @@ describe('required input on transitions', () => {
               target: 'active',
               input: { count: 2 }
             },
+            PING_REENTER: {
+              target: 'active',
+              reenter: true,
+              input: { count: 2 }
+            },
             GO: {
               target: 'other',
               input: { id: 'x' }
@@ -2681,55 +2494,6 @@ describe('required input on transitions', () => {
           }
         },
         other: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('self-transition with `reenter: true` still requires input', () => {
-    const s = setup({
-      schemas: {
-        events: {
-          PING: z.object({})
-        }
-      },
-      states: {
-        active: {
-          schemas: {
-            input: z.object({ count: z.number() })
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: { target: 'active', input: { count: 1 } },
-      states: {
-        active: {
-          on: {
-            // @ts-expect-error - reenter:true re-enters `active`, so input is required
-            PING: {
-              target: 'active',
-              reenter: true
-            }
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: { target: 'active', input: { count: 1 } },
-      states: {
-        active: {
-          on: {
-            PING: {
-              target: 'active',
-              reenter: true,
-              input: { count: 2 }
-            }
-          }
-        }
       }
     });
 

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -2695,6 +2695,110 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
+  // A self-transition WITHOUT `reenter: true` does not re-enter its target, so
+  // any provided input is dropped at runtime (see the backstop tests below).
+  // Requiring `input` there would force the user to write the very thing the
+  // runtime ignores, so it is relaxed to optional — but only for the self key,
+  // and only when not re-entering. Cross-target transitions and re-entering
+  // self-transitions still require input.
+  it('self-transition without `reenter` relaxes input; cross-transition still requires it', () => {
+    const s = setup({
+      schemas: {
+        events: {
+          PING: z.object({}),
+          GO: z.object({})
+        }
+      },
+      states: {
+        active: {
+          schemas: {
+            input: z.object({ count: z.number() })
+          }
+        },
+        other: {
+          schemas: {
+            input: z.object({ id: z.string() })
+          }
+        }
+      }
+    });
+
+    s.createMachine({
+      initial: { target: 'active', input: { count: 1 } },
+      states: {
+        active: {
+          on: {
+            // POSITIVE: self-target without `reenter` — `input` may be omitted.
+            PING: {
+              target: 'active'
+            },
+            // NEGATIVE: `other` is a DIFFERENT input-schema sibling, so `input`
+            // is still required even though the source relaxes its own self key.
+            // @ts-expect-error - target `other` declares schemas.input, so input is required
+            GO: {
+              target: 'other'
+            }
+          }
+        },
+        other: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('self-transition with `reenter: true` still requires input', () => {
+    const s = setup({
+      schemas: {
+        events: {
+          PING: z.object({})
+        }
+      },
+      states: {
+        active: {
+          schemas: {
+            input: z.object({ count: z.number() })
+          }
+        }
+      }
+    });
+
+    // NEGATIVE: `reenter: true` re-enters `active`, so its input IS applied and
+    // therefore required — the relaxation must not leak into the re-enter case.
+    s.createMachine({
+      initial: { target: 'active', input: { count: 1 } },
+      states: {
+        active: {
+          on: {
+            // @ts-expect-error - reenter:true re-enters `active`, so input is required
+            PING: {
+              target: 'active',
+              reenter: true
+            }
+          }
+        }
+      }
+    });
+
+    // POSITIVE TWIN: identical except it supplies `input` — must compile clean.
+    s.createMachine({
+      initial: { target: 'active', input: { count: 1 } },
+      states: {
+        active: {
+          on: {
+            PING: {
+              target: 'active',
+              reenter: true,
+              input: { count: 2 }
+            }
+          }
+        }
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
   // --- Runtime backstop (Change D) ---
   // Input on a transition whose target is NOT actually being (re)entered — the
   // classic case being a self-transition without `reenter: true` — would be

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -2001,9 +2001,6 @@ describe('setup', () => {
 });
 
 describe('required input on transitions', () => {
-  // Restore console.warn (and any other) spies after every test so a spy
-  // installed by a runtime test can't leak into a later test if an assertion
-  // throws before that test's manual restore runs.
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -2028,7 +2025,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: omitting `input` on a transition to an input-schema sibling errors.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2044,7 +2040,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: identical except it supplies a valid `input` — must compile clean.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2080,7 +2075,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: `userId` must be a string, not a number.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2097,7 +2091,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: correct input shape — must compile clean.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2133,7 +2126,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: function-syntax return omitting `input` errors.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2149,7 +2141,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: function-syntax return supplying valid `input` — must compile clean.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2180,7 +2171,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: eventless `always` transition omitting `input` errors.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2194,7 +2184,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: `always` supplying valid `input` — must compile clean.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2223,7 +2212,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: delayed `after` transition omitting `input` errors.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2239,7 +2227,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: `after` supplying valid `input` — must compile clean.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2270,7 +2257,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: `onTimeout` transition omitting `input` errors.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2285,7 +2271,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: `onTimeout` supplying valid `input` — must compile clean.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2319,7 +2304,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: `onDone` transition omitting `input` errors.
     s.createMachine({
       initial: 'work',
       states: {
@@ -2337,7 +2321,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: `onDone` supplying valid `input` — must compile clean.
     s.createMachine({
       initial: 'work',
       states: {
@@ -2370,7 +2353,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: `onError` transition omitting `input` errors.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2384,7 +2366,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: `onError` supplying valid `input` — must compile clean.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2412,7 +2393,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: object-form `initial` omitting `input` errors.
     s.createMachine({
       // @ts-expect-error - initial target `loading` requires input
       initial: {
@@ -2423,7 +2403,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: object-form `initial` supplying valid `input` — must compile clean.
     s.createMachine({
       initial: {
         target: 'loading',
@@ -2454,9 +2433,8 @@ describe('required input on transitions', () => {
       }
     });
 
-    // Guard: a bare sibling target to `loading` IS enforced here — proving that
-    // `createStateConfig` applies the required-input rule, so the out-of-scope
-    // positives below are non-vacuous.
+    // Guard: a bare sibling target IS enforced here, proving the optional cases
+    // below are non-vacuous.
     s.createStateConfig({
       on: {
         // @ts-expect-error - bare sibling target `loading` requires input
@@ -2466,7 +2444,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // `#id` target: type system can't correlate to a schema, so input stays optional.
     s.createStateConfig({
       on: {
         GO: {
@@ -2475,7 +2452,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // `.child` relative target: input stays optional.
     s.createStateConfig({
       on: {
         GO: {
@@ -2484,8 +2460,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // array/parallel target: bypasses the per-target union, so input stays optional
-    // (documented escape hatch).
     s.createStateConfig({
       on: {
         GO: {
@@ -2494,7 +2468,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // no-schema sibling target: `idle` declares no input schema, so input stays optional.
     s.createStateConfig({
       on: {
         GO: {
@@ -2503,7 +2476,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // no-target transition: pure context/effect transition, unaffected.
     s.createStateConfig({
       on: {
         GO: {}
@@ -2537,7 +2509,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: even an empty-object input schema requires `input`.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2554,7 +2525,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: an all-optional input schema still requires `input`.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2571,7 +2541,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWINS: supplying `input` (even `{}`) compiles clean.
     s.createMachine({
       initial: 'idle',
       states: {
@@ -2624,7 +2593,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: invoke `onDone` targeting an input-schema sibling omits `input`.
     s.createMachine({
       initial: 'loading',
       states: {
@@ -2641,7 +2609,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: invoke `onDone` supplying valid `input` — must compile clean.
     s.createMachine({
       initial: 'loading',
       states: {
@@ -2658,7 +2625,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: invoke `onError` targeting an input-schema sibling omits `input`.
     s.createMachine({
       initial: 'loading',
       states: {
@@ -2675,7 +2641,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: invoke `onError` supplying valid `input` — must compile clean.
     s.createMachine({
       initial: 'loading',
       states: {
@@ -2695,12 +2660,6 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
-  // A self-transition WITHOUT `reenter: true` does not re-enter its target, so
-  // any provided input is dropped at runtime (see the backstop tests below).
-  // Requiring `input` there would force the user to write the very thing the
-  // runtime ignores, so it is relaxed to optional — but only for the self key,
-  // and only when not re-entering. Cross-target transitions and re-entering
-  // self-transitions still require input.
   it('self-transition without `reenter` relaxes input; cross-transition still requires it', () => {
     const s = setup({
       schemas: {
@@ -2728,12 +2687,9 @@ describe('required input on transitions', () => {
       states: {
         active: {
           on: {
-            // POSITIVE: self-target without `reenter` — `input` may be omitted.
             PING: {
               target: 'active'
             },
-            // NEGATIVE: `other` is a DIFFERENT input-schema sibling, so `input`
-            // is still required even though the source relaxes its own self key.
             // @ts-expect-error - target `other` declares schemas.input, so input is required
             GO: {
               target: 'other'
@@ -2763,8 +2719,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // NEGATIVE: `reenter: true` re-enters `active`, so its input IS applied and
-    // therefore required — the relaxation must not leak into the re-enter case.
     s.createMachine({
       initial: { target: 'active', input: { count: 1 } },
       states: {
@@ -2780,7 +2734,6 @@ describe('required input on transitions', () => {
       }
     });
 
-    // POSITIVE TWIN: identical except it supplies `input` — must compile clean.
     s.createMachine({
       initial: { target: 'active', input: { count: 1 } },
       states: {
@@ -2799,11 +2752,8 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
-  // --- Runtime backstop (Change D) ---
-  // Input on a transition whose target is NOT actually being (re)entered — the
-  // classic case being a self-transition without `reenter: true` — would be
-  // silently stored but never consumed. Detect that: emit a dev warning and do
-  // NOT store the ignored input. These are real machine-execution tests.
+  // Runtime backstop: input on a transition that doesn't (re)enter its target
+  // is dropped (not stored) and warns in dev.
 
   it('self-transition without `reenter` ignores provided input and warns', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -2830,7 +2780,6 @@ describe('required input on transitions', () => {
             entryInputs.push(input);
           },
           on: {
-            // Self-transition WITHOUT reenter, carrying a DISTINCT input value.
             PING: {
               target: 'active',
               input: { count: 2 }
@@ -2842,7 +2791,6 @@ describe('required input on transitions', () => {
 
     const actor = createActor(machine).start();
 
-    // Baseline: initial input applied, entry fired exactly once.
     expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
       count: 1
     });
@@ -2850,19 +2798,14 @@ describe('required input on transitions', () => {
 
     actor.send({ type: 'PING' });
 
-    // The provided { count: 2 } is ignored: a warning fires naming the state
-    // and telling the user how to fix it...
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toContain('(machine).active');
     expect(warnSpy.mock.calls[0][0]).toContain('reenter: true');
 
-    // ...the stored input is UNCHANGED (still the original { count: 1 }),
-    // proving the ignored { count: 2 } was never stored...
     expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
       count: 1
     });
 
-    // ...and entry did not re-fire (no reenter).
     expect(entryInputs).toEqual([{ count: 1 }]);
 
     warnSpy.mockRestore();
@@ -2893,7 +2836,6 @@ describe('required input on transitions', () => {
             entryInputs.push(input);
           },
           on: {
-            // Self-transition WITH reenter: the state IS re-entered.
             PING: {
               target: 'active',
               reenter: true,
@@ -2909,13 +2851,10 @@ describe('required input on transitions', () => {
 
     actor.send({ type: 'PING' });
 
-    // The guard does not over-suppress: no warning fires...
     expect(warnSpy).not.toHaveBeenCalled();
 
-    // ...entry re-fired and saw the NEW input...
     expect(entryInputs).toEqual([{ count: 1 }, { count: 2 }]);
 
-    // ...and the stored input is updated to the new value.
     expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
       count: 2
     });
@@ -2960,13 +2899,10 @@ describe('required input on transitions', () => {
     const actor = createActor(machine).start();
     actor.send({ type: 'LOAD' });
 
-    // The common case is unaffected: no warning...
     expect(warnSpy).not.toHaveBeenCalled();
 
-    // ...entry saw the input...
     expect(entryInputs).toEqual([{ userId: 'user-1' }]);
 
-    // ...and it was stored.
     expect(actor.getSnapshot().getInputs()['(machine).loading']).toEqual({
       userId: 'user-1'
     });
@@ -2974,15 +2910,9 @@ describe('required input on transitions', () => {
     warnSpy.mockRestore();
   });
 
-  // Runtime backstop (Change D) at the COMPOUND seam. The parent is itself a
-  // compound state WITH an input schema, and the self-transition targets the
-  // parent. Distinct input values (`pv: 1` vs `pv: 2`) make this non-vacuous:
-  // whether the provided `{ pv: 2 }` is applied hinges solely on whether the
-  // parent is actually re-entered. Without `reenter` the parent stays active
-  // (not in the entry set), so its input is dropped and the dev warning fires;
-  // with `reenter: true` the parent is re-entered, so its input is applied and
-  // no warning fires. (The compound child re-enters via the default-entry path
-  // in both cases — a separate code path — and never triggers the warning.)
+  // Compound seam: a self-transition targeting the compound parent applies its
+  // input only when the parent is actually re-entered. The compound child
+  // re-enters via the default-entry path either way, which never warns.
   it('compound self-transition applies parent input only when the parent is re-entered', () => {
     const s = setup({
       states: {
@@ -2997,9 +2927,7 @@ describe('required input on transitions', () => {
       }
     });
 
-    // --- Case A: self-transition to the compound parent WITHOUT `reenter`. ---
-    // The parent stays active (not re-entered), so the provided `{ pv: 2 }` is
-    // ignored, the original `{ pv: 1 }` is retained, and the warning fires.
+    // Case A: self-transition to the compound parent WITHOUT `reenter`.
     {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const parentEntries: unknown[] = [];
@@ -3017,7 +2945,6 @@ describe('required input on transitions', () => {
               parentEntries.push(input);
             },
             on: {
-              // Compound self-transition WITHOUT reenter, carrying a DISTINCT input.
               PING: {
                 target: 'parent',
                 input: { pv: 2 }
@@ -3036,8 +2963,6 @@ describe('required input on transitions', () => {
 
       const actor = createActor(machine).start();
 
-      // Baseline: the parent's own initial input `{ pv: 1 }` reached its entry
-      // and was stored.
       expect(parentEntries).toEqual([{ pv: 1 }]);
       expect(childEntries).toEqual(['child']);
       expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
@@ -3046,30 +2971,22 @@ describe('required input on transitions', () => {
 
       actor.send({ type: 'PING' });
 
-      // The parent is NOT re-entered → the provided `{ pv: 2 }` is ignored: the
-      // warning fires once, naming the state and how to fix it...
       expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0][0]).toContain('ignored');
+      expect(warnSpy.mock.calls[0][0]).toContain('Ignored');
       expect(warnSpy.mock.calls[0][0]).toContain('(machine).parent');
       expect(warnSpy.mock.calls[0][0]).toContain('reenter: true');
 
-      // ...the parent's entry did NOT re-fire and its stored input stays the
-      // original `{ pv: 1 }`, proving the ignored `{ pv: 2 }` was never stored...
       expect(parentEntries).toEqual([{ pv: 1 }]);
       expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
         pv: 1
       });
 
-      // ...while the compound child still re-entered via the default-entry path
-      // (a separate code path that never triggers the warning).
       expect(childEntries).toEqual(['child', 'child']);
 
       warnSpy.mockRestore();
     }
 
-    // --- Case B: self-transition to the compound parent WITH `reenter: true`. ---
-    // The parent IS re-entered, so the provided `{ pv: 2 }` is applied (entry
-    // re-fires) and stored; no warning fires.
+    // Case B: self-transition to the compound parent WITH `reenter: true`.
     {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       const parentEntries: unknown[] = [];
@@ -3087,7 +3004,6 @@ describe('required input on transitions', () => {
               parentEntries.push(input);
             },
             on: {
-              // Compound self-transition WITH reenter, carrying a DISTINCT input.
               PING: {
                 target: 'parent',
                 reenter: true,
@@ -3114,18 +3030,14 @@ describe('required input on transitions', () => {
 
       actor.send({ type: 'PING' });
 
-      // The parent IS re-entered → no warning fires...
       expect(warnSpy).not.toHaveBeenCalled();
 
-      // ...its entry re-fires and sees the NEW input `{ pv: 2 }`...
       expect(parentEntries).toEqual([{ pv: 1 }, { pv: 2 }]);
 
-      // ...the stored input is updated to `{ pv: 2 }`...
       expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
         pv: 2
       });
 
-      // ...and the child re-entered again as well.
       expect(childEntries).toEqual(['child', 'child']);
 
       warnSpy.mockRestore();

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1964,93 +1964,25 @@ describe('setup', () => {
 });
 
 describe('required input on transitions', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
   // Each negative (@ts-expect-error) case is paired with a positive twin identical
   // except for `input`; the twin compiling clean proves the error is caused
   // specifically by the missing input, not something unrelated.
-  it('`on` transitions (object and function syntax) require a correctly-shaped input', () => {
+  it('requires input on every kind of transition that targets a state with an input schema', () => {
     const s = setup({
       schemas: {
         events: {
           LOAD: z.object({}),
-          LOAD_FN: z.object({})
+          LOAD_FN: z.object({}),
+          LOAD_WRONG: z.object({}),
+          PING: z.object({}),
+          PING_REENTER: z.object({})
         }
       },
       states: {
         idle: {},
-        loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            // @ts-expect-error - target `loading` declares schemas.input, so input is required
-            LOAD: {
-              target: 'loading'
-            },
-            // @ts-expect-error - returned transition to `loading` requires input
-            LOAD_FN: () => ({
-              target: 'loading'
-            })
-          }
-        },
-        loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            // @ts-expect-error - loading input requires userId: string, not number
-            LOAD: {
-              target: 'loading',
-              input: { userId: 123 }
-            }
-          }
-        },
-        loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            LOAD: {
-              target: 'loading',
-              input: { userId: 'user-1' }
-            },
-            LOAD_FN: () => ({
-              target: 'loading',
-              input: { userId: 'user-1' }
-            })
-          }
-        },
-        loading: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('state-level `always`/`after`/`onTimeout`/`onDone`/`onError` transitions require input', () => {
-    const s = setup({
-      states: {
-        idle: {},
         pending: {},
+        fetching: {},
+        failing: {},
         work: {
           states: {
             step: {}
@@ -2061,13 +1993,36 @@ describe('required input on transitions', () => {
             input: z.object({ userId: z.string() })
           }
         }
+      },
+      actorSources: {
+        load: createAsyncLogic({
+          run: async () => 'Done' as const
+        })
       }
     });
 
     s.createMachine({
-      initial: 'idle',
+      // @ts-expect-error - object-form initial targeting `loading` requires input
+      initial: {
+        target: 'loading'
+      },
       states: {
         idle: {
+          on: {
+            // @ts-expect-error - target `loading` declares schemas.input, so input is required
+            LOAD: {
+              target: 'loading'
+            },
+            // @ts-expect-error - returned transition to `loading` requires input
+            LOAD_FN: () => ({
+              target: 'loading'
+            }),
+            // @ts-expect-error - loading input requires userId: string, not number
+            LOAD_WRONG: {
+              target: 'loading',
+              input: { userId: 123 }
+            }
+          },
           // @ts-expect-error - always target `loading` requires input
           always: {
             target: 'loading'
@@ -2090,6 +2045,32 @@ describe('required input on transitions', () => {
             target: 'loading'
           }
         },
+        fetching: {
+          // @ts-expect-error - invoke onDone target `loading` requires input
+          invoke: {
+            src: 'load',
+            onDone: {
+              target: 'loading'
+            },
+            onError: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            }
+          }
+        },
+        failing: {
+          // @ts-expect-error - invoke onError target `loading` requires input
+          invoke: {
+            src: 'load',
+            onDone: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            },
+            onError: {
+              target: 'loading'
+            }
+          }
+        },
         work: {
           initial: 'step',
           states: {
@@ -2100,14 +2081,40 @@ describe('required input on transitions', () => {
             target: 'loading'
           }
         },
-        loading: {}
+        loading: {
+          on: {
+            // @ts-expect-error - self-target `loading` declares schemas.input, so input is required
+            PING: {
+              target: 'loading'
+            },
+            // @ts-expect-error - reenter:true re-enters `loading`, so input is required
+            PING_REENTER: {
+              target: 'loading',
+              reenter: true
+            }
+          }
+        }
       }
     });
 
+    // Positive twin: supplying input satisfies every transition kind above.
     s.createMachine({
-      initial: 'idle',
+      initial: {
+        target: 'loading',
+        input: { userId: 'user-1' }
+      },
       states: {
         idle: {
+          on: {
+            LOAD: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            },
+            LOAD_FN: () => ({
+              target: 'loading',
+              input: { userId: 'user-1' }
+            })
+          },
           always: {
             target: 'loading',
             input: { userId: 'user-1' }
@@ -2130,6 +2137,20 @@ describe('required input on transitions', () => {
             input: { userId: 'user-1' }
           }
         },
+        fetching: {
+          invoke: {
+            src: 'load',
+            onDone: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            },
+            onError: {
+              target: 'loading',
+              input: { userId: 'user-1' }
+            }
+          }
+        },
+        failing: {},
         work: {
           initial: 'step',
           states: {
@@ -2140,48 +2161,26 @@ describe('required input on transitions', () => {
             input: { userId: 'user-1' }
           }
         },
-        loading: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('object-form `initial` to an input-schema target requires input', () => {
-    const s = setup({
-      states: {
         loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
+          on: {
+            PING: {
+              target: 'loading',
+              input: { userId: 'user-2' }
+            },
+            PING_REENTER: {
+              target: 'loading',
+              reenter: true,
+              input: { userId: 'user-2' }
+            }
           }
         }
       }
     });
 
-    s.createMachine({
-      // @ts-expect-error - initial target `loading` requires input
-      initial: {
-        target: 'loading'
-      },
-      states: {
-        loading: {}
-      }
-    });
-
-    s.createMachine({
-      initial: {
-        target: 'loading',
-        input: { userId: 'user-1' }
-      },
-      states: {
-        loading: {}
-      }
-    });
-
     expect(true).toBe(true);
   });
 
-  it('out-of-scope and no-schema targets keep input optional', () => {
+  it('does not require input when the target has no input schema or is out of scope', () => {
     const s = setup({
       schemas: {
         events: {
@@ -2250,11 +2249,12 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
-  it('all-optional / empty input schemas still require input', () => {
+  it('requires an explicit input object even for empty or all-optional input schemas', () => {
     const s = setup({
       schemas: {
         events: {
-          LOAD: z.object({})
+          LOAD_EMPTY: z.object({}),
+          LOAD_OPTIONAL: z.object({})
         }
       },
       states: {
@@ -2280,23 +2280,11 @@ describe('required input on transitions', () => {
         idle: {
           on: {
             // @ts-expect-error - empty-object input schema still requires input
-            LOAD: {
+            LOAD_EMPTY: {
               target: 'empty'
-            }
-          }
-        },
-        empty: {},
-        allOptional: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
+            },
             // @ts-expect-error - all-optional input schema still requires input
-            LOAD: {
+            LOAD_OPTIONAL: {
               target: 'allOptional'
             }
           }
@@ -2311,23 +2299,11 @@ describe('required input on transitions', () => {
       states: {
         idle: {
           on: {
-            LOAD: {
+            LOAD_EMPTY: {
               target: 'empty',
               input: {}
-            }
-          }
-        },
-        empty: {},
-        allOptional: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            LOAD: {
+            },
+            LOAD_OPTIONAL: {
               target: 'allOptional',
               input: {}
             }
@@ -2341,171 +2317,9 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
-  it('invoke `onDone`/`onError` transition to an input-schema sibling requires input', () => {
-    const s = setup({
-      states: {
-        loading: {},
-        loaded: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
-      },
-      actorSources: {
-        load: createAsyncLogic({
-          run: async () => 'Done' as const
-        })
-      }
-    });
-
-    s.createMachine({
-      initial: 'loading',
-      states: {
-        loading: {
-          // @ts-expect-error - onDone target `loaded` requires input
-          invoke: {
-            src: 'load',
-            onDone: {
-              target: 'loaded'
-            }
-          }
-        },
-        loaded: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'loading',
-      states: {
-        loading: {
-          invoke: {
-            src: 'load',
-            onDone: {
-              target: 'loaded',
-              input: { userId: 'user-1' }
-            }
-          }
-        },
-        loaded: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'loading',
-      states: {
-        loading: {
-          // @ts-expect-error - onError target `loaded` requires input
-          invoke: {
-            src: 'load',
-            onError: {
-              target: 'loaded'
-            }
-          }
-        },
-        loaded: {}
-      }
-    });
-
-    s.createMachine({
-      initial: 'loading',
-      states: {
-        loading: {
-          invoke: {
-            src: 'load',
-            onError: {
-              target: 'loaded',
-              input: { userId: 'user-1' }
-            }
-          }
-        },
-        loaded: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
-  it('self-transition to an input-schema target requires input (uniform rule, with or without reenter)', () => {
-    const s = setup({
-      schemas: {
-        events: {
-          PING: z.object({}),
-          PING_REENTER: z.object({}),
-          GO: z.object({})
-        }
-      },
-      states: {
-        active: {
-          schemas: {
-            input: z.object({ count: z.number() })
-          }
-        },
-        other: {
-          schemas: {
-            input: z.object({ id: z.string() })
-          }
-        }
-      }
-    });
-
-    s.createMachine({
-      initial: { target: 'active', input: { count: 1 } },
-      states: {
-        active: {
-          on: {
-            // @ts-expect-error - self-target `active` declares schemas.input, so input is required
-            PING: {
-              target: 'active'
-            },
-            // @ts-expect-error - reenter:true re-enters `active`, so input is required
-            PING_REENTER: {
-              target: 'active',
-              reenter: true
-            },
-            // @ts-expect-error - target `other` declares schemas.input, so input is required
-            GO: {
-              target: 'other'
-            }
-          }
-        },
-        other: {}
-      }
-    });
-
-    // Supplying input satisfies the requirement for self, reentering, and cross targets.
-    s.createMachine({
-      initial: { target: 'active', input: { count: 1 } },
-      states: {
-        active: {
-          on: {
-            PING: {
-              target: 'active',
-              input: { count: 2 }
-            },
-            PING_REENTER: {
-              target: 'active',
-              reenter: true,
-              input: { count: 2 }
-            },
-            GO: {
-              target: 'other',
-              input: { id: 'x' }
-            }
-          }
-        },
-        other: {}
-      }
-    });
-
-    expect(true).toBe(true);
-  });
-
   // Runtime backstop: input on a transition that doesn't (re)enter its
   // target is silently dropped (not stored).
-
-  it('self-transition input: kept on internal transitions, replaced on reenter', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
+  it("a self-transition's input only takes effect when the state is re-entered", () => {
     const s = setup({
       schemas: {
         context: z.object({ count: z.number() }),
@@ -2572,9 +2386,8 @@ describe('required input on transitions', () => {
     actor.send({ type: 'MULTIPLY' });
     expect(actor.getSnapshot().context.count).toBe(3); // 1 * 3
 
-    // Internal self-transition: no exit/entry, input untouched, nothing warned.
+    // Internal self-transition: no exit/entry, input untouched.
     actor.send({ type: 'SET_MULTIPLIER_NO_REENTER' });
-    expect(warnSpy).not.toHaveBeenCalled();
     expect(entryInputs).toEqual([{ multiplier: 3 }]);
     expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
       multiplier: 3
@@ -2586,7 +2399,6 @@ describe('required input on transitions', () => {
 
     // Reentering self-transition: re-runs entry and re-resolves input to 10.
     actor.send({ type: 'SET_MULTIPLIER_REENTER' });
-    expect(warnSpy).not.toHaveBeenCalled();
     expect(entryInputs).toEqual([{ multiplier: 3 }, { multiplier: 10 }]);
     expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
       multiplier: 10
@@ -2595,63 +2407,19 @@ describe('required input on transitions', () => {
     // count 9 * 10 = 90 confirms the handler now sees the re-resolved input of 10.
     actor.send({ type: 'MULTIPLY' });
     expect(actor.getSnapshot().context.count).toBe(90); // 9 * 10
-
-    warnSpy.mockRestore();
-  });
-
-  it('normal transition to a different target applies input and does not warn', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const s = setup({
-      states: {
-        idle: {},
-        loading: {
-          schemas: {
-            input: z.object({ userId: z.string() })
-          }
-        }
-      }
-    });
-
-    const entryInputs: unknown[] = [];
-    const machine = s.createMachine({
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            LOAD: {
-              target: 'loading',
-              input: { userId: 'user-1' }
-            }
-          }
-        },
-        loading: {
-          entry: ({ input }) => {
-            entryInputs.push(input);
-          }
-        }
-      }
-    });
-
-    const actor = createActor(machine).start();
-    actor.send({ type: 'LOAD' });
-
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    expect(entryInputs).toEqual([{ userId: 'user-1' }]);
-
-    expect(actor.getSnapshot().getInputs()['(machine).loading']).toEqual({
-      userId: 'user-1'
-    });
-
-    warnSpy.mockRestore();
   });
 
   // Compound seam: a self-transition targeting the compound parent applies its
   // input only when the parent is actually re-entered. The compound child
-  // re-enters via the default-entry path either way, which never warns.
-  it('compound self-transition applies parent input only when the parent is re-entered', () => {
+  // re-enters via the default-entry path either way.
+  it("a compound state's input is replaced only on reenter, while its child always re-enters", () => {
     const s = setup({
+      schemas: {
+        events: {
+          PING: z.object({}),
+          PING_REENTER: z.object({})
+        }
+      },
       states: {
         parent: {
           schemas: {
@@ -2664,117 +2432,67 @@ describe('required input on transitions', () => {
       }
     });
 
-    // Case A: self-transition to the compound parent WITHOUT `reenter`.
-    {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const parentEntries: unknown[] = [];
-      const childEntries: string[] = [];
+    const parentEntries: unknown[] = [];
+    const childEntries: string[] = [];
 
-      const machine = s.createMachine({
-        initial: {
-          target: 'parent',
-          input: { pv: 1 }
-        },
-        states: {
-          parent: {
-            initial: 'child',
-            entry: ({ input }) => {
-              parentEntries.push(input);
+    const machine = s.createMachine({
+      initial: {
+        target: 'parent',
+        input: { pv: 1 }
+      },
+      states: {
+        parent: {
+          initial: 'child',
+          entry: ({ input }) => {
+            parentEntries.push(input);
+          },
+          on: {
+            PING: {
+              target: 'parent',
+              input: { pv: 2 }
             },
-            on: {
-              PING: {
-                target: 'parent',
-                input: { pv: 2 }
-              }
-            },
-            states: {
-              child: {
-                entry: () => {
-                  childEntries.push('child');
-                }
+            PING_REENTER: {
+              target: 'parent',
+              reenter: true,
+              input: { pv: 3 }
+            }
+          },
+          states: {
+            child: {
+              entry: () => {
+                childEntries.push('child');
               }
             }
           }
         }
-      });
+      }
+    });
 
-      const actor = createActor(machine).start();
+    const actor = createActor(machine).start();
 
-      expect(parentEntries).toEqual([{ pv: 1 }]);
-      expect(childEntries).toEqual(['child']);
-      expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
-        pv: 1
-      });
+    expect(parentEntries).toEqual([{ pv: 1 }]);
+    expect(childEntries).toEqual(['child']);
+    expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+      pv: 1
+    });
 
-      actor.send({ type: 'PING' });
+    // Without reenter: parent stays entered, so its input is unchanged —
+    // but the child still re-enters via default entry.
+    actor.send({ type: 'PING' });
 
-      expect(warnSpy).not.toHaveBeenCalled();
+    expect(parentEntries).toEqual([{ pv: 1 }]);
+    expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+      pv: 1
+    });
+    expect(childEntries).toEqual(['child', 'child']);
 
-      expect(parentEntries).toEqual([{ pv: 1 }]);
-      expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
-        pv: 1
-      });
+    // With reenter: parent exits and re-enters, re-resolving its input.
+    actor.send({ type: 'PING_REENTER' });
 
-      expect(childEntries).toEqual(['child', 'child']);
-
-      warnSpy.mockRestore();
-    }
-
-    // Case B: self-transition to the compound parent WITH `reenter: true`.
-    {
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-      const parentEntries: unknown[] = [];
-      const childEntries: string[] = [];
-
-      const machine = s.createMachine({
-        initial: {
-          target: 'parent',
-          input: { pv: 1 }
-        },
-        states: {
-          parent: {
-            initial: 'child',
-            entry: ({ input }) => {
-              parentEntries.push(input);
-            },
-            on: {
-              PING: {
-                target: 'parent',
-                reenter: true,
-                input: { pv: 2 }
-              }
-            },
-            states: {
-              child: {
-                entry: () => {
-                  childEntries.push('child');
-                }
-              }
-            }
-          }
-        }
-      });
-
-      const actor = createActor(machine).start();
-      expect(parentEntries).toEqual([{ pv: 1 }]);
-      expect(childEntries).toEqual(['child']);
-      expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
-        pv: 1
-      });
-
-      actor.send({ type: 'PING' });
-
-      expect(warnSpy).not.toHaveBeenCalled();
-
-      expect(parentEntries).toEqual([{ pv: 1 }, { pv: 2 }]);
-
-      expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
-        pv: 2
-      });
-
-      expect(childEntries).toEqual(['child', 'child']);
-
-      warnSpy.mockRestore();
-    }
+    expect(parentEntries).toEqual([{ pv: 1 }, { pv: 3 }]);
+    expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+      pv: 3
+    });
+    expect(childEntries).toEqual(['child', 'child', 'child']);
   });
 });

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -2752,10 +2752,10 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
-  // Runtime backstop: input on a transition that doesn't (re)enter its target
-  // is dropped (not stored) and warns in dev.
+  // Runtime backstop: input on a transition that doesn't (re)enter its
+  // target is silently dropped (not stored).
 
-  it('self-transition without `reenter` ignores provided input and warns', () => {
+  it('self-transition without `reenter` ignores provided input', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const s = setup({
@@ -2798,9 +2798,7 @@ describe('required input on transitions', () => {
 
     actor.send({ type: 'PING' });
 
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain('(machine).active');
-    expect(warnSpy.mock.calls[0][0]).toContain('reenter: true');
+    expect(warnSpy).not.toHaveBeenCalled();
 
     expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
       count: 1
@@ -2971,10 +2969,7 @@ describe('required input on transitions', () => {
 
       actor.send({ type: 'PING' });
 
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0][0]).toContain('Ignored');
-      expect(warnSpy.mock.calls[0][0]).toContain('(machine).parent');
-      expect(warnSpy.mock.calls[0][0]).toContain('reenter: true');
+      expect(warnSpy).not.toHaveBeenCalled();
 
       expect(parentEntries).toEqual([{ pv: 1 }]);
       expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -169,6 +169,11 @@ describe('setup', () => {
 
   it('createStateConfig should type a nested state input by dotted path', () => {
     const s = setup({
+      schemas: {
+        events: {
+          next: z.object({})
+        }
+      },
       states: {
         parent: {
           schemas: {
@@ -1415,48 +1420,6 @@ describe('setup', () => {
     inputs['(machine).active'] satisfies { sessionId: string };
 
     expect(true).toBe(true);
-  });
-
-  it('input should persist across self-transitions', () => {
-    const s = setup({
-      states: {
-        active: {
-          schemas: {
-            input: z.object({ count: z.number() })
-          }
-        }
-      }
-    });
-
-    const machine = s.createMachine({
-      initial: {
-        target: 'active',
-        input: { count: 1 }
-      },
-      states: {
-        active: {
-          on: {
-            // Self-transition without reenter
-            PING: {}
-          }
-        }
-      }
-    });
-
-    const actor = createActor(machine).start();
-
-    // Input should be set initially
-    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
-      count: 1
-    });
-
-    // Send event that triggers self-transition
-    actor.send({ type: 'PING' });
-
-    // Input should still be there
-    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
-      count: 1
-    });
   });
 
   it('invoke transitions should require context for incompatible targets', () => {
@@ -2776,14 +2739,22 @@ describe('required input on transitions', () => {
   // Runtime backstop: input on a transition that doesn't (re)enter its
   // target is silently dropped (not stored).
 
-  it('self-transition without `reenter` ignores provided input', () => {
+  it('self-transition input: kept on internal transitions, replaced on reenter', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const s = setup({
+      schemas: {
+        context: z.object({ count: z.number() }),
+        events: {
+          SET_MULTIPLIER_NO_REENTER: z.object({}),
+          SET_MULTIPLIER_REENTER: z.object({}),
+          MULTIPLY: z.object({})
+        }
+      },
       states: {
         active: {
           schemas: {
-            input: z.object({ count: z.number() })
+            input: z.object({ multiplier: z.number() })
           }
         }
       }
@@ -2791,9 +2762,10 @@ describe('required input on transitions', () => {
 
     const entryInputs: unknown[] = [];
     const machine = s.createMachine({
+      context: { count: 1 },
       initial: {
         target: 'active',
-        input: { count: 1 }
+        input: { multiplier: 3 }
       },
       states: {
         active: {
@@ -2801,82 +2773,64 @@ describe('required input on transitions', () => {
             entryInputs.push(input);
           },
           on: {
-            PING: {
+            // Internal self-transition (no reenter): stays in `active`, so
+            // this input is silently dropped and the resolved input stays 3.
+            SET_MULTIPLIER_NO_REENTER: {
               target: 'active',
-              input: { count: 2 }
-            }
-          }
-        }
-      }
-    });
-
-    const actor = createActor(machine).start();
-
-    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
-      count: 1
-    });
-    expect(entryInputs).toEqual([{ count: 1 }]);
-
-    actor.send({ type: 'PING' });
-
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
-      count: 1
-    });
-
-    expect(entryInputs).toEqual([{ count: 1 }]);
-
-    warnSpy.mockRestore();
-  });
-
-  it('self-transition with `reenter: true` applies the new input and does not warn', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const s = setup({
-      states: {
-        active: {
-          schemas: {
-            input: z.object({ count: z.number() })
-          }
-        }
-      }
-    });
-
-    const entryInputs: unknown[] = [];
-    const machine = s.createMachine({
-      initial: {
-        target: 'active',
-        input: { count: 1 }
-      },
-      states: {
-        active: {
-          entry: ({ input }) => {
-            entryInputs.push(input);
-          },
-          on: {
-            PING: {
+              input: { multiplier: 99 }
+            },
+            // Reentering self-transition: exits and re-enters `active`, so
+            // input is re-resolved to this value.
+            SET_MULTIPLIER_REENTER: {
               target: 'active',
               reenter: true,
-              input: { count: 2 }
-            }
+              input: { multiplier: 10 }
+            },
+            // Multiplies count by whatever input is currently resolved,
+            // making the running count a witness of the active multiplier.
+            MULTIPLY: ({ context, input }) => ({
+              context: { count: context.count * input.multiplier }
+            })
           }
         }
       }
     });
 
     const actor = createActor(machine).start();
-    expect(entryInputs).toEqual([{ count: 1 }]);
 
-    actor.send({ type: 'PING' });
-
-    expect(warnSpy).not.toHaveBeenCalled();
-
-    expect(entryInputs).toEqual([{ count: 1 }, { count: 2 }]);
-
+    // Initial entry resolves input to the value from the initial transition.
     expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
-      count: 2
+      multiplier: 3
     });
+    expect(entryInputs).toEqual([{ multiplier: 3 }]);
+
+    // count 1 * 3 = 3 confirms the handler sees the initial multiplier of 3.
+    actor.send({ type: 'MULTIPLY' });
+    expect(actor.getSnapshot().context.count).toBe(3); // 1 * 3
+
+    // Internal self-transition: no exit/entry, input untouched, nothing warned.
+    actor.send({ type: 'SET_MULTIPLIER_NO_REENTER' });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(entryInputs).toEqual([{ multiplier: 3 }]);
+    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
+      multiplier: 3
+    });
+
+    // count 3 * 3 = 9, not 3 * 99: the dropped input of 99 never took effect.
+    actor.send({ type: 'MULTIPLY' });
+    expect(actor.getSnapshot().context.count).toBe(9); // 3 * 3
+
+    // Reentering self-transition: re-runs entry and re-resolves input to 10.
+    actor.send({ type: 'SET_MULTIPLIER_REENTER' });
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(entryInputs).toEqual([{ multiplier: 3 }, { multiplier: 10 }]);
+    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
+      multiplier: 10
+    });
+
+    // count 9 * 10 = 90 confirms the handler now sees the re-resolved input of 10.
+    actor.send({ type: 'MULTIPLY' });
+    expect(actor.getSnapshot().context.count).toBe(90); // 9 * 10
 
     warnSpy.mockRestore();
   });

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -2660,7 +2660,7 @@ describe('required input on transitions', () => {
     expect(true).toBe(true);
   });
 
-  it('self-transition without `reenter` relaxes input; cross-transition still requires it', () => {
+  it('self-transition to an input-schema target requires input (uniform rule)', () => {
     const s = setup({
       schemas: {
         events: {
@@ -2687,12 +2687,33 @@ describe('required input on transitions', () => {
       states: {
         active: {
           on: {
+            // @ts-expect-error - self-target `active` declares schemas.input, so input is required
             PING: {
               target: 'active'
             },
             // @ts-expect-error - target `other` declares schemas.input, so input is required
             GO: {
               target: 'other'
+            }
+          }
+        },
+        other: {}
+      }
+    });
+
+    // Supplying input satisfies the requirement for both self and cross targets.
+    s.createMachine({
+      initial: { target: 'active', input: { count: 1 } },
+      states: {
+        active: {
+          on: {
+            PING: {
+              target: 'active',
+              input: { count: 2 }
+            },
+            GO: {
+              target: 'other',
+              input: { id: 'x' }
             }
           }
         },


### PR DESCRIPTION
Transitions that target a state declaring `schemas.input` now **require** an `input` property, enforced at the type level.
This applies to `on`, `always`, `after`, `onTimeout`, `onDone`, `onError`, invoke handlers, and `initial`.

```tsx
const machine = setup({
  states: {
    loading: {
      schemas: { input: z.object({ userId: z.string() }) }
    }
  }
}).createMachine({
  initial: 'idle',
  states: {
    idle: {
      on: {
        // Before: LOAD: { target: 'loading' }  — now a type error
        LOAD: { target: 'loading', input: { userId: 'user-1' } }
      }
    },
    loading: {}
  }
});
```

## Special Cases

### **Self-transitions with input**

When a state transitions to itself without `reenter: true`, it’s considered an internal transition.

However, the transition type is not aware of the current state it’s transitioning from, so there is no way to tell that we shouldn’t require input for this case.

I experimented with extending the types, but ultimately decided not to add complexity for this rare case.

However, at runtime, I ensured `input` is ignored, so only external transitions resolve input.

```tsx
active: {
  on: {
  // re-entering self-transition: input is re-resolved to 10
    setMultiplier: { 
    	reenter: true, 
	    target: 'active', 
	    input: { multiplier: 10 }
	  }
	  
    // internal self-transition without reenter
		// input is dropped, resolved input stays whatever it was on entry
    setMultiplier: {
	    target: 'active',
	    input: { multiplier: 99 }
	  },
  }
}
```

## Unhandled cases / open questions

### Targeting a state by `#id`

Since IDs are defined in `createMachine` (not `setup`), types can’t infer them by reading `setup` alone. 
Unfortunately, this case is not covered.

```tsx
const def = setup({
	states: {
	   idle: {},
	   active: {
		   schemas: {
		     input: z.object({ prop: z.string() })
		   }
	   }
	}
})

const idleStateConfig = def.createStateConfig('idle', {
	on: {
		activate: {
			target: '#active'
			// how can we tell if a state by id "#active" requires input or not?
		}
	}
})

const activeStateConfig = def.createStateConfig('active', {
	id: '#active'
})

def.createMachine({
	initial: 'idle',
	states: {
		idle: idleStateConfig,
		active: {
			id: 'active' // defined here, not in setup
		}
	}
})

```

### Parallel states

How do you pass input to multiple regions in a parallel state?

```tsx
const def = setup({
  states: {
    editor: {
      // becomes `type: 'parallel'` in createMachine
      states: {
        document: {
          states: {
            viewing: {
              schemas: { input: z.object({ docId: z.string() }) }
            }
          }
        },
        toolbar: {
          states: {
            visible: {
              schemas: { input: z.object({ layout: z.string() }) }
            }
        }
      }
    },
    idle: {}
  }
});

def.createMachine({
  initial: 'idle',
  states: {
    idle: {
      on: {
        // Entering 'editor' activates BOTH regions at once.
        // Each region's initial state requires its own input,
        // but a transition only carries a single `input`.
        // Which region does it belong to? How do we provide both?
        OPEN: { target: 'editor', input: /* ??? */ }
      }
    },
    editor: {
      type: 'parallel',
      states: {
        document: { initial: 'viewing', states: { viewing: {} } },
        toolbar: { initial: 'visible', states: { visible: {} } }
      }
    }
  }
});
```

### Transition to nested child (`parent.child`)
What should happen if both the parent and child require input?

```tsx
const def = setup({
  states: {
    idle: {},
    parent: {
      schemas: {
        input: z.object({ parentProp: z.string() }),
      },
      states: {
        child: {
          schemas: {
            input: z.object({ childProp: z.string() }),
          },
        },
      },
    },
  },
});

def.createMachine({
  initial: "idle",
  states: {
    idle: {
      on: {
        next: () => ({
          target: "parent.child",
          input: { childProp: "value" },
        }),
      },
    },
    parent: {
      entry: ({ input }) => {
        console.log(`expects ${input.parentProp}`);
      },

      initial: { target: "child", input: { childProp: "..." } },
      states: {
        child: {
          entry: ({ input }) => {
            console.log(`expects ${input.childProp}`);
          },
        },
      },
    },
  },
});
```

In that case, it may be worth constraining both at runtime and by types so entering a sub-state isn’t allowed if its parent requires input.

```tsx
idle: {
  on: {
    next: () => ({
      target: "parent", // allowed
      input: { parentProp: "value" },
    }),
    next: () => ({
      target: "parent.child", // rejected
      input: { childProp: "value" },
    }),
  },
},
```