### PR TITLE
Make `setup()` delayed and error transitions target-aware

### DIFF
--- a/.changeset/delayed-transition-context-patch.md
+++ b/.changeset/delayed-transition-context-patch.md
@@ -1,0 +1,33 @@
+---
+'xstate': patch
+---
+
+Delayed transitions (`onTimeout` and `after`) in machines created with `setup({ states })` now type the `context` patch against the **target** state's context schema, matching the behavior of `on:` transitions. Previously, a cross-state context patch that was valid at runtime failed to typecheck:
+
+```ts
+const machine = setup({
+  schemas: {
+    context: z.object({ reason: z.union([z.literal('timeout'), z.null()]) })
+  },
+  states: {
+    running: { schemas: { context: z.object({ reason: z.null() }) } },
+    expired: {
+      schemas: { context: z.object({ reason: z.literal('timeout') }) }
+    }
+  }
+}).createMachine({
+  context: { reason: null },
+  initial: 'running',
+  states: {
+    running: {
+      timeout: 5000,
+      // Previously a type error; now checked against `expired`'s context
+      onTimeout: () => ({
+        target: 'expired',
+        context: { reason: 'timeout' as const }
+      })
+    },
+    expired: { type: 'final' }
+  }
+});
+```

--- a/.changeset/delayed-transition-context-patch.md
+++ b/.changeset/delayed-transition-context-patch.md
@@ -2,7 +2,7 @@
 'xstate': patch
 ---
 
