### PR TITLE
[@xstate/store] Add configurable snapshot restoration to store undo

### DIFF
--- a/.changeset/soft-tools-restore.md
+++ b/.changeset/soft-tools-restore.md
@@ -1,0 +1,5 @@
+---
+'@xstate/store': patch
+---
+
+Allow snapshot-based undo and redo to customize restored context while preserving complete history snapshots. Restoration can enqueue emitted events, effects, and store triggers.

--- a/packages/xstate-store/src/index.ts
+++ b/packages/xstate-store/src/index.ts
@@ -21,6 +21,7 @@ export type {
   ResolveStoreEmittedPayloadMap,
   StoreEffect,
   StoreEffectEnqueue,
+  EnqueueObject,
   TriggerObject,
   CanObject,
   StoreAssigner,

--- a/packages/xstate-store/src/store.ts
+++ b/packages/xstate-store/src/store.ts
@@ -87,7 +87,7 @@ function toEvent(eventType: string, payload: any) {
       };
 }
 
-function createEnqueueObject<TEmitted extends EventObject>(
+export function createEnqueueObject<TEmitted extends EventObject>(
   effects: StoreEffect<TEmitted>[],
   trigger?: (event: EventObject) => void
 ): EnqueueObject<any, TEmitted, any> {

--- a/packages/xstate-store/src/undo.ts
+++ b/packages/xstate-store/src/undo.ts
@@ -1,14 +1,16 @@
 import {
   AnyStoreLogic,
+  EnqueueObject,
   EventObject,
   EventPayloadMap,
   ExtractEvents,
+  StoreEffect,
   StoreContext,
   StoreExtension,
   StoreLogic,
   StoreSnapshot
 } from './types.ts';
-import { appendInternalEventTypes } from './store.ts';
+import { appendInternalEventTypes, createEnqueueObject } from './store.ts';
 
 interface UndoRedoEventOptions<
   TContext extends StoreContext,
@@ -29,7 +31,9 @@ interface UndoRedoEventOptions<
 
 interface UndoRedoSnapshotOptions<
   TContext extends StoreContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TEmitted extends EventObject,
+  TEventPayloadMap extends EventPayloadMap
 > {
   /** A function that returns the transaction ID of an event. */
   getTransactionId?: (
@@ -51,27 +55,44 @@ interface UndoRedoSnapshotOptions<
     pastSnapshot: StoreSnapshot<TContext>,
     currentSnapshot: StoreSnapshot<TContext>
   ) => boolean;
+  /** Customizes the context restored by snapshot-based undo/redo. */
+  restore?: (
+    args: {
+      current: TContext;
+      next: TContext;
+      direction: 'undo' | 'redo';
+    },
+    enqueue: EnqueueObject<TContext, TEmitted, TEventPayloadMap>
+  ) => TContext;
 }
 
 type UndoRedoStrategyOptions<
   TContext extends StoreContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TEmitted extends EventObject,
+  TEventPayloadMap extends EventPayloadMap
 > =
   | ({
       strategy?: 'event';
     } & UndoRedoEventOptions<TContext, TEvent>)
   | ({
       strategy: 'snapshot';
-    } & UndoRedoSnapshotOptions<TContext, TEvent>);
+    } & UndoRedoSnapshotOptions<TContext, TEvent, TEmitted, TEventPayloadMap>);
 
 // Internal: create undo/redo logic from existing logic (for .with() pattern)
 function undoRedoFromLogic<
   TContext extends StoreContext,
   TEvent extends EventObject,
-  TEmitted extends EventObject
+  TEmitted extends EventObject,
+  TEventPayloadMap extends EventPayloadMap
 >(
   logic: StoreLogic<StoreSnapshot<TContext>, TEvent, TEmitted>,
-  options?: UndoRedoStrategyOptions<TContext, TEvent>
+  options?: UndoRedoStrategyOptions<
+    TContext,
+    TEvent,
+    TEmitted,
+    TEventPayloadMap
+  >
 ): StoreLogic<
   StoreSnapshot<TContext>,
   TEvent | { type: 'undo' } | { type: 'redo' },
