### PR TITLE
Improve XState v6 runtime performance

### DIFF
--- a/.changeset/thick-cooks-retire.md
+++ b/.changeset/thick-cooks-retire.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Improve transition and actor runtime performance.

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -7,17 +7,17 @@
 - 52f23be: Add opt-in runtime Standard Schema validation through `setup({ validator })`. The standard validator is available from the separate `xstate/validation` entrypoint:
 
   ```ts
-  import { setup } from "xstate";
-  import { standardSchemaValidator } from "xstate/validation";
-  import { z } from "zod";
+  import { setup } from 'xstate';
+  import { standardSchemaValidator } from 'xstate/validation';
+  import { z } from 'zod';
 
   const machine = setup({
     validator: standardSchemaValidator(),
     schemas: {
       events: {
-        increment: z.object({ by: z.number() }),
-      },
-    },
+        increment: z.object({ by: z.number() })
+      }
+    }
   }).createMachine({});
   ```
 
@@ -39,10 +39,10 @@
   const versions = machineVersions([checkoutV1, checkoutV2]);
   const source = await versions.parseSnapshot(persisted);
   const snapshot = await migrateSnapshot(source, checkoutV2, {
-    "1": (snapshot) => ({
+    '1': (snapshot) => ({
       ...snapshot,
-      context: { total: snapshot.context.count },
-    }),
+      context: { total: snapshot.context.count }
+    })
   });
 
   createActor(checkoutV2, { snapshot }).start();
@@ -53,7 +53,7 @@
 
   ```ts
   const versions = machineVersions([checkoutV0, checkoutV1], {
-    unversioned: "0",
+    unversioned: '0'
   });
   ```
 
@@ -69,19 +69,19 @@
 
   ```ts
   createMachine({
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
-        initial: "idle",
+        initial: 'idle',
         states: {
           idle: {},
           history: {
-            type: "history",
-            target: "idle",
-          },
-        },
-      },
-    },
+            type: 'history',
+            target: 'idle'
+          }
+        }
+      }
+    }
   });
   ```
 
@@ -94,47 +94,47 @@
   ```ts
   const machine = setup({
     schemas: {
-      context: z.object({ reason: z.union([z.literal("timeout"), z.null()]) }),
+      context: z.object({ reason: z.union([z.literal('timeout'), z.null()]) })
     },
     states: {
       running: { schemas: { context: z.object({ reason: z.null() }) } },
       expired: {
-        schemas: { context: z.object({ reason: z.literal("timeout") }) },
-      },
-    },
+        schemas: { context: z.object({ reason: z.literal('timeout') }) }
+      }
+    }
   }).createMachine({
     context: { reason: null },
-    initial: "running",
+    initial: 'running',
     states: {
       running: {
         timeout: 5000,
         // Previously a type error; now checked against `expired`'s context
         onTimeout: () => ({
-          target: "expired",
-          context: { reason: "timeout" as const },
-        }),
+          target: 'expired',
+          context: { reason: 'timeout' as const }
+        })
       },
-      expired: { type: "final" },
-    },
+      expired: { type: 'final' }
+    }
   });
   ```
 
 - d9d9e29: Per-state schemas declared in `setup({ states })` are now available on the compiled machine's state nodes via `machine.states.X.schemas`, so tooling (e.g. per-state snapshot validators) can be derived from the machine alone. Previously they were only accessible on the setup return value.
 
   ```ts
-  import { setup, types } from "xstate";
+  import { setup, types } from 'xstate';
 
   const machine = setup({
     states: {
       running: {
-        schemas: { context: types<{ startedAt: number }>() },
-      },
-    },
+        schemas: { context: types<{ startedAt: number }>() }
+      }
+    }
   }).createMachine({
-    initial: "running",
+    initial: 'running',
     states: {
-      running: {},
-    },
+      running: {}
+    }
   });
 
   machine.states.running.schemas?.context; // the schema declared in setup
@@ -145,9 +145,9 @@
   ```ts
   createMachine({
     always: ({ context }) => {
-      if (context.hour < 12) return { target: "morning" };
-      return { target: "afternoon" };
-    },
+      if (context.hour < 12) return { target: 'morning' };
+      return { target: 'afternoon' };
+    }
   });
   ```
 
@@ -173,10 +173,10 @@
   const child = snapshot.children.job;
 
   const [nextSnapshot] = transition(machine, snapshot, {
-    type: "xstate.done.actor",
-    actorId: "job",
+    type: 'xstate.done.actor',
+    actorId: 'job',
     sessionId: child.sessionId,
-    output: result,
+    output: result
   });
 
   nextSnapshot.children.job; // undefined
@@ -187,7 +187,7 @@
   ```ts
   // `persisted` contains a child whose registered source is not provided.
   const restored = createActor(machineWithoutChildSource, {
-    snapshot: persisted,
+    snapshot: persisted
   });
 
   restored.getSnapshot().status; // 'error'
@@ -199,11 +199,11 @@
   const machine = createMachine({
     // ...
     on: {
-      "xstate.done.actor": {
-        matches: { actorId: "job" },
-        target: "complete",
-      },
-    },
+      'xstate.done.actor': {
+        matches: { actorId: 'job' },
+        target: 'complete'
+      }
+    }
   });
 
   // Generated events use payload identity:
@@ -226,7 +226,7 @@
     context: ({ spawn, actors }) => {
       spawn(actors.child);
       return {};
-    },
+    }
   });
   ```
 
@@ -242,7 +242,7 @@
   let [snapshot, effects] = machine.initialTransition(input);
   await executeEffects(effects, runtime);
 
-  while (snapshot.status === "active") {
+  while (snapshot.status === 'active') {
     const event = await dequeue();
     [snapshot, effects] = machine.transition(snapshot, event);
     await executeEffects(effects, runtime);
@@ -271,15 +271,15 @@
   const machine = setup({
     states: {
       complete: {
-        schemas: { context: z.object({ result: z.string() }) },
-      },
-    },
+        schemas: { context: z.object({ result: z.string() }) }
+      }
+    }
   }).createMachine({
-    initial: "planning",
+    initial: 'planning',
     states: {
       planning: {},
-      complete: {},
-    },
+      complete: {}
+    }
   });
   ```
 
@@ -317,7 +317,7 @@
   entry: (_, enq) => {
     const child = enq.spawn(childLogic);
     // Now receives events emitted synchronously during child's startup
-    enq.listen(child, "ready", () => ({ type: "CHILD_READY" }));
+    enq.listen(child, 'ready', () => ({ type: 'CHILD_READY' }));
   };
   ```
 
@@ -336,21 +336,21 @@
   const machine = setup({
     states: {
       loading: {
-        schemas: { input: z.object({ userId: z.string() }) },
-      },
-    },
+        schemas: { input: z.object({ userId: z.string() }) }
+      }
+    }
   }).createMachine({
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
-        on: { LOAD: { target: "loading", input: { userId: "u1" } } },
+        on: { LOAD: { target: 'loading', input: { userId: 'u1' } } }
       },
-      loading: {},
-    },
+      loading: {}
+    }
   });
 
   const actor = createActor(machine).start();
-  actor.send({ type: "LOAD" });
+  actor.send({ type: 'LOAD' });
 
   const persisted = actor.getPersistedSnapshot();
   const restored = createActor(machine, { snapshot: persisted }).start();
@@ -370,31 +370,31 @@
   const machine = setup({
     states: {
       active: {
-        schemas: { input: z.object({ duration: z.number() }) },
-      },
-    },
+        schemas: { input: z.object({ duration: z.number() }) }
+      }
+    }
   }).createMachine({
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
           activate: ({ event }) => ({
-            target: "active",
-            input: { duration: event.duration },
-          }),
-        },
+            target: 'active',
+            input: { duration: event.duration }
+          })
+        }
       },
       active: {
         timeout: ({ input }) => input.duration,
-        onTimeout: ({ input }) => ({ target: "idle" }),
+        onTimeout: ({ input }) => ({ target: 'idle' }),
         after: {
-          1000: ({ input }) => ({ target: "idle" }),
+          1000: ({ input }) => ({ target: 'idle' })
         },
         on: {
-          ping: ({ input }, enq) => {},
-        },
-      },
-    },
+          ping: ({ input }, enq) => {}
+        }
+      }
+    }
   });
   ```
 
@@ -405,44 +405,44 @@
 - 95a7aca: `extend(...)` now merges `actions` and `guards` schema maps instead of replacing the base setup schemas. Previously, only `events`, `emitted`, and `children` were merged.
 
   ```ts
-  import { setup, types } from "xstate";
+  import { setup, types } from 'xstate';
 
   const machine = setup({
     schemas: {
       actions: {
-        track: { params: types<{ key: string }>() },
+        track: { params: types<{ key: string }>() }
       },
       guards: {
-        hasAccess: { params: types<{ role: string }>() },
-      },
-    },
+        hasAccess: { params: types<{ role: string }>() }
+      }
+    }
   })
     .extend({
       schemas: {
         actions: {
-          notify: { params: types<{ message: string }>() },
+          notify: { params: types<{ message: string }>() }
         },
         guards: {
-          canReset: { params: types<{ reason: string }>() },
-        },
-      },
+          canReset: { params: types<{ reason: string }>() }
+        }
+      }
     })
     .createMachine({
       // Both base and extended actions/guards are available
       entry: ({ actions }, enq) => {
-        enq(actions.track({ key: "init" }));
-        enq(actions.notify({ message: "started" }));
+        enq(actions.track({ key: 'init' }));
+        enq(actions.notify({ message: 'started' }));
       },
       on: {
         RESET: ({ guards }) => {
           if (
-            guards.hasAccess({ role: "admin" }) &&
-            guards.canReset({ reason: "manual" })
+            guards.hasAccess({ role: 'admin' }) &&
+            guards.canReset({ reason: 'manual' })
           ) {
-            return { target: ".idle" };
+            return { target: '.idle' };
           }
-        },
-      },
+        }
+      }
     });
   ```
 
@@ -451,18 +451,18 @@
 - b3ef4e7: `setup(...)` now exposes the schemas defined in its configuration, making them accessible for external use.
 
   ```ts
-  import { setup, types } from "xstate";
+  import { setup, types } from 'xstate';
 
   const s = setup({
     schemas: {
       context: types<{ count: number }>(),
       events: {
-        inc: types<{ by: number }>(),
+        inc: types<{ by: number }>()
       },
       emitted: {
-        changed: types<{ value: number }>(),
-      },
-    },
+        changed: types<{ value: number }>()
+      }
+    }
   });
 
   s.schemas.context;
@@ -496,16 +496,16 @@
 
   ```ts
   const machine = createMachine({
-    initial: "working",
+    initial: 'working',
     states: {
       working: {
-        on: { done: { target: "success" } },
+        on: { done: { target: 'success' } }
       },
       success: {
-        type: "final",
-        output: { status: "ok" },
-      },
-    },
+        type: 'final',
+        output: { status: 'ok' }
+      }
+    }
   });
   ```
 
@@ -517,15 +517,15 @@
 
     ```ts
     const machine = createMachine({
-      id: "p",
-      type: "parallel",
+      id: 'p',
+      type: 'parallel',
       on: {
-        ARCHIVE: { target: "#p.phase.archive" },
+        ARCHIVE: { target: '#p.phase.archive' }
       },
       states: {
-        phase: { initial: "inquiry", states: { inquiry: {}, archive: {} } },
-        mode: { initial: "new", states: { new: {}, edit: {} } },
-      },
+        phase: { initial: 'inquiry', states: { inquiry: {}, archive: {} } },
+        mode: { initial: 'new', states: { new: {}, edit: {} } }
+      }
     });
     // sending ARCHIVE now leaves `mode` in its current state
     ```
@@ -536,7 +536,7 @@
     // from Operation.Waiting:
     on: {
       TOGGLE_MODE: {
-        target: "#Demo";
+        target: '#Demo';
       } // in the Mode region
     }
     // sending TOGGLE_MODE enters Mode.Demo without exiting Operation
@@ -557,21 +557,21 @@
 
   ```ts
   const machine = createMachine({
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
         onError: ({ event }) => ({
-          target: "failed",
+          target: 'failed',
           context: {
             message:
               event.error instanceof Error
                 ? event.error.message
-                : String(event.error),
-          },
-        }),
+                : String(event.error)
+          }
+        })
       },
-      failed: {},
-    },
+      failed: {}
+    }
   });
   ```
 
@@ -582,8 +582,8 @@
   ```ts
   const machine = setup({
     schemas: {
-      events: {},
-    },
+      events: {}
+    }
   }).createMachine({});
 
   const logic: AnyActorLogic = machine;
@@ -599,41 +599,41 @@
 - 37d3254: Setup-bound invoke transition callbacks now validate target state context requirements for `onDone`, `onError`, `onSnapshot`, and `onTimeout`. `onDone` also infers output from the invoked actor logic.
 
   ```ts
-  import { createAsyncLogic, setup } from "xstate";
-  import { z } from "zod";
+  import { createAsyncLogic, setup } from 'xstate';
+  import { z } from 'zod';
 
   const machine = setup({
     actors: {
       loadUser: createAsyncLogic({
-        run: async () => ({ name: "Ada" }),
-      }),
+        run: async () => ({ name: 'Ada' })
+      })
     },
     states: {
       loading: {},
       success: {
         schemas: {
           context: z.object({
-            user: z.object({ name: z.string() }),
-          }),
-        },
-      },
-    },
+            user: z.object({ name: z.string() })
+          })
+        }
+      }
+    }
   }).createMachine({
     context: {},
-    initial: "loading",
+    initial: 'loading',
     states: {
       loading: {
         invoke: {
-          src: "loadUser",
+          src: 'loadUser',
           // Type-safe return value for invoke callbacks
           onDone: ({ event }) => ({
-            target: "success",
-            context: { user: event.output },
-          }),
-        },
+            target: 'success',
+            context: { user: event.output }
+          })
+        }
       },
-      success: {},
-    },
+      success: {}
+    }
   });
   ```
 
@@ -684,8 +684,8 @@
   ```ts
   on: {
     FETCH: ({ context, event }) => ({
-      target: "fetching",
-      input: { url: event.url, token: context.authToken },
+      target: 'fetching',
+      input: { url: event.url, token: context.authToken }
     });
   }
   ```
@@ -699,38 +699,38 @@
 - bdc54dd: Added `createFSM(...)` for flat, actor-compatible finite state machines.
 
   ```ts
-  import { createActor, createFSM } from "xstate";
+  import { createActor, createFSM } from 'xstate';
 
   const toggleLogic = createFSM({
-    initial: "inactive",
+    initial: 'inactive',
     context: { count: 0 },
     states: {
       inactive: {
         on: {
           toggle: {
-            target: "active",
-            context: { count: 1 },
-          },
-        },
+            target: 'active',
+            context: { count: 1 }
+          }
+        }
       },
       active: {
         on: {
           toggle: ({ context }, enq) => {
-            enq(() => console.log("toggled"));
+            enq(() => console.log('toggled'));
 
             return {
-              target: "inactive",
-              context: { count: context.count + 1 },
+              target: 'inactive',
+              context: { count: context.count + 1 }
             };
-          },
-        },
-      },
-    },
+          }
+        }
+      }
+    }
   });
 
   const actor = createActor(toggleLogic).start();
 
-  actor.send({ type: "toggle" });
+  actor.send({ type: 'toggle' });
   ```
 
   `createFSM(...)` supports XState-style object transitions, function transitions, `enq` actions, initial input, state `input`, entry actions, and exit actions. Plain string targets are intentionally not supported; use object targets such as `{ target: 'active' }`.
@@ -761,16 +761,16 @@
   const machine = createMachine({
     on: {
       spawn: (_, enq) => {
-        enq.spawn(childMachine, { registryKey: "child" });
-      },
-    },
+        enq.spawn(childMachine, { registryKey: 'child' });
+      }
+    }
   });
   ```
 
 - 6798cb1: `serializeMachine(...)` and `createMachineFromConfig(...)` now represent inline functions (guards, actions, transitions, delays, route functions) as `{ '@code': string, '@lang': 'ts' }`. Non-portable values such as actor logic, runtime schemas, class instances, symbols, and bigints are omitted from the serialized JSON.
 
   ```ts
-  import { serializeMachine } from "xstate";
+  import { serializeMachine } from 'xstate';
 
   serializeMachine(machine);
   // inline functions → { '@code': '() => true', '@lang': 'ts' }
@@ -788,16 +788,16 @@
   ```ts
   createMachine({
     schemas: {
-      output: types<{ status: "ok" }>(),
+      output: types<{ status: 'ok' }>()
     },
-    initial: "done",
+    initial: 'done',
     states: {
       done: {
-        type: "final",
-        output: { status: "ok" },
-      },
+        type: 'final',
+        output: { status: 'ok' }
+      }
     },
-    output: ({ event }) => event.output,
+    output: ({ event }) => event.output
   });
   ```
 
@@ -820,11 +820,11 @@
   import {
     setup,
     type AnySetupConfig,
-    type SetupReturnFromConfig,
-  } from "xstate";
+    type SetupReturnFromConfig
+  } from 'xstate';
 
   function decorateSetup<const TConfig extends AnySetupConfig>(
-    config: TConfig,
+    config: TConfig
   ): SetupReturnFromConfig<TConfig> & { extra: true } {
     const s = setup(config) as SetupReturnFromConfig<TConfig>;
 
@@ -866,20 +866,20 @@
   ```ts
   const system = createSystem({
     registry: {
-      receiver: receiverLogic,
-    },
+      receiver: receiverLogic
+    }
   });
 
   const machine = system.setup().createMachine({
     invoke: {
       src: receiverLogic,
-      registryKey: "receiver",
-    },
+      registryKey: 'receiver'
+    }
   });
 
   const actor = system.createActor(machine).start();
 
-  system.get("receiver")?.send({ type: "HELLO" });
+  system.get('receiver')?.send({ type: 'HELLO' });
   ```
 
 ### Patch Changes
@@ -889,18 +889,18 @@
   ```ts
   createMachine({
     context: { draftAnyway: false, count: 0 },
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
           DRAFT_ANYWAY: {
-            target: "drafting",
-            context: { draftAnyway: true },
-          },
-        },
+            target: 'drafting',
+            context: { draftAnyway: true }
+          }
+        }
       },
-      drafting: {},
-    },
+      drafting: {}
+    }
   });
   ```
 
@@ -916,19 +916,19 @@
   setup({
     schemas: {
       events: {
-        go: types<{}>(),
-      },
-    },
+        go: types<{}>()
+      }
+    }
   }).createMachine({
     states: {
       active: {
         on: {
           go: (_args, enq) => {
-            enq.raise({ type: "go" });
-          },
-        },
-      },
-    },
+            enq.raise({ type: 'go' });
+          }
+        }
+      }
+    }
   });
   ```
 
@@ -939,20 +939,20 @@
     schemas: {
       context: types<{ count: number }>(),
       events: {
-        next: types<{}>(),
-      },
-    },
+        next: types<{}>()
+      }
+    }
   }).createMachine({
     context: { count: 0 },
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
-          next: () => ({ target: "done" }),
-        },
+          next: () => ({ target: 'done' })
+        }
       },
-      done: {},
-    },
+      done: {}
+    }
   });
   ```
 
