### PR TITLE
Add opt-in runtime schema validation

### DIFF
--- a/.changeset/validate-setup-boundaries.md
+++ b/.changeset/validate-setup-boundaries.md
@@ -1,0 +1,26 @@
+---
+'xstate': minor
+---
+
+Add opt-in runtime Standard Schema validation through `setup({ validator })`. The standard validator is available from the separate `xstate/validation` entrypoint:
+
+```ts
+import { setup } from 'xstate';
+import { standardSchemaValidator } from 'xstate/validation';
+import { z } from 'zod';
+
+const machine = setup({
+  validator: standardSchemaValidator(),
+  schemas: {
+    events: {
+      increment: z.object({ by: z.number() })
+    }
+  }
+}).createMachine({});
+```
+
+Validation covers machine input and incoming public events before calculation. It validates stable context, active state input and context contracts, final output, child slots, delayed raised-event timers, and emitted events before returning a completed macrostep. Validation asserts runtime values without applying schema transformations.
+
+Derived setups inherit validation unless they explicitly replace it or disable it with `validator: undefined`.
+
+Named action and guard parameters, immediate raised events, static meta and tags, persistence, restoration, and `snapshot.can()` are not validation boundaries in this initial release.

--- a/.changeset/validate-setup-boundaries.md
+++ b/.changeset/validate-setup-boundaries.md
@@ -23,4 +23,6 @@ Validation covers machine input and incoming public events before calculation. I
 
 Derived setups inherit validation unless they explicitly replace it or disable it with `validator: undefined`.
 
+The same validator can be installed on `createLogic()`, async, callback, and observable logic configurations. Those actors validate their existing input and output schema boundaries.
+
 Named action and guard parameters, immediate raised events, static meta and tags, persistence, restoration, and `snapshot.can()` are not validation boundaries in this initial release.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,10 +10,10 @@
   const versions = machineVersions([checkoutV1, checkoutV2]);
   const source = await versions.parseSnapshot(persisted);
   const snapshot = await migrateSnapshot(source, checkoutV2, {
-    "1": (snapshot) => ({
+    '1': (snapshot) => ({
       ...snapshot,
-      context: { total: snapshot.context.count },
-    }),
+      context: { total: snapshot.context.count }
+    })
   });
 
   createActor(checkoutV2, { snapshot }).start();
@@ -24,7 +24,7 @@
 
   ```ts
   const versions = machineVersions([checkoutV0, checkoutV1], {
-    unversioned: "0",
+    unversioned: '0'
   });
   ```
 
@@ -40,19 +40,19 @@
 
   ```ts
   createMachine({
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
-        initial: "idle",
+        initial: 'idle',
         states: {
           idle: {},
           history: {
-            type: "history",
-            target: "idle",
-          },
-        },
-      },
-    },
+            type: 'history',
+            target: 'idle'
+          }
+        }
+      }
+    }
   });
   ```
 
@@ -65,47 +65,47 @@
   ```ts
   const machine = setup({
     schemas: {
-      context: z.object({ reason: z.union([z.literal("timeout"), z.null()]) }),
+      context: z.object({ reason: z.union([z.literal('timeout'), z.null()]) })
     },
     states: {
       running: { schemas: { context: z.object({ reason: z.null() }) } },
       expired: {
-        schemas: { context: z.object({ reason: z.literal("timeout") }) },
-      },
-    },
+        schemas: { context: z.object({ reason: z.literal('timeout') }) }
+      }
+    }
   }).createMachine({
     context: { reason: null },
-    initial: "running",
+    initial: 'running',
     states: {
       running: {
         timeout: 5000,
         // Previously a type error; now checked against `expired`'s context
         onTimeout: () => ({
-          target: "expired",
-          context: { reason: "timeout" as const },
-        }),
+          target: 'expired',
+          context: { reason: 'timeout' as const }
+        })
       },
-      expired: { type: "final" },
-    },
+      expired: { type: 'final' }
+    }
   });
   ```
 
 - d9d9e29: Per-state schemas declared in `setup({ states })` are now available on the compiled machine's state nodes via `machine.states.X.schemas`, so tooling (e.g. per-state snapshot validators) can be derived from the machine alone. Previously they were only accessible on the setup return value.
 
   ```ts
-  import { setup, types } from "xstate";
+  import { setup, types } from 'xstate';
 
   const machine = setup({
     states: {
       running: {
-        schemas: { context: types<{ startedAt: number }>() },
-      },
-    },
+        schemas: { context: types<{ startedAt: number }>() }
+      }
+    }
   }).createMachine({
-    initial: "running",
+    initial: 'running',
     states: {
-      running: {},
-    },
+      running: {}
+    }
   });
 
   machine.states.running.schemas?.context; // the schema declared in setup
@@ -116,9 +116,9 @@
   ```ts
   createMachine({
     always: ({ context }) => {
-      if (context.hour < 12) return { target: "morning" };
-      return { target: "afternoon" };
-    },
+      if (context.hour < 12) return { target: 'morning' };
+      return { target: 'afternoon' };
+    }
   });
   ```
 
@@ -144,10 +144,10 @@
   const child = snapshot.children.job;
 
   const [nextSnapshot] = transition(machine, snapshot, {
-    type: "xstate.done.actor",
-    actorId: "job",
+    type: 'xstate.done.actor',
+    actorId: 'job',
     sessionId: child.sessionId,
-    output: result,
+    output: result
   });
 
   nextSnapshot.children.job; // undefined
@@ -158,7 +158,7 @@
   ```ts
   // `persisted` contains a child whose registered source is not provided.
   const restored = createActor(machineWithoutChildSource, {
-    snapshot: persisted,
+    snapshot: persisted
   });
 
   restored.getSnapshot().status; // 'error'
@@ -170,11 +170,11 @@
   const machine = createMachine({
     // ...
     on: {
-      "xstate.done.actor": {
-        matches: { actorId: "job" },
-        target: "complete",
-      },
-    },
+      'xstate.done.actor': {
+        matches: { actorId: 'job' },
+        target: 'complete'
+      }
+    }
   });
 
   // Generated events use payload identity:
@@ -197,7 +197,7 @@
     context: ({ spawn, actors }) => {
       spawn(actors.child);
       return {};
-    },
+    }
   });
   ```
 
@@ -213,7 +213,7 @@
   let [snapshot, effects] = machine.initialTransition(input);
   await executeEffects(effects, runtime);
 
-  while (snapshot.status === "active") {
+  while (snapshot.status === 'active') {
     const event = await dequeue();
     [snapshot, effects] = machine.transition(snapshot, event);
     await executeEffects(effects, runtime);
@@ -242,15 +242,15 @@
   const machine = setup({
     states: {
       complete: {
-        schemas: { context: z.object({ result: z.string() }) },
-      },
-    },
+        schemas: { context: z.object({ result: z.string() }) }
+      }
+    }
   }).createMachine({
-    initial: "planning",
+    initial: 'planning',
     states: {
       planning: {},
-      complete: {},
-    },
+      complete: {}
+    }
   });
   ```
 
@@ -288,7 +288,7 @@
   entry: (_, enq) => {
     const child = enq.spawn(childLogic);
     // Now receives events emitted synchronously during child's startup
-    enq.listen(child, "ready", () => ({ type: "CHILD_READY" }));
+    enq.listen(child, 'ready', () => ({ type: 'CHILD_READY' }));
   };
   ```
 
@@ -307,21 +307,21 @@
   const machine = setup({
     states: {
       loading: {
-        schemas: { input: z.object({ userId: z.string() }) },
-      },
-    },
+        schemas: { input: z.object({ userId: z.string() }) }
+      }
+    }
   }).createMachine({
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
-        on: { LOAD: { target: "loading", input: { userId: "u1" } } },
+        on: { LOAD: { target: 'loading', input: { userId: 'u1' } } }
       },
-      loading: {},
-    },
+      loading: {}
+    }
   });
 
   const actor = createActor(machine).start();
-  actor.send({ type: "LOAD" });
+  actor.send({ type: 'LOAD' });
 
   const persisted = actor.getPersistedSnapshot();
   const restored = createActor(machine, { snapshot: persisted }).start();
@@ -341,31 +341,31 @@
   const machine = setup({
     states: {
       active: {
-        schemas: { input: z.object({ duration: z.number() }) },
-      },
-    },
+        schemas: { input: z.object({ duration: z.number() }) }
+      }
+    }
   }).createMachine({
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
           activate: ({ event }) => ({
-            target: "active",
-            input: { duration: event.duration },
-          }),
-        },
+            target: 'active',
+            input: { duration: event.duration }
+          })
+        }
       },
       active: {
         timeout: ({ input }) => input.duration,
-        onTimeout: ({ input }) => ({ target: "idle" }),
+        onTimeout: ({ input }) => ({ target: 'idle' }),
         after: {
-          1000: ({ input }) => ({ target: "idle" }),
+          1000: ({ input }) => ({ target: 'idle' })
         },
         on: {
-          ping: ({ input }, enq) => {},
-        },
-      },
-    },
+          ping: ({ input }, enq) => {}
+        }
+      }
+    }
   });
   ```
 
@@ -376,44 +376,44 @@
 - 95a7aca: `extend(...)` now merges `actions` and `guards` schema maps instead of replacing the base setup schemas. Previously, only `events`, `emitted`, and `children` were merged.
 
   ```ts
-  import { setup, types } from "xstate";
+  import { setup, types } from 'xstate';
 
   const machine = setup({
     schemas: {
       actions: {
-        track: { params: types<{ key: string }>() },
+        track: { params: types<{ key: string }>() }
       },
       guards: {
-        hasAccess: { params: types<{ role: string }>() },
-      },
-    },
+        hasAccess: { params: types<{ role: string }>() }
+      }
+    }
   })
     .extend({
       schemas: {
         actions: {
-          notify: { params: types<{ message: string }>() },
+          notify: { params: types<{ message: string }>() }
         },
         guards: {
-          canReset: { params: types<{ reason: string }>() },
-        },
-      },
+          canReset: { params: types<{ reason: string }>() }
+        }
+      }
     })
     .createMachine({
       // Both base and extended actions/guards are available
       entry: ({ actions }, enq) => {
-        enq(actions.track({ key: "init" }));
-        enq(actions.notify({ message: "started" }));
+        enq(actions.track({ key: 'init' }));
+        enq(actions.notify({ message: 'started' }));
       },
       on: {
         RESET: ({ guards }) => {
           if (
-            guards.hasAccess({ role: "admin" }) &&
-            guards.canReset({ reason: "manual" })
+            guards.hasAccess({ role: 'admin' }) &&
+            guards.canReset({ reason: 'manual' })
           ) {
-            return { target: ".idle" };
+            return { target: '.idle' };
           }
-        },
-      },
+        }
+      }
     });
   ```
 
@@ -422,18 +422,18 @@
 - b3ef4e7: `setup(...)` now exposes the schemas defined in its configuration, making them accessible for external use.
 
   ```ts
-  import { setup, types } from "xstate";
+  import { setup, types } from 'xstate';
 
   const s = setup({
     schemas: {
       context: types<{ count: number }>(),
       events: {
-        inc: types<{ by: number }>(),
+        inc: types<{ by: number }>()
       },
       emitted: {
-        changed: types<{ value: number }>(),
-      },
-    },
+        changed: types<{ value: number }>()
+      }
+    }
   });
 
   s.schemas.context;
@@ -467,16 +467,16 @@
 
   ```ts
   const machine = createMachine({
-    initial: "working",
+    initial: 'working',
     states: {
       working: {
-        on: { done: { target: "success" } },
+        on: { done: { target: 'success' } }
       },
       success: {
-        type: "final",
-        output: { status: "ok" },
-      },
-    },
+        type: 'final',
+        output: { status: 'ok' }
+      }
+    }
   });
   ```
 
@@ -488,15 +488,15 @@
 
     ```ts
     const machine = createMachine({
-      id: "p",
-      type: "parallel",
+      id: 'p',
+      type: 'parallel',
       on: {
-        ARCHIVE: { target: "#p.phase.archive" },
+        ARCHIVE: { target: '#p.phase.archive' }
       },
       states: {
-        phase: { initial: "inquiry", states: { inquiry: {}, archive: {} } },
-        mode: { initial: "new", states: { new: {}, edit: {} } },
-      },
+        phase: { initial: 'inquiry', states: { inquiry: {}, archive: {} } },
+        mode: { initial: 'new', states: { new: {}, edit: {} } }
+      }
     });
     // sending ARCHIVE now leaves `mode` in its current state
     ```
@@ -507,7 +507,7 @@
     // from Operation.Waiting:
     on: {
       TOGGLE_MODE: {
-        target: "#Demo";
+        target: '#Demo';
       } // in the Mode region
     }
     // sending TOGGLE_MODE enters Mode.Demo without exiting Operation
@@ -528,21 +528,21 @@
 
   ```ts
   const machine = createMachine({
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
         onError: ({ event }) => ({
-          target: "failed",
+          target: 'failed',
           context: {
             message:
               event.error instanceof Error
                 ? event.error.message
-                : String(event.error),
-          },
-        }),
+                : String(event.error)
+          }
+        })
       },
-      failed: {},
-    },
+      failed: {}
+    }
   });
   ```
 
@@ -553,8 +553,8 @@
   ```ts
   const machine = setup({
     schemas: {
-      events: {},
-    },
+      events: {}
+    }
   }).createMachine({});
 
   const logic: AnyActorLogic = machine;
@@ -570,41 +570,41 @@
 - 37d3254: Setup-bound invoke transition callbacks now validate target state context requirements for `onDone`, `onError`, `onSnapshot`, and `onTimeout`. `onDone` also infers output from the invoked actor logic.
 
   ```ts
-  import { createAsyncLogic, setup } from "xstate";
-  import { z } from "zod";
+  import { createAsyncLogic, setup } from 'xstate';
+  import { z } from 'zod';
 
   const machine = setup({
     actors: {
       loadUser: createAsyncLogic({
-        run: async () => ({ name: "Ada" }),
-      }),
+        run: async () => ({ name: 'Ada' })
+      })
     },
     states: {
       loading: {},
       success: {
         schemas: {
           context: z.object({
-            user: z.object({ name: z.string() }),
-          }),
-        },
-      },
-    },
+            user: z.object({ name: z.string() })
+          })
+        }
+      }
+    }
   }).createMachine({
     context: {},
-    initial: "loading",
+    initial: 'loading',
     states: {
       loading: {
         invoke: {
-          src: "loadUser",
+          src: 'loadUser',
           // Type-safe return value for invoke callbacks
           onDone: ({ event }) => ({
-            target: "success",
-            context: { user: event.output },
-          }),
-        },
+            target: 'success',
+            context: { user: event.output }
+          })
+        }
       },
-      success: {},
-    },
+      success: {}
+    }
   });
   ```
 
@@ -655,8 +655,8 @@
   ```ts
   on: {
     FETCH: ({ context, event }) => ({
-      target: "fetching",
-      input: { url: event.url, token: context.authToken },
+      target: 'fetching',
+      input: { url: event.url, token: context.authToken }
     });
   }
   ```
@@ -670,38 +670,38 @@
 - bdc54dd: Added `createFSM(...)` for flat, actor-compatible finite state machines.
 
   ```ts
-  import { createActor, createFSM } from "xstate";
+  import { createActor, createFSM } from 'xstate';
 
   const toggleLogic = createFSM({
-    initial: "inactive",
+    initial: 'inactive',
     context: { count: 0 },
     states: {
       inactive: {
         on: {
           toggle: {
-            target: "active",
-            context: { count: 1 },
-          },
-        },
+            target: 'active',
+            context: { count: 1 }
+          }
+        }
       },
       active: {
         on: {
           toggle: ({ context }, enq) => {
-            enq(() => console.log("toggled"));
+            enq(() => console.log('toggled'));
 
             return {
-              target: "inactive",
-              context: { count: context.count + 1 },
+              target: 'inactive',
+              context: { count: context.count + 1 }
             };
-          },
-        },
-      },
-    },
+          }
+        }
+      }
+    }
   });
 
   const actor = createActor(toggleLogic).start();
 
-  actor.send({ type: "toggle" });
+  actor.send({ type: 'toggle' });
   ```
 
   `createFSM(...)` supports XState-style object transitions, function transitions, `enq` actions, initial input, state `input`, entry actions, and exit actions. Plain string targets are intentionally not supported; use object targets such as `{ target: 'active' }`.
@@ -732,16 +732,16 @@
   const machine = createMachine({
     on: {
       spawn: (_, enq) => {
-        enq.spawn(childMachine, { registryKey: "child" });
-      },
-    },
+        enq.spawn(childMachine, { registryKey: 'child' });
+      }
+    }
   });
   ```
 
 - 6798cb1: `serializeMachine(...)` and `createMachineFromConfig(...)` now represent inline functions (guards, actions, transitions, delays, route functions) as `{ '@code': string, '@lang': 'ts' }`. Non-portable values such as actor logic, runtime schemas, class instances, symbols, and bigints are omitted from the serialized JSON.
 
   ```ts
-  import { serializeMachine } from "xstate";
+  import { serializeMachine } from 'xstate';
 
   serializeMachine(machine);
   // inline functions → { '@code': '() => true', '@lang': 'ts' }
@@ -759,16 +759,16 @@
   ```ts
   createMachine({
     schemas: {
-      output: types<{ status: "ok" }>(),
+      output: types<{ status: 'ok' }>()
     },
-    initial: "done",
+    initial: 'done',
     states: {
       done: {
-        type: "final",
-        output: { status: "ok" },
-      },
+        type: 'final',
+        output: { status: 'ok' }
+      }
     },
-    output: ({ event }) => event.output,
+    output: ({ event }) => event.output
   });
   ```
 
@@ -791,11 +791,11 @@
   import {
     setup,
     type AnySetupConfig,
-    type SetupReturnFromConfig,
-  } from "xstate";
+    type SetupReturnFromConfig
+  } from 'xstate';
 
   function decorateSetup<const TConfig extends AnySetupConfig>(
-    config: TConfig,
+    config: TConfig
   ): SetupReturnFromConfig<TConfig> & { extra: true } {
     const s = setup(config) as SetupReturnFromConfig<TConfig>;
 
@@ -837,20 +837,20 @@
   ```ts
   const system = createSystem({
     registry: {
-      receiver: receiverLogic,
-    },
+      receiver: receiverLogic
+    }
   });
 
   const machine = system.setup().createMachine({
     invoke: {
       src: receiverLogic,
-      registryKey: "receiver",
-    },
+      registryKey: 'receiver'
+    }
   });
 
   const actor = system.createActor(machine).start();
 
-  system.get("receiver")?.send({ type: "HELLO" });
+  system.get('receiver')?.send({ type: 'HELLO' });
   ```
 
 ### Patch Changes
@@ -860,18 +860,18 @@
   ```ts
   createMachine({
     context: { draftAnyway: false, count: 0 },
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
           DRAFT_ANYWAY: {
-            target: "drafting",
-            context: { draftAnyway: true },
-          },
-        },
+            target: 'drafting',
+            context: { draftAnyway: true }
+          }
+        }
       },
-      drafting: {},
-    },
+      drafting: {}
+    }
   });
   ```
 
@@ -887,19 +887,19 @@
   setup({
     schemas: {
       events: {
-        go: types<{}>(),
-      },
-    },
+        go: types<{}>()
+      }
+    }
   }).createMachine({
     states: {
       active: {
         on: {
           go: (_args, enq) => {
-            enq.raise({ type: "go" });
-          },
-        },
-      },
-    },
+            enq.raise({ type: 'go' });
+          }
+        }
+      }
+    }
   });
   ```
 
@@ -910,20 +910,20 @@
     schemas: {
       context: types<{ count: number }>(),
       events: {
-        next: types<{}>(),
-      },
-    },
+        next: types<{}>()
+      }
+    }
   }).createMachine({
     context: { count: 0 },
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
-          next: () => ({ target: "done" }),
-        },
+          next: () => ({ target: 'done' })
+        }
       },
-      done: {},
-    },
+      done: {}
+    }
   });
   ```
 
@@ -935,15 +935,15 @@
 
   ```ts
   createMachine({
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
-          start: { target: "active" },
-        },
+          start: { target: 'active' }
+        }
       },
-      active: {},
-    },
+      active: {}
+    }
   });
   ```
 
@@ -960,15 +960,15 @@
     transition: (snapshot, event) => [snapshot, []],
     initialTransition: (input, _scope) => [
       {
-        status: "active",
+        status: 'active',
         output: undefined,
         error: undefined,
-        input,
+        input
       },
-      [],
+      []
     ],
     getInitialSnapshot: (scope, input) =>
-      logic.initialTransition(input, scope)[0],
+      logic.initialTransition(input, scope)[0]
   };
   ```
 
@@ -990,20 +990,20 @@
     }
 
     switch (effect.type) {
-      case "@xstate.start":
+      case '@xstate.start':
         effect.id;
         effect.logic;
         effect.src;
         effect.input;
         break;
 
-      case "@xstate.sendTo":
+      case '@xstate.sendTo':
         effect.target;
         effect.event;
         effect.delay;
         break;
 
-      case "@xstate.raise":
+      case '@xstate.raise':
         effect.event;
         effect.delay;
         break;
@@ -1024,10 +1024,10 @@
     schemas: {
       context: z.object({ count: z.number() }),
       events: {
-        inc: z.object({ by: z.number() }),
-      },
+        inc: z.object({ by: z.number() })
+      }
     },
-    context: { count: 0 },
+    context: { count: 0 }
   });
 
   machine.schemas?.events?.inc;
@@ -1054,21 +1054,21 @@
   ```ts
   const machine = createMachine({
     context: { value: 0 },
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
-          start: () => ({ target: "active", context: { value: 100 } }),
-        },
+          start: () => ({ target: 'active', context: { value: 100 } })
+        }
       },
       active: {
         invoke: {
           src: asyncLogic,
           // now receives { value: 100 } instead of { value: 0 }
-          input: ({ context }) => ({ val: context.value }),
-        },
-      },
-    },
+          input: ({ context }) => ({ val: context.value })
+        }
+      }
+    }
   });
   ```
 
@@ -1082,20 +1082,20 @@
 
   ```ts
   const machine = createMachine({
-    initial: "loading",
+    initial: 'loading',
     states: {
       loading: {
         invoke: {
           src: createAsyncLogic({
             run: () => {
-              throw new Error("boom"); // sync failure on start
-            },
+              throw new Error('boom'); // sync failure on start
+            }
           }),
-          onError: "failed",
-        },
+          onError: 'failed'
+        }
       },
-      failed: {},
-    },
+      failed: {}
+    }
   });
 
   const actor = createActor(machine).start(); // does not throw
@@ -1136,8 +1136,8 @@
   ```ts
   on: {
     CHECK: ({ self }) => {
-      if (self.getSnapshot().matches({ b: "b2" })) {
-        return { target: "a2" };
+      if (self.getSnapshot().matches({ b: 'b2' })) {
+        return { target: 'a2' };
       }
     };
   }
@@ -1159,33 +1159,33 @@
   Notably, `schemas.events` is a **map** of event-type → payload schema, inferred into a discriminated union keyed by `type`:
 
   ```ts
-  import { createMachine } from "xstate";
-  import { z } from "zod";
+  import { createMachine } from 'xstate';
+  import { z } from 'zod';
 
   const machine = createMachine({
     schemas: {
       context: z.object({ count: z.number() }),
       events: {
         inc: z.object({ by: z.number() }),
-        reset: z.object({}),
+        reset: z.object({})
       },
       input: z.object({ start: z.number() }),
       output: z.object({ total: z.number() }),
       emitted: { changed: z.object({ count: z.number() }) },
-      tags: z.union([z.literal("busy"), z.literal("idle")]),
-      meta: z.object({ label: z.string() }),
+      tags: z.union([z.literal('busy'), z.literal('idle')]),
+      meta: z.object({ label: z.string() })
     },
     context: ({ input }) => ({ count: input.start }),
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
         on: {
           inc: ({ context, event }) => ({
-            context: { count: context.count + event.by },
-          }),
-        },
-      },
-    },
+            context: { count: context.count + event.by }
+          })
+        }
+      }
+    }
   });
   ```
 
@@ -1209,12 +1209,12 @@
   const { createMachine, createStateConfig } = setup({
     schemas: {
       context: types<{ count: number }>(),
-      events: { INC: types<{ value: number }>() },
+      events: { INC: types<{ value: number }>() }
     },
     states: {
       idle: {},
-      loading: { schemas: { input: z.object({ userId: z.string() }) } },
-    },
+      loading: { schemas: { input: z.object({ userId: z.string() }) } }
+    }
   });
   ```
 
@@ -1234,24 +1234,24 @@
   ```ts
   const machine = createMachineFromConfig(
     {
-      initial: "loading",
+      initial: 'loading',
       states: {
         loading: {
           invoke: {
-            src: "loadUser",
-            input: { userId: "42" },
-            onDone: { target: "done" },
+            src: 'loadUser',
+            input: { userId: '42' },
+            onDone: { target: 'done' },
             timeout: 5000,
-            onTimeout: { target: "timedOut" },
-          },
+            onTimeout: { target: 'timedOut' }
+          }
         },
         done: {},
-        timedOut: {},
-      },
+        timedOut: {}
+      }
     },
     {
-      actors: { loadUser },
-    },
+      actors: { loadUser }
+    }
   );
   ```
 
@@ -1264,10 +1264,10 @@
   ```ts
   const logic = createAsyncLogic({
     run: async (_, enq) => {
-      const user = await enq.step("fetchUser", () => fetchUser());
-      const order = await enq.step("createOrder", () => createOrder(user.id));
+      const user = await enq.step('fetchUser', () => fetchUser());
+      const order = await enq.step('createOrder', () => createOrder(user.id));
       return order.id;
-    },
+    }
   });
 
   // snapshot.effects.fetchUser === { status: 'done', output: { id: 1 } }
@@ -1292,8 +1292,8 @@
 
     ```ts
     const logic = createAsyncLogic({
-      timeout: "10ms",
-      run: ({ signal }) => fetch("/slow", { signal }),
+      timeout: '10ms',
+      run: ({ signal }) => fetch('/slow', { signal })
     });
     ```
 
@@ -1329,15 +1329,15 @@
   const loadUser = createAsyncLogic({
     schemas: {
       input: z.object({ userId: z.string() }),
-      output: z.object({ name: z.string() }),
+      output: z.object({ name: z.string() })
     },
     run: async ({ input }) => {
       input.userId; // string
 
       return {
-        name: "David",
+        name: 'David'
       };
-    },
+    }
   });
   ```
 