@@ -83,6 +104,54 @@ function undoRedoFromLogic<
       : Infinity;
 
   if (options?.strategy === 'snapshot') {
+    const restore = (
+      snapshot: any,
+      historicalSnapshot: StoreSnapshot<TContext>,
+      direction: 'undo' | 'redo',
+      past: any[],
+      future: any[]
+    ): [any, StoreEffect<TEmitted>[]] => {
+      if (!options.restore) {
+        return [{ ...historicalSnapshot, past, future }, []];
+      }
+
+      const effects: StoreEffect<TEmitted>[] = [];
+      const triggeredEvents: EventObject[] = [];
+      const enqueue = createEnqueueObject<TEmitted>(effects, (event) => {
+        triggeredEvents.push(event);
+      }) as EnqueueObject<TContext, TEmitted, TEventPayloadMap>;
+      let triggeredSnapshot = {
+        ...historicalSnapshot,
+        context: options.restore(
+          {
+            current: snapshot.context,
+            next: historicalSnapshot.context,
+            direction
+          },
+          enqueue
+        )
+      };
+
+      for (const triggeredEvent of triggeredEvents) {
+        const [nextTriggeredSnapshot, triggeredEffects] = logic.transition(
+          triggeredSnapshot,
+          triggeredEvent as TEvent
+        );
+        triggeredSnapshot = nextTriggeredSnapshot;
+        effects.push(...triggeredEffects);
+      }
+
+      return [
+        {
+          ...historicalSnapshot,
+          context: triggeredSnapshot.context,
+          past,
+          future
+        },
+        effects
+      ];
+    };
+
     // Snapshot strategy
     const enhancedLogic: AnyStoreLogic = {
       ...logic,
@@ -139,7 +208,7 @@ function undoRedoFromLogic<
             });
           }
 
-          return [{ ...newSnapshot, past, future }, []];
+          return restore(snapshot, newSnapshot, 'undo', past, future);
         }
 
         if (event.type === 'redo') {
@@ -152,12 +221,25 @@ function undoRedoFromLogic<
 
           const firstItem = future[0];
           const firstTransactionId = firstItem.transactionId;
+          const currentSnapshot = {
+            status: snapshot.status,
+            context: snapshot.context,
+            output: snapshot.output,
+            error: snapshot.error
+          };
 
           let newSnapshot;
           if (firstTransactionId === undefined) {
             const item = future.shift()!;
             newSnapshot = item.snapshot;
-            past.push(item);
+            past.push(
+              options.restore
+                ? {
+                    snapshot: currentSnapshot,
+                    transactionId: firstTransactionId
+                  }
+                : item
+            );
           } else {
             while (
               future.length > 0 &&
@@ -165,7 +247,15 @@ function undoRedoFromLogic<
             ) {
               const item = future.shift()!;
               newSnapshot = item.snapshot;
-              past.push(item);
+              if (!options.restore) {
+                past.push(item);
+              }
+            }
+            if (options.restore) {
+              past.push({
+                snapshot: currentSnapshot,
+                transactionId: firstTransactionId
+              });
             }
           }
 
@@ -174,7 +264,7 @@ function undoRedoFromLogic<
             past.splice(0, excessCount);
           }
 
-          return [{ ...newSnapshot, past, future }, []];
+          return restore(snapshot, newSnapshot, 'redo', past, future);
         }
 
         const [state, effects] = logic.transition(snapshot, event);
@@ -365,7 +455,12 @@ export function undoRedo<
   TEventPayloadMap extends EventPayloadMap,
   TEmitted extends EventObject
 >(
-  options?: UndoRedoStrategyOptions<TContext, ExtractEvents<TEventPayloadMap>>
+  options?: UndoRedoStrategyOptions<
+    TContext,
+    ExtractEvents<TEventPayloadMap>,
+    TEmitted,
+    TEventPayloadMap
+  >
 ): StoreExtension<
   TContext,
   TEventPayloadMap,