@@ -964,15 +964,15 @@
 
   ```ts
   createMachine({
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
-          start: { target: "active" },
-        },
+          start: { target: 'active' }
+        }
       },
-      active: {},
-    },
+      active: {}
+    }
   });
   ```
 
@@ -989,15 +989,15 @@
     transition: (snapshot, event) => [snapshot, []],
     initialTransition: (input, _scope) => [
       {
-        status: "active",
+        status: 'active',
         output: undefined,
         error: undefined,
-        input,
+        input
       },
-      [],
+      []
     ],
     getInitialSnapshot: (scope, input) =>
-      logic.initialTransition(input, scope)[0],
+      logic.initialTransition(input, scope)[0]
   };
   ```
 
@@ -1019,20 +1019,20 @@
     }
 
     switch (effect.type) {
-      case "@xstate.start":
+      case '@xstate.start':
         effect.id;
         effect.logic;
         effect.src;
         effect.input;
         break;
 
-      case "@xstate.sendTo":
+      case '@xstate.sendTo':
         effect.target;
         effect.event;
         effect.delay;
         break;
 
-      case "@xstate.raise":
+      case '@xstate.raise':
         effect.event;
         effect.delay;
         break;
@@ -1053,10 +1053,10 @@
     schemas: {
       context: z.object({ count: z.number() }),
       events: {
-        inc: z.object({ by: z.number() }),
-      },
+        inc: z.object({ by: z.number() })
+      }
     },
-    context: { count: 0 },
+    context: { count: 0 }
   });
 
   machine.schemas?.events?.inc;
@@ -1083,21 +1083,21 @@
   ```ts
   const machine = createMachine({
     context: { value: 0 },
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         on: {
-          start: () => ({ target: "active", context: { value: 100 } }),
-        },
+          start: () => ({ target: 'active', context: { value: 100 } })
+        }
       },
       active: {
         invoke: {
           src: asyncLogic,
           // now receives { value: 100 } instead of { value: 0 }
-          input: ({ context }) => ({ val: context.value }),
-        },
-      },
-    },
+          input: ({ context }) => ({ val: context.value })
+        }
+      }
+    }
   });
   ```
 
@@ -1111,20 +1111,20 @@
 
   ```ts
   const machine = createMachine({
-    initial: "loading",
+    initial: 'loading',
     states: {
       loading: {
         invoke: {
           src: createAsyncLogic({
             run: () => {
-              throw new Error("boom"); // sync failure on start
-            },
+              throw new Error('boom'); // sync failure on start
+            }
           }),
-          onError: "failed",
-        },
+          onError: 'failed'
+        }
       },
-      failed: {},
-    },
+      failed: {}
+    }
   });
 
   const actor = createActor(machine).start(); // does not throw
@@ -1165,8 +1165,8 @@
   ```ts
   on: {
     CHECK: ({ self }) => {
-      if (self.getSnapshot().matches({ b: "b2" })) {
-        return { target: "a2" };
+      if (self.getSnapshot().matches({ b: 'b2' })) {
+        return { target: 'a2' };
       }
     };
   }
@@ -1188,33 +1188,33 @@
   Notably, `schemas.events` is a **map** of event-type → payload schema, inferred into a discriminated union keyed by `type`:
 
   ```ts
-  import { createMachine } from "xstate";
-  import { z } from "zod";
+  import { createMachine } from 'xstate';
+  import { z } from 'zod';
 
   const machine = createMachine({
     schemas: {
       context: z.object({ count: z.number() }),
       events: {
         inc: z.object({ by: z.number() }),
-        reset: z.object({}),
+        reset: z.object({})
       },
       input: z.object({ start: z.number() }),
       output: z.object({ total: z.number() }),
       emitted: { changed: z.object({ count: z.number() }) },
-      tags: z.union([z.literal("busy"), z.literal("idle")]),
-      meta: z.object({ label: z.string() }),
+      tags: z.union([z.literal('busy'), z.literal('idle')]),
+      meta: z.object({ label: z.string() })
     },
     context: ({ input }) => ({ count: input.start }),
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
         on: {
           inc: ({ context, event }) => ({
-            context: { count: context.count + event.by },
-          }),
-        },
-      },
-    },
+            context: { count: context.count + event.by }
+          })
+        }
+      }
+    }
   });
   ```
 
@@ -1238,12 +1238,12 @@
   const { createMachine, createStateConfig } = setup({
     schemas: {
       context: types<{ count: number }>(),
-      events: { INC: types<{ value: number }>() },
+      events: { INC: types<{ value: number }>() }
     },
     states: {
       idle: {},
-      loading: { schemas: { input: z.object({ userId: z.string() }) } },
-    },
+      loading: { schemas: { input: z.object({ userId: z.string() }) } }
+    }
   });
   ```
 
@@ -1263,24 +1263,24 @@
   ```ts
   const machine = createMachineFromConfig(
     {
-      initial: "loading",
+      initial: 'loading',
       states: {
         loading: {
           invoke: {
-            src: "loadUser",
-            input: { userId: "42" },
-            onDone: { target: "done" },
+            src: 'loadUser',
+            input: { userId: '42' },
+            onDone: { target: 'done' },
             timeout: 5000,
-            onTimeout: { target: "timedOut" },
-          },
+            onTimeout: { target: 'timedOut' }
+          }
         },
         done: {},
-        timedOut: {},
-      },
+        timedOut: {}
+      }
     },
     {
-      actors: { loadUser },
-    },
+      actors: { loadUser }
+    }
   );
   ```
 
@@ -1293,10 +1293,10 @@
   ```ts
   const logic = createAsyncLogic({
     run: async (_, enq) => {
-      const user = await enq.step("fetchUser", () => fetchUser());
-      const order = await enq.step("createOrder", () => createOrder(user.id));
+      const user = await enq.step('fetchUser', () => fetchUser());
+      const order = await enq.step('createOrder', () => createOrder(user.id));
       return order.id;
-    },
+    }
   });
 
   // snapshot.effects.fetchUser === { status: 'done', output: { id: 1 } }
@@ -1321,8 +1321,8 @@
 
     ```ts
     const logic = createAsyncLogic({
-      timeout: "10ms",
-      run: ({ signal }) => fetch("/slow", { signal }),
+      timeout: '10ms',
+      run: ({ signal }) => fetch('/slow', { signal })
     });
     ```
 
@@ -1358,15 +1358,15 @@
   const loadUser = createAsyncLogic({
     schemas: {
       input: z.object({ userId: z.string() }),
-      output: z.object({ name: z.string() }),
+      output: z.object({ name: z.string() })
     },
     run: async ({ input }) => {
       input.userId; // string
 
       return {
-        name: "David",
+        name: 'David'
       };
-    },
+    }
   });
   ```
 
@@ -1377,23 +1377,23 @@
   ```ts
   const logic = createCallbackLogic({
     schemas: {
-      input: z.object({ userId: z.string() }),
+      input: z.object({ userId: z.string() })
     },
     run: ({ input }) => {
       input.userId; // string
-    },
+    }
   });
   ```
 
 - [#5543](https://github.com/statelyai/xstate/pull/5543) [`52970ea`](https://github.com/statelyai/xstate/commit/52970ea75489305fd7bf1223f9b413770cd6d925) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `createStateConfig(...)` — author a standalone, fully-typed state node config (with `schemas`) that can be composed into a machine, mirroring how `setup(...).createMachine(...)` infers types.
 
   ```ts
-  import { createStateConfig } from "xstate";
+  import { createStateConfig } from 'xstate';
 
   const loading = createStateConfig({
     on: {
-      RESOLVE: "success",
-    },
+      RESOLVE: 'success'
+    }
   });
   ```
 
@@ -1407,10 +1407,10 @@
 
   ```ts
   entry: (_, enq) => {
-    const child = enq.spawn(childLogic, { id: "child" });
-    enq.listen(child, "data.*", (ev) => ({ type: "DATA", value: ev.value }));
+    const child = enq.spawn(childLogic, { id: 'child' });
+    enq.listen(child, 'data.*', (ev) => ({ type: 'DATA', value: ev.value }));
     enq.subscribeTo(child, {
-      done: (output) => ({ type: "CHILD_DONE", output }),
+      done: (output) => ({ type: 'CHILD_DONE', output })
     });
   };
   ```
@@ -1419,19 +1419,19 @@
 
   ```ts
   const machine = createMachine({
-    internalEvents: ["tick"] as const,
-    initial: "idle",
+    internalEvents: ['tick'] as const,
+    initial: 'idle',
     states: {
       idle: {
         on: {
           start: (_, enq) => {
-            enq.raise({ type: "tick" }); // allowed internally
+            enq.raise({ type: 'tick' }); // allowed internally
           },
-          tick: "running",
-        },
+          tick: 'running'
+        }
       },
-      running: {},
-    },
+      running: {}
+    }
   });
 
   // actor.send({ type: 'tick' }) from outside is rejected
@@ -1443,42 +1443,42 @@
   const machine = setup({
     states: {
       idle: {
-        schemas: { context: z.object({ user: z.null() }) },
+        schemas: { context: z.object({ user: z.null() }) }
       },
       success: {
-        schemas: { context: z.object({ user: z.string() }) },
-      },
-    },
+        schemas: { context: z.object({ user: z.string() }) }
+      }
+    }
   }).createMachine({
     schemas: {
       context: z.object({ user: z.string().nullable() }),
       events: {
-        LOAD: z.object({}),
-      },
+        LOAD: z.object({})
+      }
     },
-    initial: "idle",
+    initial: 'idle',
     context: { user: null },
     states: {
       idle: {
         on: {
           LOAD: () => ({
-            target: "success",
-            context: { user: "Ada" },
-          }),
-        },
+            target: 'success',
+            context: { user: 'Ada' }
+          })
+        }
       },
       success: {
         entry: ({ context }) => {
           context.user; // string
-        },
-      },
-    },
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
   const snapshot = actor.getSnapshot();
 
-  if (snapshot.matches("success")) {
+  if (snapshot.matches('success')) {
     snapshot.context.user; // string
   }
   ```
@@ -1489,19 +1489,19 @@
 
   ```ts
   const machine = createMachine({
-    context: { userStatus: "vip" },
-    initial: "routing",
+    context: { userStatus: 'vip' },
+    initial: 'routing',
     states: {
       routing: {
-        type: "choice",
+        type: 'choice',
         choice: ({ context }) => {
-          if (context.userStatus === "vip") return { target: "vipFlow" };
-          return { target: "standardFlow" };
-        },
+          if (context.userStatus === 'vip') return { target: 'vipFlow' };
+          return { target: 'standardFlow' };
+        }
       },
       vipFlow: {},
-      standardFlow: {},
-    },
+      standardFlow: {}
+    }
   });
   ```
 
@@ -1549,10 +1549,10 @@
   - Machines are serializable again: `serializeMachine(machine)` returns the JSON-safe definition. Inline functions, actor logic, and runtime schemas appear as explicit `{ "$unserializable": ... }` markers. `createMachineFromConfig(json)` is also exported from `xstate` and round-trips losslessly with `serializeMachine`:
 
     ```ts
-    import { createMachineFromConfig, serializeMachine } from "xstate";
+    import { createMachineFromConfig, serializeMachine } from 'xstate';
 
     const revived = createMachineFromConfig(
-      JSON.parse(JSON.stringify(serializeMachine(machine))),
+      JSON.parse(JSON.stringify(serializeMachine(machine)))
     );
     ```
 
@@ -1571,16 +1571,16 @@
   ```ts
   const actor = createActor(machine, {
     inspect: (ev) => {
-      if (ev.type === "@xstate.actor") {
+      if (ev.type === '@xstate.actor') {
         // topology: ev.actorRef, ev.parentRef, ev.id, ev.src, ev.snapshot
-      } else if (ev.type === "@xstate.transition") {
+      } else if (ev.type === '@xstate.transition') {
         ev.event; // the event that caused the transition
         ev.snapshot; // resulting snapshot
         ev.actions; // ActionRecord[] — executed actions (always present)
         ev.sent; // SentRecord[] — relayed/scheduled events (always present)
         ev.microsteps; // microstep transitions (always present)
       }
-    },
+    }
   });
   ```
 
@@ -1602,12 +1602,12 @@
 
     ```ts
     const machine = createMachine({
-      version: "2",
+      version: '2',
       migrate: (persisted, fromVersion) => ({
         ...persisted,
-        version: "2",
-        context: upgradeContext(persisted.context),
-      }),
+        version: '2',
+        context: upgradeContext(persisted.context)
+      })
       // ...
     });
     ```
@@ -1629,10 +1629,10 @@
 - [#5543](https://github.com/statelyai/xstate/pull/5543) [`d11c72d`](https://github.com/statelyai/xstate/commit/d11c72df0d83cfa5fc4445995b85e79a601c1c9e) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add atom APIs to XState and make actors readable by atoms.
 
   ```ts
-  import { createActor, createAtom, fromTransition } from "xstate";
+  import { createActor, createAtom, fromTransition } from 'xstate';
 
   const actor = createActor(
-    fromTransition((count: number, event: { type: "inc" }) => count + 1, 0),
+    fromTransition((count: number, event: { type: 'inc' }) => count + 1, 0)
   ).start();
 
   const count = createAtom(() => actor.get().context);
@@ -1643,27 +1643,27 @@
   `schemas` fields accept any [Standard Schema](https://standardschema.dev) (Zod, Valibot, …) for runtime validation _and_ inference. When you only want types, `types<T>()` provides the inference with no runtime validation (it's a Standard Schema whose validation is the identity function):
 
   ```ts
-  import { createMachine, types } from "xstate";
+  import { createMachine, types } from 'xstate';
 
   const machine = createMachine({
     schemas: {
       context: types<{ count: number }>(),
       events: {
         inc: types<{ by: number }>(),
-        reset: types<{}>(),
-      },
+        reset: types<{}>()
+      }
     },
     context: { count: 0 },
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
         on: {
           inc: ({ context, event }) => ({
-            context: { count: context.count + event.by },
-          }),
-        },
-      },
-    },
+            context: { count: context.count + event.by }
+          })
+        }
+      }
+    }
   });
   ```
 
@@ -1690,22 +1690,22 @@
 
   ```ts
   const machine = createMachine({
-    initial: "off",
+    initial: 'off',
     states: {
-      off: { on: { GO: "on.hist" } },
+      off: { on: { GO: 'on.hist' } },
       on: {
-        type: "parallel",
+        type: 'parallel',
         states: {
-          regA: { initial: "a1", states: { a1: {}, a2: {} } },
-          regB: { initial: "b1", states: { b1: {}, b2: {} } },
-          hist: { type: "history", history: "deep" },
-        },
-      },
-    },
+          regA: { initial: 'a1', states: { a1: {}, a2: {} } },
+          regB: { initial: 'b1', states: { b1: {}, b2: {} } },
+          hist: { type: 'history', history: 'deep' }
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
-  actor.send({ type: "GO" });
+  actor.send({ type: 'GO' });
   actor.getSnapshot().value; // { on: { regA: 'a1', regB: 'b1' } }
   ```
 
@@ -1721,15 +1721,15 @@
 
   ```ts
   const machine = createMachine({
-    initial: "idle",
+    initial: 'idle',
     states: {
       idle: {
         invoke: {
           src: fromPromise(async () => 42),
-          systemId: "myActor", // previously caused: "Actor with system ID 'myActor' already exists"
-        },
-      },
-    },
+          systemId: 'myActor' // previously caused: "Actor with system ID 'myActor' already exists"
+        }
+      }
+    }
   });
 
   // Now works correctly — returns [snapshot, actions] without throwing
@@ -1767,17 +1767,17 @@
   ```ts
   const machine = setup({
     guards: {
-      isReady: ({ context }) => context.ready,
-    },
+      isReady: ({ context }) => context.ready
+    }
   }).createMachine({
     states: {
       review: {
-        id: "review",
+        id: 'review',
         route: {
-          guard: "isReady",
-        },
-      },
-    },
+          guard: 'isReady'
+        }
+      }
+    }
   });
   ```
 
