### PR TITLE
[@xstate/store] Fix undo after redo in the snapshot strategy

### DIFF
--- a/.changeset/rotten-jokes-invent.md
+++ b/.changeset/rotten-jokes-invent.md
@@ -1,0 +1,20 @@
+---
+'@xstate/store': patch
+---
+
+Fixed snapshot-based undo/redo so that undoing after a redo steps back through history instead of staying put.
+
+```ts
+const store = createStore({
+  context: { count: 0 },
+  on: { inc: (ctx) => ({ count: ctx.count + 1 }) }
+}).with(undoRedo({ strategy: 'snapshot' }));
+
+store.trigger.inc(); // 1
+store.trigger.inc(); // 2
+store.trigger.inc(); // 3
+store.trigger.undo(); // 2
+store.trigger.undo(); // 1
+store.trigger.redo(); // 2
+store.trigger.undo(); // 1 (previously stayed at 2)
+```

--- a/packages/xstate-store/src/undo.ts
+++ b/packages/xstate-store/src/undo.ts
@@ -230,34 +230,22 @@ function undoRedoFromLogic<
 
           let newSnapshot;
           if (firstTransactionId === undefined) {
-            const item = future.shift()!;
-            newSnapshot = item.snapshot;
-            past.push(
-              options.restore
-                ? {
-                    snapshot: currentSnapshot,
-                    transactionId: firstTransactionId
-                  }
-                : item
-            );
+            newSnapshot = future.shift()!.snapshot;
           } else {
             while (
               future.length > 0 &&
               future[0].transactionId === firstTransactionId
             ) {
-              const item = future.shift()!;
-              newSnapshot = item.snapshot;
-              if (!options.restore) {
-                past.push(item);
-              }
-            }
-            if (options.restore) {
-              past.push({
-                snapshot: currentSnapshot,
-                transactionId: firstTransactionId
-              });
+              newSnapshot = future.shift()!.snapshot;
             }
           }
+
+          // Both stacks hold the snapshot that preceded the change, so a redo
+          // pushes the snapshot it is moving away from, not the one it restores.
+          past.push({
+            snapshot: currentSnapshot,
+            transactionId: firstTransactionId
+          });
 
           const excessCount = past.length - historyLimit;
           if (excessCount > 0) {

--- a/packages/xstate-store/test/undo.test.ts
+++ b/packages/xstate-store/test/undo.test.ts
@@ -534,6 +534,32 @@ describe('undoRedo with snapshot strategy', () => {
     expect(store.getSnapshot().context.count).toBe(3);
   });
 
+  it('should undo back into history after a redo', () => {
+    const store = createStore({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 })
+      }
+    }).with(undoRedo({ strategy: 'snapshot' }));
+
+    store.trigger.inc();
+    store.trigger.inc();
+    store.trigger.inc();
+    store.trigger.undo();
+    store.trigger.undo();
+    expect(store.getSnapshot().context.count).toBe(1);
+    store.trigger.redo();
+    expect(store.getSnapshot().context.count).toBe(2);
+
+    // Undoing the redo returns to the snapshot the redo moved away from
+    store.trigger.undo();
+    expect(store.getSnapshot().context.count).toBe(1);
+    store.trigger.undo();
+    expect(store.getSnapshot().context.count).toBe(0);
+    store.trigger.redo();
+    expect(store.getSnapshot().context.count).toBe(1);
+  });
+
   it('should group events by transaction ID', () => {
     const store = createStore({
       context: { count: 0 },
@@ -565,6 +591,41 @@ describe('undoRedo with snapshot strategy', () => {
     expect(store.getSnapshot().context.count).toBe(2);
 
     // Undo first transaction (both increments)
+    store.trigger.undo();
+    expect(store.getSnapshot().context.count).toBe(0);
+  });
+
+  it('should undo back into history after redoing a transaction', () => {
+    const store = createStore({
+      context: { count: 0 },
+      on: {
+        inc: (ctx) => ({ count: ctx.count + 1 }),
+        dec: (ctx) => ({ count: ctx.count - 1 })
+      }
+    }).with(
+      undoRedo({
+        strategy: 'snapshot',
+        getTransactionId: (event) => {
+          return event.type;
+        }
+      })
+    );
+
+    // First transaction
+    store.trigger.inc();
+    store.trigger.inc();
+
+    // Second transaction
+    store.trigger.dec();
+    store.trigger.dec();
+
+    store.trigger.undo();
+    store.trigger.undo();
+    expect(store.getSnapshot().context.count).toBe(0);
+
+    // Redo the first transaction, then undo it again
+    store.trigger.redo();
+    expect(store.getSnapshot().context.count).toBe(2);
     store.trigger.undo();
     expect(store.getSnapshot().context.count).toBe(0);
   });


### PR DESCRIPTION
## The bug

With `undoRedo({ strategy: 'snapshot' })`, an undo that follows a redo does nothing, and the history is off by one from then on:

```ts
const store = createStore({
  context: { count: 0 },
  on: { inc: (ctx) => ({ count: ctx.count + 1 }) }
}).with(undoRedo({ strategy: 'snapshot' }));

store.trigger.inc(); // 1
store.trigger.inc(); // 2
store.trigger.inc(); // 3
store.trigger.undo(); // 2
store.trigger.undo(); // 1
store.trigger.redo(); // 2
store.trigger.undo(); // 2  ← expected 1
store.trigger.undo(); // 0  ← skipped 1 entirely
store.trigger.redo(); // 2  ← 1 is no longer reachable
```

The event strategy (the default) and the snapshot strategy with a `restore` function both produce the correct `1, 0, 1` for those last three steps, so the three strategies disagree with each other today.

## Cause

Both stacks store the snapshot that *preceded* the change that produced the entry: the normal transition path pushes the pre-event snapshot onto `past`, and `undo` unshifts the pre-undo snapshot onto `future`.

`redo` broke that invariant — it pushed `item`, the snapshot it was restoring, onto `past`. The next `undo` then popped the state the store had just moved *to*, which is why it appears to do nothing. The following undo skips a step because that entry replaced the one that should have been there.

`#5608` added the correct push (`currentSnapshot`) but only on the `options.restore` path, which is why the behaviour differs depending on whether `restore` is supplied. The defect itself dates back to `#5415`, where the snapshot strategy was introduced.

## The fix

Push the pre-redo snapshot in every case. Since both branches now push the same entry, the transaction loop no longer needs to push per item and the `options.restore` special-casing disappears — the two paths were only ever different because one of them was wrong.

## Verification

- Two regression tests added to `undo.test.ts`, one for single snapshots and one for transaction groups. Both are red on `main` (`expected 2 to be 1`, `expected 2 to be +0`) and green with the fix.
- The 42 pre-existing `undo.test.ts` tests pass unchanged, including `should apply historyLimit during redo` and `should maintain correct state when interleaving undo/redo with new events` — those sequences either end on a redo or redo all the way back to the head, which is why the defect went unnoticed.
- `pnpm test` (114 files, 2312 tests), `pnpm lint`, `pnpm format:check` and `pnpm typecheck` are all green locally.
- Changeset included (`patch` for `@xstate/store`).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->