### PR TITLE
fix(xstate-vue): correct vitest include glob so tests are discovered

### DIFF
--- a/.changeset/tidy-badgers-attack.md
+++ b/.changeset/tidy-badgers-attack.md
@@ -1,0 +1,5 @@
+---
+'@xstate/vue': patch
+---
+
+Fixed the test configuration so that the package's tests are correctly discovered and run. The `include` glob in `vitest.config.mts` pointed to a non-existent file, which meant no tests were executed and coverage was reported as 0%.

--- a/packages/xstate-vue/vitest.config.mts
+++ b/packages/xstate-vue/vitest.config.mts
@@ -1,7 +1,7 @@
 import vue from '@vitejs/plugin-vue';
 import { defineProject } from 'vitest/config';
 
-export const include = ['test/vue.test.ts'];
+export const include = ['test/**/*.test.{ts,tsx}'];
 
 export default defineProject({
   plugins: [vue()],


### PR DESCRIPTION
## What

Fixes the `@xstate/vue` vitest config so its tests are actually discovered. `packages/xstate-vue/vitest.config.mts` had:

```ts
include: ['test/vue.test.ts']
```

but that file does not exist. The four real tests (`useActor`, `useActorRef`, `useMachine`, `useSelector`) never matched the glob, so vitest registered **zero** tests for the `@xstate/vue` project and coverage reported 0%.

## How

Changed the glob to `['test/**/*.test.{ts,tsx}']`, so the existing test files are picked up. Sibling packages (react/solid/svelte) don't override `include` and rely on vitest's default glob; vue was the outlier.

## Testing

- Before: `No test files found` for the `@xstate/vue` project.
- After: 4 test files discovered, `13 passed (13)`.

Closes #5592