@@ -1788,14 +1788,14 @@
 - [#5429](https://github.com/statelyai/xstate/pull/5429) [`9d9c1fe`](https://github.com/statelyai/xstate/commit/9d9c1fe9df43936aa6ab43a4694645a6966ace12) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `mapState(snapshot, mapper)` to map a snapshot to values based on active state(s).
 
   ```ts
-  import { mapState } from "xstate";
+  import { mapState } from 'xstate';
 
   const results = mapState(snapshot, {
     states: {
-      loading: { map: () => "Loading..." },
+      loading: { map: () => 'Loading...' },
       success: { map: (snap) => snap.context.data },
-      error: { map: (snap) => snap.context.error.message },
-    },
+      error: { map: (snap) => snap.context.error.message }
+    }
   });
 
   console.log(results);
@@ -1813,8 +1813,8 @@
   const machine = createMachine({
     // ... machine config
     options: {
-      maxIterations: 1000, // set a limit to enable infinite loop detection
-    },
+      maxIterations: 1000 // set a limit to enable infinite loop detection
+    }
   });
   ```
 
@@ -1830,12 +1830,12 @@
   such as when you only want to explore events that currently pass guards:
 
   ```ts
-  import { createTestModel } from "xstate/graph";
+  import { createTestModel } from 'xstate/graph';
 
   const model = createTestModel(machine);
 
   const paths = model.getSimplePaths({
-    filterEvents: (state, event) => state.can(event),
+    filterEvents: (state, event) => state.can(event)
   });
   ```
 
@@ -1866,24 +1866,24 @@
 
   ```ts
   const machine = setup({}).createMachine({
-    id: "app",
-    initial: "home",
+    id: 'app',
+    initial: 'home',
     states: {
-      home: { id: "home", route: {} },
+      home: { id: 'home', route: {} },
       dashboard: {
-        initial: "overview",
+        initial: 'overview',
         states: {
-          overview: { id: "overview", route: {} },
-          settings: { id: "settings", route: {} },
-        },
-      },
-    },
+          overview: { id: 'overview', route: {} },
+          settings: { id: 'settings', route: {} }
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
 
   // Route directly to deeply nested state from anywhere
-  actor.send({ type: "xstate.route", to: "#settings" });
+  actor.send({ type: 'xstate.route', to: '#settings' });
   ```
 
   Routes support guards for conditional navigation:
@@ -1908,23 +1908,23 @@
 - [#5457](https://github.com/statelyai/xstate/pull/5457) [`287b51e`](https://github.com/statelyai/xstate/commit/287b51eb80abc521f8c35fa73df177a0b9dfd3bc) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `getInitialMicrosteps(…)` and `getMicrosteps(…)` functions that return an array of `[snapshot, actions]` tuples for each microstep in a transition.
 
   ```ts
-  import { createMachine, getInitialMicrosteps, getMicrosteps } from "xstate";
+  import { createMachine, getInitialMicrosteps, getMicrosteps } from 'xstate';
 
   const machine = createMachine({
-    initial: "a",
+    initial: 'a',
     states: {
       a: {
-        entry: () => console.log("enter a"),
+        entry: () => console.log('enter a'),
         on: {
-          NEXT: "b",
-        },
+          NEXT: 'b'
+        }
       },
       b: {
-        entry: () => console.log("enter b"),
-        always: "c",
+        entry: () => console.log('enter b'),
+        always: 'c'
       },
-      c: {},
-    },
+      c: {}
+    }
   });
 
   // Get microsteps from initial transition
@@ -1935,7 +1935,7 @@
 
   // Get microsteps from a transition
   const microsteps = getMicrosteps(machine, initialMicrosteps[0][0], {
-    type: "NEXT",
+    type: 'NEXT'
   });
   // Returns: [
   //  [snapshotB, [entryActionB]],
@@ -1944,8 +1944,8 @@
 
   // Each microstep is a tuple of [snapshot, actions]
   for (const [snapshot, actions] of microsteps) {
-    console.log("State:", snapshot.value);
-    console.log("Actions:", actions.length);
+    console.log('State:', snapshot.value);
+    console.log('Actions:', actions.length);
   }
   ```
 
@@ -1956,7 +1956,7 @@
 - [#5406](https://github.com/statelyai/xstate/pull/5406) [`703c3a1`](https://github.com/statelyai/xstate/commit/703c3a109c824f2334ede31d8428e923d2727e6e) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `getNextTransitions(state)` utility to get all transitions available from current `state`.
 
   ```ts
-  import { getNextTransitions } from "xstate";
+  import { getNextTransitions } from 'xstate';
 
   // ...
 
@@ -1982,7 +1982,7 @@
 
   ```ts
   // Matches any event with a type that starts with `FEEDBACK.`
-  assertEvent(event, "FEEDBACK.*");
+  assertEvent(event, 'FEEDBACK.*');
   ```
 
 ### Patch Changes
@@ -1996,35 +1996,35 @@
 - [#5371](https://github.com/statelyai/xstate/pull/5371) [`b8ec3b1`](https://github.com/statelyai/xstate/commit/b8ec3b153fbacae078c03cd07678271e0456679a) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Add `setup.extend()` method to incrementally extend machine setup configurations with additional actions, guards, and delays. This enables composable and reusable machine setups where extended actions, guards, and delays can reference base actions, guards, and delays and support chaining multiple extensions:
 
   ```ts
-  import { setup, not, and } from "xstate";
+  import { setup, not, and } from 'xstate';
 
   const baseSetup = setup({
     guards: {
       isAuthenticated: () => true,
-      hasPermission: () => false,
-    },
+      hasPermission: () => false
+    }
   });
 
   const extendedSetup = baseSetup.extend({
     guards: {
       // Type-safe guard references
-      isUnauthenticated: not("isAuthenticated"),
-      canAccess: and(["isAuthenticated", "hasPermission"]),
-    },
+      isUnauthenticated: not('isAuthenticated'),
+      canAccess: and(['isAuthenticated', 'hasPermission'])
+    }
   });
 
   // Both base and extended guards are available
   extendedSetup.createMachine({
     on: {
       LOGIN: {
-        guard: "isAuthenticated",
-        target: "authenticated",
+        guard: 'isAuthenticated',
+        target: 'authenticated'
       },
       LOGOUT: {
-        guard: "isUnauthenticated",
-        target: "unauthenticated",
-      },
-    },
+        guard: 'isUnauthenticated',
+        target: 'unauthenticated'
+      }
+    }
   });
   ```
 
@@ -2041,9 +2041,9 @@
     invoke: [
       {
         src: childMachine,
-        systemId: "test",
-      },
-    ],
+        systemId: 'test'
+      }
+    ]
   });
   const system = createActor(machine);
 
@@ -2057,7 +2057,7 @@
 - [#5379](https://github.com/statelyai/xstate/pull/5379) [`98f9ddd`](https://github.com/statelyai/xstate/commit/98f9ddde939320fb698ef382f6712a0753d55ca5) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Make `actor.systemId` public:
 
   ```ts
-  const actor = createActor(machine, { systemId: "test" });
+  const actor = createActor(machine, { systemId: 'test' });
   actor.systemId; // 'test'
   ```
 
@@ -2079,9 +2079,9 @@
       context: {
         count: number;
       };
-      events: { type: "inc"; value: number } | { type: "TEST" };
-      emitted: { type: "PING" };
-    },
+      events: { type: 'inc'; value: number } | { type: 'TEST' };
+      emitted: { type: 'PING' };
+    }
   });
 
   // Custom action
@@ -2091,10 +2091,10 @@
 
   // Type-bound built-ins (no wrapper needed)
   const increment = machineSetup.assign({
-    count: ({ context }) => context.count + 1,
+    count: ({ context }) => context.count + 1
   });
-  const raiseTest = machineSetup.raise({ type: "TEST" });
-  const ping = machineSetup.emit({ type: "PING" });
+  const raiseTest = machineSetup.raise({ type: 'TEST' });
+  const ping = machineSetup.emit({ type: 'PING' });
   const batch = machineSetup.enqueueActions(({ enqueue, check }) => {
     if (check(() => true)) {
       enqueue(increment);
@@ -2103,7 +2103,7 @@
 
   const machine = machineSetup.createMachine({
     context: { count: 0 },
-    entry: [action, increment, raiseTest, ping, batch],
+    entry: [action, increment, raiseTest, ping, batch]
   });
   ```
 
@@ -2131,12 +2131,12 @@
   });
 
   const machine = lightMachineSetup.createMachine({
-    initial: "green",
+    initial: 'green',
     states: {
       green,
       yellow,
-      red,
-    },
+      red
+    }
   });
   ```
 
@@ -2147,9 +2147,9 @@
 - [#5351](https://github.com/statelyai/xstate/pull/5351) [`71387ff`](https://github.com/statelyai/xstate/commit/71387ff0af86715fe233c33236fe6e6a8746e56f) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Fix: Emit callback errors no longer crash the actor
 
   ```ts
-  actor.on("event", () => {
+  actor.on('event', () => {
     // Will no longer crash the actor
-    throw new Error("oops");
+    throw new Error('oops');
   });
   ```
 
@@ -2166,16 +2166,16 @@
 - [#5287](https://github.com/statelyai/xstate/pull/5287) [`e07a7cd8462473188a0fb646a965e61be1ce6ae3`](https://github.com/statelyai/xstate/commit/e07a7cd8462473188a0fb646a965e61be1ce6ae3) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The graph and model-based testing utilities from @xstate/graph (and @xstate/test previously) were moved to the core `xstate` package.
 
   ```ts
-  import { createMachine } from "xstate";
-  import { getShortestPaths } from "xstate/graph";
+  import { createMachine } from 'xstate';
+  import { getShortestPaths } from 'xstate/graph';
 
   const machine = createMachine({
     // ...
   });
 
   const paths = getShortestPaths(machine, {
-    fromState: "a",
-    toState: "b",
+    fromState: 'a',
+    toState: 'b'
   });
   ```
 
@@ -2205,7 +2205,7 @@
 
   ```ts
   const childMachine = createMachine({
-    types: { input: {} as { value: number } },
+    types: { input: {} as { value: number } }
   });
 
   const machine = createMachine({
@@ -2214,9 +2214,9 @@
       ref: spawn(
         childMachine,
         // Input is now required!
-        { input: { value: 42 } },
-      ),
-    }),
+        { input: { value: 42 } }
+      )
+    })
   });
   ```
 
@@ -2227,7 +2227,7 @@
 - [#4954](https://github.com/statelyai/xstate/pull/4954) [`8c4b70652acaef2702f32435362e4755679a516d`](https://github.com/statelyai/xstate/commit/8c4b70652acaef2702f32435362e4755679a516d) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Added a new `transition` function that takes an actor logic, a snapshot, and an event, and returns a tuple containing the next snapshot and the actions to execute. This function is a pure function and does not execute the actions itself. It can be used like this:
 
   ```ts
-  import { transition } from "xstate";
+  import { transition } from 'xstate';
 
   const [nextState, actions] = transition(actorLogic, currentState, event);
   // Execute actions as needed
@@ -2236,7 +2236,7 @@
   Added a new `initialTransition` function that takes an actor logic and an optional input, and returns a tuple containing the initial snapshot and the actions to execute from the initial transition. This function is also a pure function and does not execute the actions itself. It can be used like this:
 
   ```ts
-  import { initialTransition } from "xstate";
+  import { initialTransition } from 'xstate';
 
   const [initialState, actions] = initialTransition(actorLogic, input);
   // Execute actions as needed
@@ -2266,47 +2266,47 @@
 
   ```ts
   const machine = setup({}).createMachine({
-    initial: "green",
+    initial: 'green',
     states: {
       green: {},
       yellow: {},
       red: {
-        initial: "walk",
+        initial: 'walk',
         states: {
           walk: {},
           wait: {},
-          stop: {},
-        },
+          stop: {}
+        }
       },
       emergency: {
-        type: "parallel",
+        type: 'parallel',
         states: {
           main: {
-            initial: "blinking",
+            initial: 'blinking',
             states: {
-              blinking: {},
-            },
+              blinking: {}
+            }
           },
           cross: {
-            initial: "blinking",
+            initial: 'blinking',
             states: {
-              blinking: {},
-            },
-          },
-        },
-      },
-    },
+              blinking: {}
+            }
+          }
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
 
   const stateValue = actor.getSnapshot().value;
 
-  if (stateValue === "green") {
+  if (stateValue === 'green') {
     // ...
-  } else if (stateValue === "yellow") {
+  } else if (stateValue === 'yellow') {
     // ...
-  } else if ("red" in stateValue) {
+  } else if ('red' in stateValue) {
     stateValue;
     // {
     //   red: "walk" | "wait" | "stop";
@@ -2327,7 +2327,7 @@
 - [#5054](https://github.com/statelyai/xstate/pull/5054) [`853f6daa0b`](https://github.com/statelyai/xstate/commit/853f6daa0b58bab6ea4153043f9efcfb18d18172) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `CallbackLogicFunction` type (previously `InvokeCallback`) is now exported. This is the callback function that you pass into `fromCallback(callbackLogicFn)` to create an actor from a callback function.
 
   ```ts
-  import { type CallbackLogicFunction } from "xstate";
+  import { type CallbackLogicFunction } from 'xstate';
 
   // ...
   ```
@@ -2368,23 +2368,23 @@
   const machine = setup({
     // ...
   }).createMachine({
-    id: "root",
-    initial: "parentState",
+    id: 'root',
+    initial: 'parentState',
     states: {
       parentState: {
         meta: {},
-        initial: "childState",
+        initial: 'childState',
         states: {
           childState: {
-            meta: {},
+            meta: {}
           },
           stateWithId: {
-            id: "state with id",
-            meta: {},
-          },
-        },
-      },
-    },
+            id: 'state with id',
+            meta: {}
+          }
+        }
+      }
+    }
   });
 
   const actor = createActor(machine);
@@ -2393,15 +2393,15 @@
 
   // Auto-completed keys:
   metaValues.root;
-  metaValues["root.parentState"];
-  metaValues["root.parentState.childState"];
-  metaValues["state with id"];
+  metaValues['root.parentState'];
+  metaValues['root.parentState.childState'];
+  metaValues['state with id'];
 
   // @ts-expect-error
-  metaValues["root.parentState.stateWithId"];
+  metaValues['root.parentState.stateWithId'];
 
   // @ts-expect-error
-  metaValues["unknown state"];
+  metaValues['unknown state'];
   ```
 
 ### Patch Changes
@@ -2417,12 +2417,12 @@
 - [#4981](https://github.com/statelyai/xstate/pull/4981) [`c4ae156b2`](https://github.com/statelyai/xstate/commit/c4ae156b278779e898aeb8d86b089de2cf959683) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Added `sendParent` to the `enqueueActions` feature. This allows users to enqueue actions that send events to the parent actor within the `enqueueActions` block.
 
   ```js
-  import { createMachine, enqueueActions } from "xstate";
+  import { createMachine, enqueueActions } from 'xstate';
 
   const childMachine = createMachine({
     entry: enqueueActions(({ enqueue }) => {
-      enqueue.sendParent({ type: "CHILD_READY" });
-    }),
+      enqueue.sendParent({ type: 'CHILD_READY' });
+    })
   });
   ```
 
@@ -2436,10 +2436,10 @@
   - `CallbackActorRef`: actor created by [`fromCallback`](https://stately.ai/docs/actors#fromcallback)
 
     ```ts
-    import { fromCallback, createActor } from "xstate";
+    import { fromCallback, createActor } from 'xstate';
 
     /** The events the actor receives. */
-    type Event = { type: "someEvent" };
+    type Event = { type: 'someEvent' };
     /** The actor's input. */
     type Input = { name: string };
 
@@ -2449,22 +2449,22 @@
       // ^? CallbackActorRef<Event, Input>
 
       receive((event) => {
-        if (event.type === "someEvent") {
+        if (event.type === 'someEvent') {
           console.log(`${input.name}: received "someEvent" event`);
           // logs 'myActor: received "someEvent" event'
         }
       });
     });
 
-    const actor = createActor(logic, { input: { name: "myActor" } });
+    const actor = createActor(logic, { input: { name: 'myActor' } });
     //    ^? CallbackActorRef<Event, Input>
     ```
 
   - `ObservableActorRef`: actor created by [`fromObservable`](https://stately.ai/docs/actors#fromobservable) and [`fromEventObservable`](https://stately.ai/docs/actors#fromeventobservable)
 
     ```ts
-    import { fromObservable, createActor } from "xstate";
-    import { interval } from "rxjs";
+    import { fromObservable, createActor } from 'xstate';
+    import { interval } from 'rxjs';
 
     /** The type of the value observed by the actor's logic. */
     type Context = number;
@@ -2489,7 +2489,7 @@
   - `PromiseActorRef`: actor created by [`fromPromise`](https://stately.ai/docs/actors#actors-as-promises)
 
     ```ts
-    import { fromPromise, createActor } from "xstate";
+    import { fromPromise, createActor } from 'xstate';
 
     /** The actor's resolved output. */
     type Output = string;
@@ -2506,14 +2506,14 @@
       return url;
     });
 
-    const actor = createActor(logic, { input: { message: "hello world" } });
+    const actor = createActor(logic, { input: { message: 'hello world' } });
     //    ^? PromiseActorRef<Output, Input>
     ```
 
   - `TransitionActorRef`: actor created by [`fromTransition`](https://stately.ai/docs/actors#fromtransition)
 
     ```ts
-    import { fromTransition, createActor, type AnyActorSystem } from "xstate";
+    import { fromTransition, createActor, type AnyActorSystem } from 'xstate';
 
     /** The actor's stored context. */
     type Context = {
@@ -2523,7 +2523,7 @@
       step: number;
     };
     /** The events the actor receives. */
-    type Event = { type: "increment" };
+    type Event = { type: 'increment' };
     /** The actor's input. */
     type Input = { step?: number };
 
@@ -2536,10 +2536,10 @@
         actorScope.self;
         //         ^? TransitionActorRef<Context, Event>
 
-        if (event.type === "increment") {
+        if (event.type === 'increment') {
           return {
             ...state,
-            count: state.count + state.step,
+            count: state.count + state.step
           };
         }
         return state;
@@ -2550,9 +2550,9 @@
 
         return {
           count: 0,
-          step: input.step ?? 1,
+          step: input.step ?? 1
         };
-      },
+      }
     );
 
     const actor = createActor(logic, { input: { step: 10 } });
@@ -2576,14 +2576,14 @@
 
   // Inspection events will be logged
   actor.start();
-  actor.send({ type: "anEvent" });
+  actor.send({ type: 'anEvent' });
 
   // ...
 
   sub.unsubscribe();
 
   // Will no longer log inspection events
-  actor.send({ type: "someEvent" });
+  actor.send({ type: 'someEvent' });
   ```
 
 - [#4942](https://github.com/statelyai/xstate/pull/4942) [`9caaa1f70`](https://github.com/statelyai/xstate/commit/9caaa1f7039f2f50096afd3885560dd40f6f17c0) Thanks [@boneskull](https://github.com/boneskull)! - `DoneActorEvent` and `ErrorActorEvent` now contain property `actorId`, which refers to the ID of the actor the event refers to.
@@ -2596,8 +2596,8 @@
   const logic = fromPromise(async ({ emit }) => {
     // ...
     emit({
-      type: "emitted",
-      msg: "hello",
+      type: 'emitted',
+      msg: 'hello'
     });
     // ...
   });
@@ -2609,8 +2609,8 @@
   const logic = fromTransition((state, event, { emit }) => {
     // ...
     emit({
-      type: "emitted",
-      msg: "hello",
+      type: 'emitted',
+      msg: 'hello'
     });
     // ...
     return state;
@@ -2624,8 +2624,8 @@
     // ...
 
     emit({
-      type: "emitted",
-      msg: "hello",
+      type: 'emitted',
+      msg: 'hello'
     });
 
     // ...
@@ -2638,8 +2638,8 @@
   const logic = fromCallback(({ emit }) => {
     // ...
     emit({
-      type: "emitted",
-      msg: "hello",
+      type: 'emitted',
+      msg: 'hello'
     });
     // ...
   });
@@ -2662,7 +2662,7 @@
 - [#4905](https://github.com/statelyai/xstate/pull/4905) [`dbeafeb25`](https://github.com/statelyai/xstate/commit/dbeafeb25eed63ee1d2b027f10bc63d9937ab073) Thanks [@davidkpiano](https://github.com/davidkpiano)! - You can now use a wildcard to listen for _any_ emitted event from an actor:
 
   ```ts
-  actor.on("*", (emitted) => {
+  actor.on('*', (emitted) => {
     console.log(emitted); // Any emitted event
   });
   ```
@@ -2675,7 +2675,7 @@
 
   ```ts
   const logic = fromPromise(({ signal }) =>
-    fetch("https://api.example.com", { signal }),
+    fetch('https://api.example.com', { signal })
   );
   ```
 
@@ -2693,7 +2693,7 @@
       assign({
         // ...
       });
-    },
+    }
   });
   ```
 
@@ -2708,17 +2708,17 @@
     types: {
       meta: {} as {
         layout: string;
-      },
-    },
+      }
+    }
   }).createMachine({
-    initial: "home",
+    initial: 'home',
     states: {
       home: {
         meta: {
-          layout: "full",
-        },
-      },
-    },
+          layout: 'full'
+        }
+      }
+    }
   });
 
   const actor = createActor(machine).start();
@@ -2739,15 +2739,15 @@
     actors: {
       existingActor: fromPromise(async () => {
         // ...
-      }),
-    },
+      })
+    }
   }).createMachine({
     invoke: {
       src: fromPromise(async () => {
         // Inline actor
-      }),
+      })
       // ...
-    },
+    }
   });
   ```
 
@@ -2758,14 +2758,14 @@
 - [#4822](https://github.com/statelyai/xstate/pull/4822) [`f7f1fbbf3`](https://github.com/statelyai/xstate/commit/f7f1fbbf3d56af9fcffe6ef9a37ab5953a90ca72) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `clock` and `logger` specified in the `options` object of `createActor(logic, options)` will now propagate to all actors created within the same actor system.
 
   ```ts
-  import { setup, log, createActor } from "xstate";
+  import { setup, log, createActor } from 'xstate';
 
   const childMachine = setup({
     // ...
   }).createMachine({
     // ...
     // Uses custom logger from root actor
-    entry: log("something"),
+    entry: log('something')
   });
 
   const parentMachine = setup({
@@ -2773,14 +2773,14 @@
   }).createMachine({
     // ...
     invoke: {
-      src: childMachine,
-    },
+      src: childMachine
+    }
   });
 
   const actor = createActor(parentMachine, {
     logger: (...args) => {
       // custom logger for args
-    },
+    }
   });
 
   actor.start();
@@ -2799,28 +2799,28 @@
 - [#4746](https://github.com/statelyai/xstate/pull/4746) [`b570ba20d`](https://github.com/statelyai/xstate/commit/b570ba20d7350819cbaf6740ff00a2bad5ffedfe) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The new `emit(…)` action creator emits events that can be received by listeners. Actors are now event emitters.
 
   ```ts
-  import { emit } from "xstate";
+  import { emit } from 'xstate';
 
   const machine = createMachine({
     // ...
     on: {
       something: {
         actions: emit({
-          type: "emitted",
-          some: "data",
-        }),
-      },
-    },
+          type: 'emitted',
+          some: 'data'
+        })
+      }
+    }
     // ...
   });
 
   const actor = createActor(machine).start();
 