@@ -1348,23 +1348,23 @@
   ```ts
   const logic = createCallbackLogic({
     schemas: {
-      input: z.object({ userId: z.string() }),
+      input: z.object({ userId: z.string() })
     },
     run: ({ input }) => {
       input.userId; // string
-    },
+    }
   });
   ```
 
 - [#5543](https://github.com/statelyai/xstate/pull/5543) [`52970ea`](https://github.com/statelyai/xstate/commit/52970ea75489305fd7bf1223f9b413770cd6d925) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `createStateConfig(...)` — author a standalone, fully-typed state node config (with `schemas`) that can be composed into a machine, mirroring how `setup(...).createMachine(...)` infers types.
 
   ```ts
-  import { createStateConfig } from "xstate";
+  import { createStateConfig } from 'xstate';
 
   const loading = createStateConfig({
     on: {
-      RESOLVE: "success",
-    },
+      RESOLVE: 'success'
+    }
   });
   ```
 
@@ -1378,10 +1378,10 @@
 
   ```ts
   entry: (_, enq) => {
-    const child = enq.spawn(childLogic, { id: "child" });
-    enq.listen(child, "data.*", (ev) => ({ type: "DATA", value: ev.value }));
+    const child = enq.spawn(childLogic, { id: 'child' });
+    enq.listen(child, 'data.*', (ev) => ({ type: 'DATA', value: ev.value }));
     enq.subscribeTo(child, {
-      done: (output) => ({ type: "CHILD_DONE", output }),
+      done: (output) => ({ type: 'CHILD_DONE', output })
     });
   };
   ```
@@ -1390,19 +1390,19 @@
 
   ```ts
   const machine = createMachine({
-    internalEvents: ["tick"] as const,
-    initial: "idle",
+    internalEvents: ['tick'] as const,
+    initial: 'idle',
     states: {
       idle: {
         on: {
           start: (_, enq) => {
-            enq.raise({ type: "tick" }); // allowed internally
+            enq.raise({ type: 'tick' }); // allowed internally
           },
-          tick: "running",
-        },
+          tick: 'running'
+        }
       },
-      running: {},
-    },
+      running: {}
+    }
   });
 
   // actor.send({ type: 'tick' }) from outside is rejected
@@ -1414,42 +1414,42 @@
   const machine = setup({
     states: {
       idle: {
-        schemas: { context: z.object({ user: z.null() }) },
+        schemas: { context: z.object({ user: z.null() }) }
       },
       success: {
-        schemas: { context: z.object({ user: z.string() }) },
-      },
-    },
+        schemas: { context: z.object({ user: z.string() }) }
+      }
+    }
   }).createMachine({
     schemas: {
       context: z.object({ user: z.string().nullable() }),
       events: {
-        LOAD: z.object({}),
-      },
+        LOAD: z.object({})
+      }
     },
-    initial: "idle",
+    initial: 'idle',
     context: { user: null },
     states: {
       idle: {
         on: {
           LOAD: () => ({
-            target: "success",
-            context: { user: "Ada" },
-          }),
-        },
+            target: 'success',
+            context: { user: 'Ada' }
+          })
+        }
       },
       success: {
         entry: ({ context }) => {
           context.user; // string
-        },
-      },
-    },
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
   const snapshot = actor.getSnapshot();
 
-  if (snapshot.matches("success")) {
+  if (snapshot.matches('success')) {
     snapshot.context.user; // string
   }
   ```
@@ -1460,19 +1460,19 @@
 
   ```ts
   const machine = createMachine({
-    context: { userStatus: "vip" },
-    initial: "routing",
+    context: { userStatus: 'vip' },
+    initial: 'routing',
     states: {
       routing: {
-        type: "choice",
+        type: 'choice',
         choice: ({ context }) => {
-          if (context.userStatus === "vip") return { target: "vipFlow" };
-          return { target: "standardFlow" };
-        },
+          if (context.userStatus === 'vip') return { target: 'vipFlow' };
+          return { target: 'standardFlow' };
+        }
       },
       vipFlow: {},
-      standardFlow: {},
-    },
+      standardFlow: {}
+    }
   });
   ```
 
@@ -1520,10 +1520,10 @@
   - Machines are serializable again: `serializeMachine(machine)` returns the JSON-safe definition. Inline functions, actor logic, and runtime schemas appear as explicit `{ "$unserializable": ... }` markers. `createMachineFromConfig(json)` is also exported from `xstate` and round-trips losslessly with `serializeMachine`:
 
     ```ts
-    import { createMachineFromConfig, serializeMachine } from "xstate";
+    import { createMachineFromConfig, serializeMachine } from 'xstate';
 
     const revived = createMachineFromConfig(
-      JSON.parse(JSON.stringify(serializeMachine(machine))),
+      JSON.parse(JSON.stringify(serializeMachine(machine)))
     );
     ```
 
@@ -1542,16 +1542,16 @@
   ```ts
   const actor = createActor(machine, {
     inspect: (ev) => {
-      if (ev.type === "@xstate.actor") {
+      if (ev.type === '@xstate.actor') {
         // topology: ev.actorRef, ev.parentRef, ev.id, ev.src, ev.snapshot
-      } else if (ev.type === "@xstate.transition") {
+      } else if (ev.type === '@xstate.transition') {
         ev.event; // the event that caused the transition
         ev.snapshot; // resulting snapshot
         ev.actions; // ActionRecord[] — executed actions (always present)
         ev.sent; // SentRecord[] — relayed/scheduled events (always present)
         ev.microsteps; // microstep transitions (always present)
       }
-    },
+    }
   });
   ```
 
@@ -1573,12 +1573,12 @@
 
     ```ts
     const machine = createMachine({
-      version: "2",
+      version: '2',
       migrate: (persisted, fromVersion) => ({
         ...persisted,
-        version: "2",
-        context: upgradeContext(persisted.context),
-      }),
+        version: '2',
+        context: upgradeContext(persisted.context)
+      })
       // ...
     });
     ```
@@ -1600,10 +1600,10 @@
 - [#5543](https://github.com/statelyai/xstate/pull/5543) [`d11c72d`](https://github.com/statelyai/xstate/commit/d11c72df0d83cfa5fc4445995b85e79a601c1c9e) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add atom APIs to XState and make actors readable by atoms.
 
   ```ts
-  import { createActor, createAtom, fromTransition } from "xstate";
+  import { createActor, createAtom, fromTransition } from 'xstate';
 
   const actor = createActor(
-    fromTransition((count: number, event: { type: "inc" }) => count + 1, 0),
+    fromTransition((count: number, event: { type: 'inc' }) => count + 1, 0)
   ).start();
 
   const count = createAtom(() => actor.get().context);
@@ -1614,27 +1614,27 @@
   `schemas` fields accept any [Standard Schema](https://standardschema.dev) (Zod, Valibot, …) for runtime validation _and_ inference. When you only want types, `types<T>()` provides the inference with no runtime validation (it's a Standard Schema whose validation is the identity function):
 
   ```ts
-  import { createMachine, types } from "xstate";
+  import { createMachine, types } from 'xstate';
 
   const machine = createMachine({
     schemas: {
       context: types<{ count: number }>(),
       events: {
         inc: types<{ by: number }>(),
-        reset: types<{}>(),
-      },
+        reset: types<{}>()
+      }
     },
     context: { count: 0 },
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
         on: {
           inc: ({ context, event }) => ({
-            context: { count: context.count + event.by },
-          }),
-        },
-      },
-    },
+            context: { count: context.count + event.by }
+          })
+        }
+      }
+    }
   });
   ```
 
@@ -1661,22 +1661,22 @@
 
   ```ts
   const machine = createMachine({
-    initial: "off",
+    initial: 'off',
     states: {
-      off: { on: { GO: "on.hist" } },
+      off: { on: { GO: 'on.hist' } },
       on: {
-        type: "parallel",
+        type: 'parallel',
         states: {
-          regA: { initial: "a1", states: { a1: {}, a2: {} } },
-          regB: { initial: "b1", states: { b1: {}, b2: {} } },
-          hist: { type: "history", history: "deep" },
-        },
-      },
-    },
+          regA: { initial: 'a1', states: { a1: {}, a2: {} } },
+          regB: { initial: 'b1', states: { b1: {}, b2: {} } },
+          hist: { type: 'history', history: 'deep' }
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
-  actor.send({ type: "GO" });
+  actor.send({ type: 'GO' });
   actor.getSnapshot().value; // { on: { regA: 'a1', regB: 'b1' } }
   ```
 
@@ -1692,15 +1692,15 @@
 
   ```ts
   const machine = createMachine({
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         invoke: {
           src: fromPromise(async () => 42),
-          systemId: "myActor", // previously caused: "Actor with system ID 'myActor' already exists"
-        },
-      },
-    },
+          systemId: 'myActor' // previously caused: "Actor with system ID 'myActor' already exists"
+        }
+      }
+    }
   });
 
   // Now works correctly — returns [snapshot, actions] without throwing
@@ -1738,17 +1738,17 @@
   ```ts
   const machine = setup({
     guards: {
-      isReady: ({ context }) => context.ready,
-    },
+      isReady: ({ context }) => context.ready
+    }
   }).createMachine({
     states: {
       review: {
-        id: "review",
+        id: 'review',
         route: {
-          guard: "isReady",
-        },
-      },
-    },
+          guard: 'isReady'
+        }
+      }
+    }
   });
   ```
 
@@ -1759,14 +1759,14 @@
 - [#5429](https://github.com/statelyai/xstate/pull/5429) [`9d9c1fe`](https://github.com/statelyai/xstate/commit/9d9c1fe9df43936aa6ab43a4694645a6966ace12) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `mapState(snapshot, mapper)` to map a snapshot to values based on active state(s).
 
   ```ts
-  import { mapState } from "xstate";
+  import { mapState } from 'xstate';
 
   const results = mapState(snapshot, {
     states: {
-      loading: { map: () => "Loading..." },
+      loading: { map: () => 'Loading...' },
       success: { map: (snap) => snap.context.data },
-      error: { map: (snap) => snap.context.error.message },
-    },
+      error: { map: (snap) => snap.context.error.message }
+    }
   });
 
   console.log(results);
@@ -1784,8 +1784,8 @@
   const machine = createMachine({
     // ... machine config
     options: {
-      maxIterations: 1000, // set a limit to enable infinite loop detection
-    },
+      maxIterations: 1000 // set a limit to enable infinite loop detection
+    }
   });
   ```
 
@@ -1801,12 +1801,12 @@
   such as when you only want to explore events that currently pass guards:
 
   ```ts
-  import { createTestModel } from "xstate/graph";
+  import { createTestModel } from 'xstate/graph';
 
   const model = createTestModel(machine);
 
   const paths = model.getSimplePaths({
-    filterEvents: (state, event) => state.can(event),
+    filterEvents: (state, event) => state.can(event)
   });
   ```
 
@@ -1837,24 +1837,24 @@
 
   ```ts
   const machine = setup({}).createMachine({
-    id: "app",
-    initial: "home",
+    id: 'app',
+    initial: 'home',
     states: {
-      home: { id: "home", route: {} },
+      home: { id: 'home', route: {} },
       dashboard: {
-        initial: "overview",
+        initial: 'overview',
         states: {
-          overview: { id: "overview", route: {} },
-          settings: { id: "settings", route: {} },
-        },
-      },
-    },
+          overview: { id: 'overview', route: {} },
+          settings: { id: 'settings', route: {} }
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
 
   // Route directly to deeply nested state from anywhere
-  actor.send({ type: "xstate.route", to: "#settings" });
+  actor.send({ type: 'xstate.route', to: '#settings' });
   ```
 
   Routes support guards for conditional navigation:
@@ -1879,23 +1879,23 @@
 - [#5457](https://github.com/statelyai/xstate/pull/5457) [`287b51e`](https://github.com/statelyai/xstate/commit/287b51eb80abc521f8c35fa73df177a0b9dfd3bc) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `getInitialMicrosteps(…)` and `getMicrosteps(…)` functions that return an array of `[snapshot, actions]` tuples for each microstep in a transition.
 
   ```ts
-  import { createMachine, getInitialMicrosteps, getMicrosteps } from "xstate";
+  import { createMachine, getInitialMicrosteps, getMicrosteps } from 'xstate';
 
   const machine = createMachine({
-    initial: "a",
+    initial: 'a',
     states: {
       a: {
-        entry: () => console.log("enter a"),
+        entry: () => console.log('enter a'),
         on: {
-          NEXT: "b",
-        },
+          NEXT: 'b'
+        }
       },
       b: {
-        entry: () => console.log("enter b"),
-        always: "c",
+        entry: () => console.log('enter b'),
+        always: 'c'
       },
-      c: {},
-    },
+      c: {}
+    }
   });
 
   // Get microsteps from initial transition
@@ -1906,7 +1906,7 @@
 
   // Get microsteps from a transition
   const microsteps = getMicrosteps(machine, initialMicrosteps[0][0], {
-    type: "NEXT",
+    type: 'NEXT'
   });
   // Returns: [
   //  [snapshotB, [entryActionB]],
@@ -1915,8 +1915,8 @@
 
   // Each microstep is a tuple of [snapshot, actions]
   for (const [snapshot, actions] of microsteps) {
-    console.log("State:", snapshot.value);
-    console.log("Actions:", actions.length);
+    console.log('State:', snapshot.value);
+    console.log('Actions:', actions.length);
   }
   ```
 
@@ -1927,7 +1927,7 @@
 - [#5406](https://github.com/statelyai/xstate/pull/5406) [`703c3a1`](https://github.com/statelyai/xstate/commit/703c3a109c824f2334ede31d8428e923d2727e6e) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `getNextTransitions(state)` utility to get all transitions available from current `state`.
 
   ```ts
-  import { getNextTransitions } from "xstate";
+  import { getNextTransitions } from 'xstate';
 
   // ...
 
@@ -1953,7 +1953,7 @@
 
   ```ts
   // Matches any event with a type that starts with `FEEDBACK.`
-  assertEvent(event, "FEEDBACK.*");
+  assertEvent(event, 'FEEDBACK.*');
   ```
 
 ### Patch Changes
@@ -1967,35 +1967,35 @@
 - [#5371](https://github.com/statelyai/xstate/pull/5371) [`b8ec3b1`](https://github.com/statelyai/xstate/commit/b8ec3b153fbacae078c03cd07678271e0456679a) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `setup.extend()` method to incrementally extend machine setup configurations with additional actions, guards, and delays. This enables composable and reusable machine setups where extended actions, guards, and delays can reference base actions, guards, and delays and support chaining multiple extensions:
 
   ```ts
-  import { setup, not, and } from "xstate";
+  import { setup, not, and } from 'xstate';
 
   const baseSetup = setup({
     guards: {
       isAuthenticated: () => true,
-      hasPermission: () => false,
-    },
+      hasPermission: () => false
+    }
   });
 
   const extendedSetup = baseSetup.extend({
     guards: {
       // Type-safe guard references
-      isUnauthenticated: not("isAuthenticated"),
-      canAccess: and(["isAuthenticated", "hasPermission"]),
-    },
+      isUnauthenticated: not('isAuthenticated'),
+      canAccess: and(['isAuthenticated', 'hasPermission'])
+    }
   });
 
   // Both base and extended guards are available
   extendedSetup.createMachine({
     on: {
       LOGIN: {
-        guard: "isAuthenticated",
-        target: "authenticated",
+        guard: 'isAuthenticated',
+        target: 'authenticated'
       },
       LOGOUT: {
-        guard: "isUnauthenticated",
-        target: "unauthenticated",
-      },
-    },
+        guard: 'isUnauthenticated',
+        target: 'unauthenticated'
+      }
+    }
   });
   ```
 
@@ -2012,9 +2012,9 @@
     invoke: [
       {
         src: childMachine,
-        systemId: "test",
-      },
-    ],
+        systemId: 'test'
+      }
+    ]
   });
   const system = createActor(machine);
 
@@ -2028,7 +2028,7 @@
 - [#5379](https://github.com/statelyai/xstate/pull/5379) [`98f9ddd`](https://github.com/statelyai/xstate/commit/98f9ddde939320fb698ef382f6712a0753d55ca5) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Make `actor.systemId` public:
 
   ```ts
-  const actor = createActor(machine, { systemId: "test" });
+  const actor = createActor(machine, { systemId: 'test' });
   actor.systemId; // 'test'
   ```
 
@@ -2050,9 +2050,9 @@
       context: {
         count: number;
       };
-      events: { type: "inc"; value: number } | { type: "TEST" };
-      emitted: { type: "PING" };
-    },
+      events: { type: 'inc'; value: number } | { type: 'TEST' };
+      emitted: { type: 'PING' };
+    }
   });
 
   // Custom action
@@ -2062,10 +2062,10 @@
 
   // Type-bound built-ins (no wrapper needed)
   const increment = machineSetup.assign({
-    count: ({ context }) => context.count + 1,
+    count: ({ context }) => context.count + 1
   });
-  const raiseTest = machineSetup.raise({ type: "TEST" });
-  const ping = machineSetup.emit({ type: "PING" });
+  const raiseTest = machineSetup.raise({ type: 'TEST' });
+  const ping = machineSetup.emit({ type: 'PING' });
   const batch = machineSetup.enqueueActions(({ enqueue, check }) => {
     if (check(() => true)) {
       enqueue(increment);
@@ -2074,7 +2074,7 @@
 
   const machine = machineSetup.createMachine({
     context: { count: 0 },
-    entry: [action, increment, raiseTest, ping, batch],
+    entry: [action, increment, raiseTest, ping, batch]
   });
   ```
 
@@ -2102,12 +2102,12 @@
   });
 
   const machine = lightMachineSetup.createMachine({
-    initial: "green",
+    initial: 'green',
     states: {
       green,
       yellow,
-      red,
-    },
+      red
+    }
   });
   ```
 
@@ -2118,9 +2118,9 @@
 - [#5351](https://github.com/statelyai/xstate/pull/5351) [`71387ff`](https://github.com/statelyai/xstate/commit/71387ff0af86715fe233c33236fe6e6a8746e56f) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Fix: Emit callback errors no longer crash the actor
 
   ```ts
-  actor.on("event", () => {
+  actor.on('event', () => {
     // Will no longer crash the actor
-    throw new Error("oops");
+    throw new Error('oops');
   });
   ```
 
@@ -2137,16 +2137,16 @@
 - [#5287](https://github.com/statelyai/xstate/pull/5287) [`e07a7cd8462473188a0fb646a965e61be1ce6ae3`](https://github.com/statelyai/xstate/commit/e07a7cd8462473188a0fb646a965e61be1ce6ae3) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The graph and model-based testing utilities from @xstate/graph (and @xstate/test previously) were moved to the core `xstate` package.
 
   ```ts
-  import { createMachine } from "xstate";
-  import { getShortestPaths } from "xstate/graph";
+  import { createMachine } from 'xstate';
+  import { getShortestPaths } from 'xstate/graph';
 
   const machine = createMachine({
     // ...
   });
 
   const paths = getShortestPaths(machine, {
-    fromState: "a",
-    toState: "b",
+    fromState: 'a',
+    toState: 'b'
   });
   ```
 
@@ -2176,7 +2176,7 @@
 
   ```ts
   const childMachine = createMachine({
-    types: { input: {} as { value: number } },
+    types: { input: {} as { value: number } }
   });
 
   const machine = createMachine({
@@ -2185,9 +2185,9 @@
       ref: spawn(
         childMachine,
         // Input is now required!
-        { input: { value: 42 } },
-      ),
-    }),
+        { input: { value: 42 } }
+      )
+    })
   });
   ```
 
@@ -2198,7 +2198,7 @@
 - [#4954](https://github.com/statelyai/xstate/pull/4954) [`8c4b70652acaef2702f32435362e4755679a516d`](https://github.com/statelyai/xstate/commit/8c4b70652acaef2702f32435362e4755679a516d) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Added a new `transition` function that takes an actor logic, a snapshot, and an event, and returns a tuple containing the next snapshot and the actions to execute. This function is a pure function and does not execute the actions itself. It can be used like this:
 
   ```ts
-  import { transition } from "xstate";
+  import { transition } from 'xstate';
 
   const [nextState, actions] = transition(actorLogic, currentState, event);
   // Execute actions as needed
@@ -2207,7 +2207,7 @@
   Added a new `initialTransition` function that takes an actor logic and an optional input, and returns a tuple containing the initial snapshot and the actions to execute from the initial transition. This function is also a pure function and does not execute the actions itself. It can be used like this:
 
   ```ts
-  import { initialTransition } from "xstate";
+  import { initialTransition } from 'xstate';
 
   const [initialState, actions] = initialTransition(actorLogic, input);
   // Execute actions as needed
@@ -2237,47 +2237,47 @@
 
   ```ts
   const machine = setup({}).createMachine({
-    initial: "green",
+    initial: 'green',
     states: {
       green: {},
       yellow: {},
       red: {
-        initial: "walk",
+        initial: 'walk',
         states: {
           walk: {},
           wait: {},
-          stop: {},
-        },
+          stop: {}
+        }
       },
       emergency: {
-        type: "parallel",
+        type: 'parallel',
         states: {
           main: {
-            initial: "blinking",
+            initial: 'blinking',
             states: {
-              blinking: {},
-            },
+              blinking: {}
+            }
           },
           cross: {
-            initial: "blinking",
+            initial: 'blinking',
             states: {
-              blinking: {},
-            },
-          },
-        },
-      },
-    },
+              blinking: {}
+            }
+          }
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
 
   const stateValue = actor.getSnapshot().value;
 
-  if (stateValue === "green") {
+  if (stateValue === 'green') {
     // ...
-  } else if (stateValue === "yellow") {
+  } else if (stateValue === 'yellow') {
     // ...
-  } else if ("red" in stateValue) {
+  } else if ('red' in stateValue) {
     stateValue;
     // {
     //   red: "walk" | "wait" | "stop";
@@ -2298,7 +2298,7 @@
 - [#5054](https://github.com/statelyai/xstate/pull/5054) [`853f6daa0b`](https://github.com/statelyai/xstate/commit/853f6daa0b58bab6ea4153043f9efcfb18d18172) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `CallbackLogicFunction` type (previously `InvokeCallback`) is now exported. This is the callback function that you pass into `fromCallback(callbackLogicFn)` to create an actor from a callback function.
 
   ```ts
-  import { type CallbackLogicFunction } from "xstate";
+  import { type CallbackLogicFunction } from 'xstate';
 
   // ...
   ```
@@ -2339,23 +2339,23 @@
   const machine = setup({
     // ...
   }).createMachine({
-    id: "root",
-    initial: "parentState",
+    id: 'root',
+    initial: 'parentState',
     states: {
       parentState: {
         meta: {},
-        initial: "childState",
+        initial: 'childState',
         states: {
           childState: {
-            meta: {},
+            meta: {}
           },
           stateWithId: {
-            id: "state with id",
-            meta: {},
-          },
-        },
-      },
-    },
+            id: 'state with id',
+            meta: {}
+          }
+        }
+      }
+    }
   });
 
   const actor = createActor(machine);
@@ -2364,15 +2364,15 @@
 
   // Auto-completed keys:
   metaValues.root;
-  metaValues["root.parentState"];
-  metaValues["root.parentState.childState"];
-  metaValues["state with id"];
+  metaValues['root.parentState'];
+  metaValues['root.parentState.childState'];
+  metaValues['state with id'];
 
   // @ts-expect-error
-  metaValues["root.parentState.stateWithId"];
+  metaValues['root.parentState.stateWithId'];
 
   // @ts-expect-error
-  metaValues["unknown state"];
+  metaValues['unknown state'];
   ```
 
 ### Patch Changes
@@ -2388,12 +2388,12 @@
 - [#4981](https://github.com/statelyai/xstate/pull/4981) [`c4ae156b2`](https://github.com/statelyai/xstate/commit/c4ae156b278779e898aeb8d86b089de2cf959683) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Added `sendParent` to the `enqueueActions` feature. This allows users to enqueue actions that send events to the parent actor within the `enqueueActions` block.
 
   ```js
-  import { createMachine, enqueueActions } from "xstate";
+  import { createMachine, enqueueActions } from 'xstate';
 
   const childMachine = createMachine({
     entry: enqueueActions(({ enqueue }) => {
-      enqueue.sendParent({ type: "CHILD_READY" });
-    }),
+      enqueue.sendParent({ type: 'CHILD_READY' });
+    })
   });
   ```
 
@@ -2407,10 +2407,10 @@
   - `CallbackActorRef`: actor created by [`fromCallback`](https://stately.ai/docs/actors#fromcallback)
 
     ```ts
-    import { fromCallback, createActor } from "xstate";
+    import { fromCallback, createActor } from 'xstate';
 
     /** The events the actor receives. */
-    type Event = { type: "someEvent" };
+    type Event = { type: 'someEvent' };
     /** The actor's input. */
     type Input = { name: string };
 
@@ -2420,22 +2420,22 @@
       // ^? CallbackActorRef<Event, Input>
 
       receive((event) => {
-        if (event.type === "someEvent") {
+        if (event.type === 'someEvent') {
           console.log(`${input.name}: received "someEvent" event`);
           // logs 'myActor: received "someEvent" event'
         }
       });
     });
 
-    const actor = createActor(logic, { input: { name: "myActor" } });
+    const actor = createActor(logic, { input: { name: 'myActor' } });
     //    ^? CallbackActorRef<Event, Input>
     ```
 
   - `ObservableActorRef`: actor created by [`fromObservable`](https://stately.ai/docs/actors#fromobservable) and [`fromEventObservable`](https://stately.ai/docs/actors#fromeventobservable)
 
     ```ts
-    import { fromObservable, createActor } from "xstate";
-    import { interval } from "rxjs";
+    import { fromObservable, createActor } from 'xstate';
+    import { interval } from 'rxjs';
 
     /** The type of the value observed by the actor's logic. */
     type Context = number;
@@ -2460,7 +2460,7 @@
   - `PromiseActorRef`: actor created by [`fromPromise`](https://stately.ai/docs/actors#actors-as-promises)
 
     ```ts
-    import { fromPromise, createActor } from "xstate";
+    import { fromPromise, createActor } from 'xstate';
 
     /** The actor's resolved output. */
     type Output = string;
@@ -2477,14 +2477,14 @@
       return url;
     });
 
-    const actor = createActor(logic, { input: { message: "hello world" } });
+    const actor = createActor(logic, { input: { message: 'hello world' } });
     //    ^? PromiseActorRef<Output, Input>
     ```
 
   - `TransitionActorRef`: actor created by [`fromTransition`](https://stately.ai/docs/actors#fromtransition)
 
     ```ts
-    import { fromTransition, createActor, type AnyActorSystem } from "xstate";
+    import { fromTransition, createActor, type AnyActorSystem } from 'xstate';
 
     /** The actor's stored context. */
     type Context = {
@@ -2494,7 +2494,7 @@
       step: number;
     };
     /** The events the actor receives. */
-    type Event = { type: "increment" };
+    type Event = { type: 'increment' };
     /** The actor's input. */
     type Input = { step?: number };
 
@@ -2507,10 +2507,10 @@
         actorScope.self;
         //         ^? TransitionActorRef<Context, Event>
 
-        if (event.type === "increment") {
+        if (event.type === 'increment') {
           return {
             ...state,
-            count: state.count + state.step,
+            count: state.count + state.step
           };
         }
         return state;
@@ -2521,9 +2521,9 @@
 
         return {
           count: 0,
-          step: input.step ?? 1,
+          step: input.step ?? 1
         };
-      },
+      }
     );
 
     const actor = createActor(logic, { input: { step: 10 } });
@@ -2547,14 +2547,14 @@
 
   // Inspection events will be logged
   actor.start();
-  actor.send({ type: "anEvent" });
+  actor.send({ type: 'anEvent' });
 
   // ...
 
   sub.unsubscribe();
 
   // Will no longer log inspection events
-  actor.send({ type: "someEvent" });
+  actor.send({ type: 'someEvent' });
   ```
 
 - [#4942](https://github.com/statelyai/xstate/pull/4942) [`9caaa1f70`](https://github.com/statelyai/xstate/commit/9caaa1f7039f2f50096afd3885560dd40f6f17c0) Thanks [@boneskull](https://github.com/boneskull)! - `DoneActorEvent` and `ErrorActorEvent` now contain property `actorId`, which refers to the ID of the actor the event refers to.
@@ -2567,8 +2567,8 @@
   const logic = fromPromise(async ({ emit }) => {
     // ...
     emit({
-      type: "emitted",
-      msg: "hello",
+      type: 'emitted',
+      msg: 'hello'
     });
     // ...
   });
@@ -2580,8 +2580,8 @@
   const logic = fromTransition((state, event, { emit }) => {
     // ...
     emit({
-      type: "emitted",
-      msg: "hello",
+      type: 'emitted',
+      msg: 'hello'
     });
     // ...
     return state;
@@ -2595,8 +2595,8 @@
     // ...
 
     emit({
-      type: "emitted",
-      msg: "hello",
+      type: 'emitted',
+      msg: 'hello'
     });
 
     // ...
@@ -2609,8 +2609,8 @@
   const logic = fromCallback(({ emit }) => {
     // ...
     emit({
-      type: "emitted",
-      msg: "hello",
+      type: 'emitted',
+      msg: 'hello'
     });
     // ...
   });
@@ -2633,7 +2633,7 @@
 - [#4905](https://github.com/statelyai/xstate/pull/4905) [`dbeafeb25`](https://github.com/statelyai/xstate/commit/dbeafeb25eed63ee1d2b027f10bc63d9937ab073) Thanks [@davidkpiano](https://github.com/davidkpiano)! - You can now use a wildcard to listen for _any_ emitted event from an actor:
 
   ```ts
-  actor.on("*", (emitted) => {
+  actor.on('*', (emitted) => {
     console.log(emitted); // Any emitted event
   });
   ```
@@ -2646,7 +2646,7 @@
 
   ```ts
   const logic = fromPromise(({ signal }) =>
-    fetch("https://api.example.com", { signal }),
+    fetch('https://api.example.com', { signal })
   );
   ```
 
@@ -2664,7 +2664,7 @@
       assign({
         // ...
       });
-    },
+    }
   });
   ```
 
@@ -2679,17 +2679,17 @@
     types: {
       meta: {} as {
         layout: string;
-      },
-    },
+      }
+    }
   }).createMachine({
-    initial: "home",
+    initial: 'home',
     states: {
       home: {
         meta: {
-          layout: "full",
-        },
-      },
-    },
+          layout: 'full'
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
@@ -2710,15 +2710,15 @@
     actors: {
       existingActor: fromPromise(async () => {
         // ...
-      }),
-    },
+      })
+    }
   }).createMachine({
     invoke: {
       src: fromPromise(async () => {
         // Inline actor
-      }),
+      })
       // ...
-    },
+    }
   });
   ```
 
@@ -2729,14 +2729,14 @@
 - [#4822](https://github.com/statelyai/xstate/pull/4822) [`f7f1fbbf3`](https://github.com/statelyai/xstate/commit/f7f1fbbf3d56af9fcffe6ef9a37ab5953a90ca72) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `clock` and `logger` specified in the `options` object of `createActor(logic, options)` will now propagate to all actors created within the same actor system.
 
   ```ts
-  import { setup, log, createActor } from "xstate";
+  import { setup, log, createActor } from 'xstate';
 
   const childMachine = setup({
     // ...
   }).createMachine({
     // ...
     // Uses custom logger from root actor
-    entry: log("something"),
+    entry: log('something')
   });
 
   const parentMachine = setup({
@@ -2744,14 +2744,14 @@
   }).createMachine({
     // ...
     invoke: {
-      src: childMachine,
-    },
+      src: childMachine
+    }
   });
 
   const actor = createActor(parentMachine, {
     logger: (...args) => {
       // custom logger for args
-    },
+    }
   });
 
   actor.start();
@@ -2770,28 +2770,28 @@
 - [#4746](https://github.com/statelyai/xstate/pull/4746) [`b570ba20d`](https://github.com/statelyai/xstate/commit/b570ba20d7350819cbaf6740ff00a2bad5ffedfe) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The new `emit(…)` action creator emits events that can be received by listeners. Actors are now event emitters.
 
   ```ts
-  import { emit } from "xstate";
+  import { emit } from 'xstate';
 
   const machine = createMachine({
     // ...
     on: {
       something: {
         actions: emit({
-          type: "emitted",
-          some: "data",
-        }),
-      },
-    },
+          type: 'emitted',
+          some: 'data'
+        })
+      }
+    }
     // ...
   });
 
   const actor = createActor(machine).start();
 
