### PR TITLE
Fix/final output state input

### DIFF
--- a/.changeset/final-output-state-input.md
+++ b/.changeset/final-output-state-input.md
@@ -1,0 +1,23 @@
+---
+'xstate': patch
+---
+
+Final state `output` mappers now receive the state's `input`.
+
+```ts
+LOAD: ({ event }) => ({
+  target: 'done',
+  input: { userId: event.userId }
+})
+
+// ...
+
+done: {
+  type: 'final',
+  output: ({ input }) => ({
+    userId: input.userId
+  })
+}
+```
+
+Previously, `input` was unavailable in final `output` mappers. Now it is forwarded the same way as for `entry` / `exit` actions.

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1260,7 +1260,8 @@ function microstep(
                   rootCompletionNode.output,
                   nextState.context,
                   event,
-                  actorScope.self
+                  actorScope.self,
+                  stateInputMap[rootCompletionNode.id]
                 );
         } else if (rootCompletionNode.type === 'parallel') {
           const parallelDoneType = `xstate.done.state.${rootCompletionNode.id}`;
@@ -1592,7 +1593,8 @@ function microstep(
                     stateNodeToEnter.output,
                     nextState.context,
                     event,
-                    actorScope.self
+                    actorScope.self,
+                    stateInput
                   )
                 : undefined
             )
@@ -1614,7 +1616,8 @@ function microstep(
                       region.output,
                       nextState.context,
                       event,
-                      actorScope.self
+                      actorScope.self,
+                      stateInputMap[region.id]
                     )
                   : undefined;
               continue;
@@ -1638,7 +1641,8 @@ function microstep(
                     finalChild.output,
                     nextState.context,
                     event,
-                    actorScope.self
+                    actorScope.self,
+                    stateInputMap[finalChild.id]
                   )
                 : undefined;
           }

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -102,13 +102,27 @@ export type InferGuards<TGuardSchemaMap extends GuardSchemas> =
         ) => boolean;
       };
 
+type OutputMapper<
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  TResult,
+  TInput = Record<string, unknown> | undefined
+> = (
+  args: Parameters<Mapper<TContext, TEvent, TResult, TEvent>>[0] & {
+    input: TInput;
+  }
+) => TResult;
+
 type OutputConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
-  TOutput
+  TOutput,
+  TInput = Record<string, unknown> | undefined
 > = unknown extends TOutput
-  ? Mapper<TContext, TEvent, NonReducibleUnknown, TEvent> | NonReducibleUnknown
-  : Mapper<TContext, TEvent, TOutput, TEvent> | TOutput;
+  ?
+      | OutputMapper<TContext, TEvent, NonReducibleUnknown, TInput>
+      | NonReducibleUnknown
+  : OutputMapper<TContext, TEvent, TOutput, TInput> | TOutput;
 
 export type ValidateTopLevelFinalOutputs<
   TConfig,
@@ -1202,7 +1216,7 @@ interface Next_RegularStateNodeConfig<
    * The output data will be evaluated with the current `context` and placed on
    * the `.data` property of the event.
    */
-  output?: OutputConfig<TContext, TEvent, TOutput>;
+  output?: OutputConfig<TContext, TEvent, TOutput, TInput>;
   /**
    * The unique ID of the state node, which can be referenced as a transition
    * target via the `#id` syntax.

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -179,7 +179,8 @@ export function resolveOutput<
     | NonReducibleUnknown,
   context: TContext,
   event: TExpressionEvent,
-  self: AnyActor
+  self: AnyActor,
+  input?: Record<string, unknown>
 ): unknown {
   if (typeof mapper === 'function') {
     const outputMapper = mapper as Mapper<
@@ -192,7 +193,8 @@ export function resolveOutput<
       context,
       event,
       output: getEventOutput(event),
-      self
+      self,
+      input
     } as unknown as Parameters<typeof outputMapper>[0];
 
     return outputMapper(args);

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1003,6 +1003,48 @@ describe('setup', () => {
     expect(exitInputs).toEqual([{ userId: 'user-456' }]);
   });
 
+  it('final output should receive input', () => {
+    const receivedInputs: unknown[] = [];
+
+    const s = setup({
+      states: {
+        idle: {},
+        done: {
+          schemas: {
+            input: z.object({
+              userId: z.string()
+            })
+          }
+        }
+      }
+    });
+
+    const machine = s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            LOAD: {
+              target: 'done',
+              input: { userId: 'user-123' }
+            }
+          }
+        },
+        done: {
+          type: 'final',
+          output: ({ input }) => {
+            receivedInputs.push(input);
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'LOAD' });
+
+    expect(receivedInputs).toEqual([{ userId: 'user-123' }]);
+  });
+
   it('transition should pass input to target state', () => {
     const receivedInputs: unknown[] = [];
 


### PR DESCRIPTION

Final state `output` mappers now receive the state's `input`.

```ts
LOAD: ({ event }) => ({
  target: 'done',
  input: { userId: event.userId }
})

// ...

done: {
  type: 'final',
  output: ({ input }) => ({
    userId: input.userId
  })
}
```

Previously, `input` was unavailable in final `output` mappers. Now it is forwarded the same way as for `entry` / `exit` actions.