-  actor.on("emitted", (event) => {
+  actor.on('emitted', (event) => {
     console.log(event);
   });
 
-  actor.send({ type: "something" });
+  actor.send({ type: 'something' });
   // logs:
   // {
   //   type: 'emitted',
@@ -2864,24 +2864,24 @@
 
   ```ts
   const machine = createMachine({
-    initial: "a",
+    initial: 'a',
     states: {
       a: {
         on: {
-          event: "b",
-        },
+          event: 'b'
+        }
       },
       b: {
-        entry: "someAction",
-        always: "c",
+        entry: 'someAction',
+        always: 'c'
       },
-      c: {},
-    },
+      c: {}
+    }
   });
 
   const actor = createActor(machine, {
     inspect: (inspEvent) => {
-      if (inspEvent.type === "@xstate.microstep") {
+      if (inspEvent.type === '@xstate.microstep') {
         console.log(inspEvent.snapshot);
         // logs:
         // { value: 'a', … }
@@ -2891,17 +2891,17 @@
         console.log(inspEvent.event);
         // logs:
         // { type: 'event', … }
-      } else if (inspEvent.type === "@xstate.action") {
+      } else if (inspEvent.type === '@xstate.action') {
         console.log(inspEvent.action);
         // logs:
         // { type: 'someAction', … }
       }
-    },
+    }
   });
 
   actor.start();
 
-  actor.send({ type: "event" });
+  actor.send({ type: 'event' });
   ```
 
 ## 5.6.2
@@ -2911,13 +2911,13 @@
 - [#4731](https://github.com/statelyai/xstate/pull/4731) [`960cdcbcb`](https://github.com/statelyai/xstate/commit/960cdcbcb88eb565bba2f03f3eeceff6001576d9) Thanks [@davidkpiano](https://github.com/davidkpiano)! - You can now import `getInitialSnapshot(…)` from `xstate` directly, which is useful for getting a mock of the initial snapshot when interacting with machines (or other actor logic) without `createActor(…)`:
 
   ```ts
-  import { getInitialSnapshot } from "xstate";
-  import { someMachine } from "./someMachine";
+  import { getInitialSnapshot } from 'xstate';
+  import { someMachine } from './someMachine';
 
   // Returns the initial snapshot (state) of the machine
   const initialSnapshot = getInitialSnapshot(
     someMachine,
-    { name: "Mateusz" }, // optional input
+    { name: 'Mateusz' } // optional input
   );
   ```
 
@@ -2968,13 +2968,13 @@
   If the `snapshot` is `undefined`, the initial snapshot of the `actorLogic` is used.
 
   ```ts
-  import { getNextSnapshot } from "xstate";
-  import { trafficLightMachine } from "./trafficLightMachine.ts";
+  import { getNextSnapshot } from 'xstate';
+  import { trafficLightMachine } from './trafficLightMachine.ts';
 
   const nextSnapshot = getNextSnapshot(
     trafficLightMachine, // actor logic
     undefined, // snapshot (or initial state if undefined)
-    { type: "TIMER" },
+    { type: 'TIMER' }
   ); // event object
 
   console.log(nextSnapshot.value);
@@ -2983,7 +2983,7 @@
   const nextSnapshot2 = getNextSnapshot(
     trafficLightMachine, // actor logic
     nextSnapshot, // snapshot
-    { type: "TIMER" },
+    { type: 'TIMER' }
   ); // event object
 
   console.log(nextSnapshot2.value);
@@ -3010,9 +3010,9 @@
   setup({/* ... */}).createMachine({
     context: ({ spawn, self }) => {
       return {
-        childRef: spawn("child", { input: { parent: self } }),
+        childRef: spawn('child', { input: { parent: self } })
       };
-    },
+    }
   });
   ```
 
@@ -3070,14 +3070,14 @@
 - [#4198](https://github.com/statelyai/xstate/pull/4198) [`ca58904ad`](https://github.com/statelyai/xstate/commit/ca58904ade8047ac9969838d2932b31846ac479c) Thanks [@davidkpiano](https://github.com/davidkpiano)! - Introduce `toPromise(actor)`, which creates a promise from an `actor` that resolves with the actor snapshot's `output` when done, or rejects with the actor snapshot's `error` when it fails.
 
   ```ts
-  import { createMachine, createActor, toPromise } from "xstate";
+  import { createMachine, createActor, toPromise } from 'xstate';
 
   const machine = createMachine({
     // ...
     states: {
       // ...
-      done: { type: "final", output: 42 },
-    },
+      done: { type: 'final', output: 42 }
+    }
   });
 
   const actor = createActor(machine);
@@ -3129,7 +3129,7 @@
   createMachine({
     types: {} as {
       context: { count: number };
-    },
+    }
     // Missing context property
   });
 
@@ -3139,8 +3139,8 @@
       context: { count: number };
     },
     context: {
-      count: 0,
-    },
+      count: 0
+    }
   });
   ```
 
@@ -3167,8 +3167,8 @@
 
   ```js
   const lightMachine = createMachine({
-    id: "light",
-    initial: "green",
+    id: 'light',
+    initial: 'green',
     states: {
       green: {},
       yellow: {},
@@ -3177,10 +3177,10 @@
         // initial: 'walk',
         states: {
           walk: {},
-          wait: {},
-        },
-      },
-    },
+          wait: {}
+        }
+      }
+    }
   });
   ```
 
@@ -3193,15 +3193,15 @@
 - d3d6149c7: IDs for delayed events are no longer derived from event types so this won't work automatically:
 
   ```ts
-  entry: raise({ type: "TIMER" }, { delay: 200 });
-  exit: cancel("TIMER");
+  entry: raise({ type: 'TIMER' }, { delay: 200 });
+  exit: cancel('TIMER');
   ```
 
   Please use explicit IDs:
 
   ```ts
-  entry: raise({ type: "TIMER" }, { delay: 200, id: "myTimer" });
-  exit: cancel("myTimer");
+  entry: raise({ type: 'TIMER' }, { delay: 200, id: 'myTimer' });
+  exit: cancel('myTimer');
   ```
 
 - d3d6149c7: Removed `State#toStrings` method.
@@ -3211,7 +3211,7 @@
   const machine = createMachine({
     // This will produce the TS error:
     // "Type 'string' is not assignable to type 'object | undefined'"
-    context: "some string",
+    context: 'some string'
   });
   ```
 
@@ -3225,8 +3225,8 @@
     invoke: {
       src: emailMachine,
       // Registers `emailMachine` as `emailer` on the system
-      systemId: "emailer",
-    },
+      systemId: 'emailer'
+    }
   });
   ```
 
@@ -3235,8 +3235,8 @@
     // ...
     entry: assign({
       emailer: (ctx, ev, { spawn }) =>
-        spawn(emailMachine, { systemId: "emailer" }),
-    }),
+        spawn(emailMachine, { systemId: 'emailer' })
+    })
   });
   ```
 
@@ -3247,10 +3247,10 @@
     // ...
     entry: sendTo(
       (ctx, ev, { system }) => {
-        return system.get("emailer");
+        return system.get('emailer');
       },
-      { type: "SEND_EMAIL", subject: "Hello", body: "World" },
-    ),
+      { type: 'SEND_EMAIL', subject: 'Hello', body: 'World' }
+    )
   });
   ```
 
@@ -3303,7 +3303,7 @@
   // Now a snapshot object with { status, output, error, context }
   const promiseActorSnapshot = promiseActor.getSnapshot();
 
-  if (promiseActorSnapshot.status === "done") {
+  if (promiseActorSnapshot.status === 'done') {
     console.log(promiseActorSnapshot.output); // 42
   }
   ```
@@ -3325,7 +3325,7 @@
   // ...
 
   const restoredActor = createActor(machine, {
-    snapshot: persistedSnapshot,
+    snapshot: persistedSnapshot
   }).start();
   ```
 
@@ -3333,13 +3333,13 @@
   - Dev tools integration has been simplified, and Redux dev tools support is no longer the default. It can be included from `xstate/devTools/redux`:
 
   ```js
-  import { createActor } from "xstate";
-  import { createReduxDevTools } from "xstate/devTools/redux";
+  import { createActor } from 'xstate';
+  import { createReduxDevTools } from 'xstate/devTools/redux';
 
   const service = createActor(someMachine, {
     devTools: createReduxDevTools({
       // Redux Dev Tools options
-    }),
+    })
   });
   ```
 
@@ -3347,7 +3347,7 @@
 
   ```js
   const service = createActor(someMachine, {
-    devTools: true, // attaches via window.__xstate__.register(service)
+    devTools: true // attaches via window.__xstate__.register(service)
   });
   ```
 
@@ -3355,7 +3355,7 @@
 
   ```js
   const myCustomDevTools = (actorRef) => {
-    console.log("Got a actorRef!");
+    console.log('Got a actorRef!');
 
     actorRef.subscribe((state) => {
       // ...
@@ -3363,7 +3363,7 @@
   };
 
   const actorRef = createActor(someMachine, {
-    devTools: myCustomDevTools,
+    devTools: myCustomDevTools
   });
   ```
 
@@ -3471,19 +3471,19 @@
   - `not(guard1)` returns `true` if a single guard evaluates to `false`, otherwise `true`
 
   ```js
-  import { and, or, not } from "xstate/guards";
+  import { and, or, not } from 'xstate/guards';
 
   const someMachine = createMachine({
     // ...
     on: {
       EVENT: {
-        target: "somewhere",
+        target: 'somewhere',
         guard: and([
-          "stringGuard",
-          or([{ type: "anotherGuard" }, not(() => false)]),
-        ]),
-      },
-    },
+          'stringGuard',
+          or([{ type: 'anotherGuard' }, not(() => false)])
+        ])
+      }
+    }
   });
   ```
 
@@ -3533,9 +3533,9 @@
         createMachine({
           // ...
         }),
-        { systemId: "actorRef" },
-      ),
-    }),
+        { systemId: 'actorRef' }
+      )
+    })
   });
   ```
 
@@ -3563,18 +3563,18 @@
   ```js
   const greetMachine = createMachine({
     context: ({ input }) => ({
-      greeting: `Hello ${input.name}!`,
+      greeting: `Hello ${input.name}!`
     }),
     entry: (_, event) => {
       event.type; // 'xstate.init'
       event.input; // { name: 'David' }
-    },
+    }
     // ...
   });
 
   const actor = createActor(greetMachine, {
     // Pass input data to the machine
-    input: { name: "David" },
+    input: { name: 'David' }
   }).start();
   ```
 
@@ -3726,16 +3726,16 @@
 
   ```ts
   createMachine({
-    initial: "a",
+    initial: 'a',
     states: {
       a: {
         after: {
-          10000: "b",
-          noon: "c",
-        },
-      },
+          10000: 'b',
+          noon: 'c'
+        }
+      }
       // ...
-    },
+    }
   });
   ```
 
@@ -3744,7 +3744,7 @@
 - d3d6149c7: The `createEmptyActor()` function has been added to make it easier to create actors that do nothing ("empty" actors). This is useful for testing, or for some integrations such as `useActor(actor)` in `@xstate/react` that require an actor:
 
   ```jsx
-  import { createEmptyActor } from "xstate";
+  import { createEmptyActor } from 'xstate';
 
   const SomeComponent = (props) => {
     // props.actor may be undefined
@@ -3838,7 +3838,7 @@
   assign((ctx, ev, { spawn }) => {
     return {
       ...ctx,
-      actorRef: spawn(promiseActor),
+      actorRef: spawn(promiseActor)
     };
   });
   ```
@@ -3846,7 +3846,7 @@
   In addition to that, you can now `spawn` actors defined in your implementations object, in the same way that you were already able to do that with `invoke`. To do that just reference the defined actor like this:
 
   ```js
-  spawn("promiseActor");
+  spawn('promiseActor');
   ```
 
 - d3d6149c7: `State` class has been removed and replaced by `MachineSnapshot` object. They largely have the same properties and methods. On of the main noticeable results of this change is that you can no longer check `state instanceof State`.
@@ -3875,9 +3875,9 @@
     //   ]
     // }),
     enqueueActions(({ enqueue }) => {
-      enqueue("action1");
-      enqueue("action2");
-    }),
+      enqueue('action1');
+      enqueue('action2');
+    })
   ];
   ```
 
@@ -3890,11 +3890,11 @@
     //   }
     // ]),
     enqueueActions(({ enqueue, check }) => {
-      if (check("someGuard")) {
-        enqueue("action1");
-        enqueue("action2");
+      if (check('someGuard')) {
+        enqueue('action1');
+        enqueue('action2');
       }
-    }),
+    })
   ];
   ```
 
@@ -3962,21 +3962,21 @@
   const machine = createMachine({
     types: {} as {
       actors: {
-        src: "fetchData"; // src name (inline behaviors ideally inferred)
-        id: "fetch1" | "fetch2"; // possible ids (optional)
+        src: 'fetchData'; // src name (inline behaviors ideally inferred)
+        id: 'fetch1' | 'fetch2'; // possible ids (optional)
         logic: typeof fetcher;
       };
     },
     invoke: {
-      src: "fetchData", // strongly typed
-      id: "fetch2", // strongly typed
+      src: 'fetchData', // strongly typed
+      id: 'fetch2', // strongly typed
       onDone: {
         actions: ({ event }) => {
           event.output; // strongly typed as { result: string }
-        },
+        }
       },
-      input: { foo: "hello" }, // strongly typed
-    },
+      input: { foo: 'hello' } // strongly typed
+    }
   });
   ```
 
@@ -4022,26 +4022,26 @@
 
   ```ts
   const machine = createMachine({
-    initial: "started",
+    initial: 'started',
     states: {
       started: {
         // ...
       },
       finished: {
-        type: "final",
+        type: 'final'
         // moved to the top level
         //
         // output: {
         //   status: 200
         // }
-      },
+      }
     },
     // This will be the final output of the machine
     // present on `snapshot.output` and in the done events received by the parent
     // when the machine reaches the top-level final state ("finished")
     output: {
-      status: 200,
-    },
+      status: 200
+    }
   });
   ```
 
@@ -4110,15 +4110,15 @@
   const machine = createMachine({
     context: ({ spawn }) => ({
       // This will be persisted
-      ref: spawn("reducer", { id: "child" }),
+      ref: spawn('reducer', { id: 'child' })
 
       // This cannot be persisted:
       // ref: spawn(fromTransition((s) => s, { count: 42 }), { id: 'child' })
-    }),
+    })
   }).provide({
     actors: {
-      reducer: fromTransition((s) => s, { count: 42 }),
-    },
+      reducer: fromTransition((s) => s, { count: 42 })
+    }
   });
   ```
 
@@ -4157,7 +4157,7 @@
     actor.subscribe({
       error: (error) => {
         // handle error
-      },
+      }
     });
     ```
   - If an observer does not have an error handler, the error will be thrown in a clear stack so bug tracking services can collect it.