-  actor.on("emitted", (event) => {
+  actor.on('emitted', (event) => {
     console.log(event);
   });
 
-  actor.send({ type: "something" });
+  actor.send({ type: 'something' });
   // logs:
   // {
   //   type: 'emitted',
@@ -2835,24 +2835,24 @@
 
   ```ts
   const machine = createMachine({
-    initial: "a",
+    initial: 'a',
     states: {
       a: {
         on: {
-          event: "b",
-        },
+          event: 'b'
+        }
       },
       b: {
-        entry: "someAction",
-        always: "c",
+        entry: 'someAction',
+        always: 'c'
       },
-      c: {},
-    },
+      c: {}
+    }
   });
 
   const actor = createActor(machine, {
     inspect: (inspEvent) => {
-      if (inspEvent.type === "@xstate.microstep") {
+      if (inspEvent.type === '@xstate.microstep') {
         console.log(inspEvent.snapshot);
         // logs:
         // { value: 'a', … }
@@ -2862,17 +2862,17 @@
         console.log(inspEvent.event);
         // logs:
         // { type: 'event', … }
-      } else if (inspEvent.type === "@xstate.action") {
+      } else if (inspEvent.type === '@xstate.action') {
         console.log(inspEvent.action);
         // logs:
         // { type: 'someAction', … }
       }
-    },
+    }
   });
 
   actor.start();
 
-  actor.send({ type: "event" });
+  actor.send({ type: 'event' });
   ```
 
 ## 5.6.2
@@ -2882,13 +2882,13 @@
 - [#4731](https://github.com/statelyai/xstate/pull/4731) [`960cdcbcb`](https://github.com/statelyai/xstate/commit/960cdcbcb88eb565bba2f03f3eeceff6001576d9) Thanks [@davidkpiano](https://github.com/davidkpiano)! - You can now import `getInitialSnapshot(…)` from `xstate` directly, which is useful for getting a mock of the initial snapshot when interacting with machines (or other actor logic) without `createActor(…)`:
 
   ```ts
-  import { getInitialSnapshot } from "xstate";
-  import { someMachine } from "./someMachine";
+  import { getInitialSnapshot } from 'xstate';
+  import { someMachine } from './someMachine';
 
   // Returns the initial snapshot (state) of the machine
   const initialSnapshot = getInitialSnapshot(
     someMachine,
-    { name: "Mateusz" }, // optional input
+    { name: 'Mateusz' } // optional input
   );
   ```
 
@@ -2939,13 +2939,13 @@
   If the `snapshot` is `undefined`, the initial snapshot of the `actorLogic` is used.
 
   ```ts
-  import { getNextSnapshot } from "xstate";
-  import { trafficLightMachine } from "./trafficLightMachine.ts";
+  import { getNextSnapshot } from 'xstate';
+  import { trafficLightMachine } from './trafficLightMachine.ts';
 
   const nextSnapshot = getNextSnapshot(
     trafficLightMachine, // actor logic
     undefined, // snapshot (or initial state if undefined)
-    { type: "TIMER" },
+    { type: 'TIMER' }
   ); // event object
 
   console.log(nextSnapshot.value);
@@ -2954,7 +2954,7 @@
   const nextSnapshot2 = getNextSnapshot(
     trafficLightMachine, // actor logic
     nextSnapshot, // snapshot
-    { type: "TIMER" },
+    { type: 'TIMER' }
   ); // event object
 
   console.log(nextSnapshot2.value);
@@ -2981,9 +2981,9 @@
   setup({/* ... */}).createMachine({
     context: ({ spawn, self }) => {
       return {
-        childRef: spawn("child", { input: { parent: self } }),
+        childRef: spawn('child', { input: { parent: self } })
       };
-    },
+    }
   });
   ```
 
@@ -3041,14 +3041,14 @@
 - [#4198](https://github.com/statelyai/xstate/pull/4198) [`ca58904ad`](https://github.com/statelyai/xstate/commit/ca58904ade8047ac9969838d2932b31846ac479c) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Introduce `toPromise(actor)`, which creates a promise from an `actor` that resolves with the actor snapshot's `output` when done, or rejects with the actor snapshot's `error` when it fails.
 
   ```ts
-  import { createMachine, createActor, toPromise } from "xstate";
+  import { createMachine, createActor, toPromise } from 'xstate';
 
   const machine = createMachine({
     // ...
     states: {
       // ...
-      done: { type: "final", output: 42 },
-    },
+      done: { type: 'final', output: 42 }
+    }
   });
 
   const actor = createActor(machine);
@@ -3100,7 +3100,7 @@
   createMachine({
     types: {} as {
       context: { count: number };
-    },
+    }
     // Missing context property
   });
 
@@ -3110,8 +3110,8 @@
       context: { count: number };
     },
     context: {
-      count: 0,
-    },
+      count: 0
+    }
   });
   ```
 
@@ -3138,8 +3138,8 @@
 
   ```js
   const lightMachine = createMachine({
-    id: "light",
-    initial: "green",
+    id: 'light',
+    initial: 'green',
     states: {
       green: {},
       yellow: {},
@@ -3148,10 +3148,10 @@
         // initial: 'walk',
         states: {
           walk: {},
-          wait: {},
-        },
-      },
-    },
+          wait: {}
+        }
+      }
+    }
   });
   ```
 
@@ -3164,15 +3164,15 @@
 - d3d6149c7: IDs for delayed events are no longer derived from event types so this won't work automatically:
 
   ```ts
-  entry: raise({ type: "TIMER" }, { delay: 200 });
-  exit: cancel("TIMER");
+  entry: raise({ type: 'TIMER' }, { delay: 200 });
+  exit: cancel('TIMER');
   ```
 
   Please use explicit IDs:
 
   ```ts
-  entry: raise({ type: "TIMER" }, { delay: 200, id: "myTimer" });
-  exit: cancel("myTimer");
+  entry: raise({ type: 'TIMER' }, { delay: 200, id: 'myTimer' });
+  exit: cancel('myTimer');
   ```
 
 - d3d6149c7: Removed `State#toStrings` method.
@@ -3182,7 +3182,7 @@
   const machine = createMachine({
     // This will produce the TS error:
     // "Type 'string' is not assignable to type 'object | undefined'"
-    context: "some string",
+    context: 'some string'
   });
   ```
 
@@ -3196,8 +3196,8 @@
     invoke: {
       src: emailMachine,
       // Registers `emailMachine` as `emailer` on the system
-      systemId: "emailer",
-    },
+      systemId: 'emailer'
+    }
   });
   ```
 
@@ -3206,8 +3206,8 @@
     // ...
     entry: assign({
       emailer: (ctx, ev, { spawn }) =>
-        spawn(emailMachine, { systemId: "emailer" }),
-    }),
+        spawn(emailMachine, { systemId: 'emailer' })
+    })
   });
   ```
 
@@ -3218,10 +3218,10 @@
     // ...
     entry: sendTo(
       (ctx, ev, { system }) => {
-        return system.get("emailer");
+        return system.get('emailer');
       },
-      { type: "SEND_EMAIL", subject: "Hello", body: "World" },
-    ),
+      { type: 'SEND_EMAIL', subject: 'Hello', body: 'World' }
+    )
   });
   ```
 
@@ -3274,7 +3274,7 @@
   // Now a snapshot object with { status, output, error, context }
   const promiseActorSnapshot = promiseActor.getSnapshot();
 
-  if (promiseActorSnapshot.status === "done") {
+  if (promiseActorSnapshot.status === 'done') {
     console.log(promiseActorSnapshot.output); // 42
   }
   ```
@@ -3296,7 +3296,7 @@
   // ...
 
   const restoredActor = createActor(machine, {
-    snapshot: persistedSnapshot,
+    snapshot: persistedSnapshot
   }).start();
   ```
 
@@ -3304,13 +3304,13 @@
   - Dev tools integration has been simplified, and Redux dev tools support is no longer the default. It can be included from `xstate/devTools/redux`:
 
   ```js
-  import { createActor } from "xstate";
-  import { createReduxDevTools } from "xstate/devTools/redux";
+  import { createActor } from 'xstate';
+  import { createReduxDevTools } from 'xstate/devTools/redux';
 
   const service = createActor(someMachine, {
     devTools: createReduxDevTools({
       // Redux Dev Tools options
-    }),
+    })
   });
   ```
 
@@ -3318,7 +3318,7 @@
 
   ```js
   const service = createActor(someMachine, {
-    devTools: true, // attaches via window.__xstate__.register(service)
+    devTools: true // attaches via window.__xstate__.register(service)
   });
   ```
 
@@ -3326,7 +3326,7 @@
 
   ```js
   const myCustomDevTools = (actorRef) => {
-    console.log("Got a actorRef!");
+    console.log('Got a actorRef!');
 
     actorRef.subscribe((state) => {
       // ...
@@ -3334,7 +3334,7 @@
   };
 
   const actorRef = createActor(someMachine, {
-    devTools: myCustomDevTools,
+    devTools: myCustomDevTools
   });
   ```
 
@@ -3442,19 +3442,19 @@
   - `not(guard1)` returns `true` if a single guard evaluates to `false`, otherwise `true`
 
   ```js
-  import { and, or, not } from "xstate/guards";
+  import { and, or, not } from 'xstate/guards';
 
   const someMachine = createMachine({
     // ...
     on: {
       EVENT: {
-        target: "somewhere",
+        target: 'somewhere',
         guard: and([
-          "stringGuard",
-          or([{ type: "anotherGuard" }, not(() => false)]),
-        ]),
-      },
-    },
+          'stringGuard',
+          or([{ type: 'anotherGuard' }, not(() => false)])
+        ])
+      }
+    }
   });
   ```
 
@@ -3504,9 +3504,9 @@
         createMachine({
           // ...
         }),
-        { systemId: "actorRef" },
-      ),
-    }),
+        { systemId: 'actorRef' }
+      )
+    })
   });
   ```
 
@@ -3534,18 +3534,18 @@
   ```js
   const greetMachine = createMachine({
     context: ({ input }) => ({
-      greeting: `Hello ${input.name}!`,
+      greeting: `Hello ${input.name}!`
     }),
     entry: (_, event) => {
       event.type; // 'xstate.init'
       event.input; // { name: 'David' }
-    },
+    }
     // ...
   });
 
   const actor = createActor(greetMachine, {
     // Pass input data to the machine
-    input: { name: "David" },
+    input: { name: 'David' }
   }).start();
   ```
 
@@ -3697,16 +3697,16 @@
 
   ```ts
   createMachine({
-    initial: "a",
+    initial: 'a',
     states: {
       a: {
         after: {
-          10000: "b",
-          noon: "c",
-        },
-      },
+          10000: 'b',
+          noon: 'c'
+        }
+      }
       // ...
-    },
+    }
   });
   ```
 
@@ -3715,7 +3715,7 @@
 - d3d6149c7: The `createEmptyActor()` function has been added to make it easier to create actors that do nothing ("empty" actors). This is useful for testing, or for some integrations such as `useActor(actor)` in `@xstate/react` that require an actor:
 
   ```jsx
-  import { createEmptyActor } from "xstate";
+  import { createEmptyActor } from 'xstate';
 
   const SomeComponent = (props) => {
     // props.actor may be undefined
@@ -3809,7 +3809,7 @@
   assign((ctx, ev, { spawn }) => {
     return {
       ...ctx,
-      actorRef: spawn(promiseActor),
+      actorRef: spawn(promiseActor)
     };
   });
   ```
@@ -3817,7 +3817,7 @@
   In addition to that, you can now `spawn` actors defined in your implementations object, in the same way that you were already able to do that with `invoke`. To do that just reference the defined actor like this:
 
   ```js
-  spawn("promiseActor");
+  spawn('promiseActor');
   ```
 
 - d3d6149c7: `State` class has been removed and replaced by `MachineSnapshot` object. They largely have the same properties and methods. On of the main noticeable results of this change is that you can no longer check `state instanceof State`.
@@ -3846,9 +3846,9 @@
     //   ]
     // }),
     enqueueActions(({ enqueue }) => {
-      enqueue("action1");
-      enqueue("action2");
-    }),
+      enqueue('action1');
+      enqueue('action2');
+    })
   ];
   ```
 
@@ -3861,11 +3861,11 @@
     //   }
     // ]),
     enqueueActions(({ enqueue, check }) => {
-      if (check("someGuard")) {
-        enqueue("action1");
-        enqueue("action2");
+      if (check('someGuard')) {
+        enqueue('action1');
+        enqueue('action2');
       }
-    }),
+    })
   ];
   ```
 
@@ -3933,21 +3933,21 @@
   const machine = createMachine({
     types: {} as {
       actors: {
-        src: "fetchData"; // src name (inline behaviors ideally inferred)
-        id: "fetch1" | "fetch2"; // possible ids (optional)
+        src: 'fetchData'; // src name (inline behaviors ideally inferred)
+        id: 'fetch1' | 'fetch2'; // possible ids (optional)
         logic: typeof fetcher;
       };
     },
     invoke: {
-      src: "fetchData", // strongly typed
-      id: "fetch2", // strongly typed
+      src: 'fetchData', // strongly typed
+      id: 'fetch2', // strongly typed
       onDone: {
         actions: ({ event }) => {
           event.output; // strongly typed as { result: string }
-        },
+        }
       },
-      input: { foo: "hello" }, // strongly typed
-    },
+      input: { foo: 'hello' } // strongly typed
+    }
   });
   ```
 
@@ -3993,26 +3993,26 @@
 
   ```ts
   const machine = createMachine({
-    initial: "started",
+    initial: 'started',
     states: {
       started: {
         // ...
       },
       finished: {
-        type: "final",
+        type: 'final'
         // moved to the top level
         //
         // output: {
         //   status: 200
         // }
-      },
+      }
     },
     // This will be the final output of the machine
     // present on `snapshot.output` and in the done events received by the parent
     // when the machine reaches the top-level final state ("finished")
     output: {
-      status: 200,
-    },
+      status: 200
+    }
   });
   ```
 
@@ -4081,15 +4081,15 @@
   const machine = createMachine({
     context: ({ spawn }) => ({
       // This will be persisted
-      ref: spawn("reducer", { id: "child" }),
+      ref: spawn('reducer', { id: 'child' })
 
       // This cannot be persisted:
       // ref: spawn(fromTransition((s) => s, { count: 42 }), { id: 'child' })
-    }),
+    })
   }).provide({
     actors: {
-      reducer: fromTransition((s) => s, { count: 42 }),
-    },
+      reducer: fromTransition((s) => s, { count: 42 })
+    }
   });
   ```
 
@@ -4128,7 +4128,7 @@
     actor.subscribe({
       error: (error) => {
         // handle error
-      },
+      }
     });
     ```
   - If an observer does not have an error handler, the error will be thrown in a clear stack so bug tracking services can collect it.
@@ -4136,7 +4136,7 @@
 - d3d6149c7: You can now `spawnChild(...)` actors directly outside of `assign(...)` action creators:
 
   ```ts
-  import { createMachine, spawnChild } from "xstate";
+  import { createMachine, spawnChild } from 'xstate';
 
   const listenerMachine = createMachine({
     // ...
@@ -4145,16 +4145,16 @@
   const parentMachine = createMachine({
     // ...
     on: {
-      "listener.create": {
-        entry: spawnChild(listenerMachine, { id: "listener" }),
-      },
-    },
+      'listener.create': {
+        entry: spawnChild(listenerMachine, { id: 'listener' })
+      }
+    }
     // ...
   });
 
   const actor = createActor(parentMachine).start();
 
-  actor.send({ type: "listener.create" });
+  actor.send({ type: 'listener.create' });
 
   actor.getSnapshot().children.listener; // ActorRefFrom<typeof listenerMachine>
   ```
@@ -4166,27 +4166,27 @@
   createMachine({
     types: {} as {
       events:
-        | { type: "mouse.click.up"; direction: "up" }
-        | { type: "mouse.click.down"; direction: "down" }
-        | { type: "mouse.move" }
-        | { type: "keypress" };
+        | { type: 'mouse.click.up'; direction: 'up' }
+        | { type: 'mouse.click.down'; direction: 'down' }
+        | { type: 'mouse.move' }
+        | { type: 'keypress' };
     },
     on: {
-      "mouse.click.*": {
+      'mouse.click.*': {
         actions: ({ event }) => {
           event.type;
           // 'mouse.click.up' | 'mouse.click.down'
           event.direction;
           // 'up' | 'down'
-        },
+        }
       },
-      "mouse.*": {
+      'mouse.*': {
         actions: ({ event }) => {
           event.type;
           // 'mouse.click.up' | 'mouse.click.down' | 'mouse.move'
-        },
-      },
-    },
+        }
+      }
+    }
   });
   ```
 
@@ -4197,14 +4197,14 @@
   createMachine({
     types: {} as {
       actions:
-        { type: "greet"; params: { surname: string } } | { type: "poke" };
+        { type: 'greet'; params: { surname: string } } | { type: 'poke' };
     },
     entry: {
-      type: "greet",
+      type: 'greet',
       params: ({ context }) => ({
-        surname: "Doe",
-      }),
-    },
+        surname: 'Doe'
+      })
+    }
   });
   ```
 
@@ -4214,12 +4214,12 @@
   const machine = setup({
     types: {} as {
       children: {
-        myId: "actorKey";
+        myId: 'actorKey';
       };
     },
     actors: {
-      actorKey: child,
-    },
+      actorKey: child
+    }
   }).createMachine({});
 
   const actorRef = createActor(machine).start();
@@ -4234,13 +4234,13 @@
     types: {} as {
       guards:
         | {
-            type: "isGreaterThan";
+            type: 'isGreaterThan';
             params: {
               count: number;
             };
           }
-        | { type: "plainGuard" };
-    },
+        | { type: 'plainGuard' };
+    }
     // ...
   });
   ```
@@ -4250,8 +4250,8 @@
   ```ts
   createMachine({
     types: {} as {
-      tags: "pending" | "success" | "error";
-    },
+      tags: 'pending' | 'success' | 'error';
+    }
     // ...
   });
   ```
@@ -4305,17 +4305,17 @@
     {
       // ...
       entry: {
-        type: "greet",
-        params: { message: "hello" },
-      },
+        type: 'greet',
+        params: { message: 'hello' }
+      }
     },
     {
       actions: {
         greet: (_, params) => {
           params.message; // 'hello'
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -4332,16 +4332,16 @@
     context: ({ input }) => ({
       // Strongly-typed input!
       emailSubject: input.subject,
-      emailBody: input.message.trim(),
-    }),
+      emailBody: input.message.trim()
+    })
   });
 
   const emailActor = interpret(emailMachine, {
     input: {
       // Strongly-typed input!
-      subject: "Hello, world!",
-      message: "This is a test.",
-    },
+      subject: 'Hello, world!',
+      message: 'This is a test.'
+    }
   }).start();
   ```
 
@@ -4367,19 +4367,19 @@
       on: {
         EVENT: {
           guard: {
-            type: "isGreaterThan",
-            params: { value: 10 },
-          },
-        },
-      },
+            type: 'isGreaterThan',
+            params: { value: 10 }
+          }
+        }
+      }
     },
     {
       guards: {
         isGreaterThan: (_, params) => {
           params.value; // 10
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -4389,7 +4389,7 @@
   - `@xstate.snapshot` - An actor ref emitted a snapshot due to a received event
 
   ```ts
-  import { createMachine } from "xstate";
+  import { createMachine } from 'xstate';
 
   const machine = createMachine({
     // ...
@@ -4397,22 +4397,22 @@
 
   const actor = createActor(machine, {
     inspect: (inspectionEvent) => {
-      if (inspectionEvent.type === "@xstate.actor") {
+      if (inspectionEvent.type === '@xstate.actor') {
         console.log(inspectionEvent.actorRef);
       }
 
-      if (inspectionEvent.type === "@xstate.event") {
+      if (inspectionEvent.type === '@xstate.event') {
         console.log(inspectionEvent.sourceRef);
         console.log(inspectionEvent.targetRef);
         console.log(inspectionEvent.event);
       }
 
-      if (inspectionEvent.type === "@xstate.snapshot") {
+      if (inspectionEvent.type === '@xstate.snapshot') {
         console.log(inspectionEvent.actorRef);
         console.log(inspectionEvent.event);
         console.log(inspectionEvent.snapshot);
       }
-    },
+    }
   });
   ```
 
@@ -4425,31 +4425,31 @@
     entry: enqueueActions(({ context, event, enqueue, check }) => {
       // assign action
       enqueue.assign({
-        count: context.count + 1,
+        count: context.count + 1
       });
 
       // Conditional actions (replaces choose(...))
       if (event.someOption) {
-        enqueue.sendTo("someActor", { type: "blah", thing: context.thing });
+        enqueue.sendTo('someActor', { type: 'blah', thing: context.thing });
 
         // other actions
-        enqueue("namedAction");
+        enqueue('namedAction');
         // with params
-        enqueue({ type: "greet", params: { message: "hello" } });
+        enqueue({ type: 'greet', params: { message: 'hello' } });
       } else {
         // inline
-        enqueue(() => console.log("hello"));
+        enqueue(() => console.log('hello'));
 
         // even built-in actions
       }
 
       // Use check(...) to conditionally enqueue actions based on a guard
-      if (check({ type: "someGuard" })) {
+      if (check({ type: 'someGuard' })) {
         // ...
       }
 
       // no return
-    }),
+    })
   });
   ```
 
@@ -4459,20 +4459,20 @@
   ```ts
   createMachine({
     types: {} as {
-      actions: { type: "greet"; params: { name: string } };
+      actions: { type: 'greet'; params: { name: string } };
     },
     entry: [
       {
-        type: "greet",
+        type: 'greet',
         params: {
-          name: "David",
-        },
+          name: 'David'
+        }
       },
       // @ts-expect-error
-      { type: "greet" },
+      { type: 'greet' },
       // @ts-expect-error
-      { type: "unknownAction" },
-    ],
+      { type: 'unknownAction' }
+    ]
     // ...
   });
   ```
@@ -4490,10 +4490,10 @@
   const machine = createMachine({
     types: {} as {
       output: {
-        result: "pass" | "fail";
+        result: 'pass' | 'fail';
         score: number;
       };
-    },
+    }
     // ...
   });
 
@@ -4515,7 +4515,7 @@
 - d3d6149c7: You can now use the `setup({ ... }).createMachine({ ... })` function to setup implementations for `actors`, `actions`, `guards`, and `delays` that will be used in the created machine:
 
   ```ts
-  import { setup, createMachine } from "xstate";
+  import { setup, createMachine } from 'xstate';
 
   const fetchUser = fromPromise(async ({ input }) => {
     const response = await fetch(`/user/${input.id}`);
@@ -4525,33 +4525,33 @@
 
   const machine = setup({
     actors: {
-      fetchUser,
+      fetchUser
     },
     actions: {
-      clearUser: assign({ user: undefined }),
+      clearUser: assign({ user: undefined })
     },
     guards: {
-      isUserAdmin: (_, params) => params.user.role === "admin",
-    },
+      isUserAdmin: (_, params) => params.user.role === 'admin'
+    }
   }).createMachine({
     // ...
     invoke: {
       // Strongly typed!
-      src: "fetchUser",
+      src: 'fetchUser',
       input: ({ context }) => ({ id: context.userId }),
       onDone: {
         guard: {
-          type: "isUserAdmin",
-          params: ({ context }) => ({ user: context.user }),
+          type: 'isUserAdmin',
+          params: ({ context }) => ({ user: context.user })
         },
-        target: "success",
-        actions: assign({ user: ({ event }) => event.output }),
+        target: 'success',
+        actions: assign({ user: ({ event }) => event.output })
       },
       onError: {
-        target: "failure",
-        actions: "clearUser",
-      },
-    },
+        target: 'failure',
+        actions: 'clearUser'
+      }
+    }
   });
   ```
 
@@ -4560,8 +4560,8 @@
   ```ts
   createMachine({
     types: {} as {
-      delays: "one second" | "one minute";
-    },
+      delays: 'one second' | 'one minute';
+    }
     // ...
   });
   ```
@@ -4584,7 +4584,7 @@
 
   ```ts
   createMachine({
-    on: [{ event: "FOO", target: "#id" }],
+    on: [{ event: 'FOO', target: '#id' }]
     // ...
   });
   ```
@@ -4594,8 +4594,8 @@
   ```ts
   createMachine({
     on: {
-      FOO: "#id",
-    },
+      FOO: '#id'
+    }
     // ...
   });
   ```
@@ -4660,9 +4660,9 @@
     //   ]
     // }),
     enqueueActions(({ enqueue }) => {
-      enqueue("action1");
-      enqueue("action2");
-    }),
+      enqueue('action1');
+      enqueue('action2');
+    })
   ];
   ```
 
@@ -4675,11 +4675,11 @@
     //   }
     // ]),
     enqueueActions(({ enqueue, check }) => {
-      if (check("someGuard")) {
-        enqueue("action1");
-        enqueue("action2");
+      if (check('someGuard')) {
+        enqueue('action1');
+        enqueue('action2');
       }
-    }),
+    })
   ];
   ```
 
@@ -4699,31 +4699,31 @@
     entry: enqueueActions(({ context, event, enqueue, check }) => {
       // assign action
       enqueue.assign({
-        count: context.count + 1,
+        count: context.count + 1
       });
 
       // Conditional actions (replaces choose(...))
       if (event.someOption) {
-        enqueue.sendTo("someActor", { type: "blah", thing: context.thing });
+        enqueue.sendTo('someActor', { type: 'blah', thing: context.thing });
 
         // other actions
-        enqueue("namedAction");
+        enqueue('namedAction');
         // with params
-        enqueue({ type: "greet", params: { message: "hello" } });
+        enqueue({ type: 'greet', params: { message: 'hello' } });
       } else {
         // inline
-        enqueue(() => console.log("hello"));
+        enqueue(() => console.log('hello'));
 
         // even built-in actions
       }
 
       // Use check(...) to conditionally enqueue actions based on a guard
-      if (check({ type: "someGuard" })) {
+      if (check({ type: 'someGuard' })) {
         // ...
       }
 
       // no return
-    }),
+    })
   });
   ```
 
@@ -4762,22 +4762,22 @@
 - [#4488](https://github.com/statelyai/xstate/pull/4488) [`9ca3c3dcf`](https://github.com/statelyai/xstate/commit/9ca3c3dcf25aba67aab5b6390766c273e9eba766) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `spawn(...)` action creator has been renamed to `spawnChild(...)` to avoid confusion.
 
   ```ts
-  import { spawnChild, assign } from "xstate";
+  import { spawnChild, assign } from 'xstate';
 
   const childMachine = createMachine({
     on: {
       someEvent: {
         actions: [
           // spawnChild(...) instead of spawn(...)
-          spawnChild("someSrc"),
+          spawnChild('someSrc'),
 
           // spawn() is used inside of assign()
           assign({
-            anotherRef: ({ spawn }) => spawn("anotherSrc"),
-          }),
-        ],
-      },
-    },
+            anotherRef: ({ spawn }) => spawn('anotherSrc')
+          })
+        ]
+      }
+    }
   });
   ```
 
@@ -4797,12 +4797,12 @@
   const machine = setup({
     types: {} as {
       children: {
-        myId: "actorKey";
+        myId: 'actorKey';
       };
     },
     actors: {
-      actorKey: child,
-    },
+      actorKey: child
+    }
   }).createMachine({});
 
   const actorRef = createActor(machine).start();
