### PR TITLE
Improve v6 runtime throughput

### DIFF
--- a/.changeset/faster-v6-runtime.md
+++ b/.changeset/faster-v6-runtime.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Improve state machine actor throughput for event bursts, child delivery, and compound and parallel machines.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -36,6 +36,7 @@ import {
   resolveStateValue,
   transitionNode
 } from './stateUtils.ts';
+import type { TransitionSelectionResults } from './stateUtils.ts';
 import {
   createSpawnEffect,
   resolveActionsWithContext
@@ -218,6 +219,8 @@ export class StateMachine<
   public states: StateNode<TContext, TEvent>['states'];
   public events: Array<EventDescriptor<TEvent>>;
   public internalEventDescriptors: ReadonlyArray<string>;
+  /** @internal Skips eventless-selection scans for machines without `always`. */
+  public _hasEventlessTransitions: boolean;
   constructor(
     /** The raw config used to create the machine. */
     public config: Next_MachineConfig<
@@ -283,6 +286,9 @@ export class StateMachine<
     this.root._initialize();
     formatRouteTransitions(this.root);
     this.root._refreshEventMetadata();
+    this._hasEventlessTransitions = Array.from(this.idMap.values()).some(
+      (stateNode) => !!stateNode.always?.length
+    );
 
     this.states = this.root.states; // TODO: remove!
     this.events = this.root.events;
@@ -688,10 +694,18 @@ export class StateMachine<
       TConfig
     >,
     event: TEvent,
-    self: AnyActor
+    self: AnyActor,
+    selectionResults?: TransitionSelectionResults
   ): Array<AnyTransitionDefinition> {
     return (
-      transitionNode(this.root, snapshot.value, snapshot, event, self) || []
+      transitionNode(
+        this.root,
+        snapshot.value,
+        snapshot,
+        event,
+        self,
+        selectionResults
+      ) || []
     );
   }
 
@@ -810,8 +824,7 @@ export class StateMachine<
         children: {},
         status: 'active'
       },