@@ -4165,7 +4165,7 @@
 - d3d6149c7: You can now `spawnChild(...)` actors directly outside of `assign(...)` action creators:
 
   ```ts
-  import { createMachine, spawnChild } from "xstate";
+  import { createMachine, spawnChild } from 'xstate';
 
   const listenerMachine = createMachine({
     // ...
@@ -4174,16 +4174,16 @@
   const parentMachine = createMachine({
     // ...
     on: {
-      "listener.create": {
-        entry: spawnChild(listenerMachine, { id: "listener" }),
-      },
-    },
+      'listener.create': {
+        entry: spawnChild(listenerMachine, { id: 'listener' })
+      }
+    }
     // ...
   });
 
   const actor = createActor(parentMachine).start();
 
-  actor.send({ type: "listener.create" });
+  actor.send({ type: 'listener.create' });
 
   actor.getSnapshot().children.listener; // ActorRefFrom<typeof listenerMachine>
   ```
@@ -4195,27 +4195,27 @@
   createMachine({
     types: {} as {
       events:
-        | { type: "mouse.click.up"; direction: "up" }
-        | { type: "mouse.click.down"; direction: "down" }
-        | { type: "mouse.move" }
-        | { type: "keypress" };
+        | { type: 'mouse.click.up'; direction: 'up' }
+        | { type: 'mouse.click.down'; direction: 'down' }
+        | { type: 'mouse.move' }
+        | { type: 'keypress' };
     },
     on: {
-      "mouse.click.*": {
+      'mouse.click.*': {
         actions: ({ event }) => {
           event.type;
           // 'mouse.click.up' | 'mouse.click.down'
           event.direction;
           // 'up' | 'down'
-        },
+        }
       },
-      "mouse.*": {
+      'mouse.*': {
         actions: ({ event }) => {
           event.type;
           // 'mouse.click.up' | 'mouse.click.down' | 'mouse.move'
-        },
-      },
-    },
+        }
+      }
+    }
   });
   ```
 
@@ -4226,14 +4226,14 @@
   createMachine({
     types: {} as {
       actions:
-        { type: "greet"; params: { surname: string } } | { type: "poke" };
+        { type: 'greet'; params: { surname: string } } | { type: 'poke' };
     },
     entry: {
-      type: "greet",
+      type: 'greet',
       params: ({ context }) => ({
-        surname: "Doe",
-      }),
-    },
+        surname: 'Doe'
+      })
+    }
   });
   ```
 
@@ -4243,12 +4243,12 @@
   const machine = setup({
     types: {} as {
       children: {
-        myId: "actorKey";
+        myId: 'actorKey';
       };
     },
     actors: {
-      actorKey: child,
-    },
+      actorKey: child
+    }
   }).createMachine({});
 
   const actorRef = createActor(machine).start();
@@ -4263,13 +4263,13 @@
     types: {} as {
       guards:
         | {
-            type: "isGreaterThan";
+            type: 'isGreaterThan';
             params: {
               count: number;
             };
           }
-        | { type: "plainGuard" };
-    },
+        | { type: 'plainGuard' };
+    }
     // ...
   });
   ```
@@ -4279,8 +4279,8 @@
   ```ts
   createMachine({
     types: {} as {
-      tags: "pending" | "success" | "error";
-    },
+      tags: 'pending' | 'success' | 'error';
+    }
     // ...
   });
   ```
@@ -4334,17 +4334,17 @@
     {
       // ...
       entry: {
-        type: "greet",
-        params: { message: "hello" },
-      },
+        type: 'greet',
+        params: { message: 'hello' }
+      }
     },
     {
       actions: {
         greet: (_, params) => {
           params.message; // 'hello'
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -4361,16 +4361,16 @@
     context: ({ input }) => ({
       // Strongly-typed input!
       emailSubject: input.subject,
-      emailBody: input.message.trim(),
-    }),
+      emailBody: input.message.trim()
+    })
   });
 
   const emailActor = interpret(emailMachine, {
     input: {
       // Strongly-typed input!
-      subject: "Hello, world!",
-      message: "This is a test.",
-    },
+      subject: 'Hello, world!',
+      message: 'This is a test.'
+    }
   }).start();
   ```
 
@@ -4396,19 +4396,19 @@
       on: {
         EVENT: {
           guard: {
-            type: "isGreaterThan",
-            params: { value: 10 },
-          },
-        },
-      },
+            type: 'isGreaterThan',
+            params: { value: 10 }
+          }
+        }
+      }
     },
     {
       guards: {
         isGreaterThan: (_, params) => {
           params.value; // 10
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -4418,7 +4418,7 @@
   - `@xstate.snapshot` - An actor ref emitted a snapshot due to a received event
 
   ```ts
-  import { createMachine } from "xstate";
+  import { createMachine } from 'xstate';
 
   const machine = createMachine({
     // ...
@@ -4426,22 +4426,22 @@
 
   const actor = createActor(machine, {
     inspect: (inspectionEvent) => {
-      if (inspectionEvent.type === "@xstate.actor") {
+      if (inspectionEvent.type === '@xstate.actor') {
         console.log(inspectionEvent.actorRef);
       }
 
-      if (inspectionEvent.type === "@xstate.event") {
+      if (inspectionEvent.type === '@xstate.event') {
         console.log(inspectionEvent.sourceRef);
         console.log(inspectionEvent.targetRef);
         console.log(inspectionEvent.event);
       }
 
-      if (inspectionEvent.type === "@xstate.snapshot") {
+      if (inspectionEvent.type === '@xstate.snapshot') {
         console.log(inspectionEvent.actorRef);
         console.log(inspectionEvent.event);
         console.log(inspectionEvent.snapshot);
       }
-    },
+    }
   });
   ```
 
@@ -4454,31 +4454,31 @@
     entry: enqueueActions(({ context, event, enqueue, check }) => {
       // assign action
       enqueue.assign({
-        count: context.count + 1,
+        count: context.count + 1
       });
 
       // Conditional actions (replaces choose(...))
       if (event.someOption) {
-        enqueue.sendTo("someActor", { type: "blah", thing: context.thing });
+        enqueue.sendTo('someActor', { type: 'blah', thing: context.thing });
 
         // other actions
-        enqueue("namedAction");
+        enqueue('namedAction');
         // with params
-        enqueue({ type: "greet", params: { message: "hello" } });
+        enqueue({ type: 'greet', params: { message: 'hello' } });
       } else {
         // inline
-        enqueue(() => console.log("hello"));
+        enqueue(() => console.log('hello'));
 
         // even built-in actions
       }
 
       // Use check(...) to conditionally enqueue actions based on a guard
-      if (check({ type: "someGuard" })) {
+      if (check({ type: 'someGuard' })) {
         // ...
       }
 
       // no return
-    }),
+    })
   });
   ```
 
@@ -4488,20 +4488,20 @@
   ```ts
   createMachine({
     types: {} as {
-      actions: { type: "greet"; params: { name: string } };
+      actions: { type: 'greet'; params: { name: string } };
     },
     entry: [
       {
-        type: "greet",
+        type: 'greet',
         params: {
-          name: "David",
-        },
+          name: 'David'
+        }
       },
       // @ts-expect-error
-      { type: "greet" },
+      { type: 'greet' },
       // @ts-expect-error
-      { type: "unknownAction" },
-    ],
+      { type: 'unknownAction' }
+    ]
     // ...
   });
   ```
@@ -4519,10 +4519,10 @@
   const machine = createMachine({
     types: {} as {
       output: {
-        result: "pass" | "fail";
+        result: 'pass' | 'fail';
         score: number;
       };
-    },
+    }
     // ...
   });
 
@@ -4544,7 +4544,7 @@
 - d3d6149c7: You can now use the `setup({ ... }).createMachine({ ... })` function to setup implementations for `actors`, `actions`, `guards`, and `delays` that will be used in the created machine:
 
   ```ts
-  import { setup, createMachine } from "xstate";
+  import { setup, createMachine } from 'xstate';
 
   const fetchUser = fromPromise(async ({ input }) => {
     const response = await fetch(`/user/${input.id}`);
@@ -4554,33 +4554,33 @@
 
   const machine = setup({
     actors: {
-      fetchUser,
+      fetchUser
     },
     actions: {
-      clearUser: assign({ user: undefined }),
+      clearUser: assign({ user: undefined })
     },
     guards: {
-      isUserAdmin: (_, params) => params.user.role === "admin",
-    },
+      isUserAdmin: (_, params) => params.user.role === 'admin'
+    }
   }).createMachine({
     // ...
     invoke: {
       // Strongly typed!
-      src: "fetchUser",
+      src: 'fetchUser',
       input: ({ context }) => ({ id: context.userId }),
       onDone: {
         guard: {
-          type: "isUserAdmin",
-          params: ({ context }) => ({ user: context.user }),
+          type: 'isUserAdmin',
+          params: ({ context }) => ({ user: context.user })
         },
-        target: "success",
-        actions: assign({ user: ({ event }) => event.output }),
+        target: 'success',
+        actions: assign({ user: ({ event }) => event.output })
       },
       onError: {
-        target: "failure",
-        actions: "clearUser",
-      },
-    },
+        target: 'failure',
+        actions: 'clearUser'
+      }
+    }
   });
   ```
 
@@ -4589,8 +4589,8 @@
   ```ts
   createMachine({
     types: {} as {
-      delays: "one second" | "one minute";
-    },
+      delays: 'one second' | 'one minute';
+    }
     // ...
   });
   ```
@@ -4613,7 +4613,7 @@
 
   ```ts
   createMachine({
-    on: [{ event: "FOO", target: "#id" }],
+    on: [{ event: 'FOO', target: '#id' }]
     // ...
   });
   ```
@@ -4623,8 +4623,8 @@
   ```ts
   createMachine({
     on: {
-      FOO: "#id",
-    },
+      FOO: '#id'
+    }
     // ...
   });
   ```
@@ -4689,9 +4689,9 @@
     //   ]
     // }),
     enqueueActions(({ enqueue }) => {
-      enqueue("action1");
-      enqueue("action2");
-    }),
+      enqueue('action1');
+      enqueue('action2');
+    })
   ];
   ```
 
@@ -4704,11 +4704,11 @@
     //   }
     // ]),
     enqueueActions(({ enqueue, check }) => {
-      if (check("someGuard")) {
-        enqueue("action1");
-        enqueue("action2");
+      if (check('someGuard')) {
+        enqueue('action1');
+        enqueue('action2');
       }
-    }),
+    })
   ];
   ```
 
@@ -4728,31 +4728,31 @@
     entry: enqueueActions(({ context, event, enqueue, check }) => {
       // assign action
       enqueue.assign({
-        count: context.count + 1,
+        count: context.count + 1
       });
 
       // Conditional actions (replaces choose(...))
       if (event.someOption) {
-        enqueue.sendTo("someActor", { type: "blah", thing: context.thing });
+        enqueue.sendTo('someActor', { type: 'blah', thing: context.thing });
 
         // other actions
-        enqueue("namedAction");
+        enqueue('namedAction');
         // with params
-        enqueue({ type: "greet", params: { message: "hello" } });
+        enqueue({ type: 'greet', params: { message: 'hello' } });
       } else {
         // inline
-        enqueue(() => console.log("hello"));
+        enqueue(() => console.log('hello'));
 
         // even built-in actions
       }
 
       // Use check(...) to conditionally enqueue actions based on a guard
-      if (check({ type: "someGuard" })) {
+      if (check({ type: 'someGuard' })) {
         // ...
       }
 
       // no return
-    }),
+    })
   });
   ```
 
@@ -4791,22 +4791,22 @@
 - [#4488](https://github.com/statelyai/xstate/pull/4488) [`9ca3c3dcf`](https://github.com/statelyai/xstate/commit/9ca3c3dcf25aba67aab5b6390766c273e9eba766) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `spawn(...)` action creator has been renamed to `spawnChild(...)` to avoid confusion.
 
   ```ts
-  import { spawnChild, assign } from "xstate";
+  import { spawnChild, assign } from 'xstate';
 
   const childMachine = createMachine({
     on: {
       someEvent: {
         actions: [
           // spawnChild(...) instead of spawn(...)
-          spawnChild("someSrc"),
+          spawnChild('someSrc'),
 
           // spawn() is used inside of assign()
           assign({
-            anotherRef: ({ spawn }) => spawn("anotherSrc"),
-          }),
-        ],
-      },
-    },
+            anotherRef: ({ spawn }) => spawn('anotherSrc')
+          })
+        ]
+      }
+    }
   });
   ```
 
@@ -4826,12 +4826,12 @@
   const machine = setup({
     types: {} as {
       children: {
-        myId: "actorKey";
+        myId: 'actorKey';
       };
     },
     actors: {
-      actorKey: child,
-    },
+      actorKey: child
+    }
   }).createMachine({});
 
   const actorRef = createActor(machine).start();
@@ -4864,7 +4864,7 @@
 - [#4353](https://github.com/statelyai/xstate/pull/4353) [`a3a11c84e`](https://github.com/statelyai/xstate/commit/a3a11c84e30c86afd63e47c77a46a61d926291d1) Thanks [@davidkpiano](https://github.com/davidkpiano)! - You can now use the `setup({ ... }).createMachine({ ... })` function to setup implementations for `actors`, `actions`, `guards`, and `delays` that will be used in the created machine:
 
   ```ts
-  import { setup, createMachine } from "xstate";
+  import { setup, createMachine } from 'xstate';
 
   const fetchUser = fromPromise(async ({ input }) => {
     const response = await fetch(`/user/${input.id}`);
@@ -4874,33 +4874,33 @@
 
   const machine = setup({
     actors: {
-      fetchUser,
+      fetchUser
     },
     actions: {
-      clearUser: assign({ user: undefined }),
+      clearUser: assign({ user: undefined })
     },
     guards: {
-      isUserAdmin: (_, params) => params.user.role === "admin",
-    },
+      isUserAdmin: (_, params) => params.user.role === 'admin'
+    }
   }).createMachine({
     // ...
     invoke: {
       // Strongly typed!
-      src: "fetchUser",
+      src: 'fetchUser',
       input: ({ context }) => ({ id: context.userId }),
       onDone: {
         guard: {
-          type: "isUserAdmin",
-          params: ({ context }) => ({ user: context.user }),
+          type: 'isUserAdmin',
+          params: ({ context }) => ({ user: context.user })
         },
-        target: "success",
-        actions: assign({ user: ({ event }) => event.output }),
+        target: 'success',
+        actions: assign({ user: ({ event }) => event.output })
       },
       onError: {
-        target: "failure",
-        actions: "clearUser",
-      },
-    },
+        target: 'failure',
+        actions: 'clearUser'
+      }
+    }
   });
   ```
 
@@ -4930,17 +4930,17 @@
   createMachine(
     {
       invoke: {
-        src: "child",
-      },
+        src: 'child'
+      }
     },
     {
       actors: {
         child: {
           src: childMachine,
-          input: "foo",
-        },
-      },
-    },
+          input: 'foo'
+        }
+      }
+    }
   );
   ```
 
@@ -4984,11 +4984,11 @@
         // This event is for the root actor
       }
 
-      if (event.type === "@xstate.event") {
+      if (event.type === '@xstate.event') {
         // previously event.targetRef
         event.actorRef;
       }
-    },
+    }
   });
   ```
 
@@ -5017,7 +5017,7 @@
 - [#4329](https://github.com/statelyai/xstate/pull/4329) [`41f5a7dc5`](https://github.com/statelyai/xstate/commit/41f5a7dc59a2cd946dff937664de2fa14780b007) Thanks [@davidkpiano](https://github.com/davidkpiano)! - You can now `spawn(...)` actors directly outside of `assign(...)` action creators:
 
   ```ts
-  import { createMachine, spawn } from "xstate";
+  import { createMachine, spawn } from 'xstate';
 
   const listenerMachine = createMachine({
     // ...
@@ -5026,16 +5026,16 @@
   const parentMachine = createMachine({
     // ...
     on: {
-      "listener.create": {
-        entry: spawn(listenerMachine, { id: "listener" }),
-      },
-    },
+      'listener.create': {
+        entry: spawn(listenerMachine, { id: 'listener' })
+      }
+    }
     // ...
   });
 
   const actor = createActor(parentMachine).start();
 
-  actor.send({ type: "listener.create" });
+  actor.send({ type: 'listener.create' });
 
   actor.getSnapshot().children.listener; // ActorRefFrom<typeof listenerMachine>
   ```
@@ -5047,17 +5047,17 @@
     {
       // ...
       entry: {
-        type: "greet",
-        params: { message: "hello" },
-      },
+        type: 'greet',
+        params: { message: 'hello' }
+      }
     },
     {
       actions: {
         greet: (_, params) => {
           params.message; // 'hello'
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -5070,19 +5070,19 @@
       on: {
         EVENT: {
           guard: {
-            type: "isGreaterThan",
-            params: { value: 10 },
-          },
-        },
-      },
+            type: 'isGreaterThan',
+            params: { value: 10 }
+          }
+        }
+      }
     },
     {
       guards: {
         isGreaterThan: (_, params) => {
           params.value; // 10
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -5140,16 +5140,16 @@
 
   ```ts
   createMachine({
-    initial: "a",
+    initial: 'a',
     states: {
       a: {
         after: {
-          10000: "b",
-          noon: "c",
-        },
-      },
+          10000: 'b',
+          noon: 'c'
+        }
+      }
       // ...
-    },
+    }
   });
   ```
 
@@ -5159,15 +5159,15 @@
   const machine = createMachine({
     context: ({ spawn }) => ({
       // This will be persisted
-      ref: spawn("reducer", { id: "child" }),
+      ref: spawn('reducer', { id: 'child' })
 
       // This cannot be persisted:
       // ref: spawn(fromTransition((s) => s, { count: 42 }), { id: 'child' })
-    }),
+    })
   }).provide({
     actors: {
-      reducer: fromTransition((s) => s, { count: 42 }),
-    },
+      reducer: fromTransition((s) => s, { count: 42 })
+    }
   });
   ```
 
@@ -5196,8 +5196,8 @@
     InspectedActorEvent,
     InspectedEventEvent,
     InspectedSnapshotEvent,
-    InspectionEvent,
-  } from "xstate";
+    InspectionEvent
+  } from 'xstate';
   ```
 
 ## 5.0.0-beta.33