@@ -4835,7 +4835,7 @@
 - [#4353](https://github.com/statelyai/xstate/pull/4353) [`a3a11c84e`](https://github.com/statelyai/xstate/commit/a3a11c84e30c86afd63e47c77a46a61d926291d1) Thanks [@davidkpiano](https://github.com/davidkpiano)! - You can now use the `setup({ ... }).createMachine({ ... })` function to setup implementations for `actors`, `actions`, `guards`, and `delays` that will be used in the created machine:
 
   ```ts
-  import { setup, createMachine } from "xstate";
+  import { setup, createMachine } from 'xstate';
 
   const fetchUser = fromPromise(async ({ input }) => {
     const response = await fetch(`/user/${input.id}`);
@@ -4845,33 +4845,33 @@
 
   const machine = setup({
     actors: {
-      fetchUser,
+      fetchUser
     },
     actions: {
-      clearUser: assign({ user: undefined }),
+      clearUser: assign({ user: undefined })
     },
     guards: {
-      isUserAdmin: (_, params) => params.user.role === "admin",
-    },
+      isUserAdmin: (_, params) => params.user.role === 'admin'
+    }
   }).createMachine({
     // ...
     invoke: {
       // Strongly typed!
-      src: "fetchUser",
+      src: 'fetchUser',
       input: ({ context }) => ({ id: context.userId }),
       onDone: {
         guard: {
-          type: "isUserAdmin",
-          params: ({ context }) => ({ user: context.user }),
+          type: 'isUserAdmin',
+          params: ({ context }) => ({ user: context.user })
         },
-        target: "success",
-        actions: assign({ user: ({ event }) => event.output }),
+        target: 'success',
+        actions: assign({ user: ({ event }) => event.output })
       },
       onError: {
-        target: "failure",
-        actions: "clearUser",
-      },
-    },
+        target: 'failure',
+        actions: 'clearUser'
+      }
+    }
   });
   ```
 
@@ -4901,17 +4901,17 @@
   createMachine(
     {
       invoke: {
-        src: "child",
-      },
+        src: 'child'
+      }
     },
     {
       actors: {
         child: {
           src: childMachine,
-          input: "foo",
-        },
-      },
-    },
+          input: 'foo'
+        }
+      }
+    }
   );
   ```
 
@@ -4955,11 +4955,11 @@
         // This event is for the root actor
       }
 
-      if (event.type === "@xstate.event") {
+      if (event.type === '@xstate.event') {
         // previously event.targetRef
         event.actorRef;
       }
-    },
+    }
   });
   ```
 
@@ -4988,7 +4988,7 @@
 - [#4329](https://github.com/statelyai/xstate/pull/4329) [`41f5a7dc5`](https://github.com/statelyai/xstate/commit/41f5a7dc59a2cd946dff937664de2fa14780b007) Thanks [@davidkpiano](https://github.com/davidkpiano)! - You can now `spawn(...)` actors directly outside of `assign(...)` action creators:
 
   ```ts
-  import { createMachine, spawn } from "xstate";
+  import { createMachine, spawn } from 'xstate';
 
   const listenerMachine = createMachine({
     // ...
@@ -4997,16 +4997,16 @@
   const parentMachine = createMachine({
     // ...
     on: {
-      "listener.create": {
-        entry: spawn(listenerMachine, { id: "listener" }),
-      },
-    },
+      'listener.create': {
+        entry: spawn(listenerMachine, { id: 'listener' })
+      }
+    }
     // ...
   });
 
   const actor = createActor(parentMachine).start();
 
-  actor.send({ type: "listener.create" });
+  actor.send({ type: 'listener.create' });
 
   actor.getSnapshot().children.listener; // ActorRefFrom<typeof listenerMachine>
   ```
@@ -5018,17 +5018,17 @@
     {
       // ...
       entry: {
-        type: "greet",
-        params: { message: "hello" },
-      },
+        type: 'greet',
+        params: { message: 'hello' }
+      }
     },
     {
       actions: {
         greet: (_, params) => {
           params.message; // 'hello'
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -5041,19 +5041,19 @@
       on: {
         EVENT: {
           guard: {
-            type: "isGreaterThan",
-            params: { value: 10 },
-          },
-        },
-      },
+            type: 'isGreaterThan',
+            params: { value: 10 }
+          }
+        }
+      }
     },
     {
       guards: {
         isGreaterThan: (_, params) => {
           params.value; // 10
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -5111,16 +5111,16 @@
 
   ```ts
   createMachine({
-    initial: "a",
+    initial: 'a',
     states: {
       a: {
         after: {
-          10000: "b",
-          noon: "c",
-        },
-      },
+          10000: 'b',
+          noon: 'c'
+        }
+      }
       // ...
-    },
+    }
   });
   ```
 
@@ -5130,15 +5130,15 @@
   const machine = createMachine({
     context: ({ spawn }) => ({
       // This will be persisted
-      ref: spawn("reducer", { id: "child" }),
+      ref: spawn('reducer', { id: 'child' })
 
       // This cannot be persisted:
       // ref: spawn(fromTransition((s) => s, { count: 42 }), { id: 'child' })
-    }),
+    })
   }).provide({
     actors: {
-      reducer: fromTransition((s) => s, { count: 42 }),
-    },
+      reducer: fromTransition((s) => s, { count: 42 })
+    }
   });
   ```
 
@@ -5167,8 +5167,8 @@
     InspectedActorEvent,
     InspectedEventEvent,
     InspectedSnapshotEvent,
-    InspectionEvent,
-  } from "xstate";
+    InspectionEvent
+  } from 'xstate';
   ```
 
 ## 5.0.0-beta.33
@@ -5181,7 +5181,7 @@
   - `@xstate.snapshot` - An actor ref emitted a snapshot due to a received event
 
   ```ts
-  import { createMachine } from "xstate";
+  import { createMachine } from 'xstate';
 
   const machine = createMachine({
     // ...
@@ -5189,22 +5189,22 @@
 
   const actor = createActor(machine, {
     inspect: (inspectionEvent) => {
-      if (inspectionEvent.type === "@xstate.actor") {
+      if (inspectionEvent.type === '@xstate.actor') {
         console.log(inspectionEvent.actorRef);
       }
 
-      if (inspectionEvent.type === "@xstate.event") {
+      if (inspectionEvent.type === '@xstate.event') {
         console.log(inspectionEvent.sourceRef);
         console.log(inspectionEvent.targetRef);
         console.log(inspectionEvent.event);
       }
 
-      if (inspectionEvent.type === "@xstate.snapshot") {
+      if (inspectionEvent.type === '@xstate.snapshot') {
         console.log(inspectionEvent.actorRef);
         console.log(inspectionEvent.event);
         console.log(inspectionEvent.snapshot);
       }
-    },
+    }
   });
   ```
 
@@ -5228,26 +5228,26 @@
 
   ```ts
   const machine = createMachine({
-    initial: "started",
+    initial: 'started',
     states: {
       started: {
         // ...
       },
       finished: {
-        type: "final",
+        type: 'final'
         // moved to the top level
         //
         // output: {
         //   status: 200
         // }
-      },
+      }
     },
     // This will be the final output of the machine
     // present on `snapshot.output` and in the done events received by the parent
     // when the machine reaches the top-level final state ("finished")
     output: {
-      status: 200,
-    },
+      status: 200
+    }
   });
   ```
 
@@ -5312,7 +5312,7 @@
   // Now a snapshot object with { status, output, error, context }
   const promiseActorSnapshot = promiseActor.getSnapshot();
 
-  if (promiseActorSnapshot.status === "done") {
+  if (promiseActorSnapshot.status === 'done') {
     console.log(promiseActorSnapshot.output); // 42
   }
   ```
@@ -5344,8 +5344,8 @@
     type CallbackActorLogic,
     type ObservableActorLogic,
     type PromiseActorLogic,
-    type TransitionActorLogic,
-  } from "xstate";
+    type TransitionActorLogic
+  } from 'xstate';
   ```
 
 - [#4222](https://github.com/statelyai/xstate/pull/4222) [`41822f05e`](https://github.com/statelyai/xstate/commit/41822f05e46c2b439a69fac48872a4a6efe65739) Thanks [@Andarist](https://github.com/Andarist)! - `spawn` can now benefit from the actor types. Its arguments are strongly-typed based on them.
@@ -5373,14 +5373,14 @@
   createMachine({
     types: {} as {
       actions:
-        { type: "greet"; params: { surname: string } } | { type: "poke" };
+        { type: 'greet'; params: { surname: string } } | { type: 'poke' };
     },
     entry: {
-      type: "greet",
+      type: 'greet',
       params: ({ context }) => ({
-        surname: "Doe",
-      }),
-    },
+        surname: 'Doe'
+      })
+    }
   });
   ```
 
@@ -5394,27 +5394,27 @@
   createMachine({
     types: {} as {
       events:
-        | { type: "mouse.click.up"; direction: "up" }
-        | { type: "mouse.click.down"; direction: "down" }
-        | { type: "mouse.move" }
-        | { type: "keypress" };
+        | { type: 'mouse.click.up'; direction: 'up' }
+        | { type: 'mouse.click.down'; direction: 'down' }
+        | { type: 'mouse.move' }
+        | { type: 'keypress' };
     },
     on: {
-      "mouse.click.*": {
+      'mouse.click.*': {
         actions: ({ event }) => {
           event.type;
           // 'mouse.click.up' | 'mouse.click.down'
           event.direction;
           // 'up' | 'down'
-        },
+        }
       },
-      "mouse.*": {
+      'mouse.*': {
         actions: ({ event }) => {
           event.type;
           // 'mouse.click.up' | 'mouse.click.down' | 'mouse.move'
-        },
-      },
-    },
+        }
+      }
+    }
   });
   ```
 
@@ -5427,8 +5427,8 @@
   ```ts
   createMachine({
     types: {} as {
-      tags: "pending" | "success" | "error";
-    },
+      tags: 'pending' | 'success' | 'error';
+    }
     // ...
   });
   ```
@@ -5440,8 +5440,8 @@
   ```ts
   createMachine({
     types: {} as {
-      delays: "one second" | "one minute";
-    },
+      delays: 'one second' | 'one minute';
+    }
     // ...
   });
   ```
@@ -5457,13 +5457,13 @@
     types: {} as {
       guards:
         | {
-            type: "isGreaterThan";
+            type: 'isGreaterThan';
             params: {
               count: number;
             };
           }
-        | { type: "plainGuard" };
-    },
+        | { type: 'plainGuard' };
+    }
     // ...
   });
   ```
@@ -5483,20 +5483,20 @@
   ```ts
   createMachine({
     types: {} as {
-      actions: { type: "greet"; params: { name: string } };
+      actions: { type: 'greet'; params: { name: string } };
     },
     entry: [
       {
-        type: "greet",
+        type: 'greet',
         params: {
-          name: "David",
-        },
+          name: 'David'
+        }
       },
       // @ts-expect-error
-      { type: "greet" },
+      { type: 'greet' },
       // @ts-expect-error
-      { type: "unknownAction" },
-    ],
+      { type: 'unknownAction' }
+    ]
     // ...
   });
   ```
@@ -5507,10 +5507,10 @@
   const machine = createMachine({
     types: {} as {
       output: {
-        result: "pass" | "fail";
+        result: 'pass' | 'fail';
         score: number;
       };
-    },
+    }
     // ...
   });
 
@@ -5553,7 +5553,7 @@
     actor.subscribe({
       error: (error) => {
         // handle error
-      },
+      }
     });
     ```
   - If an observer does not have an error handler, the error will be thrown in a clear stack so bug tracking services can collect it.
@@ -5571,16 +5571,16 @@
     context: ({ input }) => ({
       // Strongly-typed input!
       emailSubject: input.subject,
-      emailBody: input.message.trim(),
-    }),
+      emailBody: input.message.trim()
+    })
   });
 
   const emailActor = interpret(emailMachine, {
     input: {
       // Strongly-typed input!
-      subject: "Hello, world!",
-      message: "This is a test.",
-    },
+      subject: 'Hello, world!',
+      message: 'This is a test.'
+    }
   }).start();
   ```
 
@@ -5596,21 +5596,21 @@
   const machine = createMachine({
     types: {} as {
       actors: {
-        src: "fetchData"; // src name (inline behaviors ideally inferred)
-        id: "fetch1" | "fetch2"; // possible ids (optional)
+        src: 'fetchData'; // src name (inline behaviors ideally inferred)
+        id: 'fetch1' | 'fetch2'; // possible ids (optional)
         logic: typeof fetcher;
       };
     },
     invoke: {
-      src: "fetchData", // strongly typed
-      id: "fetch2", // strongly typed
+      src: 'fetchData', // strongly typed
+      id: 'fetch2', // strongly typed
       onDone: {
         actions: ({ event }) => {
           event.output; // strongly typed as { result: string }
-        },
+        }
       },
-      input: { foo: "hello" }, // strongly typed
-    },
+      input: { foo: 'hello' } // strongly typed
+    }
   });
   ```
 
@@ -5629,7 +5629,7 @@
 - [#4159](https://github.com/statelyai/xstate/pull/4159) [`8bfbb8531`](https://github.com/statelyai/xstate/commit/8bfbb85316d305dc33b00b6e6170652fa248b20b) Thanks [@Andarist](https://github.com/Andarist)! - The `cancel` action was added to the main export:
 
   ```ts
-  import { cancel } from "xstate";
+  import { cancel } from 'xstate';
   ```
 
 ## 5.0.0-beta.19
@@ -5643,7 +5643,7 @@
   createMachine({
     types: {} as {
       context: { count: number };
-    },
+    }
     // Missing context property
   });
 
@@ -5653,8 +5653,8 @@
       context: { count: number };
     },
     context: {
-      count: 0,
-    },
+      count: 0
+    }
   });
   ```
 
@@ -5698,15 +5698,15 @@
 - [#4127](https://github.com/statelyai/xstate/pull/4127) [`cdaddc266`](https://github.com/statelyai/xstate/commit/cdaddc2667f9021cd9452206aab1227d5a5c229c) Thanks [@Andarist](https://github.com/Andarist)! - IDs for delayed events are no longer derived from event types so this won't work automatically:
 
   ```ts
-  entry: raise({ type: "TIMER" }, { delay: 200 });
-  exit: cancel("TIMER");
+  entry: raise({ type: 'TIMER' }, { delay: 200 });
+  exit: cancel('TIMER');
   ```
 
   Please use explicit IDs:
 
   ```ts
-  entry: raise({ type: "TIMER" }, { delay: 200, id: "myTimer" });
-  exit: cancel("myTimer");
+  entry: raise({ type: 'TIMER' }, { delay: 200, id: 'myTimer' });
+  exit: cancel('myTimer');
   ```
 
 - [#4127](https://github.com/statelyai/xstate/pull/4127) [`cdaddc266`](https://github.com/statelyai/xstate/commit/cdaddc2667f9021cd9452206aab1227d5a5c229c) Thanks [@Andarist](https://github.com/Andarist)! - All builtin action creators (`assign`, `sendTo`, etc) are now returning _functions_. They exact shape of those is considered an implementation detail of XState and users are meant to only pass around the returned values.
@@ -5717,7 +5717,7 @@
 
   ```ts
   createMachine({
-    on: [{ event: "FOO", target: "#id" }],
+    on: [{ event: 'FOO', target: '#id' }]
     // ...
   });
   ```
@@ -5727,8 +5727,8 @@
   ```ts
   createMachine({
     on: {
-      FOO: "#id",
-    },
+      FOO: '#id'
+    }
     // ...
   });
   ```
@@ -5754,25 +5754,25 @@
   ```ts
   const machine = createMachine(
     {
-      initial: "home",
+      initial: 'home',
       states: {
         home: {
           on: {
             NEXT: {
-              target: "success",
-              guard: "hasSelection",
-            },
-          },
+              target: 'success',
+              guard: 'hasSelection'
+            }
+          }
         },
-        success: {},
-      },
+        success: {}
+      }
     },
     {
       guards: {
         // `hasSelection` is a guard object that references the `stateIn` guard
-        hasSelection: stateIn("selected"),
-      },
-    },
+        hasSelection: stateIn('selected')
+      }
+    }
   );
   ```
 
@@ -5783,7 +5783,7 @@
 - [#4098](https://github.com/statelyai/xstate/pull/4098) [`ae7691811`](https://github.com/statelyai/xstate/commit/ae7691811d0ac92294532ce1e5ede3898ecffbc7) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `log`, `pure`, `choose`, and `stop` actions were added to the main export:
 
   ```ts
-  import { log, pure, choose, stop } from "xstate";
+  import { log, pure, choose, stop } from 'xstate';
   ```
 
 ## 5.0.0-beta.14
@@ -5838,9 +5838,9 @@
         createMachine({
           // ...
         }),
-        { systemId: "actorRef" },
-      ),
-    }),
+        { systemId: 'actorRef' }
+      )
+    })
   });
   ```
 
@@ -5926,7 +5926,7 @@
 - [#3968](https://github.com/statelyai/xstate/pull/3968) [`eecb31b8f`](https://github.com/statelyai/xstate/commit/eecb31b8f43efc4580887ad850336ea74cfba537) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `createEmptyActor()` function has been added to make it easier to create actors that do nothing ("empty" actors). This is useful for testing, or for some integrations such as `useActor(actor)` in `@xstate/react` that require an actor:
 
   ```jsx
-  import { createEmptyActor } from "xstate";
+  import { createEmptyActor } from 'xstate';
 
   const SomeComponent = (props) => {
     // props.actor may be undefined
@@ -6060,8 +6060,8 @@
     invoke: {
       src: emailMachine,
       // Registers `emailMachine` as `emailer` on the system
-      key: "emailer",
-    },
+      key: 'emailer'
+    }
   });
   ```
 
@@ -6069,8 +6069,8 @@
   const machine = createMachine({
     // ...
     entry: assign({
-      emailer: (ctx, ev, { spawn }) => spawn(emailMachine, { key: "emailer" }),
-    }),
+      emailer: (ctx, ev, { spawn }) => spawn(emailMachine, { key: 'emailer' })
+    })
   });
   ```
 
@@ -6081,10 +6081,10 @@
     // ...
     entry: sendTo(
       (ctx, ev, { system }) => {
-        return system.get("emailer");
+        return system.get('emailer');
       },
-      { type: "SEND_EMAIL", subject: "Hello", body: "World" },
-    ),
+      { type: 'SEND_EMAIL', subject: 'Hello', body: 'World' }
+    )
   });
   ```
 
@@ -6130,7 +6130,7 @@
   // ...
 
   const restoredActor = interpret(machine, {
-    state: persistedState,
+    state: persistedState
   }).start();
   ```
 
@@ -6158,18 +6158,18 @@
   ```js
   const greetMachine = createMachine({
     context: ({ input }) => ({
-      greeting: `Hello ${input.name}!`,
+      greeting: `Hello ${input.name}!`
     }),
     entry: (_, event) => {
       event.type; // 'xstate.init'
       event.input; // { name: 'David' }
-    },
+    }
     // ...
   });
 
   const actor = interpret(greetMachine, {
     // Pass input data to the machine
-    input: { name: "David" },
+    input: { name: 'David' }
   }).start();
   ```
 
@@ -6250,11 +6250,11 @@
   ```ts
   const machine = createMachine({
     // `tags` attached to machine via typegen
-    tsTypes: {} as import("./machine.typegen").Typegen0,
-    tags: ["a", "b"],
+    tsTypes: {} as import('./machine.typegen').Typegen0,
+    tags: ['a', 'b'],
     states: {
-      idle: { tags: "c" },
-    },
+      idle: { tags: 'c' }
+    }
   });
 
   type Tags = TagsFrom<typeof machine>; // 'a' | 'b' | 'c'
@@ -6264,10 +6264,10 @@
 
   ```ts
   const machine = createMachine({
-    tags: ["a", "b"],
+    tags: ['a', 'b'],
     states: {
-      idle: { tags: "c" },
-    },
+      idle: { tags: 'c' }
+    }
   });
 
   type Tags = TagsFrom<typeof machine>; // string
@@ -6296,7 +6296,7 @@
   ```ts
   actions: assign({
     counter: 0,
-    delta: (ctx, ev) => ev.delta,
+    delta: (ctx, ev) => ev.delta
   });
   ```
 
@@ -6395,14 +6395,14 @@
   ```ts
   const machine = createMachine(
     {
-      entry: ["doStuff"],
+      entry: ['doStuff']
     },
     {
       actions: {
-        doStuff: pure(() => ["someAction"]),
-        someAction: () => console.log("executed by doStuff"),
-      },
-    },
+        doStuff: pure(() => ['someAction']),
+        someAction: () => console.log('executed by doStuff')
+      }
+    }
   );
   ```
 
@@ -6417,7 +6417,7 @@
 - [#3588](https://github.com/statelyai/xstate/pull/3588) [`a4c8ead99`](https://github.com/statelyai/xstate/commit/a4c8ead9963f5e9097896ba0fdc1cdcc0acfd621) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The actions `raise` and `sendTo` can now be imported directly from `xstate`:
 
   ```js
-  import { raise, sendTo } from "xstate";
+  import { raise, sendTo } from 'xstate';
 
   // ...
   ```
@@ -6527,8 +6527,8 @@
 
   ```js
   const lightMachine = createMachine({
-    id: "light",
-    initial: "green",
+    id: 'light',
+    initial: 'green',
     states: {
       green: {},
       yellow: {},
@@ -6537,10 +6537,10 @@
         // initial: 'walk',
         states: {
           walk: {},
-          wait: {},
-        },
-      },
-    },
+          wait: {}
+        }
+      }
+    }
   });
   ```
 
@@ -6556,7 +6556,7 @@
   const machine = createMachine({
     // This will produce the TS error:
     // "Type 'string' is not assignable to type 'object | undefined'"
-    context: "some string",
+    context: 'some string'
   });
   ```
 
@@ -6589,13 +6589,13 @@
   - Dev tools integration has been simplified, and Redux dev tools support is no longer the default. It can be included from `xstate/devTools/redux`:
 
   ```js
-  import { interpret } from "xstate";
-  import { createReduxDevTools } from "xstate/devTools/redux";
+  import { interpret } from 'xstate';
+  import { createReduxDevTools } from 'xstate/devTools/redux';
 
   const service = interpret(someMachine, {
     devTools: createReduxDevTools({
       // Redux Dev Tools options
-    }),
+    })
   });
   ```
 
@@ -6603,7 +6603,7 @@
 
   ```js
   const service = interpret(someMachine, {
-    devTools: true, // attaches via window.__xstate__.register(service)
+    devTools: true // attaches via window.__xstate__.register(service)
   });
   ```
 
@@ -6611,7 +6611,7 @@
 
   ```js
   const myCustomDevTools = (service) => {
-    console.log("Got a service!");
+    console.log('Got a service!');
 
     service.subscribe((state) => {
       // ...
@@ -6619,7 +6619,7 @@
   };
 
   const service = interpret(someMachine, {
-    devTools: myCustomDevTools,
+    devTools: myCustomDevTools
   });
   ```
 
@@ -6666,19 +6666,19 @@
   - `not(guard1)` returns `true` if a single guard evaluates to `false`, otherwise `true`
 
   ```js
-  import { and, or, not } from "xstate/guards";
+  import { and, or, not } from 'xstate/guards';
 
   const someMachine = createMachine({
     // ...
     on: {
       EVENT: {
-        target: "somewhere",
+        target: 'somewhere',
         guard: and([
-          "stringGuard",
-          or([{ type: "anotherGuard" }, not(() => false)]),
-        ]),
-      },
-    },
+          'stringGuard',
+          or([{ type: 'anotherGuard' }, not(() => false)])
+        ])
+      }
+    }
   });
   ```
 
@@ -6842,7 +6842,7 @@
   assign((ctx, ev, { spawn }) => {
     return {
       ...ctx,
-      actorRef: spawn(promiseActor),
+      actorRef: spawn(promiseActor)
     };
   });
   ```
@@ -6850,7 +6850,7 @@
   In addition to that, you can now `spawn` actors defined in your implementations object, in the same way that you were already able to do that with `invoke`. To do that just reference the defined actor like this:
 
   ```js
-  spawn("promiseActor");
+  spawn('promiseActor');
   ```
 
 - [#2869](https://github.com/statelyai/xstate/pull/2869) [`9437c3de9`](https://github.com/statelyai/xstate/commit/9437c3de912c2a38c04798cbb94f267a1e5db3f8) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `service.batch(events)` method is no longer available.
@@ -6991,13 +6991,13 @@
   Example usage:
 
   ```js
-  import { waitFor } from "xstate/lib/waitFor";
+  import { waitFor } from 'xstate/lib/waitFor';
 
   // This will
   const loggedInState = await waitFor(
     loginService,
-    (state) => state.hasTag("loggedIn"),
-    { timeout: Infinity },
+    (state) => state.hasTag('loggedIn'),
+    { timeout: Infinity }
   );
   ```
 
@@ -7024,16 +7024,16 @@
   Example usage:
 
   ```js
-  import { waitFor } from "xstate/lib/waitFor";
+  import { waitFor } from 'xstate/lib/waitFor';
 
   // ...
   const loginService = interpret(loginMachine).start();
 
   const loggedInState = await waitFor(loginService, (state) =>
-    state.hasTag("loggedIn"),
+    state.hasTag('loggedIn')
   );
 
-  loggedInState.hasTag("loggedIn"); // true
+  loggedInState.hasTag('loggedIn'); // true
   ```
 
 - [#3200](https://github.com/statelyai/xstate/pull/3200) [`56c0a36`](https://github.com/statelyai/xstate/commit/56c0a36f222195d0b18edd7a72d5429a213b3808) Thanks [@Andarist](https://github.com/Andarist)! - Subscribing to a stopped interpreter will now always immediately emit its state and call a completion callback.
@@ -7067,12 +7067,12 @@
   ```ts
   const machine = createMachine({
     // this encodes that we still expect `myAction` to be provided
-    tsTypes: {} as Typegen0,
+    tsTypes: {} as Typegen0
   });
   const service: InterpreterFrom<typeof machine> = machine.withConfig({
     actions: {
-      myAction: () => {},
-    },
+      myAction: () => {}
+    }
   });
   ```
 
@@ -7129,7 +7129,7 @@
 - [#3040](https://github.com/statelyai/xstate/pull/3040) [`18dc2b3e2`](https://github.com/statelyai/xstate/commit/18dc2b3e2c49527b2155063490bb7295f1f06043) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `AnyState` and `AnyStateMachine` types are now available, which can be used to express any state and state machine, respectively:
 
   ```ts
-  import type { AnyState, AnyStateMachine } from "xstate";
+  import type { AnyState, AnyStateMachine } from 'xstate';
 
   // A function that takes in any state machine
   function visualizeMachine(machine: AnyStateMachine) {
@@ -7144,12 +7144,12 @@
 - [#3042](https://github.com/statelyai/xstate/pull/3042) [`e53396f08`](https://github.com/statelyai/xstate/commit/e53396f083091db26c117000ce6ec070914360e9) Thanks [@suerta-git](https://github.com/suerta-git)! - Added the `AnyStateConfig` type, which represents any `StateConfig<...>`:
 
   ```ts
-  import type { AnyStateConfig } from "xstate";
-  import { State } from "xstate";
+  import type { AnyStateConfig } from 'xstate';
+  import { State } from 'xstate';
 
   // Retrieving the state config from localStorage
   const stateConfig: AnyStateConfig = JSON.parse(
-    localStorage.getItem("app-state"),
+    localStorage.getItem('app-state')
   );
 
   // Use State.create() to restore state from config object with correct type
@@ -7167,11 +7167,11 @@
   ```js
   // Persisting a state
   someService.subscribe((state) => {
-    localStorage.setItem("some-state", JSON.stringify(state));
+    localStorage.setItem('some-state', JSON.stringify(state));
   });
 
   // Restoring a state
-  const stateJson = localStorage.getItem("some-state");
+  const stateJson = localStorage.getItem('some-state');
 
   // No need to convert `stateJson` object to a state!
   const someService = interpret(someMachine).start(stateJson);
@@ -7212,7 +7212,7 @@
 
   ```ts
   const machine = createMachine({
-    tsTypes: {},
+    tsTypes: {}
   });
   ```
 
@@ -7225,13 +7225,13 @@
 - [#2962](https://github.com/statelyai/xstate/pull/2962) [`32520650b`](https://github.com/statelyai/xstate/commit/32520650b7d6b43e416b896054033432aaede5d5) Thanks [@mattpocock](https://github.com/mattpocock)! - Added `t()`, which can be used to provide types for `schema` attributes in machine configs:
 
   ```ts
-  import { t, createMachine } from "xstate";
+  import { t, createMachine } from 'xstate';
 
   const machine = createMachine({
     schema: {
       context: t<{ value: number }>(),
-      events: t<{ type: "EVENT_1" } | { type: "EVENT_2" }>(),
-    },
+      events: t<{ type: 'EVENT_1' } | { type: 'EVENT_2' }>()
+    }
   });
   ```
 
@@ -7259,36 +7259,36 @@
 
   ```js
   createMachine({
-    id: "test",
-    initial: "p",
+    id: 'test',
+    initial: 'p',
     states: {
       p: {
-        type: "parallel",
+        type: 'parallel',
         states: {
           // Before this change, both invoke IDs would be 'someSource',
           // which is incorrect.
           a: {
             invoke: {
-              src: "someSource",
+              src: 'someSource'
               // generated invoke ID: 'test.p.a:invocation[0]'
-            },
+            }
           },
           b: {
             invoke: {
-              src: "someSource",
+              src: 'someSource'
               // generated invoke ID: 'test.p.b:invocation[0]'
-            },
-          },
-        },
-      },
-    },
+            }
+          }
+        }
+      }
+    }
   });
   ```
 
 - [#2925](https://github.com/statelyai/xstate/pull/2925) [`239b4666a`](https://github.com/statelyai/xstate/commit/239b4666ac302d80c028fef47c6e8ab7e0ae2757) Thanks [@devanfarrell](https://github.com/devanfarrell)! - The `sendTo(actorRef, event)` action creator introduced in `4.27.0`, which was not accessible from the package exports, can now be used just like other actions:
 
   ```js
-  import { actions } from "xstate";
+  import { actions } from 'xstate';
 
   const { sendTo } = actions;
   ```
@@ -7336,15 +7336,15 @@
     states: {
       active: {
         // ...
-        description: "The task is in progress",
+        description: 'The task is in progress',
         on: {
           DEACTIVATE: {
             // ...
-            description: "Deactivates the task",
-          },
-        },
-      },
-    },
+            description: 'Deactivates the task'
+          }
+        }
+      }
+    }
   });
   ```
 
@@ -7363,8 +7363,8 @@
 - [#2740](https://github.com/statelyai/xstate/pull/2740) [`707cb981f`](https://github.com/statelyai/xstate/commit/707cb981fdb8a5c75cacb7e9bfa5c7e5a1cc1c88) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with tags being missed on a service state after starting that service using a state value, like this:
 
   ```js