-      this,
-      actorScope.self
+      this
     );
 
     if (typeof context === 'function') {

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -34,9 +34,9 @@ import {
   isStateId,
   macrostep,
   resolveStateValue,
-  transitionNode
+  transitionNode,
+  type TransitionSelectionResults
 } from './stateUtils.ts';
-import type { TransitionSelectionResults } from './stateUtils.ts';
 import {
   createSpawnEffect,
   resolveActionsWithContext

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -9,9 +9,9 @@ import {
   getCandidates,
   getEventDescriptorKey,
   getDelayedTransitions,
-  matchesActorSession
+  matchesActorSession,
+  type TransitionSelectionResults
 } from './stateUtils.ts';
-import type { TransitionSelectionResults } from './stateUtils.ts';
 import type {
   DelayedTransitionDefinition,
   EventObject,

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -11,6 +11,7 @@ import {
   getDelayedTransitions,
   matchesActorSession
 } from './stateUtils.ts';
+import type { TransitionSelectionResults } from './stateUtils.ts';
 import type {
   DelayedTransitionDefinition,
   EventObject,
@@ -145,6 +146,7 @@ export class StateNode<
   public after!: Array<DelayedTransitionDefinition<any, any>>;
   public events!: Array<EventDescriptor<any>>;
   public ownEvents!: Array<EventDescriptor<any>>;
+  private _candidateCache?: Map<string, AnyTransitionDefinition[]>;
 
   constructor(
     /** The raw config used to create the machine. */
@@ -298,13 +300,15 @@ export class StateNode<
   public next(
     snapshot: AnyMachineSnapshot,
     event: AnyEventObject,
-    self: AnyActor
+    self: AnyActor,
+    selectionResults?: TransitionSelectionResults
   ): Array<AnyTransitionDefinition> | undefined {
-    const candidates: Array<AnyTransitionDefinition> = memo(
-      this,
-      `candidates-${getEventDescriptorKey(event)}`,
-      () => getCandidates(this, event)
-    );
+    const descriptorKey = getEventDescriptorKey(event);
+    let candidates = this._candidateCache?.get(descriptorKey);
+    if (!candidates) {
+      candidates = getCandidates(this, event);
+      (this._candidateCache ??= new Map()).set(descriptorKey, candidates);
+    }
 
     for (const candidate of candidates) {
       const guardPassed = evaluateCandidate(
@@ -312,7 +316,8 @@ export class StateNode<
         event,
         snapshot,
         this,
-        self
+        self,
+        selectionResults
       );
 
       if (guardPassed) {

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -388,14 +388,16 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     // Announce actor topology: emitted once for every actor (root and every
     // spawned/invoked child) so the actor graph can be drawn before any
     // transitions occur. This is the only place actor identity is announced.
-    this.system._sendInspectionEvent({
-      type: '@xstate.actor',
-      actorRef: this,
-      parentRef: this._parent,
-      id: this.id,
-      src: this.src,
-      snapshot: this._snapshot
-    });
+    if (this.system._hasInspectionObservers?.() ?? true) {
+      this.system._sendInspectionEvent({
+        type: '@xstate.actor',
+        actorRef: this,
+        parentRef: this._parent,
+        id: this.id,
+        src: this.src,
+        snapshot: this._snapshot
+      });
+    }
   }
 
   // array of functions to defer
@@ -438,10 +440,12 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     const exec = () => {
       // Record every executed action for the '@xstate.transition' inspection
       // event's `actions[]` facet (replaces the v5 '@xstate.action' event).
-      (this._collectedActions ??= []).push({
-        type: action.type,
-        params: action.params
-      });
+      if (this.system._hasInspectionObservers?.() ?? true) {
+        (this._collectedActions ??= []).push({
+          type: action.type,
+          params: action.params
+        });
+      }
       const saveExecutingCustomAction = executingCustomAction;
       try {
         executingCustomAction = true;
@@ -571,18 +575,20 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     snapshot: SnapshotFrom<TLogic>,
     event: EventObject
   ): void {
-    this.system._sendInspectionEvent({
-      type: '@xstate.transition',
-      actorRef: this,
-      event,
-      sourceRef: this._lastSourceRef,
-      targetRef: this,
-      snapshot,
-      microsteps: this._collectedMicrosteps ?? emptyInspectionRecords,
-      actions: this._collectedActions ?? emptyInspectionRecords,
-      sent: this._collectedSent ?? emptyInspectionRecords,
-      eventType: event.type
-    });
+    if (this.system._hasInspectionObservers?.() ?? true) {
+      this.system._sendInspectionEvent({
+        type: '@xstate.transition',
+        actorRef: this,
+        event,
+        sourceRef: this._lastSourceRef,
+        targetRef: this,
+        snapshot,
+        microsteps: this._collectedMicrosteps ?? emptyInspectionRecords,
+        actions: this._collectedActions ?? emptyInspectionRecords,
+        sent: this._collectedSent ?? emptyInspectionRecords,
+        eventType: event.type
+      });
+    }
     this._collectedMicrosteps = undefined;
     this._collectedActions = undefined;
     this._collectedSent = undefined;

--- a/packages/core/src/snapshotActorRef.ts
+++ b/packages/core/src/snapshotActorRef.ts
@@ -131,6 +131,7 @@ export function createSnapshotSystem(
     getAll: () => Object.fromEntries(keyedActors),
     // Pure transition resolution must not leak topology inspection events into
     // a live runtime system.
+    _hasInspectionObservers: () => false,
     _sendInspectionEvent: () => {}
   });
 

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1337,14 +1337,6 @@ function microstep(
     let historyValue = currentSnapshot.historyValue;
     const originalContext = currentSnapshot.context;
 
-    const resolvePlanningTransition = createTransitionResultResolver(
-      currentSnapshot,
-      event,
-      actorScope,
-      false,
-      selectionResults
-    );
-
     const filteredTransitions =
       transitions.length === 1
         ? transitions
@@ -1352,7 +1344,13 @@ function microstep(
             transitions,
             mutStateNodeSet,
             currentSnapshot,
-            resolvePlanningTransition
+            createTransitionResultResolver(
+              currentSnapshot,
+              event,
+              actorScope,
+              false,
+              selectionResults
+            )
           );
     const getCurrentTransitionResult = createTransitionResultResolver(
       currentSnapshot,
@@ -1361,12 +1359,10 @@ function microstep(
       true,
       selectionResults
     );
-    const transitionResults = filteredTransitions.map(
-      getCurrentTransitionResult
-    );
-    const changesState = transitionResults.some(
-      ({ targets, reenter }) => !!targets?.length || !!reenter
-    );
+    const changesState = filteredTransitions.some((transition) => {
+      const { targets, reenter } = getCurrentTransitionResult(transition);
+      return !!targets?.length || !!reenter;
+    });
     const getStateActionsAndContext = (
       transitionFn: any,
       context: MachineContext,
@@ -2372,6 +2368,7 @@ export function macrostep(
       );
     }
 
+    let selectionResults: TransitionSelectionResults | undefined;
     let enabledTransitions: AnyTransitionDefinition[] =
       shouldSelectEventlessTransitions
         ? selectEventlessTransitions(nextSnapshot, nextEvent, actorScope)
@@ -2386,27 +2383,13 @@ export function macrostep(
         break;
       }
       nextEvent = internalQueue.shift()!;
-      const selectionResults: TransitionSelectionResults = new Map();
+      selectionResults = new Map();
       enabledTransitions = nextSnapshot.machine.getTransitionData(
         nextSnapshot as any,
         nextEvent,
         actorScope.self,
         selectionResults
       );
-      const step = microstep(
-        enabledTransitions,
-        nextSnapshot,
-        actorScope,
-        nextEvent,
-        false,
-        internalQueue,
-        selectionResults
-      );
-      nextSnapshot = step[0];
-      shouldSelectEventlessTransitions = nextSnapshot !== previousState;
-      addMicrostep(step, enabledTransitions);
-      removeTerminatedChild(nextEvent);
-      continue;
     }
 
     const step = microstep(
@@ -2415,7 +2398,8 @@ export function macrostep(
       actorScope,
       nextEvent,
       false,
-      internalQueue
+      internalQueue,
+      selectionResults
     );
     nextSnapshot = step[0];
     shouldSelectEventlessTransitions = nextSnapshot !== previousState;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -285,7 +285,8 @@ function getEventTypeAliases(event: EventObject): string[] {
 }
 
 export function getEventDescriptorKey(event: EventObject): string {
-  return getEventTypeAliases(event).join('|');
+  const legacyType = getLegacyEventType(event);
+  return legacyType ? `${event.type}|${legacyType}` : event.type;
 }
 
 export function matchesActorSession(
@@ -921,6 +922,17 @@ export function getStateNodes(
   return allStateNodes;
 }
 
+export type TransitionSelectionResult = {
+  enabled: boolean;
+  result: unknown;
+  reusable: boolean;
+};
+
+export type TransitionSelectionResults = Map<
+  AnyTransitionDefinition,
+  TransitionSelectionResult
+>;
+
 export function transitionNode<
   TContext extends MachineContext,
   TEvent extends EventObject
@@ -938,15 +950,16 @@ export function transitionNode<
     any // TStateSchema
   >,
   event: TEvent,
-  self: AnyActor
+  self: AnyActor,
+  selectionResults?: TransitionSelectionResults
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   // leaf node
   if (typeof stateValue === 'string') {
     const childStateNode = getStateNode(stateNode, stateValue);
-    const next = childStateNode.next(snapshot, event, self);
+    const next = childStateNode.next(snapshot, event, self, selectionResults);
 
     if (!next || !next.length) {
-      return stateNode.next(snapshot, event, self);
+      return stateNode.next(snapshot, event, self, selectionResults);
     }
 
     return next;
@@ -962,11 +975,12 @@ export function transitionNode<
       stateValue[subStateKey]!,
       snapshot,
       event,
-      self
+      self,
+      selectionResults
     );
 
     if (!next || !next.length) {
-      return stateNode.next(snapshot, event, self);
+      return stateNode.next(snapshot, event, self, selectionResults);
     }
 
     return next;
@@ -987,7 +1001,8 @@ export function transitionNode<
       subStateValue,
       snapshot,
       event,
-      self
+      self,
+      selectionResults
     );
     if (innerTransitions) {
       allInnerTransitions.push(...innerTransitions);
@@ -995,7 +1010,7 @@ export function transitionNode<
   }
 
   if (!allInnerTransitions.length) {
-    return stateNode.next(snapshot, event, self);
+    return stateNode.next(snapshot, event, self, selectionResults);
   }
 
   return allInnerTransitions;
@@ -1049,8 +1064,7 @@ function removeConflictingTransitions(
   enabledTransitions: Array<AnyTransitionDefinition>,
   stateNodeSet: Set<AnyStateNode>,
   snapshot: AnyMachineSnapshot,
-  event: AnyEventObject,
-  actorScope: AnyActorScope
+  resolveTransition: TransitionResultResolver
 ): Array<AnyTransitionDefinition> {
   const filteredTransitions = new Set<AnyTransitionDefinition>();
   const exitSets = new Map<AnyTransitionDefinition, Array<AnyStateNode>>();
@@ -1062,8 +1076,7 @@ function removeConflictingTransitions(
         [transition],
         stateNodeSet,
         snapshot,
-        event,
-        actorScope
+        resolveTransition
       );
       exitSets.set(transition, exitSet);
     }
@@ -1100,20 +1113,51 @@ function removeConflictingTransitions(
   return Array.from(filteredTransitions);
 }
 
+type ResolvableTransition = Parameters<typeof getTransitionResult>[0];
+type TransitionResultResolver = (
+  transition: ResolvableTransition
+) => ReturnType<typeof getTransitionResult>;
+
+function createTransitionResultResolver(
+  snapshot: AnyMachineSnapshot,
+  event: AnyEventObject,
+  actorScope: AnyActorScope,
+  resolveActions: boolean,
+  selectionResults?: TransitionSelectionResults
+): TransitionResultResolver {
+  let cache:
+    | Map<ResolvableTransition, ReturnType<typeof getTransitionResult>>
+    | undefined;
+  return (transition) => {
+    if (!transition.to) {
+      return getTransitionResult(transition, snapshot, event, actorScope, {
+        resolveActions,
+        selectionResult: selectionResults?.get(
+          transition as AnyTransitionDefinition
+        )
+      });
+    }
+    let result = cache?.get(transition);
+    if (!result) {
+      result = getTransitionResult(transition, snapshot, event, actorScope, {
+        resolveActions,
+        selectionResult: selectionResults?.get(
+          transition as AnyTransitionDefinition
+        )
+      });
+      (cache ??= new Map()).set(transition, result);
+    }
+    return result;
+  };
+}
+
 function getEffectiveTargetStates(
   transition: Pick<AnyTransitionDefinition, 'target' | 'source'>,
   snapshot: AnyMachineSnapshot,
-  event: AnyEventObject,
-  actorScope: AnyActorScope
+  resolveTransition: TransitionResultResolver
 ): Array<AnyStateNode> {
   const historyValue = snapshot.historyValue;
-  const { targets } = getTransitionResult(
-    transition,
-    snapshot,
-    event,
-    actorScope,
-    { resolveActions: false }
-  );
+  const { targets } = resolveTransition(transition);
   if (!targets) {
     return [];
   }
@@ -1130,8 +1174,7 @@ function getEffectiveTargetStates(
         for (const node of getEffectiveTargetStates(
           resolveHistoryDefaultTransition(targetNode),
           snapshot,
-          event,
-          actorScope
+          resolveTransition
         )) {
           targetSet.add(node);
         }
@@ -1171,23 +1214,15 @@ function narrowParallelDomain(
 function getTransitionDomain(
   transition: AnyTransitionDefinition,
   snapshot: AnyMachineSnapshot,
-  event: AnyEventObject,
-  actorScope: AnyActorScope
+  resolveTransition: TransitionResultResolver
 ): AnyStateNode | undefined {
   const targetStates = getEffectiveTargetStates(
     transition,
     snapshot,
-    event,
-    actorScope
+    resolveTransition
   );
 
-  const { reenter } = getTransitionResult(
-    transition,
-    snapshot,
-    event,
-    actorScope,
-    { resolveActions: false }
-  );
+  const { reenter } = resolveTransition(transition);
 
   if (
     targetStates.every(
@@ -1226,25 +1261,17 @@ function computeExitSet(
   transitions: Array<AnyTransitionDefinition>,
   stateNodeSet: Set<AnyStateNode>,
   snapshot: AnyMachineSnapshot,
-  event: AnyEventObject,
-  actorScope: AnyActorScope
+  resolveTransition: TransitionResultResolver
 ): Array<AnyStateNode> {
   const statesToExit = new Set<AnyStateNode>();
   for (const transition of transitions) {
-    const { targets, reenter } = getTransitionResult(
-      transition,
-      snapshot,
-      event,
-      actorScope,
-      { resolveActions: false }
-    );
+    const { targets, reenter } = resolveTransition(transition);
 
     if (targets?.length) {
       const domain = getTransitionDomain(
         transition,
         snapshot,
-        event,
-        actorScope
+        resolveTransition
       );
 
       if (reenter && transition.source === domain) {
@@ -1296,7 +1323,8 @@ function microstep(
   actorScope: AnyActorScope,
   event: AnyEventObject,
   isInitial: boolean,
-  internalQueue: Array<AnyEventObject>
+  internalQueue: Array<AnyEventObject>,
+  selectionResults?: TransitionSelectionResults
 ): Microstep {
   const executableActions: ExecutableActionObject[] = [];
 
@@ -1309,16 +1337,36 @@ function microstep(
     let historyValue = currentSnapshot.historyValue;
     const originalContext = currentSnapshot.context;
 
-    const filteredTransitions = removeConflictingTransitions(
-      transitions,
-      mutStateNodeSet,
+    const resolvePlanningTransition = createTransitionResultResolver(
       currentSnapshot,
       event,
-      actorScope
+      actorScope,
+      false,
+      selectionResults
     );
-    const getCurrentTransitionResult = (
-      transition: Parameters<typeof getTransitionResult>[0]
-    ) => getTransitionResult(transition, currentSnapshot, event, actorScope);
+
+    const filteredTransitions =
+      transitions.length === 1
+        ? transitions
+        : removeConflictingTransitions(
+            transitions,
+            mutStateNodeSet,
+            currentSnapshot,
+            resolvePlanningTransition
+          );
+    const getCurrentTransitionResult = createTransitionResultResolver(
+      currentSnapshot,
+      event,
+      actorScope,
+      true,
+      selectionResults
+    );
+    const transitionResults = filteredTransitions.map(
+      getCurrentTransitionResult
+    );
+    const changesState = transitionResults.some(
+      ({ targets, reenter }) => !!targets?.length || !!reenter
+    );
     const getStateActionsAndContext = (
       transitionFn: any,
       context: MachineContext,
@@ -1395,8 +1443,7 @@ function microstep(
         filteredTransitions,
         mutStateNodeSet,
         currentSnapshot,
-        event,
-        actorScope
+        getCurrentTransitionResult
       );
 
       statesToExit.sort((a, b) => b.order - a.order);
@@ -1472,7 +1519,7 @@ function microstep(
     };
 
     // Exit states
-    if (!isInitial) {
+    if (!isInitial && changesState) {
       exitStates();
     }
 
@@ -1643,17 +1690,10 @@ function microstep(
         const domain = getTransitionDomain(
           transition,
           currentSnapshot,
-          event,
-          actorScope
+          getCurrentTransitionResult
         );
 
-        const { targets, reenter } = getTransitionResult(
-          transition,
-          currentSnapshot,
-          event,
-          actorScope,
-          { resolveActions: false }
-        );
+        const { targets, reenter } = getCurrentTransitionResult(transition);
 
         for (const targetNode of targets ?? []) {
           if (
@@ -1670,8 +1710,7 @@ function microstep(
         const targetStates = getEffectiveTargetStates(
           transition,
           currentSnapshot,
-          event,
-          actorScope
+          getCurrentTransitionResult
         );
         for (const s of targetStates) {
           const ancestors = getProperAncestors(s, domain);
@@ -1700,13 +1739,7 @@ function microstep(
       };
       let stateInputsChanged = false;
       for (const transition of filteredTransitions) {
-        const { targets, input } = getTransitionResult(
-          transition,
-          currentSnapshot,
-          event,
-          actorScope,
-          { resolveActions: false }
-        );
+        const { targets, input } = getCurrentTransitionResult(transition);
         if (input && targets) {
           for (const targetNode of targets) {
             stateInputMap[targetNode.id] = input;
@@ -1946,7 +1979,9 @@ function microstep(
     }
 
     // Enter states
-    enterStates();
+    if (isInitial || changesState) {
+      enterStates();
+    }
 
     const nextStateNodes = [...mutStateNodeSet];
 
@@ -2041,7 +2076,10 @@ export function getTransitionResult(
   snapshot: AnyMachineSnapshot,
   event: AnyEventObject,
   actorScope: AnyActorScope,
-  options?: { resolveActions?: boolean }
+  options?: {
+    resolveActions?: boolean;
+    selectionResult?: TransitionSelectionResult;
+  }
 ): {
   targets: Readonly<AnyStateNode[]> | undefined;
   context: MachineContext | undefined;
@@ -2069,15 +2107,18 @@ export function getTransitionResult(
   if (transition.to) {
     const actions: AnyAction[] = [];
     const internalEvents: EventObject[] = [];
-    const enqueue = createTransitionEnqueue(
-      actorScope,
-      actions,
-      internalEvents,
-      false,
-      options?.resolveActions ?? true
-    );
-
-    const res = transition.to(transitionArgs, enqueue);
+    const res = options?.selectionResult?.reusable
+      ? options.selectionResult.result
+      : transition.to(
+          transitionArgs,
+          createTransitionEnqueue(
+            actorScope,
+            actions,
+            internalEvents,
+            false,
+            options?.resolveActions ?? true
+          )
+        );
 
     const targets = res?.target
       ? resolveTarget(transition.source, toArray(res.target) as string[])
@@ -2204,10 +2245,12 @@ export function macrostep(
   ) {
     // collect microsteps; surfaced on the enclosing '@xstate.transition' event
     // via its `microsteps[]` facet (there is no standalone microstep event)
-    const collectedMicrosteps =
-      ((actorScope.self as any)._collectedMicrosteps as any[]) || [];
-    collectedMicrosteps.push(...transitions);
-    (actorScope.self as any)._collectedMicrosteps = collectedMicrosteps;
+    if (actorScope.system._hasInspectionObservers?.() ?? true) {
+      const collectedMicrosteps =
+        ((actorScope.self as any)._collectedMicrosteps as any[]) || [];
+      collectedMicrosteps.push(...transitions);
+      (actorScope.self as any)._collectedMicrosteps = collectedMicrosteps;
+    }
     microsteps.push(step);
   }
 
@@ -2258,11 +2301,13 @@ export function macrostep(
   if (nextEvent.type !== XSTATE_INIT && nextEvent.type !== XSTATE_TIMER) {
     const currentEvent = nextEvent;
     const isErr = isErrorEvent(currentEvent);
+    const selectionResults: TransitionSelectionResults = new Map();
 
     const transitions = nextSnapshot.machine.getTransitionData(
       nextSnapshot as any,
       currentEvent,
-      actorScope.self
+      actorScope.self,
+      selectionResults
     );
 
     if (isErr && !transitions.length) {
@@ -2293,11 +2338,19 @@ export function macrostep(
       actorScope,
       nextEvent,
       false, // isInitial
-      internalQueue
+      internalQueue,
+      selectionResults
     );
     nextSnapshot = step[0];
     addMicrostep(step, transitions);
     removeTerminatedChild(currentEvent);
+  }
+
+  if (
+    !internalQueue.length &&
+    snapshot.machine._hasEventlessTransitions === false
+  ) {
+    return completeMacrostep();
   }
 
   let shouldSelectEventlessTransitions = true;
@@ -2333,11 +2386,27 @@ export function macrostep(
         break;
       }
       nextEvent = internalQueue.shift()!;
+      const selectionResults: TransitionSelectionResults = new Map();
       enabledTransitions = nextSnapshot.machine.getTransitionData(
         nextSnapshot as any,
         nextEvent,
-        actorScope.self
+        actorScope.self,
+        selectionResults
       );
+      const step = microstep(
+        enabledTransitions,
+        nextSnapshot,
+        actorScope,
+        nextEvent,
+        false,
+        internalQueue,
+        selectionResults
+      );
+      nextSnapshot = step[0];
+      shouldSelectEventlessTransitions = nextSnapshot !== previousState;
+      addMicrostep(step, enabledTransitions);
+      removeTerminatedChild(nextEvent);
+      continue;
     }
 
     const step = microstep(
@@ -2379,7 +2448,7 @@ export function hasEffect(
   self: AnyActor
 ): boolean {
   if (transition.to) {
-    return transitionToHasEffect(
+    return evaluateTransitionFunction(
       transition.to,
       context,
       event,
@@ -2387,13 +2456,34 @@ export function hasEffect(
       self,
       snapshot.machine.sources,
       transition.source.id
-    );
+    ).enabled;
   }
 
   return false;
 }
 
-function transitionToHasEffect(
+const transitionEffectSignal = new Error('Transition effect');
+const triggerTransitionEffect = () => {
+  throw transitionEffectSignal;
+};
+let transitionEffectEnqueue: ReturnType<typeof createEnqueueObject> | undefined;
+function getTransitionEffectEnqueue() {
+  return (transitionEffectEnqueue ??= createEnqueueObject(
+    {
+      emit: triggerTransitionEffect,
+      cancel: triggerTransitionEffect,
+      log: triggerTransitionEffect,
+      raise: triggerTransitionEffect,
+      spawn: triggerTransitionEffect,
+      sendTo: triggerTransitionEffect,
+      stop: triggerTransitionEffect
+    },
+    triggerTransitionEffect
+  ));
+}
+const transitionEffectParent = { send: triggerTransitionEffect };
+
+function evaluateTransitionFunction(
   transitionTo: NonNullable<AnyTransitionDefinition['to']>,
   context: MachineContext,
   event: EventObject,
@@ -2401,15 +2491,10 @@ function transitionToHasEffect(
   self: AnyActor,
   sources: AnyMachineSnapshot['machine']['sources'],
   sourceId: string
-) {
-  let hasEffect = false;
+): TransitionSelectionResult {
   let res;
 
   try {
-    const triggerEffect = () => {
-      hasEffect = true;
-      throw new Error('Effect triggered');
-    };
     res = transitionTo(
       {
         context,
@@ -2419,36 +2504,23 @@ function transitionToHasEffect(
         system: self.system,
         value: snapshot.value,
         children: snapshot.children,
-        parent: {
-          send: triggerEffect
-        } as any,
+        parent: transitionEffectParent as any,
         actions: sources.actions,
         actors: sources.actors,
         guards: sources.guards,
         delays: sources.delays,
         input: getStateInput(snapshot, sourceId)
       },
-      createEnqueueObject(
-        {
-          emit: triggerEffect,
-          cancel: triggerEffect,
-          log: triggerEffect,
-          raise: triggerEffect,
-          spawn: triggerEffect,
-          sendTo: triggerEffect,
-          stop: triggerEffect
-        },
-        triggerEffect
-      )
+      getTransitionEffectEnqueue()
     );
   } catch (err) {
-    if (hasEffect) {
-      return true;
+    if (err === transitionEffectSignal) {
+      return { enabled: true, result: undefined, reusable: false };
     }
     throw err;
   }
 
-  return res !== undefined;
+  return { enabled: res !== undefined, result: res, reusable: true };
 }
 
 function stopChildren(
@@ -2527,8 +2599,7 @@ function selectEventlessTransitions(
     Array.from(enabledTransitionSet),
     new Set(snapshot._nodes),
     snapshot,
-    event,
-    actorScope
+    createTransitionResultResolver(snapshot, event, actorScope, false)
   );
 }
 
@@ -2537,7 +2608,8 @@ export function evaluateCandidate(
   event: EventObject,
   snapshot: AnyMachineSnapshot,
   stateNode: AnyStateNode,
-  self: AnyActor
+  self: AnyActor,
+  selectionResults?: TransitionSelectionResults
 ): boolean {
   if (candidate.matches && !matchesEvent(event, candidate.matches)) {
     return false;
@@ -2567,7 +2639,7 @@ export function evaluateCandidate(
   }
 
   if (candidate.to) {
-    return transitionToHasEffect(
+    const evaluation = evaluateTransitionFunction(
       candidate.to,
       snapshot.context,
       event,
@@ -2576,6 +2648,8 @@ export function evaluateCandidate(
       stateNode.machine.sources,
       candidate.source.id
     );
+    selectionResults?.set(candidate, evaluation);
+    return evaluation.enabled;
   }
 
   return true;

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -61,6 +61,7 @@ import {
   resolveActionsWithContext
 } from './transitionActions.ts';
 import { parseDurationToMilliseconds } from './delay.ts';
+import { transitionEffectSignal, transitionEffectTargets } from './system.ts';
 
 type AnyStateNodeIterable = Iterable<AnyStateNode>;
 
@@ -2241,7 +2242,10 @@ export function macrostep(
   ) {
     // collect microsteps; surfaced on the enclosing '@xstate.transition' event
     // via its `microsteps[]` facet (there is no standalone microstep event)
-    if (actorScope.system._hasInspectionObservers?.() ?? true) {
+    if (
+      event.type === XSTATE_INIT ||
+      (actorScope.system._hasInspectionObservers?.() ?? true)
+    ) {
       const collectedMicrosteps =
         ((actorScope.self as any)._collectedMicrosteps as any[]) || [];
       collectedMicrosteps.push(...transitions);
@@ -2446,7 +2450,6 @@ export function hasEffect(
   return false;
 }
 
-const transitionEffectSignal = new Error('Transition effect');
 const triggerTransitionEffect = () => {
   throw transitionEffectSignal;
 };
@@ -2465,7 +2468,6 @@ function getTransitionEffectEnqueue() {
     triggerTransitionEffect
   ));
 }
-const transitionEffectParent = { send: triggerTransitionEffect };
 
 function evaluateTransitionFunction(
   transitionTo: NonNullable<AnyTransitionDefinition['to']>,
@@ -2477,6 +2479,10 @@ function evaluateTransitionFunction(
   sourceId: string
 ): TransitionSelectionResult {
   let res;
+  const parent = self._parent;
+  if (parent) {
+    transitionEffectTargets.push(parent);
+  }
 
   try {
     res = transitionTo(
@@ -2488,7 +2494,7 @@ function evaluateTransitionFunction(
         system: self.system,
         value: snapshot.value,
         children: snapshot.children,
-        parent: transitionEffectParent as any,
+        parent,
         actions: sources.actions,
         actors: sources.actors,
         guards: sources.guards,
@@ -2502,6 +2508,10 @@ function evaluateTransitionFunction(
       return { enabled: true, result: undefined, reusable: false };
     }
     throw err;
+  } finally {
+    if (parent) {
+      transitionEffectTargets.pop();
+    }
   }
 
   return { enabled: res !== undefined, result: res, reusable: true };

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -183,6 +183,8 @@ export interface ActorSystem<
       | Observer<InspectionEvent>
       | ((inspectionEvent: InspectionEvent) => void)
   ) => Subscription;
+  /** @internal Avoids collecting inspection-only transition metadata. */
+  _hasInspectionObservers?: () => boolean;
   /** @internal */
   _sendInspectionEvent: (
     event: HomomorphicOmit<InspectionEvent, 'rootId'>
@@ -496,6 +498,10 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
         this._inspectionObservers?.delete(observer);
       }
     };
+  }
+
+  public _hasInspectionObservers(): boolean {
+    return !!this._inspectionObservers?.size;
   }
 
   public _sendInspectionEvent(

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -38,6 +38,11 @@ interface Scheduler {
 
 let nextFallbackSystemId = 0;
 
+/** @internal */
+export const transitionEffectSignal = new Error('Transition effect');
+/** @internal */
+export const transitionEffectTargets: AnyActor[] = [];
+
 function createSystemId(): string {
   let crypto: Crypto | undefined;
   try {
@@ -565,6 +570,12 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
     target: AnyActor,
     event: AnyEventObject
   ): void {
+    if (
+      transitionEffectTargets.length &&
+      transitionEffectTargets.includes(target)
+    ) {
+      throw transitionEffectSignal;
+    }
     this.sendEvent(source, target, event);
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1101,6 +1101,8 @@ export interface AnyStateMachine extends AnyActorLogic {
   id: string;
   root: AnyStateNode;
   /** @internal */
+  _hasEventlessTransitions?: boolean;
+  /** @internal */
   idMap: Map<string, AnyStateNode>;
   options?: { maxIterations?: number };
   states: StateNodesConfig<any, any>;
@@ -1116,7 +1118,8 @@ export interface AnyStateMachine extends AnyActorLogic {
   getTransitionData(
     snapshot: any,
     event: any,
-    actor: AnyActorRef
+    actor: AnyActorRef,
+    selectionResults?: Map<AnyTransitionDefinition, unknown>
   ): AnyTransitionDefinition[];
   /** @internal */
   _canTransition(snapshot: AnyMachineSnapshot, event: any): boolean;

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -569,6 +569,32 @@ describe('inspect', () => {
     expect(events.some((e) => e.type === '@xstate.transition')).toBe(true);
   });
 
+  it('actor.system.inspect(…) captures initial microsteps before start', () => {
+    const actor = createActor(
+      createMachine({
+        initial: 'a',
+        states: {
+          a: { always: () => ({ target: 'b' }) },
+          b: {}
+        }
+      })
+    );
+    const events: InspectionEvent[] = [];
+
+    actor.system.inspect((event) => events.push(event));
+    actor.start();
+
+    const initialTransition = events.find(
+      (event) =>
+        event.type === '@xstate.transition' && event.event.type === XSTATE_INIT
+    );
+    expect(initialTransition?.type).toBe('@xstate.transition');
+    if (initialTransition?.type !== '@xstate.transition') {
+      throw new Error('Initial transition was not inspected.');
+    }
+    expect(initialTransition.microsteps).toHaveLength(1);
+  });
+
   it('actor.system.inspect(…) can inspect actors (observer)', () => {
     const actor = createActor(createMachine({}));
     const events: InspectionEvent[] = [];

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -86,6 +86,23 @@ function describeEffects(effects: ExecutableActionObject[]): string[] {
 }
 
 describe('transition function', () => {
+  it('does not repeatedly resolve a selected transition during a microstep', () => {
+    const update = vi.fn(({ context }: { context: { count: number } }) => ({
+      context: { count: context.count + 1 }
+    }));
+    const machine = createMachine({
+      context: { count: 0 },
+      on: { UPDATE: update }
+    });
+    const actor = createActor(machine).start();
+
+    update.mockClear();
+    actor.send({ type: 'UPDATE' });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(actor.getSnapshot().context).toEqual({ count: 1 });
+  });
+
   it('resolves mapper context on object transitions', () => {
     const machine = createMachine({
       schemas: {

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -103,6 +103,65 @@ describe('transition function', () => {
     expect(actor.getSnapshot().context).toEqual({ count: 1 });
   });
 
+  it('resolves a selected transition with the real parent', () => {
+    const childMachine = createMachine({
+      context: { parent: undefined as unknown },
+      on: {
+        CHECK: ({ parent }) => ({ context: { parent } })
+      }
+    });
+    const parent = createActor(
+      createMachine({
+        invoke: { id: 'child', src: childMachine }
+      })
+    ).start();
+    const child = parent.getSnapshot().children.child!;
+
+    child.send({ type: 'CHECK' });
+
+    expect(child.getSnapshot().context.parent).toBe(parent);
+  });
+
+  it('resolves a root transition with an undefined parent', () => {
+    const machine = createMachine({
+      context: { hasParent: true },
+      on: {
+        CHECK: ({ parent }) => ({ context: { hasParent: !!parent } })
+      }
+    });
+    const actor = createActor(machine).start();
+
+    actor.send({ type: 'CHECK' });
+
+    expect(actor.getSnapshot().context.hasParent).toBe(false);
+  });
+
+  it('does not send to the parent during transition selection', () => {
+    const childMachine = createMachine({
+      on: {
+        CHECK: ({ parent }) => {
+          parent?.send({ type: 'CHILD' });
+          return {};
+        }
+      }
+    });
+    const parent = createActor(
+      createMachine({
+        context: { received: 0 },
+        on: {
+          CHILD: ({ context }) => ({
+            context: { received: context.received + 1 }
+          })
+        },
+        invoke: { id: 'child', src: childMachine }
+      })
+    ).start();
+
+    parent.getSnapshot().children.child!.send({ type: 'CHECK' });
+
+    expect(parent.getSnapshot().context.received).toBe(1);
+  });
+
   it('resolves mapper context on object transitions', () => {
     const machine = createMachine({
       schemas: {


### PR DESCRIPTION
## Summary

- reuse effect-free transition-function results across selection and execution
- cache transition planning within a microstep and skip work that cannot affect state
- avoid inspection bookkeeping when no inspector is attached
- defer initial actor-reference attachment until the actor snapshot is finalized

## Impact

Five-process medians from the checked-in neutral runtime harness, compared with published `6.0.0-alpha.31` results:

| Scenario | alpha.31 | This branch | Change |
| --- | ---: | ---: | ---: |
| Flat burst | 310,945/s | 1,053,927/s | +238.9% |
| Observed burst | 313,104/s | 1,025,469/s | +227.5% |
| Child delivery | 307,889/s | 982,000/s | +218.9% |
| Flat lifecycle | 255,363/s | 289,184/s | +13.2% |
| Parent-child lifecycle | 76,923/s | 83,619/s | +8.7% |
| Compound burst | 309,071/s | 1,014,886/s | +228.4% |
| Parallel burst | 240,442/s | 836,820/s | +248.0% |

The branch beats the comparison implementation in all managed burst/delivery scenarios and parent-child lifecycle. Flat lifecycle remains lower and is not optimized with a separate execution engine.

Memory slopes remain effectively unchanged: idle actors 2.20 to 2.15 KiB, two independent actors 3.93 to 3.93 KiB, and parent-child actors 4.03 to 4.02 KiB.

The public pure `transition()` helper is intentionally excluded from this runtime slice; its repeated inert-scope construction is a separate optimization seam.

## Validation

- `pnpm test:core` — 2,119 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- rebuilt local package and reran the runtime throughput and forced-GC memory harness