@@ -5210,7 +5210,7 @@
   - `@xstate.snapshot` - An actor ref emitted a snapshot due to a received event
 
   ```ts
-  import { createMachine } from "xstate";
+  import { createMachine } from 'xstate';
 
   const machine = createMachine({
     // ...
@@ -5218,22 +5218,22 @@
 
   const actor = createActor(machine, {
     inspect: (inspectionEvent) => {
-      if (inspectionEvent.type === "@xstate.actor") {
+      if (inspectionEvent.type === '@xstate.actor') {
         console.log(inspectionEvent.actorRef);
       }
 
-      if (inspectionEvent.type === "@xstate.event") {
+      if (inspectionEvent.type === '@xstate.event') {
         console.log(inspectionEvent.sourceRef);
         console.log(inspectionEvent.targetRef);
         console.log(inspectionEvent.event);
       }
 
-      if (inspectionEvent.type === "@xstate.snapshot") {
+      if (inspectionEvent.type === '@xstate.snapshot') {
         console.log(inspectionEvent.actorRef);
         console.log(inspectionEvent.event);
         console.log(inspectionEvent.snapshot);
       }
-    },
+    }
   });
   ```
 
@@ -5257,26 +5257,26 @@
 
   ```ts
   const machine = createMachine({
-    initial: "started",
+    initial: 'started',
     states: {
       started: {
         // ...
       },
       finished: {
-        type: "final",
+        type: 'final'
         // moved to the top level
         //
         // output: {
         //   status: 200
         // }
-      },
+      }
     },
     // This will be the final output of the machine
     // present on `snapshot.output` and in the done events received by the parent
     // when the machine reaches the top-level final state ("finished")
     output: {
-      status: 200,
-    },
+      status: 200
+    }
   });
   ```
 
@@ -5341,7 +5341,7 @@
   // Now a snapshot object with { status, output, error, context }
   const promiseActorSnapshot = promiseActor.getSnapshot();
 
-  if (promiseActorSnapshot.status === "done") {
+  if (promiseActorSnapshot.status === 'done') {
     console.log(promiseActorSnapshot.output); // 42
   }
   ```
@@ -5373,8 +5373,8 @@
     type CallbackActorLogic,
     type ObservableActorLogic,
     type PromiseActorLogic,
-    type TransitionActorLogic,
-  } from "xstate";
+    type TransitionActorLogic
+  } from 'xstate';
   ```
 
 - [#4222](https://github.com/statelyai/xstate/pull/4222) [`41822f05e`](https://github.com/statelyai/xstate/commit/41822f05e46c2b439a69fac48872a4a6efe65739) Thanks [@Andarist](https://github.com/Andarist)! - `spawn` can now benefit from the actor types. Its arguments are strongly-typed based on them.
@@ -5402,14 +5402,14 @@
   createMachine({
     types: {} as {
       actions:
-        { type: "greet"; params: { surname: string } } | { type: "poke" };
+        { type: 'greet'; params: { surname: string } } | { type: 'poke' };
     },
     entry: {
-      type: "greet",
+      type: 'greet',
       params: ({ context }) => ({
-        surname: "Doe",
-      }),
-    },
+        surname: 'Doe'
+      })
+    }
   });
   ```
 
@@ -5423,27 +5423,27 @@
   createMachine({
     types: {} as {
       events:
-        | { type: "mouse.click.up"; direction: "up" }
-        | { type: "mouse.click.down"; direction: "down" }
-        | { type: "mouse.move" }
-        | { type: "keypress" };
+        | { type: 'mouse.click.up'; direction: 'up' }
+        | { type: 'mouse.click.down'; direction: 'down' }
+        | { type: 'mouse.move' }
+        | { type: 'keypress' };
     },
     on: {
-      "mouse.click.*": {
+      'mouse.click.*': {
         actions: ({ event }) => {
           event.type;
           // 'mouse.click.up' | 'mouse.click.down'
           event.direction;
           // 'up' | 'down'
-        },
+        }
       },
-      "mouse.*": {
+      'mouse.*': {
         actions: ({ event }) => {
           event.type;
           // 'mouse.click.up' | 'mouse.click.down' | 'mouse.move'
-        },
-      },
-    },
+        }
+      }
+    }
   });
   ```
 
@@ -5456,8 +5456,8 @@
   ```ts
   createMachine({
     types: {} as {
-      tags: "pending" | "success" | "error";
-    },
+      tags: 'pending' | 'success' | 'error';
+    }
     // ...
   });
   ```
@@ -5469,8 +5469,8 @@
   ```ts
   createMachine({
     types: {} as {
-      delays: "one second" | "one minute";
-    },
+      delays: 'one second' | 'one minute';
+    }
     // ...
   });
   ```
@@ -5486,13 +5486,13 @@
     types: {} as {
       guards:
         | {
-            type: "isGreaterThan";
+            type: 'isGreaterThan';
             params: {
               count: number;
             };
           }
-        | { type: "plainGuard" };
-    },
+        | { type: 'plainGuard' };
+    }
     // ...
   });
   ```
@@ -5512,20 +5512,20 @@
   ```ts
   createMachine({
     types: {} as {
-      actions: { type: "greet"; params: { name: string } };
+      actions: { type: 'greet'; params: { name: string } };
     },
     entry: [
       {
-        type: "greet",
+        type: 'greet',
         params: {
-          name: "David",
-        },
+          name: 'David'
+        }
       },
       // @ts-expect-error
-      { type: "greet" },
+      { type: 'greet' },
       // @ts-expect-error
-      { type: "unknownAction" },
-    ],
+      { type: 'unknownAction' }
+    ]
     // ...
   });
   ```
@@ -5536,10 +5536,10 @@
   const machine = createMachine({
     types: {} as {
       output: {
-        result: "pass" | "fail";
+        result: 'pass' | 'fail';
         score: number;
       };
-    },
+    }
     // ...
   });
 
@@ -5582,7 +5582,7 @@
     actor.subscribe({
       error: (error) => {
         // handle error
-      },
+      }
     });
     ```
   - If an observer does not have an error handler, the error will be thrown in a clear stack so bug tracking services can collect it.
@@ -5600,16 +5600,16 @@
     context: ({ input }) => ({
       // Strongly-typed input!
       emailSubject: input.subject,
-      emailBody: input.message.trim(),
-    }),
+      emailBody: input.message.trim()
+    })
   });
 
   const emailActor = interpret(emailMachine, {
     input: {
       // Strongly-typed input!
-      subject: "Hello, world!",
-      message: "This is a test.",
-    },
+      subject: 'Hello, world!',
+      message: 'This is a test.'
+    }
   }).start();
   ```
 
@@ -5625,21 +5625,21 @@
   const machine = createMachine({
     types: {} as {
       actors: {
-        src: "fetchData"; // src name (inline behaviors ideally inferred)
-        id: "fetch1" | "fetch2"; // possible ids (optional)
+        src: 'fetchData'; // src name (inline behaviors ideally inferred)
+        id: 'fetch1' | 'fetch2'; // possible ids (optional)
         logic: typeof fetcher;
       };
     },
     invoke: {
-      src: "fetchData", // strongly typed
-      id: "fetch2", // strongly typed
+      src: 'fetchData', // strongly typed
+      id: 'fetch2', // strongly typed
       onDone: {
         actions: ({ event }) => {
           event.output; // strongly typed as { result: string }
-        },
+        }
       },
-      input: { foo: "hello" }, // strongly typed
-    },
+      input: { foo: 'hello' } // strongly typed
+    }
   });
   ```
 
@@ -5658,7 +5658,7 @@
 - [#4159](https://github.com/statelyai/xstate/pull/4159) [`8bfbb8531`](https://github.com/statelyai/xstate/commit/8bfbb85316d305dc33b00b6e6170652fa248b20b) Thanks [@Andarist](https://github.com/Andarist)! - The `cancel` action was added to the main export:
 
   ```ts
-  import { cancel } from "xstate";
+  import { cancel } from 'xstate';
   ```
 
 ## 5.0.0-beta.19
@@ -5672,7 +5672,7 @@
   createMachine({
     types: {} as {
       context: { count: number };
-    },
+    }
     // Missing context property
   });
 
@@ -5682,8 +5682,8 @@
       context: { count: number };
     },
     context: {
-      count: 0,
-    },
+      count: 0
+    }
   });
   ```
 
@@ -5727,15 +5727,15 @@
 - [#4127](https://github.com/statelyai/xstate/pull/4127) [`cdaddc266`](https://github.com/statelyai/xstate/commit/cdaddc2667f9021cd9452206aab1227d5a5c229c) Thanks [@Andarist](https://github.com/Andarist)! - IDs for delayed events are no longer derived from event types so this won't work automatically:
 
   ```ts
-  entry: raise({ type: "TIMER" }, { delay: 200 });
-  exit: cancel("TIMER");
+  entry: raise({ type: 'TIMER' }, { delay: 200 });
+  exit: cancel('TIMER');
   ```
 
   Please use explicit IDs:
 
   ```ts
-  entry: raise({ type: "TIMER" }, { delay: 200, id: "myTimer" });
-  exit: cancel("myTimer");
+  entry: raise({ type: 'TIMER' }, { delay: 200, id: 'myTimer' });
+  exit: cancel('myTimer');
   ```
 
 - [#4127](https://github.com/statelyai/xstate/pull/4127) [`cdaddc266`](https://github.com/statelyai/xstate/commit/cdaddc2667f9021cd9452206aab1227d5a5c229c) Thanks [@Andarist](https://github.com/Andarist)! - All builtin action creators (`assign`, `sendTo`, etc) are now returning _functions_. They exact shape of those is considered an implementation detail of XState and users are meant to only pass around the returned values.
@@ -5746,7 +5746,7 @@
 
   ```ts
   createMachine({
-    on: [{ event: "FOO", target: "#id" }],
+    on: [{ event: 'FOO', target: '#id' }]
     // ...
   });
   ```
@@ -5756,8 +5756,8 @@
   ```ts
   createMachine({
     on: {
-      FOO: "#id",
-    },
+      FOO: '#id'
+    }
     // ...
   });
   ```
@@ -5783,25 +5783,25 @@
   ```ts
   const machine = createMachine(
     {
-      initial: "home",
+      initial: 'home',
       states: {
         home: {
           on: {
             NEXT: {
-              target: "success",
-              guard: "hasSelection",
-            },
-          },
+              target: 'success',
+              guard: 'hasSelection'
+            }
+          }
         },
-        success: {},
-      },
+        success: {}
+      }
     },
     {
       guards: {
         // `hasSelection` is a guard object that references the `stateIn` guard
-        hasSelection: stateIn("selected"),
-      },
-    },
+        hasSelection: stateIn('selected')
+      }
+    }
   );
   ```
 
@@ -5812,7 +5812,7 @@
 - [#4098](https://github.com/statelyai/xstate/pull/4098) [`ae7691811`](https://github.com/statelyai/xstate/commit/ae7691811d0ac92294532ce1e5ede3898ecffbc7) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `log`, `pure`, `choose`, and `stop` actions were added to the main export:
 
   ```ts
-  import { log, pure, choose, stop } from "xstate";
+  import { log, pure, choose, stop } from 'xstate';
   ```
 
 ## 5.0.0-beta.14
@@ -5867,9 +5867,9 @@
         createMachine({
           // ...
         }),
-        { systemId: "actorRef" },
-      ),
-    }),
+        { systemId: 'actorRef' }
+      )
+    })
   });
   ```
 
@@ -5955,7 +5955,7 @@
 - [#3968](https://github.com/statelyai/xstate/pull/3968) [`eecb31b8f`](https://github.com/statelyai/xstate/commit/eecb31b8f43efc4580887ad850336ea74cfba537) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `createEmptyActor()` function has been added to make it easier to create actors that do nothing ("empty" actors). This is useful for testing, or for some integrations such as `useActor(actor)` in `@xstate/react` that require an actor:
 
   ```jsx
-  import { createEmptyActor } from "xstate";
+  import { createEmptyActor } from 'xstate';
 
   const SomeComponent = (props) => {
     // props.actor may be undefined
@@ -6089,8 +6089,8 @@
     invoke: {
       src: emailMachine,
       // Registers `emailMachine` as `emailer` on the system
-      key: "emailer",
-    },
+      key: 'emailer'
+    }
   });
   ```
 
@@ -6098,8 +6098,8 @@
   const machine = createMachine({
     // ...
     entry: assign({
-      emailer: (ctx, ev, { spawn }) => spawn(emailMachine, { key: "emailer" }),
-    }),
+      emailer: (ctx, ev, { spawn }) => spawn(emailMachine, { key: 'emailer' })
+    })
   });
   ```
 
@@ -6110,10 +6110,10 @@
     // ...
     entry: sendTo(
       (ctx, ev, { system }) => {
-        return system.get("emailer");
+        return system.get('emailer');
       },
-      { type: "SEND_EMAIL", subject: "Hello", body: "World" },
-    ),
+      { type: 'SEND_EMAIL', subject: 'Hello', body: 'World' }
+    )
   });
   ```
 
@@ -6159,7 +6159,7 @@
   // ...
 
   const restoredActor = interpret(machine, {
-    state: persistedState,
+    state: persistedState
   }).start();
   ```
 
@@ -6187,18 +6187,18 @@
   ```js
   const greetMachine = createMachine({
     context: ({ input }) => ({
-      greeting: `Hello ${input.name}!`,
+      greeting: `Hello ${input.name}!`
     }),
     entry: (_, event) => {
       event.type; // 'xstate.init'
       event.input; // { name: 'David' }
-    },
+    }
     // ...
   });
 
   const actor = interpret(greetMachine, {
     // Pass input data to the machine
-    input: { name: "David" },
+    input: { name: 'David' }
   }).start();
   ```
 
@@ -6279,11 +6279,11 @@
   ```ts
   const machine = createMachine({
     // `tags` attached to machine via typegen
-    tsTypes: {} as import("./machine.typegen").Typegen0,
-    tags: ["a", "b"],
+    tsTypes: {} as import('./machine.typegen').Typegen0,
+    tags: ['a', 'b'],
     states: {
-      idle: { tags: "c" },
-    },
+      idle: { tags: 'c' }
+    }
   });
 
   type Tags = TagsFrom<typeof machine>; // 'a' | 'b' | 'c'
@@ -6293,10 +6293,10 @@
 
   ```ts
   const machine = createMachine({
-    tags: ["a", "b"],
+    tags: ['a', 'b'],
     states: {
-      idle: { tags: "c" },
-    },
+      idle: { tags: 'c' }
+    }
   });
 
   type Tags = TagsFrom<typeof machine>; // string
@@ -6325,7 +6325,7 @@
   ```ts
   actions: assign({
     counter: 0,
-    delta: (ctx, ev) => ev.delta,
+    delta: (ctx, ev) => ev.delta
   });
   ```
 
@@ -6424,14 +6424,14 @@
   ```ts
   const machine = createMachine(
     {
-      entry: ["doStuff"],
+      entry: ['doStuff']
     },
     {
       actions: {
-        doStuff: pure(() => ["someAction"]),
-        someAction: () => console.log("executed by doStuff"),
-      },
-    },
+        doStuff: pure(() => ['someAction']),
+        someAction: () => console.log('executed by doStuff')
+      }
+    }
   );
   ```
 
@@ -6446,7 +6446,7 @@
 - [#3588](https://github.com/statelyai/xstate/pull/3588) [`a4c8ead99`](https://github.com/statelyai/xstate/commit/a4c8ead9963f5e9097896ba0fdc1cdcc0acfd621) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The actions `raise` and `sendTo` can now be imported directly from `xstate`:
 
   ```js
-  import { raise, sendTo } from "xstate";
+  import { raise, sendTo } from 'xstate';
 
   // ...
   ```
@@ -6556,8 +6556,8 @@
 
   ```js
   const lightMachine = createMachine({
-    id: "light",
-    initial: "green",
+    id: 'light',
+    initial: 'green',
     states: {
       green: {},
       yellow: {},
@@ -6566,10 +6566,10 @@
         // initial: 'walk',
         states: {
           walk: {},
-          wait: {},
-        },
-      },
-    },
+          wait: {}
+        }
+      }
+    }
   });
   ```
 
@@ -6585,7 +6585,7 @@
   const machine = createMachine({
     // This will produce the TS error:
     // "Type 'string' is not assignable to type 'object | undefined'"
-    context: "some string",
+    context: 'some string'
   });
   ```
 
@@ -6618,13 +6618,13 @@
   - Dev tools integration has been simplified, and Redux dev tools support is no longer the default. It can be included from `xstate/devTools/redux`:
 
   ```js
-  import { interpret } from "xstate";
-  import { createReduxDevTools } from "xstate/devTools/redux";
+  import { interpret } from 'xstate';
+  import { createReduxDevTools } from 'xstate/devTools/redux';
 
   const service = interpret(someMachine, {
     devTools: createReduxDevTools({
       // Redux Dev Tools options
-    }),
+    })
   });
   ```
 
@@ -6632,7 +6632,7 @@
 
   ```js
   const service = interpret(someMachine, {
-    devTools: true, // attaches via window.__xstate__.register(service)
+    devTools: true // attaches via window.__xstate__.register(service)
   });
   ```
 
@@ -6640,7 +6640,7 @@
 
   ```js
   const myCustomDevTools = (service) => {
-    console.log("Got a service!");
+    console.log('Got a service!');
 
     service.subscribe((state) => {
       // ...
@@ -6648,7 +6648,7 @@
   };
 
   const service = interpret(someMachine, {
-    devTools: myCustomDevTools,
+    devTools: myCustomDevTools
   });
   ```
 
@@ -6695,19 +6695,19 @@
   - `not(guard1)` returns `true` if a single guard evaluates to `false`, otherwise `true`
 
   ```js
-  import { and, or, not } from "xstate/guards";
+  import { and, or, not } from 'xstate/guards';
 
   const someMachine = createMachine({
     // ...
     on: {
       EVENT: {
-        target: "somewhere",
+        target: 'somewhere',
         guard: and([
-          "stringGuard",
-          or([{ type: "anotherGuard" }, not(() => false)]),
-        ]),
-      },
-    },
+          'stringGuard',
+          or([{ type: 'anotherGuard' }, not(() => false)])
+        ])
+      }
+    }
   });
   ```
 
@@ -6871,7 +6871,7 @@
   assign((ctx, ev, { spawn }) => {
     return {
       ...ctx,
-      actorRef: spawn(promiseActor),
+      actorRef: spawn(promiseActor)
     };
   });
   ```
@@ -6879,7 +6879,7 @@
   In addition to that, you can now `spawn` actors defined in your implementations object, in the same way that you were already able to do that with `invoke`. To do that just reference the defined actor like this:
 
   ```js
-  spawn("promiseActor");
+  spawn('promiseActor');
   ```
 
 - [#2869](https://github.com/statelyai/xstate/pull/2869) [`9437c3de9`](https://github.com/statelyai/xstate/commit/9437c3de912c2a38c04798cbb94f267a1e5db3f8) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `service.batch(events)` method is no longer available.
@@ -7020,13 +7020,13 @@
   Example usage:
 
   ```js