-  const service = interpret(machine).start("active");
-  service.state.hasTag("foo"); // this should now return a correct result
+  const service = interpret(machine).start('active');
+  service.state.hasTag('foo'); // this should now return a correct result
   ```
 
 - [#2691](https://github.com/statelyai/xstate/pull/2691) [`a72806035`](https://github.com/statelyai/xstate/commit/a728060353c9cb9bdb0cd37aacf793498a8750c8) Thanks [@davidkpiano](https://github.com/statelyai)! - Meta data can now be specified for `invoke` configs in the `invoke.meta` property:
@@ -7375,12 +7375,12 @@
     invoke: {
       src: (ctx, e) => findUser(ctx.userId),
       meta: {
-        summary: "Finds user",
-        updatedAt: "2021-09-...",
-        version: "4.12.2",
+        summary: 'Finds user',
+        updatedAt: '2021-09-...',
+        version: '4.12.2'
         // other descriptive meta properties
-      },
-    },
+      }
+    }
   });
   ```
 
@@ -7415,9 +7415,9 @@
     { foo: 100 },
     {
       events: {
-        BAR: () => ({}),
-      },
-    },
+        BAR: () => ({})
+      }
+    }
   );
 
   model.createMachine({
@@ -7425,8 +7425,8 @@
     entry: (ctx) => {},
     exit: assign({
       // `ctx` was of type `unknown`
-      foo: (ctx) => 42,
-    }),
+      foo: (ctx) => 42
+    })
   });
   ```
 
@@ -7444,30 +7444,30 @@
 
   ```js
   const machine = createMachine({
-    initial: "inactive",
+    initial: 'inactive',
     states: {
       inactive: {
         on: {
-          TOGGLE: "active",
-        },
+          TOGGLE: 'active'
+        }
       },
       active: {
         on: {
-          DO_SOMETHING: { actions: ["something"] },
-        },
-      },
-    },
+          DO_SOMETHING: { actions: ['something'] }
+        }
+      }
+    }
   });
 
   const state = machine.initialState;
 
-  state.can("TOGGLE"); // true
-  state.can("DO_SOMETHING"); // false
+  state.can('TOGGLE'); // true
+  state.can('DO_SOMETHING'); // false
 
   // Also takes in full event objects:
   state.can({
-    type: "DO_SOMETHING",
-    data: 42,
+    type: 'DO_SOMETHING',
+    data: 42
   }); // false
   ```
 
@@ -7486,14 +7486,14 @@
   const model = createModel(
     {},
     {
-      events: {},
-    },
+      events: {}
+    }
   );
 
   model.createMachine({
     // These actions will cause TS to not compile
-    entry: "someAction",
-    exit: { type: "someObjectAction" },
+    entry: 'someAction',
+    exit: { type: 'someObjectAction' }
   });
   ```
 
@@ -7546,12 +7546,12 @@
   ```ts
   createMachine({
     context: {/* ... */}, // ✅ This is allowed
-    initial: "inner",
+    initial: 'inner',
     states: {
       inner: {
-        context: {/* ... */}, // ❌ This will no longer compile
-      },
-    },
+        context: {/* ... */} // ❌ This will no longer compile
+      }
+    }
   });
   ```
 
@@ -7563,7 +7563,7 @@
 
   ```js
   const copy = machine.withContext(() => ({
-    ref: spawn(() => {}),
+    ref: spawn(() => {})
   }));
   ```
 
@@ -7579,7 +7579,7 @@
 
   ```ts
   // `state.context` became `any` erroneously
-  if (state.matches("inactive")) {
+  if (state.matches('inactive')) {
     console.log(state.context.count);
   }
   ```
@@ -7599,9 +7599,9 @@
       assign({ count: (ctx) => ctx.count + 1 }),
       (ctx) => console.log(ctx.count), // 1
       assign({ count: (ctx) => ctx.count + 1 }),
-      (ctx) => console.log(ctx.count), // 2
+      (ctx) => console.log(ctx.count) // 2
     ],
-    preserveActionOrder: true,
+    preserveActionOrder: true
   });
 
   // With `.preserveActionOrder: false` (default)
@@ -7612,8 +7612,8 @@
       assign({ count: (ctx) => ctx.count + 1 }),
       (ctx) => console.log(ctx.count), // 2
       assign({ count: (ctx) => ctx.count + 1 }),
-      (ctx) => console.log(ctx.count), // 2
-    ],
+      (ctx) => console.log(ctx.count) // 2
+    ]
     // preserveActionOrder: false
   });
   ```
@@ -7627,13 +7627,13 @@
   ```ts
   const machine = createMachine({
     context: () => ({
-      someRef: spawn(someExistingRef, "something"),
+      someRef: spawn(someExistingRef, 'something')
     }),
     on: {
       SOME_EVENT: {
-        actions: send("AN_EVENT", { to: "something" }),
-      },
-    },
+        actions: send('AN_EVENT', { to: 'something' })
+      }
+    }
   });
   ```
 
@@ -7657,14 +7657,14 @@
 - [`432b60f7`](https://github.com/statelyai/xstate/commit/432b60f7bcbcee9510e0d86311abbfd75b1a674e) [#2280](https://github.com/statelyai/xstate/pull/2280) Thanks [@davidkpiano](https://github.com/statelyai)! - Actors can now be invoked/spawned from reducers using the `fromReducer(...)` behavior creator:
 
   ```ts
-  import { fromReducer } from "xstate/lib/behaviors";
+  import { fromReducer } from 'xstate/lib/behaviors';
 
-  type CountEvent = { type: "INC" } | { type: "DEC" };
+  type CountEvent = { type: 'INC' } | { type: 'DEC' };
 
   const countReducer = (count: number, event: CountEvent): number => {
-    if (event.type === "INC") {
+    if (event.type === 'INC') {
       return count + 1;
-    } else if (event.type === "DEC") {
+    } else if (event.type === 'DEC') {
       return count - 1;
     }
 
@@ -7673,17 +7673,17 @@
 
   const countMachine = createMachine({
     invoke: {
-      id: "count",
-      src: () => fromReducer(countReducer, 0),
+      id: 'count',
+      src: () => fromReducer(countReducer, 0)
     },
     on: {
       INC: {
-        actions: forwardTo("count"),
+        actions: forwardTo('count')
       },
       DEC: {
-        actions: forwardTo("count"),
-      },
-    },
+        actions: forwardTo('count')
+      }
+    }
   });
   ```
 
@@ -7692,8 +7692,8 @@
   ```ts
   const machine = createMachine<{ ref: ActorRef<SomeEvent> }>({
     context: () => ({
-      ref: spawn(anotherMachine, "some-id"), // spawn immediately!
-    }),
+      ref: spawn(anotherMachine, 'some-id') // spawn immediately!
+    })
     // ...
   });
   ```
@@ -7713,7 +7713,7 @@
   ```ts
   interface ActorRef<
     TEvent extends EventObject,
-    TEmitted = any,
+    TEmitted = any
   > extends Subscribable<TEmitted> {
     send: (event: TEvent) => void;
     id: string;
@@ -7721,7 +7721,7 @@
     subscribe(
       next: (value: T) => void,
       error?: (error: any) => void,
-      complete?: () => void,
+      complete?: () => void
     ): Subscription;
     getSnapshot: () => TEmitted | undefined;
   }
@@ -7741,10 +7741,10 @@
   const machine = createMachine<typeof someModel>({
     // missing context - will give a TS error!
     // context: someModel.initialContext,
-    initial: "somewhere",
+    initial: 'somewhere',
     states: {
-      somewhere: {},
-    },
+      somewhere: {}
+    }
   });
   ```
 
@@ -7753,7 +7753,7 @@
   ```ts
   invoke: () => (sendBack, receive) => {
     // Will now be constrained to events that the parent machine can receive
-    sendBack({ type: "SOME_EVENT" });
+    sendBack({ type: 'SOME_EVENT' });
   };
   ```
 
@@ -7799,16 +7799,16 @@
   ```js
   const machine = createMachine({
     context: {
-      promiseRef: null,
+      promiseRef: null
     },
-    initial: "pending",
+    initial: 'pending',
     states: {
       pending: {
         entry: assign({
-          promiseRef: () => spawn(fetch(/* ... */), "some-promise"),
-        }),
-      },
-    },
+          promiseRef: () => spawn(fetch(/* ... */), 'some-promise')
+        })
+      }
+    }
   });
 
   const service = interpret(machine)
@@ -7853,25 +7853,25 @@
 
   ```js
   const machine = createMachine({
-    initial: "green",
+    initial: 'green',
     states: {
       green: {
-        tags: "go", // single tag
+        tags: 'go' // single tag
       },
       yellow: {
-        tags: "go",
+        tags: 'go'
       },
       red: {
-        tags: ["stop", "other"], // multiple tags
-      },
-    },
+        tags: ['stop', 'other'] // multiple tags
+      }
+    }
   });
   ```
 
   You can query whether a state has a tag via `state.hasTag(tag)`:
 
   ```js
-  const canGo = state.hasTag("go");
+  const canGo = state.hasTag('go');
   // => `true` if in 'green' or 'red' state
   ```
 
@@ -7892,9 +7892,9 @@
     context: { value: 42 },
     on: {
       INC: {
-        actions: assign({ value: (ctx) => ctx.value + 1 }),
-      },
-    },
+        actions: assign({ value: (ctx) => ctx.value + 1 })
+      }
+    }
   });
   ```
 
@@ -7928,23 +7928,23 @@
     schema: {
       // Example in JSON Schema (anything can be used)
       context: {
-        type: "object",
+        type: 'object',
         properties: {
-          foo: { type: "string" },
-          bar: { type: "number" },
+          foo: { type: 'string' },
+          bar: { type: 'number' },
           baz: {
-            type: "object",
+            type: 'object',
             properties: {
-              one: { type: "string" },
-            },
-          },
-        },
+              one: { type: 'string' }
+            }
+          }
+        }
       },
       events: {
-        FOO: { type: "object" },
-        BAR: { type: "object" },
-      },
-    },
+        FOO: { type: 'object' },
+        BAR: { type: 'object' }
+      }
+    }
     // ...
   });
   ```
@@ -7952,15 +7952,15 @@
   Additionally, the new `createSchema()` identity function allows any schema "metadata" to be represented by a specific type, which makes type inference easier without having to specify generic types:
 
   ```ts
-  import { createSchema, createMachine } from "xstate";
+  import { createSchema, createMachine } from 'xstate';
 
   // Both `context` and `events` are inferred in the rest of the machine!
   const machine = createMachine({
     schema: {
       context: createSchema<{ count: number }>(),
       // No arguments necessary
-      events: createSchema<{ type: "FOO" } | { type: "BAR" }>(),
-    },
+      events: createSchema<{ type: 'FOO' } | { type: 'BAR' }>()
+    }
     // ...
   });
   ```
@@ -7968,40 +7968,40 @@
 - [`5febfe83`](https://github.com/statelyai/xstate/commit/5febfe83a7e5e866c0a4523ea4f86a966af7c50f) [#1955](https://github.com/statelyai/xstate/pull/1955) Thanks [@davidkpiano](https://github.com/statelyai)! - Event creators can now be modeled inside of the 2nd argument of `createModel()`, and types for both `context` and `events` will be inferred properly in `createMachine()` when given the `typeof model` as the first generic parameter.
 
   ```ts
-  import { createModel } from "xstate/lib/model";
+  import { createModel } from 'xstate/lib/model';
 
   const userModel = createModel(
     // initial context
     {
-      name: "David",
-      age: 30,
+      name: 'David',
+      age: 30
     },
     // creators (just events for now)
     {
       events: {
         updateName: (value: string) => ({ value }),
         updateAge: (value: number) => ({ value }),
-        anotherEvent: () => ({}), // no payload
-      },
-    },
+        anotherEvent: () => ({}) // no payload
+      }
+    }
   );
 
   const machine = createMachine<typeof userModel>({
     context: userModel.initialContext,
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
         on: {
           updateName: {/* ... */},
-          updateAge: {/* ... */},
-        },
-      },
-    },
+          updateAge: {/* ... */}
+        }
+      }
+    }
   });
 
   const nextState = machine.transition(
     undefined,
-    userModel.events.updateName("David"),
+    userModel.events.updateName('David')
   );
   ```
 
@@ -8180,30 +8180,30 @@
 
   ```js
   const child = createMachine({
-    initial: "bar",
+    initial: 'bar',
     context: {},
     states: {
       bar: {
         entry: assign({
           promise: () => {
-            return spawn(() => Promise.resolve("answer"));
-          },
-        }),
-      },
-    },
+            return spawn(() => Promise.resolve('answer'));
+          }
+        })
+      }
+    }
   });
 
   const parent = createMachine({
-    initial: "foo",
+    initial: 'foo',
     states: {
       foo: {
         invoke: {
           src: child,
-          onDone: "end",
-        },
+          onDone: 'end'
+        }
       },
-      end: { type: "final" },
-    },
+      end: { type: 'final' }
+    }
   });
 
   interpret(parent).start();
@@ -8222,28 +8222,28 @@
   ```js
   const machine = createMachine(
     {
-      initial: "searching",
+      initial: 'searching',
       states: {
         searching: {
           invoke: {
             src: {
-              type: "search",
-              endpoint: "example.com",
-            },
+              type: 'search',
+              endpoint: 'example.com'
+            }
             // ...
-          },
+          }
           // ...
-        },
-      },
+        }
+      }
     },
     {
       services: {
         search: (context, event, { src }) => {
           console.log(src);
           // => { endpoint: 'example.com' }
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -8384,13 +8384,13 @@
   ```js
   entry: [
     choose([
-      { cond: (ctx) => ctx > 100, actions: raise("TOGGLE") },
+      { cond: (ctx) => ctx > 100, actions: raise('TOGGLE') },
       {
-        cond: "hasMagicBottle",
-        actions: [assign((ctx) => ({ counter: ctx.counter + 1 }))],
+        cond: 'hasMagicBottle',
+        actions: [assign((ctx) => ({ counter: ctx.counter + 1 }))]
       },
-      { actions: ["fallbackAction"] },
-    ]),
+      { actions: ['fallbackAction'] }
+    ])
   ];
   ```
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,20 @@
       "import": "./dist/xstate-actors.cjs.mjs",
       "default": "./dist/xstate-actors.cjs.js"
     },
+    "./validation": {
+      "types": {
+        "import": "./dist/xstate-validation.cjs.mjs",
+        "default": "./dist/xstate-validation.cjs.js"
+      },
+      "development": {
+        "module": "./dist/xstate-validation.development.esm.js",
+        "import": "./dist/xstate-validation.development.cjs.mjs",
+        "default": "./dist/xstate-validation.development.cjs.js"
+      },
+      "module": "./dist/xstate-validation.esm.js",
+      "import": "./dist/xstate-validation.cjs.mjs",
+      "default": "./dist/xstate-validation.cjs.js"
+    },
     "./package.json": "./package.json"
   },
   "imports": {
@@ -72,6 +86,7 @@
     "guards",
     "dev",
     "graph",
+    "validation",
     "bin"
   ],
   "keywords": [
@@ -108,7 +123,8 @@
     "entrypoints": [
       "./index.ts",
       "./actors/index.ts",
-      "./graph/index.ts"
+      "./graph/index.ts",
+      "./validation/index.ts"
     ]
   }
 }

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -83,22 +83,10 @@ import {
   resolveReferencedActor,
   toStatePath
 } from './utils.ts';
-import type {
-  MachineValidationRequest,
-  MachineValidator
-} from './validation.types.ts';
+import { assertValid } from './validation.ts';
+import type { ActorLogicValidator } from './validation.types.ts';
 
 const STATE_IDENTIFIER = '#';
-
-function assertValid(
-  validator: MachineValidator,
-  request: MachineValidationRequest
-): void {
-  const error = validator.check(request);
-  if (error) {
-    throw error;
-  }
-}
 
 let emptyCanActor: AnyActor | undefined;
 let emptyCanActorScope: AnyActorScope | undefined;
@@ -248,7 +236,7 @@ export class StateMachine<
       internalEvents?: readonly string[];
     },
     sources?: Sources,
