### PR TITLE
fix(core): don't throw when warning about unserializable event sent to stopped actor

### DIFF
--- a/.changeset/tender-cameras-cheer.md
+++ b/.changeset/tender-cameras-cheer.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Sending an event to a stopped actor no longer throws when the event contains unserializable data (e.g. circular references). Previously, the development-only warning that an event was sent to a stopped actor used `JSON.stringify` on the event, which could throw and mask the intended warning. The warning is now emitted safely regardless of the event's contents.

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -729,7 +729,12 @@ export class Actor<TLogic extends AnyActorLogic>
     if (this._processingStatus === ProcessingStatus.Stopped) {
       // do nothing
       if (isDevelopment) {
-        const eventString = JSON.stringify(event);
+        let eventString: string;
+        try {
+          eventString = JSON.stringify(event);
+        } catch {
+          eventString = String(event);
+        }
 
         console.warn(
           `Event "${event.type}" was sent to stopped actor "${this.id} (${this.sessionId})". This actor has already reached its final state, and will not transition.\nEvent: ${eventString}`

--- a/packages/core/test/interpreter.test.ts
+++ b/packages/core/test/interpreter.test.ts
@@ -1188,6 +1188,38 @@ describe('interpreter', () => {
       return promise;
     });
 
+    it('should not throw when sending an unserializable event to a stopped actor', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const testMachine = createMachine({
+        initial: 'waiting',
+        states: {
+          waiting: {
+            on: {
+              TRIGGER: 'active'
+            }
+          },
+          active: {}
+        }
+      });
+
+      const service = createActor(testMachine).start();
+
+      service.stop();
+
+      // event with a circular reference cannot be JSON.stringify'd
+      const circular: any = { type: 'TRIGGER' };
+      circular.self = circular;
+
+      expect(() => {
+        service.send(circular);
+      }).not.toThrow();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      warnSpy.mockRestore();
+    });
+
     it('stopping a not-started interpreter should not crash', () => {
       const service = createActor(
         createMachine({


### PR DESCRIPTION
## Problem

When an event is sent to an actor that has already stopped, XState emits a development-only warning. That warning called `JSON.stringify(event)` to include the event in the message. If the event carried unserializable data (e.g. a circular reference), `JSON.stringify` threw, turning a harmless warning into an actual error.

## Fix

The stringification in `packages/core/src/createActor.ts` is now guarded with a `try/catch`. If `JSON.stringify` throws, it falls back to `String(event)`, so the warning is always emitted safely regardless of the event's contents.

A changeset (`.changeset/tender-cameras-cheer.md`, `xstate` patch) is included describing the fix.

## Testing

Added a test in `packages/core/test/interpreter.test.ts` covering sending an event containing a circular reference to a stopped actor, verifying the warning is emitted without throwing.

Closes #5013