-  import { waitFor } from "xstate/lib/waitFor";
+  import { waitFor } from 'xstate/lib/waitFor';
 
   // This will
   const loggedInState = await waitFor(
     loginService,
-    (state) => state.hasTag("loggedIn"),
-    { timeout: Infinity },
+    (state) => state.hasTag('loggedIn'),
+    { timeout: Infinity }
   );
   ```
 
@@ -7053,16 +7053,16 @@
   Example usage:
 
   ```js
-  import { waitFor } from "xstate/lib/waitFor";
+  import { waitFor } from 'xstate/lib/waitFor';
 
   // ...
   const loginService = interpret(loginMachine).start();
 
   const loggedInState = await waitFor(loginService, (state) =>
-    state.hasTag("loggedIn"),
+    state.hasTag('loggedIn')
   );
 
-  loggedInState.hasTag("loggedIn"); // true
+  loggedInState.hasTag('loggedIn'); // true
   ```
 
 - [#3200](https://github.com/statelyai/xstate/pull/3200) [`56c0a36`](https://github.com/statelyai/xstate/commit/56c0a36f222195d0b18edd7a72d5429a213b3808) Thanks [@Andarist](https://github.com/Andarist)! - Subscribing to a stopped interpreter will now always immediately emit its state and call a completion callback.
@@ -7096,12 +7096,12 @@
   ```ts
   const machine = createMachine({
     // this encodes that we still expect `myAction` to be provided
-    tsTypes: {} as Typegen0,
+    tsTypes: {} as Typegen0
   });
   const service: InterpreterFrom<typeof machine> = machine.withConfig({
     actions: {
-      myAction: () => {},
-    },
+      myAction: () => {}
+    }
   });
   ```
 
@@ -7158,7 +7158,7 @@
 - [#3040](https://github.com/statelyai/xstate/pull/3040) [`18dc2b3e2`](https://github.com/statelyai/xstate/commit/18dc2b3e2c49527b2155063490bb7295f1f06043) Thanks [@davidkpiano](https://github.com/davidkpiano)! - The `AnyState` and `AnyStateMachine` types are now available, which can be used to express any state and state machine, respectively:
 
   ```ts
-  import type { AnyState, AnyStateMachine } from "xstate";
+  import type { AnyState, AnyStateMachine } from 'xstate';
 
   // A function that takes in any state machine
   function visualizeMachine(machine: AnyStateMachine) {
@@ -7173,12 +7173,12 @@
 - [#3042](https://github.com/statelyai/xstate/pull/3042) [`e53396f08`](https://github.com/statelyai/xstate/commit/e53396f083091db26c117000ce6ec070914360e9) Thanks [@suerta-git](https://github.com/suerta-git)! - Added the `AnyStateConfig` type, which represents any `StateConfig<...>`:
 
   ```ts
-  import type { AnyStateConfig } from "xstate";
-  import { State } from "xstate";
+  import type { AnyStateConfig } from 'xstate';
+  import { State } from 'xstate';
 
   // Retrieving the state config from localStorage
   const stateConfig: AnyStateConfig = JSON.parse(
-    localStorage.getItem("app-state"),
+    localStorage.getItem('app-state')
   );
 
   // Use State.create() to restore state from config object with correct type
@@ -7196,11 +7196,11 @@
   ```js
   // Persisting a state
   someService.subscribe((state) => {
-    localStorage.setItem("some-state", JSON.stringify(state));
+    localStorage.setItem('some-state', JSON.stringify(state));
   });
 
   // Restoring a state
-  const stateJson = localStorage.getItem("some-state");
+  const stateJson = localStorage.getItem('some-state');
 
   // No need to convert `stateJson` object to a state!
   const someService = interpret(someMachine).start(stateJson);
@@ -7241,7 +7241,7 @@
 
   ```ts
   const machine = createMachine({
-    tsTypes: {},
+    tsTypes: {}
   });
   ```
 
@@ -7254,13 +7254,13 @@
 - [#2962](https://github.com/statelyai/xstate/pull/2962) [`32520650b`](https://github.com/statelyai/xstate/commit/32520650b7d6b43e416b896054033432aaede5d5) Thanks [@mattpocock](https://github.com/mattpocock)! - Added `t()`, which can be used to provide types for `schema` attributes in machine configs:
 
   ```ts
-  import { t, createMachine } from "xstate";
+  import { t, createMachine } from 'xstate';
 
   const machine = createMachine({
     schema: {
       context: t<{ value: number }>(),
-      events: t<{ type: "EVENT_1" } | { type: "EVENT_2" }>(),
-    },
+      events: t<{ type: 'EVENT_1' } | { type: 'EVENT_2' }>()
+    }
   });
   ```
 
@@ -7288,36 +7288,36 @@
 
   ```js
   createMachine({
-    id: "test",
-    initial: "p",
+    id: 'test',
+    initial: 'p',
     states: {
       p: {
-        type: "parallel",
+        type: 'parallel',
         states: {
           // Before this change, both invoke IDs would be 'someSource',
           // which is incorrect.
           a: {
             invoke: {
-              src: "someSource",
+              src: 'someSource'
               // generated invoke ID: 'test.p.a:invocation[0]'
-            },
+            }
           },
           b: {
             invoke: {
-              src: "someSource",
+              src: 'someSource'
               // generated invoke ID: 'test.p.b:invocation[0]'
-            },
-          },
-        },
-      },
-    },
+            }
+          }
+        }
+      }
+    }
   });
   ```
 
 - [#2925](https://github.com/statelyai/xstate/pull/2925) [`239b4666a`](https://github.com/statelyai/xstate/commit/239b4666ac302d80c028fef47c6e8ab7e0ae2757) Thanks [@devanfarrell](https://github.com/devanfarrell)! - The `sendTo(actorRef, event)` action creator introduced in `4.27.0`, which was not accessible from the package exports, can now be used just like other actions:
 
   ```js
-  import { actions } from "xstate";
+  import { actions } from 'xstate';
 
   const { sendTo } = actions;
   ```
@@ -7365,15 +7365,15 @@
     states: {
       active: {
         // ...
-        description: "The task is in progress",
+        description: 'The task is in progress',
         on: {
           DEACTIVATE: {
             // ...
-            description: "Deactivates the task",
-          },
-        },
-      },
-    },
+            description: 'Deactivates the task'
+          }
+        }
+      }
+    }
   });
   ```
 
@@ -7392,8 +7392,8 @@
 - [#2740](https://github.com/statelyai/xstate/pull/2740) [`707cb981f`](https://github.com/statelyai/xstate/commit/707cb981fdb8a5c75cacb7e9bfa5c7e5a1cc1c88) Thanks [@Andarist](https://github.com/Andarist)! - Fixed an issue with tags being missed on a service state after starting that service using a state value, like this:
 
   ```js
-  const service = interpret(machine).start("active");
-  service.state.hasTag("foo"); // this should now return a correct result
+  const service = interpret(machine).start('active');
+  service.state.hasTag('foo'); // this should now return a correct result
   ```
 
 - [#2691](https://github.com/statelyai/xstate/pull/2691) [`a72806035`](https://github.com/statelyai/xstate/commit/a728060353c9cb9bdb0cd37aacf793498a8750c8) Thanks [@davidkpiano](https://github.com/statelyai)! - Meta data can now be specified for `invoke` configs in the `invoke.meta` property:
@@ -7404,12 +7404,12 @@
     invoke: {
       src: (ctx, e) => findUser(ctx.userId),
       meta: {
-        summary: "Finds user",
-        updatedAt: "2021-09-...",
-        version: "4.12.2",
+        summary: 'Finds user',
+        updatedAt: '2021-09-...',
+        version: '4.12.2'
         // other descriptive meta properties
-      },
-    },
+      }
+    }
   });
   ```
 
@@ -7444,9 +7444,9 @@
     { foo: 100 },
     {
       events: {
-        BAR: () => ({}),
-      },
-    },
+        BAR: () => ({})
+      }
+    }
   );
 
   model.createMachine({
@@ -7454,8 +7454,8 @@
     entry: (ctx) => {},
     exit: assign({
       // `ctx` was of type `unknown`
-      foo: (ctx) => 42,
-    }),
+      foo: (ctx) => 42
+    })
   });
   ```
 
@@ -7473,30 +7473,30 @@
 
   ```js
   const machine = createMachine({
-    initial: "inactive",
+    initial: 'inactive',
     states: {
       inactive: {
         on: {
-          TOGGLE: "active",
-        },
+          TOGGLE: 'active'
+        }
       },
       active: {
         on: {
-          DO_SOMETHING: { actions: ["something"] },
-        },
-      },
-    },
+          DO_SOMETHING: { actions: ['something'] }
+        }
+      }
+    }
   });
 
   const state = machine.initialState;
 
-  state.can("TOGGLE"); // true
-  state.can("DO_SOMETHING"); // false
+  state.can('TOGGLE'); // true
+  state.can('DO_SOMETHING'); // false
 
   // Also takes in full event objects:
   state.can({
-    type: "DO_SOMETHING",
-    data: 42,
+    type: 'DO_SOMETHING',
+    data: 42
   }); // false
   ```
 
@@ -7515,14 +7515,14 @@
   const model = createModel(
     {},
     {
-      events: {},
-    },
+      events: {}
+    }
   );
 
   model.createMachine({
     // These actions will cause TS to not compile
-    entry: "someAction",
-    exit: { type: "someObjectAction" },
+    entry: 'someAction',
+    exit: { type: 'someObjectAction' }
   });
   ```
 
@@ -7575,12 +7575,12 @@
   ```ts
   createMachine({
     context: {/* ... */}, // ✅ This is allowed
-    initial: "inner",
+    initial: 'inner',
     states: {
       inner: {
-        context: {/* ... */}, // ❌ This will no longer compile
-      },
-    },
+        context: {/* ... */} // ❌ This will no longer compile
+      }
+    }
   });
   ```
 
@@ -7592,7 +7592,7 @@
 
   ```js
   const copy = machine.withContext(() => ({
-    ref: spawn(() => {}),
+    ref: spawn(() => {})
   }));
   ```
 
@@ -7608,7 +7608,7 @@
 
   ```ts
   // `state.context` became `any` erroneously
-  if (state.matches("inactive")) {
+  if (state.matches('inactive')) {
     console.log(state.context.count);
   }
   ```
@@ -7628,9 +7628,9 @@
       assign({ count: (ctx) => ctx.count + 1 }),
       (ctx) => console.log(ctx.count), // 1
       assign({ count: (ctx) => ctx.count + 1 }),
-      (ctx) => console.log(ctx.count), // 2
+      (ctx) => console.log(ctx.count) // 2
     ],
-    preserveActionOrder: true,
+    preserveActionOrder: true
   });
 
   // With `.preserveActionOrder: false` (default)
@@ -7641,8 +7641,8 @@
       assign({ count: (ctx) => ctx.count + 1 }),
       (ctx) => console.log(ctx.count), // 2
       assign({ count: (ctx) => ctx.count + 1 }),
-      (ctx) => console.log(ctx.count), // 2
-    ],
+      (ctx) => console.log(ctx.count) // 2
+    ]
     // preserveActionOrder: false
   });
   ```
@@ -7656,13 +7656,13 @@
   ```ts
   const machine = createMachine({
     context: () => ({
-      someRef: spawn(someExistingRef, "something"),
+      someRef: spawn(someExistingRef, 'something')
     }),
     on: {
       SOME_EVENT: {
-        actions: send("AN_EVENT", { to: "something" }),
-      },
-    },
+        actions: send('AN_EVENT', { to: 'something' })
+      }
+    }
   });
   ```
 
@@ -7686,14 +7686,14 @@
 - [`432b60f7`](https://github.com/statelyai/xstate/commit/432b60f7bcbcee9510e0d86311abbfd75b1a674e) [#2280](https://github.com/statelyai/xstate/pull/2280) Thanks [@davidkpiano](https://github.com/statelyai)! - Actors can now be invoked/spawned from reducers using the `fromReducer(...)` behavior creator:
 
   ```ts
-  import { fromReducer } from "xstate/lib/behaviors";
+  import { fromReducer } from 'xstate/lib/behaviors';
 
-  type CountEvent = { type: "INC" } | { type: "DEC" };
+  type CountEvent = { type: 'INC' } | { type: 'DEC' };
 
   const countReducer = (count: number, event: CountEvent): number => {
-    if (event.type === "INC") {
+    if (event.type === 'INC') {
       return count + 1;
-    } else if (event.type === "DEC") {
+    } else if (event.type === 'DEC') {
       return count - 1;
     }
 
@@ -7702,17 +7702,17 @@
 
   const countMachine = createMachine({
     invoke: {
-      id: "count",
-      src: () => fromReducer(countReducer, 0),
+      id: 'count',
+      src: () => fromReducer(countReducer, 0)
     },
     on: {
       INC: {
-        actions: forwardTo("count"),
+        actions: forwardTo('count')
       },
       DEC: {
-        actions: forwardTo("count"),
-      },
-    },
+        actions: forwardTo('count')
+      }
+    }
   });
   ```
 
@@ -7721,8 +7721,8 @@
   ```ts
   const machine = createMachine<{ ref: ActorRef<SomeEvent> }>({
     context: () => ({
-      ref: spawn(anotherMachine, "some-id"), // spawn immediately!
-    }),
+      ref: spawn(anotherMachine, 'some-id') // spawn immediately!
+    })
     // ...
   });
   ```
@@ -7742,7 +7742,7 @@
   ```ts
   interface ActorRef<
     TEvent extends EventObject,
-    TEmitted = any,
+    TEmitted = any
   > extends Subscribable<TEmitted> {
     send: (event: TEvent) => void;
     id: string;
@@ -7750,7 +7750,7 @@
     subscribe(
       next: (value: T) => void,
       error?: (error: any) => void,
-      complete?: () => void,
+      complete?: () => void
     ): Subscription;
     getSnapshot: () => TEmitted | undefined;
   }
@@ -7770,10 +7770,10 @@
   const machine = createMachine<typeof someModel>({
     // missing context - will give a TS error!
     // context: someModel.initialContext,
-    initial: "somewhere",
+    initial: 'somewhere',
     states: {
-      somewhere: {},
-    },
+      somewhere: {}
+    }
   });
   ```
 
@@ -7782,7 +7782,7 @@
   ```ts
   invoke: () => (sendBack, receive) => {
     // Will now be constrained to events that the parent machine can receive
-    sendBack({ type: "SOME_EVENT" });
+    sendBack({ type: 'SOME_EVENT' });
   };
   ```
 
@@ -7828,16 +7828,16 @@
   ```js
   const machine = createMachine({
     context: {
-      promiseRef: null,
+      promiseRef: null
     },
-    initial: "pending",
+    initial: 'pending',
     states: {
       pending: {
         entry: assign({
-          promiseRef: () => spawn(fetch(/* ... */), "some-promise"),
-        }),
-      },
-    },
+          promiseRef: () => spawn(fetch(/* ... */), 'some-promise')
+        })
+      }
+    }
   });
 
   const service = interpret(machine)
@@ -7882,25 +7882,25 @@
 
   ```js
   const machine = createMachine({
-    initial: "green",
+    initial: 'green',
     states: {
       green: {
-        tags: "go", // single tag
+        tags: 'go' // single tag
       },
       yellow: {
-        tags: "go",
+        tags: 'go'
       },
       red: {
-        tags: ["stop", "other"], // multiple tags
-      },
-    },
+        tags: ['stop', 'other'] // multiple tags
+      }
+    }
   });
   ```
 
   You can query whether a state has a tag via `state.hasTag(tag)`:
 
   ```js
-  const canGo = state.hasTag("go");
+  const canGo = state.hasTag('go');
   // => `true` if in 'green' or 'red' state
   ```
 
@@ -7921,9 +7921,9 @@
     context: { value: 42 },
     on: {
       INC: {
-        actions: assign({ value: (ctx) => ctx.value + 1 }),
-      },
-    },
+        actions: assign({ value: (ctx) => ctx.value + 1 })
+      }
+    }
   });
   ```
 
@@ -7957,23 +7957,23 @@
     schema: {
       // Example in JSON Schema (anything can be used)
       context: {
-        type: "object",
+        type: 'object',
         properties: {
-          foo: { type: "string" },
-          bar: { type: "number" },
+          foo: { type: 'string' },
+          bar: { type: 'number' },
           baz: {
-            type: "object",
+            type: 'object',
             properties: {
-              one: { type: "string" },
-            },
-          },
-        },
+              one: { type: 'string' }
+            }
+          }
+        }
       },
       events: {
-        FOO: { type: "object" },
-        BAR: { type: "object" },
-      },
-    },
+        FOO: { type: 'object' },
+        BAR: { type: 'object' }
+      }
+    }
     // ...
   });
   ```
@@ -7981,15 +7981,15 @@
   Additionally, the new `createSchema()` identity function allows any schema "metadata" to be represented by a specific type, which makes type inference easier without having to specify generic types:
 
   ```ts
-  import { createSchema, createMachine } from "xstate";
+  import { createSchema, createMachine } from 'xstate';
 
   // Both `context` and `events` are inferred in the rest of the machine!
   const machine = createMachine({
     schema: {
       context: createSchema<{ count: number }>(),
       // No arguments necessary
-      events: createSchema<{ type: "FOO" } | { type: "BAR" }>(),
-    },
+      events: createSchema<{ type: 'FOO' } | { type: 'BAR' }>()
+    }
     // ...
   });
   ```