-    public validator?: MachineValidator
+    public validator?: ActorLogicValidator
   ) {
     this.id = config.id || '(machine)';
     this.sources = {
@@ -457,7 +445,7 @@ export class StateMachine<
     if (this.validator) {
       assertValid(this.validator, {
         kind: 'event',
-        machine: this,
+        logic: this,
         event,
         eventOrigin:
           actorScope && (actorScope.self as any)._lastSourceRef
@@ -484,7 +472,7 @@ export class StateMachine<
       if (this.validator) {
         assertValid(this.validator, {
           kind: 'result',
-          machine: this,
+          logic: this,
           snapshot: returnedSnapshot,
           effects: []
         });
@@ -511,7 +499,7 @@ export class StateMachine<
     if (this.validator) {
       assertValid(this.validator, {
         kind: 'result',
-        machine: this,
+        logic: this,
         snapshot: returnedSnapshot,
         effects
       });
@@ -921,7 +909,7 @@ export class StateMachine<
     if (this.validator) {
       assertValid(this.validator, {
         kind: 'input',
-        machine: this,
+        logic: this,
         input
       });
     }
@@ -956,7 +944,7 @@ export class StateMachine<
       if (this.validator) {
         assertValid(this.validator, {
           kind: 'result',
-          machine: this,
+          logic: this,
           snapshot: returnedSnapshot,
           effects
         });

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -83,8 +83,22 @@ import {
   resolveReferencedActor,
   toStatePath
 } from './utils.ts';
+import type {
+  MachineValidationRequest,
+  MachineValidator
+} from './validation.types.ts';
 
 const STATE_IDENTIFIER = '#';
+
+function assertValid(
+  validator: MachineValidator,
+  request: MachineValidationRequest
+): void {
+  const error = validator.check(request);
+  if (error) {
+    throw error;
+  }
+}
 
 let emptyCanActor: AnyActor | undefined;
 let emptyCanActorScope: AnyActorScope | undefined;
@@ -233,7 +247,8 @@ export class StateMachine<
       schemas?: AnyMachineSchemas;
       internalEvents?: readonly string[];
     },
-    sources?: Sources
+    sources?: Sources,
+    public validator?: MachineValidator
   ) {
     this.id = config.id || '(machine)';
     this.sources = {
@@ -318,24 +333,28 @@ export class StateMachine<
   > {
     const { actions, guards, actors, delays } = this.sources;
 
-    const provided = new StateMachine(this.config, {
-      actions: {
-        ...actions,
-        ...sources.actions
-      } as Sources['actions'],
-      guards: {
-        ...guards,
-        ...sources.guards
-      } as Sources['guards'],
-      actors: {
-        ...actors,
-        ...sources.actors
-      } as Sources['actors'],
-      delays: {
-        ...delays,
-        ...sources.delays
-      } as Sources['delays']
-    }) as unknown as this;
+    const provided = new StateMachine(
+      this.config,
+      {
+        actions: {
+          ...actions,
+          ...sources.actions
+        } as Sources['actions'],
+        guards: {
+          ...guards,
+          ...sources.guards
+        } as Sources['guards'],
+        actors: {
+          ...actors,
+          ...sources.actors
+        } as Sources['actors'],
+        delays: {
+          ...delays,
+          ...sources.delays
+        } as Sources['delays']
+      },
+      this.validator
+    ) as unknown as this;
     // Providing sources does not change the serializable definition.
     provided._json = this._json;
     return provided;
@@ -435,6 +454,17 @@ export class StateMachine<
         this,
         snapshot as SnapshotFrom<this>
       )) as NonNullable<typeof actorScope>;
+    if (this.validator) {
+      assertValid(this.validator, {
+        kind: 'event',
+        machine: this,
+        event,
+        eventOrigin:
+          actorScope && (actorScope.self as any)._lastSourceRef
+            ? 'actor'
+            : 'external'
+      });
+    }
     if (usesInertScope) {
       setInertActorScopeSnapshot(resolvedActorScope, snapshot, false);
     }
@@ -451,6 +481,14 @@ export class StateMachine<
         usesInertScope && fastSnapshot !== snapshot
           ? attachSnapshotActorRef(this, resolvedActorScope, fastSnapshot)
           : this._attachPureActorRef(fastSnapshot, resolvedActorScope);
+      if (this.validator) {
+        assertValid(this.validator, {
+          kind: 'result',
+          machine: this,
+          snapshot: returnedSnapshot,
+          effects: []
+        });
+      }
       return [returnedSnapshot, []];
     }
 
@@ -469,6 +507,15 @@ export class StateMachine<
         ? nextSnapshot
         : attachSnapshotActorRef(this, resolvedActorScope, nextSnapshot)
       : this._attachPureActorRef(nextSnapshot, resolvedActorScope);
+    const effects = this._collectEffects(microsteps);
+    if (this.validator) {
+      assertValid(this.validator, {
+        kind: 'result',
+        machine: this,
+        snapshot: returnedSnapshot,
+        effects
+      });
+    }
     return [
       returnedSnapshot as MachineSnapshot<
         TContext,
@@ -480,7 +527,7 @@ export class StateMachine<
         TMeta,
         TConfig
       >,
-      this._collectEffects(microsteps)
+      effects
     ];
   }
 
@@ -871,6 +918,13 @@ export class StateMachine<
     >,
     ExecutableActionObjectFromLogic<this>
   > {
+    if (this.validator) {
+      assertValid(this.validator, {
+        kind: 'input',
+        machine: this,
+        input
+      });
+    }
     const usesInertScope = !actorScope;
     const resolvedActorScope = (actorScope ??
       createInertActorScope(this)) as NonNullable<typeof actorScope>;
@@ -883,15 +937,35 @@ export class StateMachine<
     const contextSpawnEffects = Object.values(preInitialState.children)
       .filter(Boolean)
       .map((actor) => createSpawnEffect(actor as AnyActor));
-    let nextState: AnyMachineSnapshot;
-    let initialActions: ReadonlyArray<ExecutableActionObject> = [];
-    let microsteps: ReadonlyArray<
-      readonly [unknown, ReadonlyArray<ExecutableActionObject>]
-    > = [];
-    let macroState: AnyMachineSnapshot;
+    const finalizeInitialResult = (
+      macroState: AnyMachineSnapshot,
+      microsteps: ReadonlyArray<
+        readonly [unknown, ReadonlyArray<ExecutableActionObject>]
+      >
+    ): ActorLogicTransitionResult<
+      SnapshotFrom<this>,
+      ExecutableActionObjectFromLogic<this>
+    > => {
+      if (usesInertScope) {
+        setInertActorScopeSnapshot(resolvedActorScope, macroState, false);
+      }
+      const returnedSnapshot = usesInertScope
+        ? attachSnapshotActorRef(this, resolvedActorScope, macroState)
+        : this._attachPureActorRef(macroState, resolvedActorScope);
+      const effects = this._collectEffects(microsteps);
+      if (this.validator) {
+        assertValid(this.validator, {
+          kind: 'result',
+          machine: this,
+          snapshot: returnedSnapshot,
+          effects
+        });
+      }
+      return [returnedSnapshot as SnapshotFrom<this>, effects];
+    };
 
     try {
-      [nextState, initialActions] = initialMicrostep(
+      const [nextState, initialActions] = initialMicrostep(
         this.root,
         preInitialState,
         resolvedActorScope,
@@ -899,7 +973,7 @@ export class StateMachine<
         internalQueue
       );
 
-      ({ snapshot: macroState, microsteps } = macrostep(
+      const { snapshot: macroState, microsteps } = macrostep(
         nextState,
         initEvent as AnyEventObject,
         resolvedActorScope,
@@ -910,7 +984,8 @@ export class StateMachine<
             ExecutableActionObject[]
           ]
         ]
-      ));
+      );
+      return finalizeInitialResult(macroState, microsteps);
     } catch (err) {
       if (!this.root.config.onError) {
         throw err;
@@ -928,21 +1003,11 @@ export class StateMachine<
           ]
         ]
       );
-      macroState = errorMacrostep.snapshot;
-      microsteps = errorMacrostep.microsteps;
-      initialActions = [];
+      return finalizeInitialResult(
+        errorMacrostep.snapshot,
+        errorMacrostep.microsteps
+      );
     }
-
-    if (usesInertScope) {
-      setInertActorScopeSnapshot(resolvedActorScope, macroState, false);
-    }
-    const returnedSnapshot = usesInertScope
-      ? attachSnapshotActorRef(this, resolvedActorScope, macroState)
-      : this._attachPureActorRef(macroState, resolvedActorScope);
-    return [
-      returnedSnapshot as SnapshotFrom<this>,
-      this._collectEffects(microsteps)
-    ];
   }
 
   public start(

--- a/packages/core/src/actors/callback.ts
+++ b/packages/core/src/actors/callback.ts
@@ -9,6 +9,7 @@ import {
   Snapshot
 } from '../types';
 import { StandardSchemaV1 } from '../schema.types.ts';
+import type { ActorLogicValidator } from '../validation.types.ts';
 import { createLogic as createBaseLogic } from './logic.ts';
 
 interface CallbackInstanceState<TEvent extends EventObject> {
@@ -130,6 +131,7 @@ export interface CallbackLogicConfig<
   TEmitted extends EventObject = EventObject,
   TInputSchema extends StandardSchemaV1 = StandardSchemaV1
 > {
+  validator?: ActorLogicValidator;
   schemas?: {
     input?: TInputSchema;
   };
@@ -213,11 +215,7 @@ export function createCallbackLogic<
     StandardSchemaV1.InferOutput<TInputSchema>,
     TEmitted,
     TInputSchema
-  > & {
-    schemas: {
-      input: TInputSchema;
-    };
-  }
+  > & { schemas: { input: TInputSchema } }
 ): CallbackActorLogic<
   TEvent,
   StandardSchemaV1.InferOutput<TInputSchema>,
@@ -256,8 +254,13 @@ export function createCallbackLogic<
     typeof callbackOrConfig === 'function'
       ? undefined
       : callbackOrConfig.schemas;
+  const validator =
+    typeof callbackOrConfig === 'function'
+      ? undefined
+      : callbackOrConfig.validator;
 
   return createBaseLogic<undefined, undefined, TEvent, TInput, TEmitted>({
+    validator,
     schemas,
     context: undefined,
     run: (args, enq) => {

--- a/packages/core/src/actors/logic.ts
+++ b/packages/core/src/actors/logic.ts
@@ -2,6 +2,8 @@ import { XSTATE_STOP } from '../constants.ts';
 import { createInitEvent } from '../eventUtils.ts';
 import { StandardSchemaV1 } from '../schema.types.ts';
 import { ActorSystemRuntime, AnyActorSystem } from '../system.ts';
+import { assertValid } from '../validation.ts';
+import type { ActorLogicValidator } from '../validation.types.ts';
 import {
   finalizeTransitionResult,
   createCustomEffect,
@@ -91,6 +93,7 @@ export interface LogicConfig<
   TOutputSchema extends StandardSchemaV1 = StandardSchemaV1
 > {
   id?: string;
+  validator?: ActorLogicValidator;
   schemas?: {
     input?: TInputSchema;
     output?: TOutputSchema;
@@ -227,10 +230,7 @@ export function createLogic<
     TInputSchema,
     TOutputSchema
   > & {
-    schemas: {
-      input: TInputSchema;
-      output: TOutputSchema;
-    };
+    schemas: { input: TInputSchema; output: TOutputSchema };
   }
 ): LogicActorLogic<
   TContext,
@@ -254,10 +254,7 @@ export function createLogic<
     TEmitted,
     TInputSchema
   > & {
-    schemas: {
-      input: TInputSchema;
-      output?: undefined;
-    };
+    schemas: { input: TInputSchema; output?: undefined };
   }
 ): LogicActorLogic<
   TContext,
@@ -282,10 +279,7 @@ export function createLogic<
     StandardSchemaV1,
     TOutputSchema
   > & {
-    schemas: {
-      input?: undefined;
-      output: TOutputSchema;
-    };
+    schemas: { input?: undefined; output: TOutputSchema };
   }
 ): LogicActorLogic<
   TContext,
@@ -312,7 +306,7 @@ export function createLogic<
 >(
   config: LogicConfig<TContext, TOutput, TEvent, TInput, TEmitted>
 ): LogicActorLogic<TContext, TOutput, TEvent, TInput, TEmitted> {
-  const transition = ((snapshot, event, actorScope) => {
+  const calculateTransition = ((snapshot, event, actorScope) => {
     if (snapshot.status !== 'active') {
       return [snapshot, []];
     }
@@ -465,9 +459,33 @@ export function createLogic<
     ]);
   }) as LogicTransition<TContext, TOutput, TEvent, TInput, TEmitted>;
 
+  const transition = ((snapshot, event, actorScope) => {
+    if (config.validator) {
+      assertValid(config.validator, {
+        kind: 'event',
+        logic,
+        event,
+        eventOrigin: (actorScope.self as any)._lastSourceRef
+          ? 'actor'
+          : 'external'
+      });
+    }
+    const result = calculateTransition(snapshot, event, actorScope);
+    if (config.validator) {
+      assertValid(config.validator, {
+        kind: 'result',
+        logic,
+        snapshot: result[0],
+        effects: result[1]
+      });
+    }
+    return result;
+  }) as LogicTransition<TContext, TOutput, TEvent, TInput, TEmitted>;
+
   const logic: LogicActorLogic<TContext, TOutput, TEvent, TInput, TEmitted> = {
     id: config.id,
     config,
+    validator: config.validator,
     transition,
     start: (snapshot, actorScope, options) => {
       if (!options?.restored) {
@@ -484,6 +502,13 @@ export function createLogic<
       }
     },
     initialTransition: (input, actorScope) => {
+      if (config.validator) {
+        assertValid(config.validator, {
+          kind: 'input',
+          logic,
+          input
+        });
+      }
       const context = resolveContext(config.context, input);
       const snapshot = {
         status: 'active' as const,

--- a/packages/core/src/actors/observable.ts
+++ b/packages/core/src/actors/observable.ts
@@ -1,6 +1,8 @@
 import { XSTATE_INIT, XSTATE_STOP } from '../constants';
 import { StandardSchemaV1 } from '../schema.types.ts';
 import { AnyActorSystem } from '../system.ts';
+import { assertValid } from '../validation.ts';
+import type { ActorLogicValidator } from '../validation.types.ts';
 import {
   ActorLogic,
   ActorFromLogic,
@@ -114,6 +116,7 @@ export interface ObservableLogicConfig<
   TEmitted extends EventObject = EventObject,
   TInputSchema extends StandardSchemaV1 = StandardSchemaV1
 > {
+  validator?: ActorLogicValidator;
   schemas?: {
     input?: TInputSchema;
   };
@@ -142,6 +145,7 @@ export interface EventObservableLogicConfig<
   TEmitted extends EventObject = EventObject,
   TInputSchema extends StandardSchemaV1 = StandardSchemaV1
 > {
+  validator?: ActorLogicValidator;
   schemas?: {
     input?: TInputSchema;
   };
@@ -202,11 +206,7 @@ export function createObservableLogic<
     StandardSchemaV1.InferOutput<TInputSchema>,
     TEmitted,
     TInputSchema
-  > & {
-    schemas: {
-      input: TInputSchema;
-    };
-  }
+  > & { schemas: { input: TInputSchema } }
 ): ObservableActorLogic<
   TContext,
   StandardSchemaV1.InferOutput<TInputSchema>,
@@ -245,6 +245,10 @@ export function createObservableLogic<
     typeof observableCreatorOrConfig === 'function'
       ? undefined
       : observableCreatorOrConfig.schemas;
+  const validator =
+    typeof observableCreatorOrConfig === 'function'
+      ? undefined
+      : observableCreatorOrConfig.validator;
 
   return createBaseLogic<
     TContext | undefined,
@@ -253,6 +257,7 @@ export function createObservableLogic<
     TInput,
     TEmitted
   >({
+    validator,
     schemas,
     context: undefined,
     run: (args, enq) => {
@@ -385,11 +390,7 @@ export function createEventObservableLogic<
     StandardSchemaV1.InferOutput<TInputSchema>,
     TEmitted,
     TInputSchema
-  > & {
-    schemas: {
-      input: TInputSchema;
-    };
-  }
+  > & { schemas: { input: TInputSchema } }
 ): ObservableActorLogic<
   TEvent,
   StandardSchemaV1.InferOutput<TInputSchema>,
@@ -424,10 +425,15 @@ export function createEventObservableLogic<
     typeof lazyObservableOrConfig === 'function'
       ? lazyObservableOrConfig
       : lazyObservableOrConfig.run;
+  const validator =
+    typeof lazyObservableOrConfig === 'function'
+      ? undefined
+      : lazyObservableOrConfig.validator;
 
   // TODO: event types
   const logic: ObservableActorLogic<TEvent, TInput, TEmitted> = {
-    config: lazyObservable,
+    config: lazyObservableOrConfig,
+    validator,
     transition: (state, event, actorScope) => {
       if (state.status !== 'active') {
         return [state, []];
@@ -478,17 +484,20 @@ export function createEventObservableLogic<
           return [state, []];
       }
     },
-    initialTransition: (input, _) => [
-      {
+    initialTransition: (input, _) => {
+      if (validator) {
+        assertValid(validator, { kind: 'input', logic, input });
+      }
+      const snapshot = {
         status: 'active',
         output: undefined,
         error: undefined,
         context: undefined,
         input,
         _subscription: undefined
-      },
-      []
-    ],
+      } as ObservableSnapshot<TEvent, TInput>;
+      return [snapshot, []];
+    },
     getInitialSnapshot: (actorScope, input) =>
       logic.initialTransition(input, actorScope)[0],
     start: (state, { self, system, emit }) => {

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -2,6 +2,7 @@ import { parseDelayToMilliseconds } from '../delay.ts';
 import { XSTATE_INIT } from '../constants.ts';
 import { StandardSchemaV1 } from '../schema.types.ts';
 import { AnyActorSystem } from '../system.ts';
+import type { ActorLogicValidator } from '../validation.types.ts';
 import {
   ActorLogic,
   ActorFromLogic,
@@ -105,6 +106,7 @@ export interface LogicConfig<
    * particular actor instance.
    */
   id?: string;
+  validator?: ActorLogicValidator;
   /** Schemas for inferring async logic types. */
   schemas?: {
     input?: TInputSchema;
@@ -233,10 +235,7 @@ export function createAsyncLogic<
     TInputSchema,
     TOutputSchema
   > & {
-    schemas: {
-      input: TInputSchema;
-      output: TOutputSchema;
-    };
+    schemas: { input: TInputSchema; output: TOutputSchema };
   }
 ): AsyncActorLogic<
   StandardSchemaV1.InferOutput<TOutputSchema>,
@@ -261,10 +260,7 @@ export function createAsyncLogic<
     >,
     'run' | 'schemas'
   > & {
-    schemas: {
-      input: TInputSchema;
-      output?: never;
-    };
+    schemas: { input: TInputSchema; output?: never };
     run: TLogicFunction;
   }
 ): AsyncActorLogic<
@@ -284,10 +280,7 @@ export function createAsyncLogic<
     StandardSchemaV1,
     TOutputSchema
   > & {
-    schemas: {
-      input?: never;
-      output: TOutputSchema;
-    };
+    schemas: { input?: never; output: TOutputSchema };
   }
 ): AsyncActorLogic<
   StandardSchemaV1.InferOutput<TOutputSchema>,
@@ -339,6 +332,7 @@ export function createAsyncLogic<
     TEmitted
   >({
     id: config.id,
+    validator: config.validator,
     schemas: config.schemas,
     context: undefined,
     run: ({ event, input, self, system }, enq) => {

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -383,11 +383,16 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
   }
 
   /** Recover via the logic's error event if possible; otherwise error out. */
-  private _recoverOrError(err: unknown, snapshot?: SnapshotFrom<TLogic>) {
-    if (!this._tryHandleExecutionError(err, snapshot)) {
-      this._setErrorSnapshot(err);
-      this._error(err);
+  private _recoverOrError(
+    err: unknown,
+    snapshot?: SnapshotFrom<TLogic>
+  ): boolean {
+    if (this._tryHandleExecutionError(err, snapshot)) {
+      return true;
     }
+    this._setErrorSnapshot(err);
+    this._error(err);
+    return false;
   }
 
   private _tryHandleExecutionError(
@@ -460,6 +465,13 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
         // `@xstate.terminate` effect returned by the actor logic.
         break;
     }
+    this._inspectTransition(this._snapshot, event);
+  }
+
+  private _inspectTransition(
+    snapshot: SnapshotFrom<TLogic>,
+    event: EventObject
+  ): void {
     this.system._sendInspectionEvent({
       type: '@xstate.transition',
       actorRef: this as any,
@@ -472,7 +484,6 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
       sent: this._collectedSent,
       eventType: event.type
     });
-    // reset facets after emission
     this._collectedMicrosteps = [] as any;
     this._collectedActions = [];
     this._collectedSent = [];
@@ -779,7 +790,12 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     }
 
     if (caughtError) {
-      this._recoverOrError(caughtError.err);
+      this._collectedMicrosteps = [] as any;
+      this._collectedActions = [];
+      this._collectedSent = [];
+      if (!this._recoverOrError(caughtError.err)) {
+        this._inspectTransition(this._snapshot, event);
+      }
       return;
     }
 
@@ -791,7 +807,9 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
       executeExecutableEffects(effects, this._actorScope);
       this.update(snapshot, event);
     } catch (err) {
-      this._recoverOrError(err, snapshot);
+      if (!this._recoverOrError(err, snapshot)) {
+        this._inspectTransition(this._snapshot, event);
+      }
       return;
     }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,12 @@ export {
   type StandardSchemaV1,
   type TypeSchema
 } from './schema.types.ts';
+export type {
+  MachineValidationBoundary,
+  MachineValidationEventOrigin,
+  MachineValidationRequest,
+  MachineValidator
+} from './validation.types.ts';
 export { createSystem, setup } from './setup.ts';
 export type {
   AnySetupConfig,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -44,10 +44,10 @@ export {
   type TypeSchema
 } from './schema.types.ts';
 export type {
-  MachineValidationBoundary,
-  MachineValidationEventOrigin,
-  MachineValidationRequest,
-  MachineValidator
+  ActorValidationBoundary,
+  ActorValidationEventOrigin,
+  ActorValidationRequest,
+  ActorLogicValidator
 } from './validation.types.ts';
 export { createSystem, setup } from './setup.ts';
 export type {

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1,5 +1,5 @@
 import { SetupStateSchemas, StandardSchemaV1 } from './schema.types.ts';
-import type { MachineValidator } from './validation.types.ts';
+import type { ActorLogicValidator } from './validation.types.ts';
 import { StateMachine } from './StateMachine.ts';
 import {
   createActor as createActorFromLogic,
@@ -68,7 +68,9 @@ export type SetupConfig<
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
-  TValidator extends MachineValidator | undefined = MachineValidator | undefined
+  TValidator extends ActorLogicValidator | undefined =
+    | ActorLogicValidator
+    | undefined
 > = {
   validator?: TValidator;
   schemas?: TSchemas & SetupSchemas;
@@ -86,7 +88,7 @@ export type AnySetupConfig = SetupConfig<
   Sources['actors'],
   Sources['guards'],
   Sources['delays'],
-  MachineValidator | undefined
+  ActorLogicValidator | undefined
 >;
 
 interface RuntimeValidationDoesNotSupportTransformingSchemas {
@@ -156,7 +158,7 @@ type ValidateSetupStates<TStates> =
 
 type RuntimeValidationConstraint<TSchemas, TStates, TValidator> = [
   TValidator
-] extends [MachineValidator]
+] extends [ActorLogicValidator]
   ? {
       schemas?: ValidateSetupSchemas<TSchemas>;
       states?: ValidateSetupStates<TStates>;
@@ -188,7 +190,7 @@ type SetupExtensionConfig<
   TExtendActorMap extends Sources['actors'],
   TExtendGuardMap extends Sources['guards'],
   TExtendDelayMap extends Sources['delays'],
-  TExtendValidator extends MachineValidator | undefined | InheritedValidator
+  TExtendValidator extends ActorLogicValidator | undefined | InheritedValidator
 > = Omit<
   SetupConfig<
     TExtendSchemas,
@@ -201,7 +203,9 @@ type SetupExtensionConfig<
   'validator'
 > &
   ExtendValidatorConfig<TExtendValidator> &
-  (TBaseValidator extends MachineValidator ? unknown : { validator?: never }) &
+  (TBaseValidator extends ActorLogicValidator
+    ? unknown
+    : { validator?: never }) &
   RuntimeValidationConstraint<
     NoInfer<TBaseSchemas>,
     NoInfer<TBaseStates>,
@@ -1755,7 +1759,7 @@ export interface SetupReturn<
   TSetupDelayMap extends Sources['delays'] = {},
   TSetupDelays extends string = Extract<keyof TSetupDelayMap, string>,
   TSystemRegistry extends SystemRegistry = SystemRegistry,
-  TValidator extends MachineValidator | undefined = undefined
+  TValidator extends ActorLogicValidator | undefined = undefined
 > {
   /** Extends the setup configuration */
   extend<
@@ -1766,7 +1770,7 @@ export interface SetupReturn<
     TExtendGuardMap extends Sources['guards'] = {},
     TExtendDelayMap extends Sources['delays'] = {},
     const TExtendValidator extends
-      | MachineValidator
+      | ActorLogicValidator
       | undefined
       | InheritedValidator = InheritedValidator
   >(
@@ -1918,7 +1922,7 @@ export interface SetupReturn<
         meta?: TMetaSchema;
         tags?: TTagSchema;
         children?: TChildrenSchemaMap;
-      } & ([TValidator] extends [MachineValidator]
+      } & ([TValidator] extends [ActorLogicValidator]
         ? ValidateSetupSchemas<
             InlineMachineSchemas<
               TContextSchema,
@@ -2086,7 +2090,7 @@ export type SetupReturnFromConfig<TConfig extends AnySetupConfig> = SetupReturn<
   SetupConfigDelays<TConfig>,
   Extract<keyof SetupConfigDelays<TConfig>, string>,
   SystemRegistry,
-  TConfig extends { validator: infer TValidator extends MachineValidator }
+  TConfig extends { validator: infer TValidator extends ActorLogicValidator }
     ? TValidator
     : undefined
 >;
@@ -2138,7 +2142,7 @@ export function setup<
   TActorMap extends Sources['actors'] = {},
   TGuardMap extends Sources['guards'] = {},
   TDelayMap extends Sources['delays'] = {},
-  const TValidator extends MachineValidator | undefined = undefined
+  const TValidator extends ActorLogicValidator | undefined = undefined
 >(
   config: SetupConfig<
     TSchemas,
@@ -2179,7 +2183,9 @@ export function setup<
   TActorMap extends Sources['actors'] = {},
   TGuardMap extends Sources['guards'] = {},
   TDelayMap extends Sources['delays'] = {},
-  TValidator extends MachineValidator | undefined = MachineValidator | undefined
+  TValidator extends ActorLogicValidator | undefined =
+    | ActorLogicValidator
+    | undefined
 >(
   config: SetupConfig<
     TSchemas,
@@ -2220,7 +2226,7 @@ export function setup<
       TExtendGuardMap extends Sources['guards'] = {},
       TExtendDelayMap extends Sources['delays'] = {},
       const TExtendValidator extends
-        | MachineValidator
+        | ActorLogicValidator
         | undefined
         | InheritedValidator = InheritedValidator
     >(

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1,4 +1,5 @@
 import { SetupStateSchemas, StandardSchemaV1 } from './schema.types.ts';
+import type { MachineValidator } from './validation.types.ts';
 import { StateMachine } from './StateMachine.ts';
 import {
   createActor as createActorFromLogic,
@@ -66,8 +67,10 @@ export type SetupConfig<
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
-  TDelayMap extends Sources['delays']
+  TDelayMap extends Sources['delays'],
+  TValidator extends MachineValidator | undefined = MachineValidator | undefined
 > = {
+  validator?: TValidator;
   schemas?: TSchemas & SetupSchemas;
   states?: TStates;
   actions?: TActionMap;
@@ -82,8 +85,169 @@ export type AnySetupConfig = SetupConfig<
   Sources['actions'],
   Sources['actors'],
   Sources['guards'],
-  Sources['delays']
+  Sources['delays'],
+  MachineValidator | undefined
 >;
+
+interface RuntimeValidationDoesNotSupportTransformingSchemas {
+  readonly __xstate_error: 'Runtime validation does not support schemas with different input and output types';
+}
+
+type IsAny<T> = 0 extends 1 & T ? true : false;
+
+type AssertNonTransformingSchema<TSchema extends StandardSchemaV1> =
+  IsAny<StandardSchemaV1.InferInput<TSchema>> extends true
+    ? TSchema
+    : IsAny<StandardSchemaV1.InferOutput<TSchema>> extends true
+      ? TSchema
+      : [
+            StandardSchemaV1.InferInput<TSchema>,
+            StandardSchemaV1.InferOutput<TSchema>
+          ] extends [
+            StandardSchemaV1.InferOutput<TSchema>,
+            StandardSchemaV1.InferInput<TSchema>
+          ]
+        ? TSchema
+        : RuntimeValidationDoesNotSupportTransformingSchemas;
+
+type ValidateSchemaMap<TMap> =
+  TMap extends Record<string, StandardSchemaV1>
+    ? {
+        [K in keyof TMap]: TMap[K] extends StandardSchemaV1
+          ? AssertNonTransformingSchema<TMap[K]>
+          : TMap[K];
+      }
+    : TMap;
+
+type ValidateSetupSchemas<TSchemas> = TSchemas extends SetupSchemas
+  ? {
+      [K in keyof TSchemas]: K extends 'events' | 'emitted' | 'children'
+        ? ValidateSchemaMap<TSchemas[K]>
+        : K extends 'context' | 'input' | 'output'
+          ? TSchemas[K] extends StandardSchemaV1
+            ? AssertNonTransformingSchema<TSchemas[K]>
+            : TSchemas[K]
+          : TSchemas[K];
+    }
+  : TSchemas;
+
+type ValidateSetupStates<TStates> =
+  TStates extends Record<string, SetupStateSchema>
+    ? {
+        [K in keyof TStates]: TStates[K] extends SetupStateSchema
+          ? Omit<TStates[K], 'schemas' | 'states'> & {
+              schemas?: TStates[K]['schemas'] extends SetupStateSchemas
+                ? {
+                    [P in keyof TStates[K]['schemas']]: TStates[K]['schemas'][P] extends StandardSchemaV1
+                      ? AssertNonTransformingSchema<TStates[K]['schemas'][P]>
+                      : TStates[K]['schemas'][P];
+                  }
+                : TStates[K]['schemas'];
+              states?: TStates[K]['states'] extends Record<
+                string,
+                SetupStateSchema
+              >
+                ? ValidateSetupStates<TStates[K]['states']>
+                : TStates[K]['states'];
+            }
+          : TStates[K];
+      }
+    : TStates;
+
+type RuntimeValidationConstraint<TSchemas, TStates, TValidator> = [
+  TValidator
+] extends [MachineValidator]
+  ? {
+      schemas?: ValidateSetupSchemas<TSchemas>;
+      states?: ValidateSetupStates<TStates>;
+    }
+  : unknown;
+
+declare const inheritedValidator: unique symbol;
+type InheritedValidator = typeof inheritedValidator;
+
+type ResolveExtendedValidator<TBase, TExtension> = [TExtension] extends [
+  InheritedValidator
+]
+  ? TBase
+  : Exclude<TExtension, InheritedValidator>;
+
+type ExtendValidatorConfig<TExtension> = [TExtension] extends [
+  InheritedValidator
+]
+  ? { validator?: never }
+  : { validator: TExtension };
+
+type SetupExtensionConfig<
+  TBaseSchemas,
+  TBaseStates,
+  TBaseValidator,
+  TExtendSchemas extends SetupSchemas,
+  TExtendStates extends Record<string, SetupStateSchema>,
+  TExtendActionMap extends Sources['actions'],
+  TExtendActorMap extends Sources['actors'],
+  TExtendGuardMap extends Sources['guards'],
+  TExtendDelayMap extends Sources['delays'],
+  TExtendValidator extends MachineValidator | undefined | InheritedValidator
+> = Omit<
+  SetupConfig<
+    TExtendSchemas,
+    TExtendStates,
+    TExtendActionMap,
+    TExtendActorMap,
+    TExtendGuardMap,
+    TExtendDelayMap
+  >,
+  'validator'
+> &
+  ExtendValidatorConfig<TExtendValidator> &
+  (TBaseValidator extends MachineValidator ? unknown : { validator?: never }) &
+  RuntimeValidationConstraint<
+    NoInfer<TBaseSchemas>,
+    NoInfer<TBaseStates>,
+    ResolveExtendedValidator<TBaseValidator, TExtendValidator>
+  > &
+  RuntimeValidationConstraint<
+    NoInfer<TExtendSchemas>,
+    NoInfer<TExtendStates>,
+    ResolveExtendedValidator<TBaseValidator, TExtendValidator>
+  >;
+
+type InlineMachineSchemas<
+  TContextSchema,
+  TEventSchemaMap,
+  TEmittedSchemaMap,
+  TActionSchemaMap,
+  TGuardSchemaMap,
+  TInputSchema,
+  TOutputSchema,
+  TMetaSchema,
+  TTagSchema,
+  TChildrenSchemaMap
+> = {
+  context?: TContextSchema;
+  events?: TEventSchemaMap;
+  emitted?: TEmittedSchemaMap;
+  actions?: TActionSchemaMap;
+  guards?: TGuardSchemaMap;
+  input?: TInputSchema;
+  output?: TOutputSchema;
+  meta?: TMetaSchema;
+  tags?: TTagSchema;
+  children?: TChildrenSchemaMap;
+};
+
+type MachineConfigStates<TConfig> = TConfig extends {
+  states?: infer TStates;
+}
+  ? TStates
+  : {};
+
+type MachineConfigSchemas<TConfig> = TConfig extends {
+  schemas?: infer TSchemas;
+}
+  ? TSchemas
+  : {};
 
 export type SystemConfig<TSystemRegistry extends SystemRegistry> = {
   registry?: TSystemRegistry;
@@ -1590,7 +1754,8 @@ export interface SetupReturn<
   TSetupGuardMap extends Sources['guards'] = {},
   TSetupDelayMap extends Sources['delays'] = {},
   TSetupDelays extends string = Extract<keyof TSetupDelayMap, string>,
-  TSystemRegistry extends SystemRegistry = SystemRegistry
+  TSystemRegistry extends SystemRegistry = SystemRegistry,
+  TValidator extends MachineValidator | undefined = undefined
 > {
   /** Extends the setup configuration */
   extend<
@@ -1599,15 +1764,23 @@ export interface SetupReturn<
     TExtendActionMap extends Sources['actions'] = {},
     TExtendActorMap extends Sources['actors'] = {},
     TExtendGuardMap extends Sources['guards'] = {},
-    TExtendDelayMap extends Sources['delays'] = {}
+    TExtendDelayMap extends Sources['delays'] = {},
+    const TExtendValidator extends
+      | MachineValidator
+      | undefined
+      | InheritedValidator = InheritedValidator
   >(
-    config: SetupConfig<
+    config: SetupExtensionConfig<
+      TSchemas,
+      TStates,
+      TValidator,
       TExtendSchemas,
       TExtendStates,
       TExtendActionMap,
       TExtendActorMap,
       TExtendGuardMap,
-      TExtendDelayMap
+      TExtendDelayMap,
+      TExtendValidator
     >
   ): SetupReturn<
     MergeSourceMaps<TStates, TExtendStates>,
@@ -1617,7 +1790,8 @@ export interface SetupReturn<
     MergeSourceMaps<TSetupGuardMap, TExtendGuardMap>,
     MergeSourceMaps<TSetupDelayMap, TExtendDelayMap>,
     TSetupDelays | Extract<keyof TExtendDelayMap, string>,
-    TSystemRegistry
+    TSystemRegistry,
+    ResolveExtendedValidator<TValidator, TExtendValidator>
   >;
 
   /** Creates a state machine with the setup configuration */
@@ -1744,13 +1918,33 @@ export interface SetupReturn<
         meta?: TMetaSchema;
         tags?: TTagSchema;
         children?: TChildrenSchemaMap;
-      };
+      } & ([TValidator] extends [MachineValidator]
+        ? ValidateSetupSchemas<
+            InlineMachineSchemas<
+              TContextSchema,
+              TEventSchemaMap,
+              TEmittedSchemaMap,
+              TActionSchemaMap,
+              TGuardSchemaMap,
+              TInputSchema,
+              TOutputSchema,
+              TMetaSchema,
+              TTagSchema,
+              TChildrenSchemaMap
+            >
+          >
+        : unknown);
       actions?: TActionMap;
       actors?: TActorMap;
       guards?: TGuardMap;
       delays?: TDelayMap;
       states?: Record<TStateKeys, unknown>;
     } & TConfig &
+      RuntimeValidationConstraint<
+        NoInfer<MachineConfigSchemas<TConfig>>,
+        NoInfer<MachineConfigStates<TConfig>>,
+        TValidator
+      > &
       ValidateSetupDelayReferences<TConfig, TSetupDelays> &
       ValidateHistoryDefaults<TConfig> &
       ValidateStateTargets<TConfig> &
@@ -1889,7 +2083,12 @@ export type SetupReturnFromConfig<TConfig extends AnySetupConfig> = SetupReturn<
   SetupConfigActions<TConfig>,
   SetupConfigActors<TConfig>,
   SetupConfigGuards<TConfig>,
-  SetupConfigDelays<TConfig>
+  SetupConfigDelays<TConfig>,
+  Extract<keyof SetupConfigDelays<TConfig>, string>,
+  SystemRegistry,
+  TConfig extends { validator: infer TValidator extends MachineValidator }
+    ? TValidator
+    : undefined
 >;
 
 /**
@@ -1938,7 +2137,8 @@ export function setup<
   TActionMap extends Sources['actions'] = {},
   TActorMap extends Sources['actors'] = {},
   TGuardMap extends Sources['guards'] = {},
-  TDelayMap extends Sources['delays'] = {}
+  TDelayMap extends Sources['delays'] = {},
+  const TValidator extends MachineValidator | undefined = undefined
 >(
   config: SetupConfig<
     TSchemas,
@@ -1946,11 +2146,28 @@ export function setup<
     TActionMap,
     TActorMap,
     TGuardMap,
-    TDelayMap
-  >
-): SetupReturn<TStates, TSchemas, TActionMap, TActorMap, TGuardMap, TDelayMap>;
+    TDelayMap,
+    TValidator
+  > &
+    RuntimeValidationConstraint<NoInfer<TSchemas>, NoInfer<TStates>, TValidator>
+): SetupReturn<
+  TStates,
+  TSchemas,
+  TActionMap,
+  TActorMap,
+  TGuardMap,
+  TDelayMap,
+  Extract<keyof TDelayMap, string>,
+  SystemRegistry,
+  TValidator
+>;
 export function setup<const TConfig extends AnySetupConfig>(
-  config: TConfig
+  config: TConfig &
+    RuntimeValidationConstraint<
+      NoInfer<SetupConfigSchemas<TConfig>>,
+      NoInfer<SetupConfigStates<TConfig>>,
+      TConfig extends { validator: infer TValidator } ? TValidator : undefined
+    >
 ): SetupReturnFromConfig<TConfig>;
 export function setup<
   const TSchemas extends SetupSchemas = {},
@@ -1961,7 +2178,8 @@ export function setup<
   TActionMap extends Sources['actions'] = {},
   TActorMap extends Sources['actors'] = {},
   TGuardMap extends Sources['guards'] = {},
-  TDelayMap extends Sources['delays'] = {}
+  TDelayMap extends Sources['delays'] = {},
+  TValidator extends MachineValidator | undefined = MachineValidator | undefined
 >(
   config: SetupConfig<
     TSchemas,
@@ -1969,10 +2187,22 @@ export function setup<
     TActionMap,
     TActorMap,
     TGuardMap,
-    TDelayMap
+    TDelayMap,
+    TValidator
   > = {}
-): SetupReturn<TStates, TSchemas, TActionMap, TActorMap, TGuardMap, TDelayMap> {
+): SetupReturn<
+  TStates,
+  TSchemas,
+  TActionMap,
+  TActorMap,
+  TGuardMap,
+  TDelayMap,
+  Extract<keyof TDelayMap, string>,
+  SystemRegistry,
+  TValidator
+> {
   const {
+    validator,
     states = {} as TStates,
     schemas,
     actions,
@@ -1988,18 +2218,28 @@ export function setup<
       TExtendActionMap extends Sources['actions'] = {},
       TExtendActorMap extends Sources['actors'] = {},
       TExtendGuardMap extends Sources['guards'] = {},
-      TExtendDelayMap extends Sources['delays'] = {}
+      TExtendDelayMap extends Sources['delays'] = {},
+      const TExtendValidator extends
+        | MachineValidator
+        | undefined
+        | InheritedValidator = InheritedValidator
     >(
-      extension: SetupConfig<
+      extension: SetupExtensionConfig<
+        TSchemas,
+        TStates,
+        TValidator,
         TExtendSchemas,
         TExtendStates,
         TExtendActionMap,
         TExtendActorMap,
         TExtendGuardMap,
-        TExtendDelayMap
+        TExtendDelayMap,
+        TExtendValidator
       >
     ) {
-      return setup(mergeSetupConfigs(config, extension)) as SetupReturn<
+      return setup(
+        mergeSetupConfigs(config, extension as AnySetupConfig) as any
+      ) as SetupReturn<
         MergeSourceMaps<TStates, TExtendStates>,
         MergeSourceMaps<TSchemas, TExtendSchemas>,
         MergeSourceMaps<TActionMap, TExtendActionMap>,
@@ -2007,7 +2247,9 @@ export function setup<
         MergeSourceMaps<TGuardMap, TExtendGuardMap>,
         MergeSourceMaps<TDelayMap, TExtendDelayMap>,
         | Extract<keyof TDelayMap, string>
-        | Extract<keyof TExtendDelayMap, string>
+        | Extract<keyof TExtendDelayMap, string>,
+        SystemRegistry,
+        ResolveExtendedValidator<TValidator, TExtendValidator>
       >;
     },
     createMachine(machineConfig) {
@@ -2019,15 +2261,19 @@ export function setup<
       const mergedGuards = mergeMaps(guards, machineConfig.guards);
       const mergedDelays = mergeMaps(delays, machineConfig.delays);
 
-      return new StateMachine({
-        ...machineConfig,
-        ...(mergedSchemas ? { schemas: mergedSchemas } : undefined),
-        ...(mergedStates ? { states: mergedStates } : undefined),
-        ...(mergedActions ? { actions: mergedActions } : undefined),
-        ...(mergedActors ? { actors: mergedActors } : undefined),
-        ...(mergedGuards ? { guards: mergedGuards } : undefined),
-        ...(mergedDelays ? { delays: mergedDelays } : undefined)
-      } as any) as any;
+      return new StateMachine(
+        {
+          ...machineConfig,
+          ...(mergedSchemas ? { schemas: mergedSchemas } : undefined),
+          ...(mergedStates ? { states: mergedStates } : undefined),
+          ...(mergedActions ? { actions: mergedActions } : undefined),
+          ...(mergedActors ? { actors: mergedActors } : undefined),
+          ...(mergedGuards ? { guards: mergedGuards } : undefined),
+          ...(mergedDelays ? { delays: mergedDelays } : undefined)
+        } as any,
+        undefined,
+        validator
+      ) as any;
     },
     createStateConfig(...args: unknown[]) {
       return args.length > 1 ? args[1] : args[0];

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1109,7 +1109,6 @@ export interface AnyStateMachine extends AnyActorLogic {
   config: any;
   version?: string;
   schemas?: import('./types.v6.ts').AnyMachineSchemas;
-  validator?: import('./validation.types.ts').MachineValidator;
   provide(sources: any): AnyStateMachine;
   resolveState(config: any): any;
   /** @internal */
@@ -2216,6 +2215,8 @@ export interface ActorLogic<
 > {
   /** The initial setup/configuration used to create the actor logic. */
   config?: unknown;
+  /** Optional runtime validator for pure calculation boundaries. */
+  validator?: import('./validation.types.ts').ActorLogicValidator;
   /**
    * Transition function that processes the current state and an incoming event
    * to produce a new state and effects.
@@ -2302,6 +2303,7 @@ export interface ActorLogic<
 
 export interface AnyActorLogic {
   config?: unknown;
+  validator?: import('./validation.types.ts').ActorLogicValidator;
   transition(
     snapshot: any,
     event: any,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1108,6 +1108,8 @@ export interface AnyStateMachine extends AnyActorLogic {
   sources: Sources;
   config: any;
   version?: string;
+  schemas?: import('./types.v6.ts').AnyMachineSchemas;
+  validator?: import('./validation.types.ts').MachineValidator;
   provide(sources: any): AnyStateMachine;
   resolveState(config: any): any;
   /** @internal */

--- a/packages/core/src/validation.ts
+++ b/packages/core/src/validation.ts
@@ -1,0 +1,14 @@
+import type {
+  ActorLogicValidator,
+  ActorValidationRequest
+} from './validation.types.ts';
+
+export function assertValid(
+  validator: ActorLogicValidator,
+  request: ActorValidationRequest
+): void {
+  const error = validator.check(request);
+  if (error) {
+    throw error;
+  }
+}

--- a/packages/core/src/validation.types.ts
+++ b/packages/core/src/validation.types.ts
@@ -1,0 +1,42 @@
+import type {
+  AnyEventObject,
+  AnyMachineSnapshot,
+  AnyStateMachine,
+  ExecutableActionObject
+} from './types.ts';
+
+export type MachineValidationBoundary =
+  | 'input'
+  | 'event'
+  | 'context'
+  | 'state.input'
+  | 'state.context'
+  | 'emitted'
+  | 'output'
+  | 'child';
+
+export type MachineValidationEventOrigin = 'external' | 'actor' | 'raised';
+
+export type MachineValidationRequest =
+  | {
+      kind: 'input';
+      machine: AnyStateMachine;
+      input: unknown;
+    }
+  | {
+      kind: 'event';
+      machine: AnyStateMachine;
+      event: AnyEventObject;
+      eventOrigin: Exclude<MachineValidationEventOrigin, 'raised'>;
+    }
+  | {
+      kind: 'result';
+      machine: AnyStateMachine;
+      snapshot: AnyMachineSnapshot;
+      effects: readonly ExecutableActionObject[];
+    };
+
+/** Runtime schema validator installed through `setup({ validator })`. */
+export interface MachineValidator {
+  check(request: MachineValidationRequest): Error | undefined;
+}

--- a/packages/core/src/validation.types.ts
+++ b/packages/core/src/validation.types.ts
@@ -1,11 +1,11 @@
 import type {
+  AnyActorLogic,
   AnyEventObject,
-  AnyMachineSnapshot,
-  AnyStateMachine,
-  ExecutableActionObject
+  ExecutableActionObject,
+  Snapshot
 } from './types.ts';
 
-export type MachineValidationBoundary =
+export type ActorValidationBoundary =
   | 'input'
   | 'event'
   | 'context'
@@ -15,28 +15,28 @@ export type MachineValidationBoundary =
   | 'output'
   | 'child';
 
-export type MachineValidationEventOrigin = 'external' | 'actor' | 'raised';
+export type ActorValidationEventOrigin = 'external' | 'actor' | 'raised';
 
-export type MachineValidationRequest =
+export type ActorValidationRequest =
   | {
       kind: 'input';
-      machine: AnyStateMachine;
+      logic: AnyActorLogic;
       input: unknown;
     }
   | {
       kind: 'event';
-      machine: AnyStateMachine;
+      logic: AnyActorLogic;
       event: AnyEventObject;
-      eventOrigin: Exclude<MachineValidationEventOrigin, 'raised'>;
+      eventOrigin: Exclude<ActorValidationEventOrigin, 'raised'>;
     }
   | {
       kind: 'result';
-      machine: AnyStateMachine;
-      snapshot: AnyMachineSnapshot;
+      logic: AnyActorLogic;
+      snapshot: Snapshot<unknown>;
       effects: readonly ExecutableActionObject[];
     };
 
-/** Runtime schema validator installed through `setup({ validator })`. */
-export interface MachineValidator {
-  check(request: MachineValidationRequest): Error | undefined;
+/** Runtime schema validator installed on actor logic. */
+export interface ActorLogicValidator {
+  check(request: ActorValidationRequest): Error | undefined;
 }

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -1,16 +1,19 @@
 import type { StandardSchemaV1 } from '../schema.types.ts';
 import type {
-  MachineValidationBoundary,
-  MachineValidationEventOrigin,
-  MachineValidationRequest,
-  MachineValidator
+  ActorValidationBoundary,
+  ActorValidationEventOrigin,
+  ActorLogicValidator
 } from '../validation.types.ts';
+import type {
+  AnyActorLogic,
+  AnyMachineSnapshot,
+  AnyStateMachine,
+  ExecutableActionObject
+} from '../types.ts';
 
-const machineValidationErrorSymbol = Symbol.for(
-  'xstate.machineValidationError'
-);
+const actorValidationErrorSymbol = Symbol.for('xstate.actorValidationError');
 
-export type MachineValidationReason =
+export type ActorValidationReason =
   | 'invalid'
   | 'unknownEvent'
   | 'unknownEmitted'
@@ -18,37 +21,37 @@ export type MachineValidationReason =
   | 'asyncValidationUnsupported'
   | 'schemaThrew';
 
-export interface MachineValidationErrorOptions {
-  reason: MachineValidationReason;
-  boundary: MachineValidationBoundary;
-  machineId: string;
+export interface ActorValidationErrorOptions {
+  reason: ActorValidationReason;
+  boundary: ActorValidationBoundary;
+  logicId?: string;
   stateNodeId?: string;
   eventType?: string;
-  eventOrigin?: MachineValidationEventOrigin;
+  eventOrigin?: ActorValidationEventOrigin;
   childId?: string;
   issues?: readonly StandardSchemaV1.Issue[];
   cause?: unknown;
 }
 
 /** A structured failure produced by `standardSchemaValidator()`. */
-export class MachineValidationError extends Error {
-  public readonly [machineValidationErrorSymbol] = true;
-  public readonly reason: MachineValidationReason;
-  public readonly boundary: MachineValidationBoundary;
-  public readonly machineId: string;
+export class ActorValidationError extends Error {
+  public readonly [actorValidationErrorSymbol] = true;
+  public readonly reason: ActorValidationReason;
+  public readonly boundary: ActorValidationBoundary;
+  public readonly logicId?: string;
   public readonly stateNodeId?: string;
   public readonly eventType?: string;
-  public readonly eventOrigin?: MachineValidationEventOrigin;
+  public readonly eventOrigin?: ActorValidationEventOrigin;
   public readonly childId?: string;
   public readonly issues?: readonly StandardSchemaV1.Issue[];
   public override readonly cause?: unknown;
 
-  constructor(options: MachineValidationErrorOptions) {
+  constructor(options: ActorValidationErrorOptions) {
     super(getMessage(options), { cause: options.cause });
-    this.name = 'MachineValidationError';
+    this.name = 'ActorValidationError';
     this.reason = options.reason;
     this.boundary = options.boundary;
-    this.machineId = options.machineId;
+    this.logicId = options.logicId;
     this.stateNodeId = options.stateNodeId;
     this.eventType = options.eventType;
     this.eventOrigin = options.eventOrigin;
@@ -58,13 +61,13 @@ export class MachineValidationError extends Error {
   }
 }
 
-export function isMachineValidationError(
+export function isActorValidationError(
   value: unknown
-): value is MachineValidationError {
+): value is ActorValidationError {
   return !!(
     value &&
     typeof value === 'object' &&
-    machineValidationErrorSymbol in value
+    actorValidationErrorSymbol in value
   );
 }
 
@@ -76,24 +79,31 @@ export interface StandardSchemaValidatorOptions {
 interface ValidationTarget {
   schema: StandardSchemaV1 | undefined;
   value: unknown;
-  boundary: MachineValidationBoundary;
-  machineId: string;
+  boundary: ActorValidationBoundary;
+  logicId?: string;
   stateNodeId?: string;
   eventType?: string;
-  eventOrigin?: MachineValidationEventOrigin;
+  eventOrigin?: ActorValidationEventOrigin;
   childId?: string;
+}
+
+interface ActorSchemas {
+  input?: StandardSchemaV1;
+  output?: StandardSchemaV1;
+  events?: Record<string, StandardSchemaV1>;
+  emitted?: Record<string, StandardSchemaV1>;
 }
 
 /** Creates a synchronous, assertion-only Standard Schema validator. */
 export function standardSchemaValidator(
   options: StandardSchemaValidatorOptions = {}
-): MachineValidator {
+): ActorLogicValidator {
   const unknownEvents = options.unknownEvents ?? 'error';
   const unknownEmitted = options.unknownEmitted ?? 'error';
 
   const checkTarget = (
     target: ValidationTarget
-  ): MachineValidationError | undefined => {
+  ): ActorValidationError | undefined => {
     if (!target.schema) {
       if (target.boundary === 'event' && unknownEvents === 'error') {
         return createError(target, 'unknownEvent');
@@ -126,147 +136,174 @@ export function standardSchemaValidator(
   };
 
   const checkEvent = (
-    machine: MachineValidationRequest['machine'],
+    logic: AnyActorLogic,
     event: { type: string; [key: string]: unknown },
-    eventOrigin: MachineValidationEventOrigin
+    eventOrigin: ActorValidationEventOrigin
   ) => {
+    const schemas = getSchemas(logic);
     if (
-      !machine.schemas?.events ||
+      !schemas?.events ||
       event.type.startsWith('xstate.') ||
       event.type.startsWith('@xstate.')
     ) {
       return undefined;
     }
     return checkTarget({
-      schema: machine.schemas.events[event.type],
+      schema: schemas.events[event.type],
       value: getPayload(event),
       boundary: 'event',
-      machineId: machine.id,
+      logicId: getLogicId(logic),
       eventType: event.type,
       eventOrigin
     });
   };
 
-  return {
-    check(request) {
-      const { machine } = request;
-
-      if (request.kind === 'input') {
-        return checkTarget({
-          schema: machine.schemas?.input,
-          value: request.input,
-          boundary: 'input',
-          machineId: machine.id
-        });
+  const checkEmitted = (
+    logic: AnyActorLogic,
+    effects: readonly ExecutableActionObject[]
+  ) => {
+    const schemas = getSchemas(logic);
+    if (!schemas?.emitted) {
+      return undefined;
+    }
+    for (const effect of effects) {
+      if (effect.kind !== 'emit') {
+        continue;
       }
-
-      if (request.kind === 'event') {
-        return checkEvent(machine, request.event, request.eventOrigin);
-      }
-
-      const { snapshot, effects } = request;
-      let error = checkTarget({
-        schema: machine.schemas?.context,
-        value: snapshot.context,
-        boundary: 'context',
-        machineId: machine.id
+      const error = checkTarget({
+        schema: schemas.emitted[effect.event.type],
+        value: getPayload(effect.event),
+        boundary: 'emitted',
+        logicId: getLogicId(logic),
+        eventType: effect.event.type
       });
       if (error) {
         return error;
       }
+    }
+    return undefined;
+  };
 
-      for (const stateNode of snapshot._nodes) {
+  const checkMachineResult = (
+    machine: AnyStateMachine,
+    snapshot: AnyMachineSnapshot
+  ) => {
+    let error = checkTarget({
+      schema: machine.schemas?.context,
+      value: snapshot.context,
+      boundary: 'context',
+      logicId: machine.id
+    });
+    if (error) {
+      return error;
+    }
+
+    for (const stateNode of snapshot._nodes) {
+      error = checkTarget({
+        schema: stateNode.schemas?.context,
+        value: snapshot.context,
+        boundary: 'state.context',
+        logicId: machine.id,
+        stateNodeId: stateNode.id
+      });
+      if (error) {
+        return error;
+      }
+      if (stateNode.schemas?.input) {
         error = checkTarget({
-          schema: stateNode.schemas?.context,
-          value: snapshot.context,
-          boundary: 'state.context',
-          machineId: machine.id,
+          schema: stateNode.schemas.input,
+          value: snapshot._stateInputs[stateNode.id],
+          boundary: 'state.input',
+          logicId: machine.id,
           stateNodeId: stateNode.id
         });
         if (error) {
           return error;
         }
-        if (stateNode.schemas?.input) {
-          error = checkTarget({
-            schema: stateNode.schemas.input,
-            value: snapshot._stateInputs[stateNode.id],
-            boundary: 'state.input',
-            machineId: machine.id,
-            stateNodeId: stateNode.id
-          });
-          if (error) {
-            return error;
-          }
+      }
+    }
+
+    for (const childId of Object.keys(machine.schemas?.children ?? {})) {
+      const child = snapshot.children[childId];
+      if (child !== undefined) {
+        error = checkTarget({
+          schema: machine.schemas!.children![childId],
+          value: child,
+          boundary: 'child',
+          logicId: machine.id,
+          childId
+        });
+        if (error) {
+          return error;
         }
       }
+    }
 
-      for (const childId of Object.keys(machine.schemas?.children ?? {})) {
-        const child = snapshot.children[childId];
-        if (child !== undefined) {
-          error = checkTarget({
-            schema: machine.schemas!.children![childId],
-            value: child,
-            boundary: 'child',
-            machineId: machine.id,
-            childId
-          });
-          if (error) {
-            return error;
-          }
+    for (const timer of Object.values(snapshot.timers)) {
+      if (timer.type === '@xstate.raise') {
+        error = checkEvent(machine, timer.event, 'raised');
+        if (error) {
+          return error;
+        }
+      }
+    }
+
+    return undefined;
+  };
+
+  return {
+    check(request) {
+      const { logic } = request;
+      const schemas = getSchemas(logic);
+
+      if (request.kind === 'input') {
+        return checkTarget({
+          schema: schemas?.input,
+          value: request.input,
+          boundary: 'input',
+          logicId: getLogicId(logic)
+        });
+      }
+
+      if (request.kind === 'event') {
+        return checkEvent(logic, request.event, request.eventOrigin);
+      }
+
+      const { snapshot, effects } = request;
+      if (isStateMachine(logic)) {
+        const error = checkMachineResult(logic, snapshot as AnyMachineSnapshot);
+        if (error) {
+          return error;
         }
       }
 
       if (snapshot.status === 'done') {
-        error = checkTarget({
-          schema: machine.schemas?.output,
+        const error = checkTarget({
+          schema: schemas?.output,
           value: snapshot.output,
           boundary: 'output',
-          machineId: machine.id
+          logicId: getLogicId(logic)
         });
         if (error) {
           return error;
         }
       }
 
-      for (const timer of Object.values(snapshot.timers)) {
-        if (timer.type === '@xstate.raise') {
-          error = checkEvent(machine, timer.event, 'raised');
-          if (error) {
-            return error;
-          }
-        }
-      }
-
-      for (const effect of effects) {
-        if (effect.kind === 'emit' && machine.schemas?.emitted) {
-          error = checkTarget({
-            schema: machine.schemas.emitted[effect.event.type],
-            value: getPayload(effect.event),
-            boundary: 'emitted',
-            machineId: machine.id,
-            eventType: effect.event.type
-          });
-          if (error) {
-            return error;
-          }
-        }
-      }
-
-      return undefined;
+      return checkEmitted(logic, effects);
     }
   };
 }
 
 function createError(
   request: ValidationTarget,
-  reason: MachineValidationReason,
+  reason: ActorValidationReason,
   issues?: readonly StandardSchemaV1.Issue[],
   cause?: unknown
-): MachineValidationError {
-  return new MachineValidationError({
+): ActorValidationError {
+  return new ActorValidationError({
     reason,
     boundary: request.boundary,
-    machineId: request.machineId,
+    ...(request.logicId === undefined ? {} : { logicId: request.logicId }),
     ...(request.stateNodeId === undefined
       ? {}
       : { stateNodeId: request.stateNodeId }),
@@ -282,6 +319,21 @@ function createError(
   });
 }
 
+function isStateMachine(logic: AnyActorLogic): logic is AnyStateMachine {
+  return 'root' in logic && 'schemas' in logic;
+}
+
+function getSchemas(logic: AnyActorLogic): ActorSchemas | undefined {
+  if (isStateMachine(logic)) {
+    return logic.schemas;
+  }
+  return (logic.config as { schemas?: ActorSchemas } | undefined)?.schemas;
+}
+
+function getLogicId(logic: AnyActorLogic): string | undefined {
+  return 'id' in logic && typeof logic.id === 'string' ? logic.id : undefined;
+}
+
 function getPayload(event: {
   type: string;
   [key: string]: unknown;
@@ -290,7 +342,7 @@ function getPayload(event: {
   return payload;
 }
 
-function getMessage(options: MachineValidationErrorOptions): string {
+function getMessage(options: ActorValidationErrorOptions): string {
   const subject =
     options.eventType !== undefined
       ? ` "${options.eventType}"`
@@ -319,8 +371,8 @@ function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
 }
 
 export type {
-  MachineValidationBoundary,
-  MachineValidationEventOrigin,
-  MachineValidationRequest,
-  MachineValidator
+  ActorValidationBoundary,
+  ActorValidationEventOrigin,
+  ActorValidationRequest,
+  ActorLogicValidator
 } from '../validation.types.ts';

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -1,0 +1,326 @@
+import type { StandardSchemaV1 } from '../schema.types.ts';
+import type {
+  MachineValidationBoundary,
+  MachineValidationEventOrigin,
+  MachineValidationRequest,
+  MachineValidator
+} from '../validation.types.ts';
+
+const machineValidationErrorSymbol = Symbol.for(
+  'xstate.machineValidationError'
+);
+
+export type MachineValidationReason =
+  | 'invalid'
+  | 'unknownEvent'
+  | 'unknownEmitted'
+  | 'transformationUnsupported'
+  | 'asyncValidationUnsupported'
+  | 'schemaThrew';
+
+export interface MachineValidationErrorOptions {
+  reason: MachineValidationReason;
+  boundary: MachineValidationBoundary;
+  machineId: string;
+  stateNodeId?: string;
+  eventType?: string;
+  eventOrigin?: MachineValidationEventOrigin;
+  childId?: string;
+  issues?: readonly StandardSchemaV1.Issue[];
+  cause?: unknown;
+}
+
+/** A structured failure produced by `standardSchemaValidator()`. */
+export class MachineValidationError extends Error {
+  public readonly [machineValidationErrorSymbol] = true;
+  public readonly reason: MachineValidationReason;
+  public readonly boundary: MachineValidationBoundary;
+  public readonly machineId: string;
+  public readonly stateNodeId?: string;
+  public readonly eventType?: string;
+  public readonly eventOrigin?: MachineValidationEventOrigin;
+  public readonly childId?: string;
+  public readonly issues?: readonly StandardSchemaV1.Issue[];
+  public override readonly cause?: unknown;
+
+  constructor(options: MachineValidationErrorOptions) {
+    super(getMessage(options), { cause: options.cause });
+    this.name = 'MachineValidationError';
+    this.reason = options.reason;
+    this.boundary = options.boundary;
+    this.machineId = options.machineId;
+    this.stateNodeId = options.stateNodeId;
+    this.eventType = options.eventType;
+    this.eventOrigin = options.eventOrigin;
+    this.childId = options.childId;
+    this.issues = options.issues;
+    this.cause = options.cause;
+  }
+}
+
+export function isMachineValidationError(
+  value: unknown
+): value is MachineValidationError {
+  return !!(
+    value &&
+    typeof value === 'object' &&
+    machineValidationErrorSymbol in value
+  );
+}
+
+export interface StandardSchemaValidatorOptions {
+  unknownEvents?: 'error' | 'ignore';
+  unknownEmitted?: 'error' | 'ignore';
+}
+
+interface ValidationTarget {
+  schema: StandardSchemaV1 | undefined;
+  value: unknown;
+  boundary: MachineValidationBoundary;
+  machineId: string;
+  stateNodeId?: string;
+  eventType?: string;
+  eventOrigin?: MachineValidationEventOrigin;
+  childId?: string;
+}
+
+/** Creates a synchronous, assertion-only Standard Schema validator. */
+export function standardSchemaValidator(
+  options: StandardSchemaValidatorOptions = {}
+): MachineValidator {
+  const unknownEvents = options.unknownEvents ?? 'error';
+  const unknownEmitted = options.unknownEmitted ?? 'error';
+
+  const checkTarget = (
+    target: ValidationTarget
+  ): MachineValidationError | undefined => {
+    if (!target.schema) {
+      if (target.boundary === 'event' && unknownEvents === 'error') {
+        return createError(target, 'unknownEvent');
+      }
+      if (target.boundary === 'emitted' && unknownEmitted === 'error') {
+        return createError(target, 'unknownEmitted');
+      }
+      return undefined;
+    }
+
+    let result:
+      | StandardSchemaV1.Result<unknown>
+      | Promise<StandardSchemaV1.Result<unknown>>;
+    try {
+      result = target.schema['~standard'].validate(target.value);
+    } catch (cause) {
+      return createError(target, 'schemaThrew', undefined, cause);
+    }
+
+    if (isPromiseLike(result)) {
+      void Promise.resolve(result).catch(() => {});
+      return createError(target, 'asyncValidationUnsupported');
+    }
+
+    if (result.issues) {
+      return createError(target, 'invalid', result.issues);
+    }
+
+    return undefined;
+  };
+
+  const checkEvent = (
+    machine: MachineValidationRequest['machine'],
+    event: { type: string; [key: string]: unknown },
+    eventOrigin: MachineValidationEventOrigin
+  ) => {
+    if (
+      !machine.schemas?.events ||
+      event.type.startsWith('xstate.') ||
+      event.type.startsWith('@xstate.')
+    ) {
+      return undefined;
+    }
+    return checkTarget({
+      schema: machine.schemas.events[event.type],
+      value: getPayload(event),
+      boundary: 'event',
+      machineId: machine.id,
+      eventType: event.type,
+      eventOrigin
+    });
+  };
+
+  return {
+    check(request) {
+      const { machine } = request;
+
+      if (request.kind === 'input') {
+        return checkTarget({
+          schema: machine.schemas?.input,
+          value: request.input,
+          boundary: 'input',
+          machineId: machine.id
+        });
+      }
+
+      if (request.kind === 'event') {
+        return checkEvent(machine, request.event, request.eventOrigin);
+      }
+
+      const { snapshot, effects } = request;
+      let error = checkTarget({
+        schema: machine.schemas?.context,
+        value: snapshot.context,
+        boundary: 'context',
+        machineId: machine.id
+      });
+      if (error) {
+        return error;
+      }
+
+      for (const stateNode of snapshot._nodes) {
+        error = checkTarget({
+          schema: stateNode.schemas?.context,
+          value: snapshot.context,
+          boundary: 'state.context',
+          machineId: machine.id,
+          stateNodeId: stateNode.id
+        });
+        if (error) {
+          return error;
+        }
+        if (stateNode.schemas?.input) {
+          error = checkTarget({
+            schema: stateNode.schemas.input,
+            value: snapshot._stateInputs[stateNode.id],
+            boundary: 'state.input',
+            machineId: machine.id,
+            stateNodeId: stateNode.id
+          });
+          if (error) {
+            return error;
+          }
+        }
+      }
+
+      for (const childId of Object.keys(machine.schemas?.children ?? {})) {
+        const child = snapshot.children[childId];
+        if (child !== undefined) {
+          error = checkTarget({
+            schema: machine.schemas!.children![childId],
+            value: child,
+            boundary: 'child',
+            machineId: machine.id,
+            childId
+          });
+          if (error) {
+            return error;
+          }
+        }
+      }
+
+      if (snapshot.status === 'done') {
+        error = checkTarget({
+          schema: machine.schemas?.output,
+          value: snapshot.output,
+          boundary: 'output',
+          machineId: machine.id
+        });
+        if (error) {
+          return error;
+        }
+      }
+
+      for (const timer of Object.values(snapshot.timers)) {
+        if (timer.type === '@xstate.raise') {
+          error = checkEvent(machine, timer.event, 'raised');
+          if (error) {
+            return error;
+          }
+        }
+      }
+
+      for (const effect of effects) {
+        if (effect.kind === 'emit' && machine.schemas?.emitted) {
+          error = checkTarget({
+            schema: machine.schemas.emitted[effect.event.type],
+            value: getPayload(effect.event),
+            boundary: 'emitted',
+            machineId: machine.id,
+            eventType: effect.event.type
+          });
+          if (error) {
+            return error;
+          }
+        }
+      }
+
+      return undefined;
+    }
+  };
+}
+
+function createError(
+  request: ValidationTarget,
+  reason: MachineValidationReason,
+  issues?: readonly StandardSchemaV1.Issue[],
+  cause?: unknown
+): MachineValidationError {
+  return new MachineValidationError({
+    reason,
+    boundary: request.boundary,
+    machineId: request.machineId,
+    ...(request.stateNodeId === undefined
+      ? {}
+      : { stateNodeId: request.stateNodeId }),
+    ...(request.eventType === undefined
+      ? {}
+      : { eventType: request.eventType }),
+    ...(request.eventOrigin === undefined
+      ? {}
+      : { eventOrigin: request.eventOrigin }),
+    ...(request.childId === undefined ? {} : { childId: request.childId }),
+    ...(issues === undefined ? {} : { issues }),
+    ...(cause === undefined ? {} : { cause })
+  });
+}
+
+function getPayload(event: {
+  type: string;
+  [key: string]: unknown;
+}): Record<string, unknown> {
+  const { type: _, ...payload } = event;
+  return payload;
+}
+
+function getMessage(options: MachineValidationErrorOptions): string {
+  const subject =
+    options.eventType !== undefined
+      ? ` "${options.eventType}"`
+      : options.childId !== undefined
+        ? ` "${options.childId}"`
+        : '';
+
+  switch (options.reason) {
+    case 'unknownEvent':
+      return `Unknown event${subject}`;
+    case 'unknownEmitted':
+      return `Unknown emitted event${subject}`;
+    case 'asyncValidationUnsupported':
+      return `Async schema validation is unsupported for ${options.boundary}${subject}`;
+    case 'transformationUnsupported':
+      return `Schema transformations are unsupported for ${options.boundary}${subject}`;
+    case 'schemaThrew':
+      return `Schema threw while validating ${options.boundary}${subject}`;
+    case 'invalid':
+      return `Invalid ${options.boundary}${subject}`;
+  }
+}
+
+function isPromiseLike<T>(value: T | PromiseLike<T>): value is PromiseLike<T> {
+  return !!value && typeof (value as any).then === 'function';
+}
+
+export type {
+  MachineValidationBoundary,
+  MachineValidationEventOrigin,
+  MachineValidationRequest,
+  MachineValidator
+} from '../validation.types.ts';

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -199,6 +199,11 @@ export function standardSchemaValidator(
     }
 
     for (const stateNode of snapshot._nodes) {
+      // the root state node reuses the machine-level `schemas` object, which is
+      // already validated above and elsewhere; those are not state-local
+      if (stateNode === machine.root) {
+        continue;
+      }
       error = checkTarget({
         schema: stateNode.schemas?.context,
         value: snapshot.context,

--- a/packages/core/test/runtimeValidation.test.ts
+++ b/packages/core/test/runtimeValidation.test.ts
@@ -1,17 +1,22 @@
 import { z } from 'zod';
 import {
   type AnyActorRef,
-  type MachineValidator,
-  createMachine,
+  type ActorLogicValidator,
   createActor,
+  createAsyncLogic,
+  createCallbackLogic,
+  createEventObservableLogic,
+  createLogic,
+  createMachine,
+  createObservableLogic,
   initialTransition,
   setup,
   transition,
   types
 } from '../src/index.ts';
 import {
-  MachineValidationError,
-  isMachineValidationError,
+  ActorValidationError,
+  isActorValidationError,
   standardSchemaValidator
 } from '../src/validation/index.ts';
 
@@ -25,15 +30,84 @@ function getThrown(fn: () => void): unknown {
 
 function expectValidationError(
   error: unknown,
-  boundary: MachineValidationError['boundary'],
-  reason: MachineValidationError['reason'] = 'invalid'
+  boundary: ActorValidationError['boundary'],
+  reason: ActorValidationError['reason'] = 'invalid'
 ) {
-  expect(error).toBeInstanceOf(MachineValidationError);
-  expect(isMachineValidationError(error)).toBe(true);
+  expect(error).toBeInstanceOf(ActorValidationError);
+  expect(isActorValidationError(error)).toBe(true);
   expect(error).toMatchObject({ boundary, reason });
 }
 
 describe('runtime schema validation', () => {
+  it('validates input across actor logic creators', () => {
+    const input = z.object({ count: z.number() });
+    const validator = standardSchemaValidator();
+    const subscribable = {
+      subscribe: () => ({ unsubscribe: () => {} })
+    };
+    const logics = [
+      createLogic({
+        validator,
+        schemas: { input },
+        context: undefined,
+        run: () => undefined
+      }),
+      createAsyncLogic({
+        validator,
+        schemas: { input },
+        run: async () => undefined
+      }),
+      createCallbackLogic({
+        validator,
+        schemas: { input },
+        run: () => undefined
+      }),
+      createObservableLogic({
+        validator,
+        schemas: { input },
+        run: () => subscribable
+      }),
+      createEventObservableLogic({
+        validator,
+        schemas: { input },
+        run: () => subscribable
+      })
+    ];
+
+    for (const logic of logics) {
+      expectValidationError(
+        getThrown(() =>
+          initialTransition(logic as any, { count: 'invalid' } as any)
+        ),
+        'input'
+      );
+    }
+  });
+
+  it('validates generic actor output before returning it', () => {
+    const effect = vi.fn();
+    const logic = createLogic({
+      validator: standardSchemaValidator(),
+      schemas: { output: z.number() },
+      context: undefined,
+      run: (_, enq) => {
+        enq.effect(effect);
+        return { status: 'done', output: 'invalid' as any };
+      }
+    });
+
+    expectValidationError(
+      getThrown(() => initialTransition(logic)),
+      'output'
+    );
+
+    const actor = createActor(logic);
+    actor.subscribe({ error: () => {} });
+    actor.start();
+    expect(actor.getSnapshot().status).toBe('error');
+    expect(effect).not.toHaveBeenCalled();
+  });
+
   it('can be disabled by a derived setup', () => {
     const validated = setup({
       validator: standardSchemaValidator(),
@@ -49,7 +123,7 @@ describe('runtime schema validation', () => {
   });
 
   it('calls validators only at pure calculation boundaries', () => {
-    const check = vi.fn<MachineValidator['check']>(() => undefined);
+    const check = vi.fn<ActorLogicValidator['check']>(() => undefined);
     const machine = setup({ validator: { check } }).createMachine({
       on: {
         GO: (_, enq) => {

--- a/packages/core/test/runtimeValidation.test.ts
+++ b/packages/core/test/runtimeValidation.test.ts
@@ -162,6 +162,23 @@ describe('runtime schema validation', () => {
     expect(context).not.toHaveBeenCalled();
   });
 
+  it('does not validate the machine input schema as root state input', () => {
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        input: z.object({ count: z.number() }),
+        events: { GO: z.object({}) }
+      }
+    }).createMachine({
+      initial: 'idle',
+      states: { idle: { on: { GO: { target: 'done' } } }, done: {} }
+    });
+
+    const [snapshot] = initialTransition(machine, { count: 1 });
+    expect(snapshot.value).toBe('idle');
+    expect(transition(machine, snapshot, { type: 'GO' })[0].value).toBe('done');
+  });
+
   it('validates external events before guard or transition selection', () => {
     const guard = vi.fn((_event: unknown) => true);
     const machine = setup({

--- a/packages/core/test/runtimeValidation.test.ts
+++ b/packages/core/test/runtimeValidation.test.ts
@@ -1,0 +1,559 @@
+import { z } from 'zod';
+import {
+  type AnyActorRef,
+  type MachineValidator,
+  createMachine,
+  createActor,
+  initialTransition,
+  setup,
+  transition,
+  types
+} from '../src/index.ts';
+import {
+  MachineValidationError,
+  isMachineValidationError,
+  standardSchemaValidator
+} from '../src/validation/index.ts';
+
+function getThrown(fn: () => void): unknown {
+  try {
+    fn();
+  } catch (error) {
+    return error;
+  }
+}
+
+function expectValidationError(
+  error: unknown,
+  boundary: MachineValidationError['boundary'],
+  reason: MachineValidationError['reason'] = 'invalid'
+) {
+  expect(error).toBeInstanceOf(MachineValidationError);
+  expect(isMachineValidationError(error)).toBe(true);
+  expect(error).toMatchObject({ boundary, reason });
+}
+
+describe('runtime schema validation', () => {
+  it('can be disabled by a derived setup', () => {
+    const validated = setup({
+      validator: standardSchemaValidator(),
+      schemas: { input: z.object({ count: z.number() }) }
+    });
+    const unvalidated = validated.extend({ validator: undefined });
+
+    expect(() =>
+      initialTransition(unvalidated.createMachine({}), {
+        count: 'not validated'
+      } as any)
+    ).not.toThrow();
+  });
+
+  it('calls validators only at pure calculation boundaries', () => {
+    const check = vi.fn<MachineValidator['check']>(() => undefined);
+    const machine = setup({ validator: { check } }).createMachine({
+      on: {
+        GO: (_, enq) => {
+          enq.raise({ type: 'INTERNAL' });
+        },
+        INTERNAL: {}
+      }
+    });
+
+    const [snapshot] = initialTransition(machine);
+    expect(check.mock.calls.map(([request]) => request.kind)).toEqual([
+      'input',
+      'result'
+    ]);
+
+    check.mockClear();
+    transition(machine, snapshot, { type: 'GO' });
+    expect(check.mock.calls.map(([request]) => request.kind)).toEqual([
+      'event',
+      'result'
+    ]);
+  });
+
+  it('validates input before initial context construction', () => {
+    const context = vi.fn(() => ({ count: 0 }));
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { input: z.object({ count: z.number() }) }
+    }).createMachine({ context });
+
+    const error = getThrown(() =>
+      initialTransition(machine, { count: 'x' } as any)
+    );
+
+    expectValidationError(error, 'input');
+    expect(context).not.toHaveBeenCalled();
+  });
+
+  it('validates external events before guard or transition selection', () => {
+    const guard = vi.fn((_event: unknown) => true);
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { events: { GO: z.object({ count: z.number() }) } }
+    }).createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            GO: ({ event }) => (guard(event) ? { target: 'done' } : undefined)
+          }
+        },
+        done: {}
+      }
+    });
+    const [snapshot] = initialTransition(machine);
+
+    expectValidationError(
+      getThrown(() =>
+        transition(machine, snapshot, { type: 'GO', count: 'x' } as any)
+      ),
+      'event'
+    );
+    expect(guard).not.toHaveBeenCalled();
+  });
+
+  it('is strict for unknown events by default and supports open protocols', () => {
+    const create = (unknownEvents?: 'error' | 'ignore') =>
+      setup({
+        validator: standardSchemaValidator({ unknownEvents }),
+        schemas: { events: { KNOWN: z.object({}) } }
+      }).createMachine({});
+
+    const strict = create();
+    const [strictSnapshot] = initialTransition(strict);
+    expectValidationError(
+      getThrown(() =>
+        transition(strict, strictSnapshot, { type: 'UNKNOWN' } as any)
+      ),
+      'event',
+      'unknownEvent'
+    );
+
+    const open = create('ignore');
+    const [openSnapshot] = initialTransition(open);
+    expect(() =>
+      transition(open, openSnapshot, { type: 'UNKNOWN' } as any)
+    ).not.toThrow();
+  });
+
+  it('validates stable root context after the macrostep', () => {
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        context: z.object({ count: z.number() }),
+        events: { BREAK: z.object({}) }
+      }
+    }).createMachine({
+      context: { count: 0 },
+      on: {
+        BREAK: () => ({ context: { count: 'x' } as any })
+      }
+    });
+    const [snapshot] = initialTransition(machine);
+
+    expectValidationError(
+      getThrown(() => transition(machine, snapshot, { type: 'BREAK' })),
+      'context'
+    );
+  });
+
+  it('does not validate immediate raised events in v1', () => {
+    const raisedHandler = vi.fn();
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        events: {
+          GO: z.object({}),
+          RAISED: z.object({ value: z.number() })
+        }
+      }
+    }).createMachine({
+      on: {
+        GO: (_, enq) => {
+          enq.raise({ type: 'RAISED', value: 'x' } as any);
+        },
+        RAISED: () => {
+          raisedHandler();
+        }
+      }
+    });
+    const [snapshot] = initialTransition(machine);
+
+    expect(() => transition(machine, snapshot, { type: 'GO' })).not.toThrow();
+    expect(raisedHandler).toHaveBeenCalledOnce();
+  });
+
+  it('validates delayed raised events retained by the stable snapshot', () => {
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { events: { LATER: z.object({ value: z.number() }) } }
+    }).createMachine({
+      entry: (_, enq) => {
+        enq.raise({ type: 'LATER', value: 'x' } as any, { delay: 10 });
+      }
+    });
+
+    const error = getThrown(() => initialTransition(machine));
+    expectValidationError(error, 'event');
+    expect(error).toMatchObject({ eventOrigin: 'raised' });
+  });
+
+  it('validates emitted events before any effect executes', () => {
+    const action = vi.fn();
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        events: { GO: z.object({}) },
+        emitted: { notice: z.object({ value: z.number() }) }
+      },
+      actions: { action }
+    }).createMachine({
+      on: {
+        GO: ({ actions }, enq) => {
+          enq(actions.action);
+          enq.emit({ type: 'notice', value: 'x' } as any);
+        }
+      }
+    });
+    const actor = createActor(machine);
+    actor.subscribe({ error: () => {} });
+    actor.start();
+    actor.send({ type: 'GO' });
+
+    expect(actor.getSnapshot().status).toBe('error');
+    expectValidationError((actor.getSnapshot() as any).error, 'emitted');
+    expect(action).not.toHaveBeenCalled();
+  });
+
+  it('is strict for unknown emitted events and supports open protocols', () => {
+    const create = (unknownEmitted?: 'error' | 'ignore') =>
+      setup({
+        validator: standardSchemaValidator({ unknownEmitted }),
+        schemas: { emitted: { known: z.object({}) } }
+      }).createMachine({
+        entry: (_, enq) => {
+          enq.emit({ type: 'unknown' } as any);
+        }
+      });
+
+    expectValidationError(
+      getThrown(() => initialTransition(create())),
+      'emitted',
+      'unknownEmitted'
+    );
+    expect(() => initialTransition(create('ignore'))).not.toThrow();
+  });
+
+  it('surfaces terminal validation failures through transition inspection', () => {
+    const inspection: any[] = [];
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { events: { GO: z.object({ value: z.number() }) } }
+    }).createMachine({});
+    const actor = createActor(machine, {
+      inspect: (event) => inspection.push(event)
+    });
+    actor.subscribe({ error: () => {} });
+    actor.start();
+    actor.send({ type: 'GO', value: 'x' } as any);
+
+    const failure = inspection.find(
+      (event) =>
+        event.type === '@xstate.transition' &&
+        event.event.type === 'GO' &&
+        event.snapshot.status === 'error'
+    );
+    expect(failure).toBeDefined();
+    expectValidationError(failure.snapshot.error, 'event');
+    expect(failure.actions).toEqual([]);
+    expect(failure.sent).toEqual([]);
+    expect(failure.microsteps).toEqual([]);
+  });
+
+  it('does not expose rejected macrostep facets through inspection', () => {
+    const inspection: any[] = [];
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        context: z.object({ count: z.number() }),
+        events: { BREAK: z.object({}) }
+      }
+    }).createMachine({
+      context: { count: 0 },
+      on: {
+        BREAK: ({ context }) => ({
+          context: { ...context, count: 'invalid' } as any
+        })
+      }
+    });
+    const actor = createActor(machine, {
+      inspect: (event) => inspection.push(event)
+    });
+    actor.subscribe({ error: () => {} });
+    actor.start();
+    actor.send({ type: 'BREAK' });
+
+    const failure = inspection.find(
+      (event) =>
+        event.type === '@xstate.transition' &&
+        event.event.type === 'BREAK' &&
+        event.snapshot.status === 'error'
+    );
+    expect(failure).toBeDefined();
+    expectValidationError(failure.snapshot.error, 'context');
+    expect(failure.actions).toEqual([]);
+    expect(failure.sent).toEqual([]);
+    expect(failure.microsteps).toEqual([]);
+  });
+
+  it('allows active onError handlers to recover validation failures', () => {
+    const inspection: any[] = [];
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        context: z.object({ count: z.number() }),
+        events: { BREAK: z.object({}) }
+      }
+    }).createMachine({
+      context: { count: 0 },
+      initial: 'active',
+      states: {
+        active: {
+          on: { BREAK: () => ({ context: { count: 'x' } as any }) },
+          onError: { target: 'failed' }
+        },
+        failed: {}
+      }
+    });
+    const actor = createActor(machine, {
+      inspect: (event) => inspection.push(event)
+    }).start();
+
+    actor.send({ type: 'BREAK' });
+
+    expect(actor.getSnapshot()).toMatchObject({
+      status: 'active',
+      value: 'failed'
+    });
+    const recovery = inspection.find(
+      (event) =>
+        event.type === '@xstate.transition' &&
+        event.event.type === 'xstate.error.execution'
+    );
+    expect(recovery).toBeDefined();
+    expectValidationError(recovery.event.error, 'context');
+  });
+
+  it('allows root onError to recover initial result validation failures', () => {
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { context: z.object({ count: z.number() }) }
+    }).createMachine({
+      context: { count: 'invalid' } as any,
+      initial: 'active',
+      onError: () => ({
+        target: '.recovered',
+        context: { count: 0 }
+      }),
+      states: {
+        active: {},
+        recovered: {}
+      }
+    });
+
+    const [snapshot] = initialTransition(machine);
+
+    expect(snapshot).toMatchObject({
+      status: 'active',
+      value: 'recovered',
+      context: { count: 0 }
+    });
+  });
+
+  it('validates final output before completion', () => {
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        events: { FINISH: z.object({}) },
+        output: z.object({ total: z.number() })
+      }
+    }).createMachine({
+      initial: 'active',
+      states: {
+        active: { on: { FINISH: { target: 'done' } } },
+        done: { type: 'final', output: { total: 'x' } as any }
+      }
+    });
+    const [snapshot] = initialTransition(machine);
+
+    expectValidationError(
+      getThrown(() => transition(machine, snapshot, { type: 'FINISH' })),
+      'output'
+    );
+  });
+
+  it('validates state input and state-local context in the stable snapshot', () => {
+    const stateInputMachine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { events: { GO: z.object({}) } },
+      states: {
+        done: { schemas: { input: z.object({ id: z.number() }) } }
+      }
+    }).createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: { GO: { target: 'done', input: { id: 'x' } as any } }
+        },
+        done: {}
+      }
+    });
+    const [inputSnapshot] = initialTransition(stateInputMachine);
+    expectValidationError(
+      getThrown(() =>
+        transition(stateInputMachine, inputSnapshot, { type: 'GO' })
+      ),
+      'state.input'
+    );
+
+    const stateContextMachine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        context: z.object({ mode: z.string() }),
+        events: { GO: z.object({}) }
+      },
+      states: {
+        done: { schemas: { context: z.object({ mode: z.literal('done') }) } }
+      }
+    }).createMachine({
+      context: { mode: 'idle' },
+      initial: 'idle',
+      states: {
+        idle: { on: { GO: { target: 'done' } as any } },
+        done: {}
+      }
+    });
+    const [contextSnapshot] = initialTransition(stateContextMachine);
+    expectValidationError(
+      getThrown(() =>
+        transition(stateContextMachine, contextSnapshot, { type: 'GO' })
+      ),
+      'state.context'
+    );
+  });
+
+  it('does not validate named action and guard params in v1', () => {
+    const action = vi.fn();
+    const actionMachine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        events: { GO: z.object({}) },
+        actions: { track: { params: z.object({ count: z.number() }) } }
+      },
+      actions: { track: action }
+    }).createMachine({
+      on: {
+        GO: ({ actions }, enq) => {
+          enq(actions.track, { count: 'x' } as any);
+        }
+      }
+    });
+    const actionActor = createActor(actionMachine).start();
+    actionActor.send({ type: 'GO' });
+    expect(action).toHaveBeenCalledOnce();
+
+    const guard = vi.fn(() => true);
+    const guardMachine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        events: { GO: z.object({}) },
+        guards: { allowed: { params: z.object({ count: z.number() }) } }
+      },
+      guards: { allowed: guard }
+    }).createMachine({
+      on: {
+        GO: ({ guards }) => {
+          if (guards.allowed({ count: 'x' } as any)) {
+            return {};
+          }
+        }
+      }
+    });
+    const [guardSnapshot] = initialTransition(guardMachine);
+    expect(() =>
+      transition(guardMachine, guardSnapshot, { type: 'GO' })
+    ).not.toThrow();
+    expect(guard).toHaveBeenCalled();
+  });
+
+  it('validates declared child slots', () => {
+    const child = createMachine({});
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        children: {
+          worker: z.custom<AnyActorRef>(() => false, 'invalid worker')
+        }
+      },
+      actors: { worker: child }
+    }).createMachine({ invoke: { id: 'worker', src: 'worker' } });
+
+    expectValidationError(
+      getThrown(() => initialTransition(machine)),
+      'child'
+    );
+  });
+
+  it('rejects async schemas and permits type-only schemas', async () => {
+    const asyncMachine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        events: {
+          GO: z.object({}).refine(async () => true)
+        }
+      }
+    }).createMachine({});
+    const [snapshot] = initialTransition(asyncMachine);
+    expectValidationError(
+      getThrown(() => transition(asyncMachine, snapshot, { type: 'GO' })),
+      'event',
+      'asyncValidationUnsupported'
+    );
+
+    const rejectingSchema = {
+      '~standard': {
+        version: 1 as const,
+        vendor: 'test',
+        validate: () => Promise.reject(new Error('async schema failed'))
+      }
+    };
+    const rejectingMachine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { events: { GO: rejectingSchema } }
+    }).createMachine({});
+    const [rejectingSnapshot] = initialTransition(rejectingMachine);
+    expectValidationError(
+      getThrown(() =>
+        transition(rejectingMachine, rejectingSnapshot, { type: 'GO' })
+      ),
+      'event',
+      'asyncValidationUnsupported'
+    );
+    await Promise.resolve();
+
+    const typeOnlyMachine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { events: { GO: types<{ value: number }>() } }
+    }).createMachine({});
+    const [typeOnlySnapshot] = initialTransition(typeOnlyMachine);
+    expect(() =>
+      transition(typeOnlyMachine, typeOnlySnapshot, {
+        type: 'GO',
+        value: 'not checked'
+      } as any)
+    ).not.toThrow();
+  });
+});

--- a/packages/core/test/runtimeValidation.types.test.ts
+++ b/packages/core/test/runtimeValidation.types.test.ts
@@ -1,0 +1,117 @@
+import { z } from 'zod';
+import { setup } from '../src/index.ts';
+import { standardSchemaValidator } from '../src/validation/index.ts';
+
+describe('runtime validation types', () => {
+  it('rejects type-changing schemas only when validation is installed', () => {
+    const transforming = z.string().transform((value) => value.length);
+
+    setup({ schemas: { input: transforming } });
+
+    if (false) {
+      setup({
+        validator: standardSchemaValidator(),
+        // @ts-expect-error - runtime validation does not apply schema transforms
+        schemas: { input: transforming }
+      });
+    }
+  });
+
+  it('checks validated schema maps and nested state schemas', () => {
+    const transforming = z.string().transform((value) => value.length);
+
+    setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        actions: { track: { params: transforming } },
+        guards: { allowed: { params: transforming } },
+        meta: transforming
+      }
+    });
+
+    if (false) {
+      setup({
+        validator: standardSchemaValidator(),
+        schemas: {
+          events: {
+            // @ts-expect-error - event schema changes its runtime type
+            GO: transforming
+          }
+        }
+      });
+
+      setup({
+        validator: standardSchemaValidator(),
+        states: {
+          loading: {
+            schemas: {
+              // @ts-expect-error - state input schema changes its runtime type
+              input: transforming
+            }
+          }
+        }
+      });
+    }
+  });
+
+  it('allows same-type transforms as a documented generic limitation', () => {
+    setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        input: z.string().transform((value) => value.trim())
+      }
+    });
+  });
+
+  it('inherits validation across extend unless explicitly disabled', () => {
+    const transforming = z.string().transform((value) => value.length);
+    const validated = setup({ validator: standardSchemaValidator() });
+
+    if (false) {
+      validated.extend({
+        schemas: {
+          // @ts-expect-error - extended schemas inherit runtime validation
+          input: transforming
+        }
+      });
+
+      validated.createMachine({
+        schemas: {
+          // @ts-expect-error - inline machine schemas use the setup validator
+          input: transforming
+        }
+      });
+
+      validated.createMachine({
+        states: {
+          loading: {
+            schemas: {
+              // @ts-expect-error - inline state schemas use the setup validator
+              input: transforming
+            }
+          }
+        }
+      });
+    }
+
+    const unvalidated = validated.extend({
+      validator: undefined,
+      schemas: { input: transforming }
+    });
+    unvalidated.createMachine({
+      schemas: { output: transforming }
+    });
+  });
+
+  it('requires validation to be installed by the root setup', () => {
+    const transforming = z.string().transform((value) => value.length);
+    const base = setup({ schemas: { input: transforming } });
+
+    if (false) {
+      base.extend({
+        // @ts-expect-error - validation must be installed by the root setup
+        validator: standardSchemaValidator()
+      });
+    }
+  });
+});

--- a/packages/core/validation/package.json
+++ b/packages/core/validation/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "../dist/xstate-validation.cjs.js",
+  "module": "../dist/xstate-validation.esm.js",
+  "umd:main": "../dist/xstate-validation.umd.min.js",
+  "preconstruct": {
+    "umdName": "XStateValidation"
+  }
+}

--- a/scripts/bundle-size.mjs
+++ b/scripts/bundle-size.mjs
@@ -1,6 +1,6 @@
 // Bundle-size benchmark for the `xstate` package.
 //
-// Measures min+gzip size of three entry profiles bundled from the local build
+// Measures min+gzip size of representative entry profiles bundled from the local build
 // (`packages/core/dist`), compares them against the thresholds in
 // scripts/bundle-size.thresholds.json, and exits non-zero on regression.
 //
@@ -85,6 +85,28 @@ const PROFILES = {
     const actor = createActor(machine).start();
     console.log(actor.getSnapshot().value);
   `,
+  'validated-machine': `
+    import { setup, createActor } from 'xstate';
+    import { standardSchemaValidator } from 'xstate/validation';
+    const countSchema = {
+      '~standard': {
+        version: 1,
+        vendor: 'fixture',
+        validate(value) {
+          return typeof value.count === 'number'
+            ? { value }
+            : { issues: [{ message: 'Expected count' }] };
+        }
+      }
+    };
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: { events: { increment: countSchema } }
+    }).createMachine({ context: { count: 0 } });
+    const actor = createActor(machine).start();
+    actor.send({ type: 'increment', count: 1 });
+    console.log(actor.getSnapshot().context.count);
+  `,
   'kitchen-sink': `
     export * from 'xstate';
   `
@@ -133,6 +155,9 @@ try {
       metafile: why,
       // Resolve 'xstate' to the locally built package (or src for --why).
       alias: {
+        'xstate/validation': why
+          ? join(root, 'packages', 'core', 'src', 'validation', 'index.ts')
+          : join(root, 'packages', 'core', 'validation'),
         xstate: why
           ? join(root, 'packages', 'core', 'src', 'index.ts')
           : join(root, 'packages', 'core')

--- a/scripts/bundle-size.thresholds.json
+++ b/scripts/bundle-size.thresholds.json
@@ -8,6 +8,9 @@
   "machine-and-actors": {
     "maxGzipBytes": 16561
   },
+  "validated-machine": {
+    "maxGzipBytes": 21574
+  },
   "kitchen-sink": {
     "maxGzipBytes": 23667
   }


### PR DESCRIPTION
## Summary

- add the generic `ActorLogicValidator` calculation-boundary protocol
- provide `standardSchemaValidator()` and structured `ActorValidationError` diagnostics from `xstate/validation`
- validate machine input and public events at ingress
- validate stable machine snapshots and returned emissions/effects transactionally at macrostep egress
- support validation on `createLogic()`, async, callback, and observable actor logic using their existing input/output schema surfaces
- support actor error recovery and inspection without exposing rejected effects
- allow derived machine setups to inherit, replace, or explicitly disable validation

## Why

Type-only schemas do not protect runtime boundaries. This adds synchronous, library-neutral validation while preserving direct pure calls and custom interpreters. Validation lives on actor logic rather than only in `createActor()`, so all calculation paths share the same guarantees.

## Validation

- `pnpm test:core` — 2,108 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- focused runtime and type tests
- runtime benchmark completed
- minimal-machine bundle unchanged within measurement noise; actor-heavy profile adds about 105 bytes gzip

`pnpm format:check` currently reports only `packages/core/CHANGELOG.md`, introduced by the current `next` release commit and untouched by this PR.