--- a/packages/xstate-store/test/undo.test.ts
+++ b/packages/xstate-store/test/undo.test.ts
@@ -834,4 +834,243 @@ describe('undoRedo with snapshot strategy', () => {
     store.trigger.undo(); // count = 0
     expect(store.getSnapshot().context.count).toBe(0);
   });
+
+  it('should preserve orthogonal context during undo and redo', () => {
+    const store = createStore({
+      context: { document: 'a', viewport: 0 },
+      on: {
+        updateDocument: (context, event: { document: string }) => ({
+          ...context,
+          document: event.document
+        }),
+        updateViewport: (context, event: { viewport: number }) => ({
+          ...context,
+          viewport: event.viewport
+        })
+      }
+    }).with(
+      undoRedo({
+        strategy: 'snapshot',
+        skipEvent: (event) => event.type === 'updateViewport',
+        restore: ({ current, next }) => ({
+          ...next,
+          viewport: current.viewport
+        })
+      })
+    );
+
+    store.trigger.updateDocument({ document: 'b' });
+    store.trigger.updateViewport({ viewport: 10 });
+    store.trigger.undo();
+    expect(store.getSnapshot().context).toEqual({
+      document: 'a',
+      viewport: 10
+    });
+
+    store.trigger.redo();
+    expect(store.getSnapshot().context).toEqual({
+      document: 'b',
+      viewport: 10
+    });
+
+    store.trigger.updateViewport({ viewport: 20 });
+    store.trigger.undo();
+    expect(store.getSnapshot().context).toEqual({
+      document: 'a',
+      viewport: 20
+    });
+  });
+
+  it('should pass current, next, and direction to restore', () => {
+    const restore = vi.fn(({ next }) => next);
+    const store = createStore({
+      context: { count: 0 },
+      on: { inc: (context) => ({ count: context.count + 1 }) }
+    }).with(undoRedo({ strategy: 'snapshot', restore }));
+
+    store.trigger.inc();
+    store.trigger.undo();
+    store.trigger.redo();
+
+    expect(restore.mock.calls.map(([args]) => args)).toEqual([
+      { current: { count: 1 }, next: { count: 0 }, direction: 'undo' },
+      { current: { count: 0 }, next: { count: 1 }, direction: 'redo' }
+    ]);
+  });
+
+  it('should restore once for a transaction group', () => {
+    const restore = vi.fn(({ next }) => next);
+    const store = createStore({
+      context: { count: 0 },
+      on: { inc: (context) => ({ count: context.count + 1 }) }
+    }).with(
+      undoRedo({
+        strategy: 'snapshot',
+        getTransactionId: () => 'transaction',
+        restore
+      })
+    );
+
+    store.trigger.inc();
+    store.trigger.inc();
+    store.trigger.undo();
+    expect(store.getSnapshot().context.count).toBe(0);
+    store.trigger.redo();
+    expect(store.getSnapshot().context.count).toBe(2);
+    store.trigger.undo();
+    expect(store.getSnapshot().context.count).toBe(0);
+    expect(restore).toHaveBeenCalledTimes(3);
+  });
+
+  it('should run emitted events after restored context commits', () => {
+    const observed: number[] = [];
+    const store = createStore({
+      schemas: {
+        emitted: { restored: z.object({ count: z.number() }) }
+      },
+      context: { count: 0 },
+      on: { inc: (context) => ({ count: context.count + 1 }) }
+    }).with(
+      undoRedo({
+        strategy: 'snapshot',
+        restore: ({ next }, enqueue) => {
+          enqueue.emit.restored({ count: next.count });
+          return next;
+        }
+      })
+    );
+    store.on('restored', () =>
+      observed.push(store.getSnapshot().context.count)
+    );
+
+    store.trigger.inc();
+    store.trigger.undo();
+
+    expect(observed).toEqual([0]);
+  });
+
+  it('should run effects after restored context commits', () => {
+    const observed: number[] = [];
+    const store = createStore({
+      context: { count: 0 },
+      on: { inc: (context) => ({ count: context.count + 1 }) }
+    }).with(
+      undoRedo({
+        strategy: 'snapshot',
+        restore: ({ next }, enqueue) => {
+          enqueue.effect((enq) => {
+            observed.push(enq!.getSnapshot().context.count);
+          });
+          return next;
+        }
+      })
+    );
+
+    store.trigger.inc();
+    store.trigger.undo();
+
+    expect(observed).toEqual([0]);
+  });
+
+  it('should apply triggered transitions and effects once without history', () => {
+    const effect = vi.fn();
+    const store = createStore({
+      context: { count: 0 },
+      on: {
+        inc: (context) => ({ count: context.count + 1 }),
+        add: (context, event: { by: number }, enqueue) => {
+          enqueue.effect(effect);
+          return { count: context.count + event.by };
+        }
+      }
+    }).with(
+      undoRedo({
+        strategy: 'snapshot',
+        restore: ({ next }, enqueue) => {
+          enqueue.trigger.add({ by: 10 });
+          return next;
+        }
+      })
+    );
+
+    store.trigger.inc();
+    expect(store.can.undo()).toBe(true);
+    expect(effect).not.toHaveBeenCalled();
+    store.trigger.undo();
+
+    expect(store.getSnapshot().context.count).toBe(10);
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(store.can.undo()).toBe(false);
+  });
+
+  it('should not execute enqueued effects when checking can', () => {
+    const effect = vi.fn();
+    const emitted = vi.fn();
+    const store = createStore({
+      schemas: { emitted: { restored: z.object({}) } },
+      context: { count: 0 },
+      on: { inc: (context) => ({ count: context.count + 1 }) }
+    }).with(
+      undoRedo({
+        strategy: 'snapshot',
+        restore: ({ next }, enqueue) => {
+          enqueue.effect(effect);
+          enqueue.emit.restored({});
+          return next;
+        }
+      })
+    );
+    store.on('restored', emitted);
+
+    store.trigger.inc();
+    expect(store.can.undo()).toBe(true);
+    expect(effect).not.toHaveBeenCalled();
+    expect(emitted).not.toHaveBeenCalled();
+    store.trigger.undo();
+    expect(store.can.redo()).toBe(true);
+    expect(effect).toHaveBeenCalledTimes(1);
+    expect(emitted).toHaveBeenCalledTimes(1);
+  });
+
+  it('should infer restore context, emitted events, and triggers', () => {
+    createStore({
+      schemas: {
+        emitted: { restored: z.object({ count: z.number() }) }
+      },
+      context: { count: 0 },
+      on: {
+        add: (context, event: { by: number }) => ({
+          count: context.count + event.by
+        })
+      }
+    }).with(
+      undoRedo({
+        strategy: 'snapshot',
+        restore: ({ current, next, direction }, enqueue) => {
+          current.count satisfies number;
+          next.count satisfies number;
+          direction satisfies 'undo' | 'redo';
+          enqueue.emit.restored({ count: next.count });
+          enqueue.trigger.add({ by: 1 });
+
+          if (false) {
+            // @ts-expect-error
+            enqueue.emit.restored({ count: 'wrong' });
+            // @ts-expect-error
+            enqueue.trigger.add({ by: 'wrong' });
+          }
+
+          return next;
+        }
+      })
+    );
+
+    if (false) {
+      undoRedo({
+        strategy: 'event',
+        // @ts-expect-error restore is only available for snapshot strategy
+        restore: () => ({ count: 0 })
+      });
+    }
+  });
 });


### PR DESCRIPTION
Allow snapshot-based undo and redo to customize restored context while preserving complete history snapshots. Restoration can enqueue emitted events, effects, and store triggers.

```ts
const undoableStore = store.with(
  undoRedo({
    strategy: 'snapshot',
    restore: ({ current, next }) => ({
      ...next,
      viewport: current.viewport
    })
  })
);
```