-Delayed transitions (`onTimeout` and `after`) in machines created with `setup({ states })` now type the `context` patch against the **target** state's context schema, matching the behavior of `on:` transitions. Previously, a cross-state context patch that was valid at runtime failed to typecheck:
+Delayed transitions (`onTimeout` and `after`) and error transitions (`onError`) in machines created with `setup({ states })` now type the `context` patch against the **target** state's context schema, matching the behavior of `on:` transitions. Previously, a cross-state context patch that was valid at runtime failed to typecheck:
 
 ```ts
 const machine = setup({

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -36,7 +36,8 @@ import {
   SnapshotEvent,
   SingleOrArray,
   AfterEvent,
-  TimeoutEvent
+  TimeoutEvent,
+  ErrorEvent
 } from './types.ts';
 import { AnyActorSystem } from './system.ts';
 import { InspectionEvent } from './inspection.ts';
@@ -864,7 +865,14 @@ type StateNodeConfigWithNestedInput<
       Record<string, unknown>,
       TSystemRegistry
     >,
-    'on' | 'always' | 'initial' | 'invoke' | 'onDone' | 'onTimeout' | 'after'
+    | 'on'
+    | 'always'
+    | 'initial'
+    | 'invoke'
+    | 'onDone'
+    | 'onError'
+    | 'onTimeout'
+    | 'after'
   > & {
     initial?: TStateSchema['states'] extends Record<string, SetupStateSchema>
       ?
@@ -934,6 +942,22 @@ type StateNodeConfigWithNestedInput<
       StateContext<TStateSchema, TContext>,
       StateContextShape<TStateSchema, TContextShape>,
       DoneStateEvent,
+      TEvent,
+      TEmitted,
+      TChildren,
+      TMeta,
+      TActionMap,
+      TActorMap,
+      TGuardMap,
+      TDelayMap,
+      TSystemRegistry,
+      StateInput<TStateSchema>
+    >;
+    onError?: StateTransitionConfigOrTarget<
+      TSiblingStateSchemas,
+      StateContext<TStateSchema, TContext>,
+      StateContextShape<TStateSchema, TContextShape>,
+      ErrorEvent,
       TEvent,
       TEmitted,
       TChildren,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -34,7 +34,9 @@ import {
   Subscription,
   OutputArg,
   SnapshotEvent,
-  SingleOrArray
+  SingleOrArray,
+  AfterEvent,
+  TimeoutEvent
 } from './types.ts';
 import { AnyActorSystem } from './system.ts';
 import { InspectionEvent } from './inspection.ts';
@@ -862,7 +864,7 @@ type StateNodeConfigWithNestedInput<
       Record<string, unknown>,
       TSystemRegistry
     >,
-    'on' | 'always' | 'initial' | 'invoke' | 'onDone'
+    'on' | 'always' | 'initial' | 'invoke' | 'onDone' | 'onTimeout' | 'after'
   > & {
     initial?: TStateSchema['states'] extends Record<string, SetupStateSchema>
       ?
@@ -943,6 +945,40 @@ type StateNodeConfigWithNestedInput<
       TSystemRegistry,
       StateInput<TStateSchema>
     >;
+    onTimeout?: StateTransitionConfigOrTarget<
+      TSiblingStateSchemas,
+      StateContext<TStateSchema, TContext>,
+      StateContextShape<TStateSchema, TContextShape>,
+      TimeoutEvent,
+      TEvent,
+      TEmitted,
+      TChildren,
+      TMeta,
+      TActionMap,
+      TActorMap,
+      TGuardMap,
+      TDelayMap,
+      TSystemRegistry,
+      StateInput<TStateSchema>
+    >;
+    after?: {
+      [K in NoInfer<TDelays> | number]?: StateTransitionConfigOrTarget<
+        TSiblingStateSchemas,
+        StateContext<TStateSchema, TContext>,
+        StateContextShape<TStateSchema, TContextShape>,
+        AfterEvent,
+        TEvent,
+        TEmitted,
+        TChildren,
+        TMeta,
+        TActionMap,
+        TActorMap,
+        TGuardMap,
+        TDelayMap,
+        TSystemRegistry,
+        StateInput<TStateSchema>
+      >;
+    };
   },
   TStateSchema['states'] extends Record<string, SetupStateSchema>
     ? StatesWithInput<

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -7,7 +7,8 @@ import {
   createAsyncLogic,
   AnyEventObject,
   ActorLogic,
-  Snapshot
+  Snapshot,
+  setup
 } from '../src';
 import { createMachineFromConfig } from '../src/createMachineFromConfig';
 import { toMachineJSON } from '../src/scxml';
@@ -1066,6 +1067,70 @@ describe('error handling', () => {
     expect(actor.getSnapshot().value).toBe('failed');
     expect(actor.getSnapshot().status).toBe('active');
     expect(errorSpy).toHaveBeenCalledWith('transition action failed');
+  });
+
+  it('state onError accepts a cross-state context patch (typed against the target state schema)', () => {
+    const machine = setup({
+      schemas: {
+        context: z.object({
+          error: z.union([z.string(), z.null()])
+        })
+      },
+      states: {
+        active: { schemas: { context: z.object({ error: z.null() }) } },
+        failed: { schemas: { context: z.object({ error: z.string() }) } }
+      }
+    }).createMachine({
+      context: { error: null },
+      initial: 'active',
+      states: {
+        active: {
+          on: {
+            NEXT: () => {
+              throw new Error('boom');
+            }
+          },
+          onError: ({ event }) => ({
+            target: 'failed',
+            context: { error: getErrorMessage(event.error) }
+          })
+        },
+        failed: {}
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'NEXT' });
+
+    expect(actor.getSnapshot().value).toBe('failed');
+    expect(actor.getSnapshot().context).toEqual({ error: 'boom' });
+  });
+
+  it('state onError rejects a cross-state context patch that does not match the target state schema', () => {
+    setup({
+      schemas: {
+        context: z.object({
+          error: z.union([z.string(), z.null()])
+        })
+      },
+      states: {
+        active: { schemas: { context: z.object({ error: z.null() }) } },
+        failed: { schemas: { context: z.object({ error: z.string() }) } }
+      }
+    }).createMachine({
+      context: { error: null },
+      initial: 'active',
+      states: {
+        active: {
+          // @ts-expect-error - `error: null` is not assignable to the target state's context
+          onError: () => ({
+            target: 'failed',
+            context: { error: null }
+          })
+        },
+        failed: {}
+      }
+    });
   });
 
   it('state onError catches errors thrown by transition functions', () => {

--- a/packages/core/test/timeout.test.ts
+++ b/packages/core/test/timeout.test.ts
@@ -123,6 +123,89 @@ describe('state-level timeout', () => {
     expect(actor.getSnapshot().value).toBe('periodic');
   });
 
+  it('accepts a cross-state context patch (typed against the target state schema)', () => {
+    vi.useFakeTimers();
+
+    const machine = setup({
+      schemas: {
+        context: z.object({
+          reason: z.union([z.literal('timeout'), z.literal('after'), z.null()])
+        })
+      },
+      states: {
+        running: { schemas: { context: z.object({ reason: z.null() }) } },
+        expired: {
+          schemas: { context: z.object({ reason: z.literal('timeout') }) }
+        },
+        elapsed: {
+          schemas: { context: z.object({ reason: z.literal('after') }) }
+        }
+      }
+    }).createMachine({
+      context: { reason: null },
+      initial: 'running',
+      states: {
+        running: {
+          timeout: 1000,
+          onTimeout: () => ({
+            target: 'expired',
+            context: { reason: 'timeout' }
+          }),
+          after: {
+            2000: () => ({
+              target: 'elapsed',
+              context: { reason: 'after' }
+            })
+          }
+        },
+        expired: { type: 'final' },
+        elapsed: { type: 'final' }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    vi.advanceTimersByTime(1000);
+    expect(actor.getSnapshot().value).toBe('expired');
+    expect(actor.getSnapshot().context).toEqual({ reason: 'timeout' });
+  });
+
+  it('rejects a cross-state context patch that does not match the target state schema', () => {
+    setup({
+      schemas: {
+        context: z.object({
+          reason: z.union([z.literal('timeout'), z.null()])
+        })
+      },
+      states: {
+        running: { schemas: { context: z.object({ reason: z.null() }) } },
+        expired: {
+          schemas: { context: z.object({ reason: z.literal('timeout') }) }
+        }
+      }
+    }).createMachine({
+      context: { reason: null },
+      initial: 'running',
+      states: {
+        running: {
+          timeout: 1000,
+          // @ts-expect-error - `reason: null` is not assignable to the target state's context
+          onTimeout: () => ({
+            target: 'expired',
+            context: { reason: null }
+          }),
+          after: {
+            // @ts-expect-error - `reason: null` is not assignable to the target state's context
+            2000: () => ({
+              target: 'expired',
+              context: { reason: null }
+            })
+          }
+        },
+        expired: { type: 'final' }
+      }
+    });
+  });
+
   it('supports onTimeout with object form { target }', () => {
     vi.useFakeTimers();
 


### PR DESCRIPTION
### Summary

- `onTimeout`, `after`, and `onError` transitions in `setup({ states })` now type-check context patches against the **target** state's context schema, matching the existing behavior of `on:` transitions
- Previously, cross-state context patches in these transitions produced false type errors even though they were valid at runtime

### Problem

When using `setup({ states })` with per-state context schemas, `on:` transitions correctly resolved the context patch type based on the target state. However, `onTimeout`, `after`, and `onError` were missing from the `StateNodeConfigWithNestedInput` type override, so they fell back to the base typing which didn't account for sibling state schemas.

```ts
const machine = setup({
  schemas: {
    context: z.object({
      error: z.union([z.string(), z.null()]),
      reason: z.union([z.literal('timeout'), z.null()])
    })
  },
  states: {
    active: {
      schemas: {
        context: z.object({ error: z.null(), reason: z.null() })
      }
    },
    expired: {
      schemas: {
        context: z.object({ error: z.null(), reason: z.literal('timeout') })
      }
    },
    failed: {
      schemas: {
        context: z.object({ error: z.string(), reason: z.null() })
      }
    }
  }
}).createMachine({
  context: { error: null, reason: null },
  initial: 'active',
  states: {
    active: {
      timeout: 5000,
      // ✅ Previously a type error; now checked against `expired`'s context
      onTimeout: () => ({
        target: 'expired',
        context: { reason: 'timeout' as const }
      }),
      // ✅ Previously a type error; now checked against `failed`'s context
      onError: ({ event }) => ({
        target: 'failed',
        context: { error: event.error.message }
      })
    },
    expired: { type: 'final' },
    failed: { type: 'final' }
  }
});
```

### Changes

- **`packages/core/src/setup.ts`** — Added `onError`, `onTimeout`, and `after` to the pick-list of overridden keys in `StateNodeConfigWithNestedInput`, and defined their target-aware type overrides using `StateTransitionConfigOrTarget`
- **`packages/core/test/errors.test.ts`** — Added tests for `onError` accepting valid cross-state context patches and rejecting invalid ones (`@ts-expect-error`)
- **`packages/core/test/timeout.test.ts`** — Added tests for `onTimeout` and `after` accepting valid cross-state context patches and rejecting invalid ones (`@ts-expect-error`)