@@ -7997,40 +7997,40 @@
 - [`5febfe83`](https://github.com/statelyai/xstate/commit/5febfe83a7e5e866c0a4523ea4f86a966af7c50f) [#1955](https://github.com/statelyai/xstate/pull/1955) Thanks [@davidkpiano](https://github.com/statelyai)! - Event creators can now be modeled inside of the 2nd argument of `createModel()`, and types for both `context` and `events` will be inferred properly in `createMachine()` when given the `typeof model` as the first generic parameter.
 
   ```ts
-  import { createModel } from "xstate/lib/model";
+  import { createModel } from 'xstate/lib/model';
 
   const userModel = createModel(
     // initial context
     {
-      name: "David",
-      age: 30,
+      name: 'David',
+      age: 30
     },
     // creators (just events for now)
     {
       events: {
         updateName: (value: string) => ({ value }),
         updateAge: (value: number) => ({ value }),
-        anotherEvent: () => ({}), // no payload
-      },
-    },
+        anotherEvent: () => ({}) // no payload
+      }
+    }
   );
 
   const machine = createMachine<typeof userModel>({
     context: userModel.initialContext,
-    initial: "active",
+    initial: 'active',
     states: {
       active: {
         on: {
           updateName: {/* ... */},
-          updateAge: {/* ... */},
-        },
-      },
-    },
+          updateAge: {/* ... */}
+        }
+      }
+    }
   });
 
   const nextState = machine.transition(
     undefined,
-    userModel.events.updateName("David"),
+    userModel.events.updateName('David')
   );
   ```
 
@@ -8209,30 +8209,30 @@
 
   ```js
   const child = createMachine({
-    initial: "bar",
+    initial: 'bar',
     context: {},
     states: {
       bar: {
         entry: assign({
           promise: () => {
-            return spawn(() => Promise.resolve("answer"));
-          },
-        }),
-      },
-    },
+            return spawn(() => Promise.resolve('answer'));
+          }
+        })
+      }
+    }
   });
 
   const parent = createMachine({
-    initial: "foo",
+    initial: 'foo',
     states: {
       foo: {
         invoke: {
           src: child,
-          onDone: "end",
-        },
+          onDone: 'end'
+        }
       },
-      end: { type: "final" },
-    },
+      end: { type: 'final' }
+    }
   });
 
   interpret(parent).start();
@@ -8251,28 +8251,28 @@
   ```js
   const machine = createMachine(
     {
-      initial: "searching",
+      initial: 'searching',
       states: {
         searching: {
           invoke: {
             src: {
-              type: "search",
-              endpoint: "example.com",
-            },
+              type: 'search',
+              endpoint: 'example.com'
+            }
             // ...
-          },
+          }
           // ...
-        },
-      },
+        }
+      }
     },
     {
       services: {
         search: (context, event, { src }) => {
           console.log(src);
           // => { endpoint: 'example.com' }
-        },
-      },
-    },
+        }
+      }
+    }
   );
   ```
 
@@ -8413,13 +8413,13 @@
   ```js
   entry: [
     choose([
-      { cond: (ctx) => ctx > 100, actions: raise("TOGGLE") },
+      { cond: (ctx) => ctx > 100, actions: raise('TOGGLE') },
       {
-        cond: "hasMagicBottle",
-        actions: [assign((ctx) => ({ counter: ctx.counter + 1 }))],
+        cond: 'hasMagicBottle',
+        actions: [assign((ctx) => ({ counter: ctx.counter + 1 }))]
       },
-      { actions: ["fallbackAction"] },
-    ]),
+      { actions: ['fallbackAction'] }
+    ])
   ];
   ```
 

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -27,9 +27,7 @@ import { matchesState } from './utils.ts';
 import {
   copySnapshotActorRef,
   getSnapshotActorRef,
-  setSnapshotActorRef,
-  type SnapshotActorRef,
-  snapshotActorRef
+  setSnapshotActorRef
 } from './snapshotActorRef.ts';
 
 export function isMachineSnapshot(value: unknown): value is AnyMachineSnapshot {
@@ -148,9 +146,6 @@ interface MachineSnapshotBase<
   _stateInputs: Record<string, Record<string, unknown>>;
   /** @internal */
   _nextTimerId: number;
-  /** @internal */
-  [snapshotActorRef]?: SnapshotActorRef;
-
   /**
    * Whether the current state value is a subset of the given partial state
    * value.
@@ -396,7 +391,6 @@ const machineSnapshotToJSON = function toJSON(this: AnyMachineSnapshot) {
   const {
     _nodes: nodes,
     _stateInputs,
-    [snapshotActorRef]: _actorRef,
     tags,
     machine,
     getMeta,

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -20,6 +20,7 @@ import {
   getPersistedSnapshot,
   MachineSnapshot
 } from './State.ts';
+import { setSnapshotActorRef } from './snapshotActorRef.ts';
 import { StateNode } from './StateNode.ts';
 import {
   formatRouteTransitions,
@@ -536,7 +537,8 @@ export class StateMachine<
     if (isInertActorScope(actorScope)) {
       return snapshot;
     }
-    return attachSnapshotActorRef(this, actorScope, snapshot);
+    setSnapshotActorRef(snapshot, actorScope.self, actorScope.system);
+    return snapshot;
   }
 
   private _transitionFast(

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -367,8 +367,9 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
 
   /** Associates each live snapshot with this actor for later pure transitions. */
   private _setSnapshot(snapshot: SnapshotFrom<TLogic>): void {
+    const previousSnapshot = this._snapshot;
     this._snapshot = snapshot;
-    setSnapshotActorRef(snapshot, this);
+    setSnapshotActorRef(snapshot, this, this.system, previousSnapshot);
   }
 
   private _setErrorSnapshot(

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -61,7 +61,6 @@ export function createInertActorScope<T extends AnyActorLogic>(
     previousSelf && baseSystem
       ? createSnapshotSystem(
           baseSystem,
-          previousSelf,
           isMachineSnapshot(snapshot) ? (snapshot as any).children : {},
           sourceSelf ? undefined : snapshotRef?.systemState
         )

--- a/packages/core/src/snapshotActorRef.ts
+++ b/packages/core/src/snapshotActorRef.ts
@@ -1,8 +1,5 @@
 import type { AnyActor, Snapshot } from './types.ts';
 
-/** @internal */
-export const snapshotActorRef = Symbol('xstate.snapshotActorRef');
-
 /** Snapshot-scoped actor identity and system view. @internal */
 export interface SnapshotActorRef {
   actor: AnyActor;
@@ -13,6 +10,19 @@ interface SnapshotSystemState {
   children: Map<string, AnyActor>;
   keyedActors: Map<any, AnyActor>;
   snapshot: AnyActor['system']['_snapshot'];
+  sourceSystem: AnyActor['system'];
+  sourceVersion: number;
+}
+
+const snapshotActorRefs = new WeakMap<object, SnapshotActorRef>();
+
+/** Marks topology or persisted runtime state as changed. @internal */
+export function markSystemSnapshotDirty(system: AnyActor['system']): void {
+  system._snapshotVersion++;
+}
+
+function getSystemSnapshotVersion(system: AnyActor['system']): number {
+  return system._snapshotVersion;
 }
 
 function getSnapshotChildren(
@@ -31,16 +41,12 @@ function getSnapshotChildren(
  */
 export function createSnapshotSystem(
   baseSystem: AnyActor['system'],
-  _self: AnyActor,
   children: Record<string, AnyActor | undefined>,
   baseState?: SnapshotSystemState
 ): AnyActor['system'] {
   const registeredActors = new Map(baseState?.children ?? baseSystem.children);
   const keyedActors = new Map<any, AnyActor>(
-    baseState?.keyedActors ??
-      Object.entries(
-        baseSystem.getAll() as Record<string, AnyActor | undefined>
-      ).filter((entry): entry is [string, AnyActor] => !!entry[1])
+    baseState?.keyedActors ?? baseSystem.keyedActors
   );
   const reverseKeyedActors = new WeakMap<AnyActor, any>();
   const system: AnyActor['system'] = {
@@ -49,8 +55,10 @@ export function createSnapshotSystem(
     keyedActors,
     reverseKeyedActors,
     _snapshot: { ...(baseState?.snapshot ?? baseSystem._snapshot) },
+    _snapshotVersion: baseState?.sourceVersion ?? baseSystem._snapshotVersion,
     _register: (sessionId: string, actor: AnyActor) => {
       registeredActors.set(sessionId, actor);
+      markSystemSnapshotDirty(system);
       return sessionId;
     },
     _unregister: (actor: AnyActor) => {
@@ -62,6 +70,7 @@ export function createSnapshotSystem(
         keyedActors.delete(registryKey);
       }
       reverseKeyedActors.delete(actor);
+      markSystemSnapshotDirty(system);
     },
     _set: (registryKey: any, actor: AnyActor) => {
       const existing = keyedActors.get(registryKey);
@@ -72,6 +81,7 @@ export function createSnapshotSystem(
       }
       keyedActors.set(registryKey, actor);
       reverseKeyedActors.set(actor, registryKey);
+      markSystemSnapshotDirty(system);
     },
     get: (registryKey: any) => keyedActors.get(registryKey) as any,
     getAll: () => Object.fromEntries(keyedActors),
@@ -104,7 +114,7 @@ export function createSnapshotSystem(
 export function getSnapshotActorRef(
   snapshot: Snapshot<unknown>
 ): SnapshotActorRef | undefined {
-  return (snapshot as any)[snapshotActorRef];
+  return snapshotActorRefs.get(snapshot);
 }
 
 /**
@@ -118,10 +128,7 @@ export function copySnapshotActorRef(
 ): void {
   const ref = getSnapshotActorRef(source);
   if (ref) {
-    Object.defineProperty(target, snapshotActorRef, {
-      configurable: true,
-      value: ref
-    });
+    snapshotActorRefs.set(target, ref);
   }
 }
 
@@ -134,22 +141,37 @@ export function copySnapshotActorRef(
 export function setSnapshotActorRef(
   snapshot: Snapshot<unknown>,
   actor: AnyActor,
-  baseSystem: AnyActor['system'] = actor.system
+  baseSystem: AnyActor['system'] = actor.system,
+  previousSnapshot?: Snapshot<unknown>
 ): void {
+  const sourceVersion = getSystemSnapshotVersion(baseSystem);
+  const previousRef = previousSnapshot
+    ? getSnapshotActorRef(previousSnapshot)
+    : undefined;
+  const reusableRef =
+    previousRef?.actor === actor ? previousRef : getSnapshotActorRef(snapshot);
+
+  if (
+    reusableRef?.actor === actor &&
+    reusableRef.systemState.sourceSystem === baseSystem &&
+    reusableRef.systemState.sourceVersion === sourceVersion
+  ) {
+    snapshotActorRefs.set(snapshot, reusableRef);
+    return;
+  }
+
   const system = createSnapshotSystem(
     baseSystem,
-    actor,
     getSnapshotChildren(snapshot)
   );
-  Object.defineProperty(snapshot, snapshotActorRef, {
-    configurable: true,
-    value: {
-      actor,
-      systemState: {
-        children: system.children,
-        keyedActors: system.keyedActors as Map<any, AnyActor>,
-        snapshot: system._snapshot
-      }
-    } satisfies SnapshotActorRef
-  });
+  snapshotActorRefs.set(snapshot, {
+    actor,
+    systemState: {
+      children: system.children,
+      keyedActors: system.keyedActors as Map<any, AnyActor>,
+      snapshot: system._snapshot,
+      sourceSystem: baseSystem,
+      sourceVersion
+    }
+  } satisfies SnapshotActorRef);
 }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -2008,7 +2008,12 @@ function microstep(
       // If context was changed (e.g. by entry actions during self-transition),
       // clone to ensure reference inequality for eventless transition re-evaluation
       if (nextState.context !== originalContext) {
-        return [cloneMachineSnapshot(nextState), executableActions];
+        return [
+          nextState === currentSnapshot
+            ? cloneMachineSnapshot(nextState)
+            : nextState,
+          executableActions
+        ];
       }
       return [nextState, executableActions];
     }

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -13,6 +13,7 @@ import {
 } from './types.ts';
 import { XSTATE_TIMER } from './constants.ts';
 import { toObserver } from './utils.ts';
+import { markSystemSnapshotDirty } from './snapshotActorRef.ts';
 
 interface ScheduledTimer {
   id: string;
@@ -75,15 +76,21 @@ export function resolveActorId(
     const match = /^x:(\d+)$/.exec(requestedId);
     const reservedId = match ? Number(match[1]) : undefined;
     if (reservedId !== undefined && Number.isSafeInteger(reservedId)) {
-      system._snapshot._nextActorId = Math.max(
+      const nextActorId = Math.max(
         system._snapshot._nextActorId,
         reservedId + 1
       );
+      if (nextActorId !== system._snapshot._nextActorId) {
+        system._snapshot._nextActorId = nextActorId;
+        markSystemSnapshotDirty(system);
+      }
     }
     return requestedId;
   }
 
-  return `x:${system._snapshot._nextActorId++}`;
+  const id = `x:${system._snapshot._nextActorId++}`;
+  markSystemSnapshotDirty(system);
+  return id;
 }
 
 /** @internal */
@@ -194,6 +201,8 @@ export interface ActorSystem<
     _scheduledTimers: Record<ScheduledTimerId, ScheduledTimer>;
     _nextActorId: number;
   };
+  /** @internal */
+  _snapshotVersion: number;
   start: () => void;
   _clock: Clock;
   _logger: (...args: any[]) => void;
@@ -263,10 +272,12 @@ export function createRuntimeSystem<T extends ActorSystemInfo>(
       };
       const scheduledTimerId = createScheduledTimerId(source, id);
       system._snapshot._scheduledTimers[scheduledTimerId] = scheduledTimer;
+      markSystemSnapshotDirty(system);
 
       const timeout = clock.setTimeout(() => {
         delete timerMap[scheduledTimerId];
         delete system._snapshot._scheduledTimers[scheduledTimerId];
+        markSystemSnapshotDirty(system);
 
         deliver(source, source, { type: XSTATE_TIMER, id });
       }, delay);
@@ -279,6 +290,7 @@ export function createRuntimeSystem<T extends ActorSystemInfo>(
 
       delete timerMap[scheduledTimerId];
       delete system._snapshot._scheduledTimers[scheduledTimerId];
+      markSystemSnapshotDirty(system);
 
       if (timeout !== undefined) {
         clock.clearTimeout(timeout);
@@ -345,19 +357,25 @@ export function createRuntimeSystem<T extends ActorSystemInfo>(
         (options?.snapshot && (options.snapshot as any).scheduler) ?? {},
       _nextActorId: (options?.snapshot as any)?._nextActorId ?? 0
     },
+    _snapshotVersion: 0,
     _register: (sessionId, actor) => {
       children.set(sessionId, actor);
+      markSystemSnapshotDirty(system);
       return sessionId;
     },
     _unregister: (actor) => {
-      children.delete(actor.sessionId!);
+      let changed = children.delete(actor.sessionId!);
       const registryKey = reverseKeyedActors.get(actor);
 
       if (registryKey !== undefined) {
         if (keyedActors.get(registryKey) === actor) {
           keyedActors.delete(registryKey);
+          changed = true;
         }
         reverseKeyedActors.delete(actor);
+      }
+      if (changed) {
+        markSystemSnapshotDirty(system);
       }
     },
     get: (registryKey) => {
@@ -376,6 +394,9 @@ export function createRuntimeSystem<T extends ActorSystemInfo>(
 
       keyedActors.set(registryKey, actor);
       reverseKeyedActors.set(actor, registryKey);
+      if (existing !== actor) {
+        markSystemSnapshotDirty(system);
+      }
     },
     inspect: (observerOrFn) => {
       const observer = toObserver(observerOrFn);

--- a/packages/core/src/transitionActions.ts
+++ b/packages/core/src/transitionActions.ts
@@ -816,19 +816,22 @@ export function createEnqueueObject(
   };
 
   Object.assign(enqueueFn, {
-    cancel: () => {},
-    emit: () => {},
-    log: () => {},
-    raise: () => {},
-    spawn: () => ({}) as any,
-    sendTo: () => {},
-    stop: () => {},
-    listen: () => ({}) as any,
-    subscribeTo: () => ({}) as any,
+    cancel: noop,
+    emit: noop,
+    log: noop,
+    raise: noop,
+    spawn: emptyActor,
+    sendTo: noop,
+    stop: noop,
+    listen: emptyActor,
+    subscribeTo: emptyActor,
     ...props
   });
 
   return enqueueFn as any;
 }
 
-const emptyEnqueueObject = createEnqueueObject({}, () => {});
+const noop = () => {};
+const emptyActor = () => ({}) as any;
+
+const emptyEnqueueObject = createEnqueueObject({}, noop);

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -24,6 +24,7 @@ import { initialTransition } from '../src/transition';
 import { listenerLogic } from '../src/actors/listener';
 import { subscriptionLogic } from '../src/actors/subscription';
 import { XSTATE_SPAWN, XSTATE_START, XSTATE_STOP } from '../src/constants';
+import { getSnapshotActorRef } from '../src/snapshotActorRef';
 import { z } from 'zod';
 
 const isEffect =
@@ -1261,6 +1262,36 @@ describe('transition function', () => {
 
       expect(actor.system.get('child')).toBeDefined();
       expect(oldSnapshotSawChild).toBe(false);
+    });
+
+    it('reuses captured live system state until topology changes', () => {
+      const child = createMachine({});
+      const machine = createMachine({
+        context: { count: 0 },
+        on: {
+          INCREMENT: ({ context }) => ({
+            context: { count: context.count + 1 }
+          }),
+          SPAWN: (_, enq) => {
+            enq.spawn(child, { registryKey: 'child' });
+          }
+        }
+      });
+      const actor = createActor(machine).start();
+      const getSystemState = () =>
+        getSnapshotActorRef(actor.getSnapshot())!.systemState;
+      const initialSystemState = getSystemState();
+
+      actor.send({ type: 'INCREMENT' });
+      expect(getSystemState()).toBe(initialSystemState);
+
+      actor.send({ type: 'SPAWN' });
+      const spawnedSystemState = getSystemState();
+      expect(spawnedSystemState).not.toBe(initialSystemState);
+
+      actor.send({ type: 'INCREMENT' });
+      expect(getSystemState()).toBe(spawnedSystemState);
+      expect(actor.system.get('child')).toBeDefined();
     });
 
     it('does not discover future nested actors through old child refs', () => {


### PR DESCRIPTION
## Summary

- reuse snapshot-scoped actor and system state while runtime topology is unchanged
- invalidate captured system state when actor IDs, registrations, registry entries, or timers change
- reduce transition-path allocations from snapshot cloning and enqueue helper construction
- keep snapshot metadata outside serialized and enumerable snapshot data
- add regression coverage for reuse and topology invalidation

## Performance

Local Apple M1 Max / Node 25.9 measurements against the alpha.29 baseline:

- pure transition planning: ~201k/s to ~352k/s
- fenced mailbox burst: ~163k/s to ~592k/s
- child lookup/send: ~181k/s to ~563k/s
- parent and child lifecycle: ~51k/s to ~67k/s

Retained heap was unchanged at approximately 6.2 KiB per idle actor and 8.9 KiB per parent-child family. Benchmark harnesses and result artifacts are intentionally not included in this PR.

## Validation

- `pnpm test:core` — 2,110 passed, 32 skipped, 3 todo
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- changed-file formatting check
