### PR TITLE
Optimize pure transition scope allocation

### DIFF
--- a/.changeset/faster-v6-runtime.md
+++ b/.changeset/faster-v6-runtime.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Improve state machine actor throughput for event bursts, child delivery, and compound and parallel machines.
+Improve state machine actor throughput for event bursts, child delivery, and compound and parallel machines. Pure context-only transitions now avoid allocating actor runtime facilities.

--- a/.changeset/faster-v6-runtime.md
+++ b/.changeset/faster-v6-runtime.md
@@ -2,4 +2,4 @@
 'xstate': patch
 ---
 
-Improve state machine actor throughput for event bursts, child delivery, and compound and parallel machines. Pure context-only transitions now avoid allocating actor runtime facilities.
+Improve state machine actor throughput for event bursts, child delivery, and compound and parallel machines.

--- a/.changeset/tender-transitions-plan.md
+++ b/.changeset/tender-transitions-plan.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Improve the performance and memory usage of pure transitions that only update machine context.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -14,6 +14,7 @@ import {
   isInertActorScope,
   setInertActorScopeSnapshot
 } from './getNextSnapshot.ts';
+import { withActorScope } from './actorScope.ts';
 import {
   createMachineSnapshot,
   cloneMachineSnapshot,
@@ -629,7 +630,10 @@ export class StateMachine<
         ? ({ ...snapshot.context, ...selected.context } as TContext)
         : snapshot.context;
 
-    if (actorScope.system._hasInspectionObservers?.() ?? true) {
+    if (
+      !isInertActorScope(actorScope) &&
+      (actorScope.system._hasInspectionObservers?.() ?? true)
+    ) {
       const collectedMicrosteps =
         ((actorScope.self as any)._collectedMicrosteps as any[]) || [];
       collectedMicrosteps.push(selected);
@@ -696,7 +700,7 @@ export class StateMachine<
       TConfig
     >,
     event: TEvent,
-    self: AnyActor,
+    actorScope: AnyActorScope,
     selectionResults?: TransitionSelectionResults
   ): Array<AnyTransitionDefinition> {
     return (
@@ -705,7 +709,7 @@ export class StateMachine<
         snapshot.value,
         snapshot,
         event,
-        self,
+        actorScope,
         selectionResults
       ) || []
     );
@@ -732,12 +736,11 @@ export class StateMachine<
    * @internal
    */
   public _canTransition(snapshot: AnyMachineSnapshot, event: TEvent): boolean {
-    const emptyActor = getEmptyCanActor();
     const emptyActorScope = getEmptyCanActorScope();
     const transitionData = this.getTransitionData(
       snapshot as any,
       event,
-      emptyActor
+      emptyActorScope
     );
 
     if (!transitionData?.length) {
@@ -760,7 +763,13 @@ export class StateMachine<
       if (
         res.targets?.length ||
         res.context ||
-        hasEffect(transition, snapshot.context, event, snapshot, emptyActor)
+        hasEffect(
+          transition,
+          snapshot.context,
+          event,
+          snapshot,
+          emptyActorScope
+        )
       ) {
         return true;
       }
@@ -832,12 +841,16 @@ export class StateMachine<
     if (typeof context === 'function') {
       const children = {};
       const spawn = createSpawner(actorScope, this.sources.actors, children);
-      const resolvedContext = context({
-        spawn,
-        input: initEvent.input,
-        self: actorScope.self,
-        actors: this.sources.actors
-      });
+      const resolvedContext = context(
+        withActorScope(
+          {
+            spawn,
+            input: initEvent.input,
+            actors: this.sources.actors
+          },
+          actorScope
+        )
+      );
       const [nextState] = resolveActionsWithContext(
         preInitial,
         initEvent,

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -629,10 +629,12 @@ export class StateMachine<
         ? ({ ...snapshot.context, ...selected.context } as TContext)
         : snapshot.context;
 
-    const collectedMicrosteps =
-      ((actorScope.self as any)._collectedMicrosteps as any[]) || [];
-    collectedMicrosteps.push(selected);
-    (actorScope.self as any)._collectedMicrosteps = collectedMicrosteps;
+    if (actorScope.system._hasInspectionObservers?.() ?? true) {
+      const collectedMicrosteps =
+        ((actorScope.self as any)._collectedMicrosteps as any[]) || [];
+      collectedMicrosteps.push(selected);
+      (actorScope.self as any)._collectedMicrosteps = collectedMicrosteps;
+    }
 
     return cloneMachineSnapshot(snapshot, {
       ...(context !== snapshot.context ? { context } : {}),

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -14,7 +14,7 @@ import {
   isInertActorScope,
   setInertActorScopeSnapshot
 } from './getNextSnapshot.ts';
-import { withActorScope } from './actorScope.ts';
+import { withActorSelf } from './actorScope.ts';
 import {
   createMachineSnapshot,
   cloneMachineSnapshot,
@@ -842,7 +842,7 @@ export class StateMachine<
       const children = {};
       const spawn = createSpawner(actorScope, this.sources.actors, children);
       const resolvedContext = context(
-        withActorScope(
+        withActorSelf(
           {
             spawn,
             input: initEvent.input,

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -475,7 +475,7 @@ export class StateMachine<
       }
       const returnedSnapshot =
         usesInertScope && fastSnapshot !== snapshot
-          ? attachSnapshotActorRef(this, resolvedActorScope, fastSnapshot)
+          ? attachSnapshotActorRef(resolvedActorScope, fastSnapshot)
           : this._attachPureActorRef(fastSnapshot, resolvedActorScope);
       if (this.validator) {
         assertValid(this.validator, {
@@ -501,7 +501,7 @@ export class StateMachine<
     const returnedSnapshot = usesInertScope
       ? nextSnapshot === snapshot
         ? nextSnapshot
-        : attachSnapshotActorRef(this, resolvedActorScope, nextSnapshot)
+        : attachSnapshotActorRef(resolvedActorScope, nextSnapshot)
       : this._attachPureActorRef(nextSnapshot, resolvedActorScope);
     const effects = this._collectEffects(microsteps);
     if (this.validator) {
@@ -968,7 +968,7 @@ export class StateMachine<
         setInertActorScopeSnapshot(resolvedActorScope, macroState, false);
       }
       const returnedSnapshot = usesInertScope
-        ? attachSnapshotActorRef(this, resolvedActorScope, macroState)
+        ? attachSnapshotActorRef(resolvedActorScope, macroState)
         : this._attachPureActorRef(macroState, resolvedActorScope);
       const effects = this._collectEffects(microsteps);
       if (this.validator) {
@@ -1342,7 +1342,7 @@ export class StateMachine<
 
     if (usesInertScope) {
       setInertActorScopeSnapshot(resolvedActorScope, restoredSnapshot, false);
-      return attachSnapshotActorRef(this, resolvedActorScope, restoredSnapshot);
+      return attachSnapshotActorRef(resolvedActorScope, restoredSnapshot);
     }
 
     return this._attachPureActorRef(restoredSnapshot, resolvedActorScope);

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -25,7 +25,7 @@ import type {
   AnyStateNodeConfig,
   NonReducibleUnknown,
   EventDescriptor,
-  AnyActor,
+  AnyActorScope,
   AnyStateNode,
   AnyEventObject,
   AnyAction,
@@ -300,7 +300,7 @@ export class StateNode<
   public next(
     snapshot: AnyMachineSnapshot,
     event: AnyEventObject,
-    self: AnyActor,
+    actorScope: AnyActorScope,
     selectionResults?: TransitionSelectionResults
   ): Array<AnyTransitionDefinition> | undefined {
     const descriptorKey = getEventDescriptorKey(event);
@@ -316,7 +316,7 @@ export class StateNode<
         event,
         snapshot,
         this,
-        self,
+        actorScope,
         selectionResults
       );
 

--- a/packages/core/src/actorScope.ts
+++ b/packages/core/src/actorScope.ts
@@ -22,6 +22,38 @@ export function getActorScopeParent(
     : actorScope.self._parent;
 }
 
+/** Adds only `self`, preserving callback surfaces that expose no other capabilities. @internal */
+export function withActorSelf<T extends object>(
+  args: T,
+  actorScope: AnyActorScope
+): T & Pick<AnyActorScope, 'self'> {
+  if (!isLazyActorScope(actorScope)) {
+    return Object.assign(args, { self: actorScope.self });
+  }
+  Object.defineProperty(args, 'self', {
+    enumerable: true,
+    get: () => actorScope.self
+  });
+  return args as T & Pick<AnyActorScope, 'self'>;
+}
+
+/** Adds the actor reference and parent without exposing the system. @internal */
+export function withActorSelfAndParent<T extends object>(
+  args: T,
+  actorScope: AnyActorScope
+): T & Pick<AnyActorScope, 'self'> & { parent: AnyActor | undefined } {
+  if (!isLazyActorScope(actorScope)) {
+    const self = actorScope.self;
+    return Object.assign(args, { self, parent: self._parent });
+  }
+  Object.defineProperties(args, {
+    self: { enumerable: true, get: () => actorScope.self },
+    parent: { enumerable: true, get: () => getActorScopeParent(actorScope) }
+  });
+  return args as T &
+    Pick<AnyActorScope, 'self'> & { parent: AnyActor | undefined };
+}
+
 /** Adds actor capabilities without reading them until the callback does. @internal */
 export function withActorScope<T extends object>(
   args: T,

--- a/packages/core/src/actorScope.ts
+++ b/packages/core/src/actorScope.ts
@@ -1,0 +1,53 @@
+import type { AnyActor, AnyActorScope } from './types.ts';
+
+/** Marks the internal lazy scope without imposing structure on custom runtimes. @internal */
+export const lazyActorScope = Symbol();
+
+type InternalActorScope = AnyActorScope & {
+  _parent?: AnyActor;
+  [lazyActorScope]?: true;
+};
+
+/** Whether actor capabilities are represented by a lazy pure-transition scope. @internal */
+export function isLazyActorScope(actorScope: AnyActorScope): boolean {
+  return !!(actorScope as InternalActorScope)[lazyActorScope];
+}
+
+/** Reads parent metadata without otherwise touching actor capabilities. @internal */
+export function getActorScopeParent(
+  actorScope: AnyActorScope
+): AnyActor | undefined {
+  return isLazyActorScope(actorScope)
+    ? (actorScope as InternalActorScope)._parent
+    : actorScope.self._parent;
+}
+
+/** Adds actor capabilities without reading them until the callback does. @internal */
+export function withActorScope<T extends object>(
+  args: T,
+  actorScope: AnyActorScope
+): T &
+  Pick<AnyActorScope, 'self' | 'system'> & {
+    parent: AnyActor | undefined;
+  } {
+  if (!isLazyActorScope(actorScope)) {
+    const actorArgs = args as T &
+      Pick<AnyActorScope, 'self' | 'system'> & {
+        parent: AnyActor | undefined;
+      };
+    const self = actorScope.self;
+    actorArgs.self = self;
+    actorArgs.system = actorScope.system;
+    actorArgs.parent = self._parent;
+    return actorArgs;
+  }
+  Object.defineProperties(args, {
+    self: { enumerable: true, get: () => actorScope.self },
+    system: { enumerable: true, get: () => actorScope.system },
+    parent: { enumerable: true, get: () => getActorScopeParent(actorScope) }
+  });
+  return args as T &
+    Pick<AnyActorScope, 'self' | 'system'> & {
+      parent: AnyActor | undefined;
+    };
+}

--- a/packages/core/src/fsm.ts
+++ b/packages/core/src/fsm.ts
@@ -7,6 +7,7 @@ import {
   createTransitionEnqueue,
   resolveActionsWithContext
 } from './transitionActions.ts';
+import { isLazyActorScope, withActorScope } from './actorScope.ts';
 import type {
   ActorLogic,
   ActorScope,
@@ -437,16 +438,16 @@ export function createFSM<
         ? actionsConfig[i]
         : actionsConfig;
       const result = action(
-        {
-          context: context ?? snapshot.context,
-          event: event as TEvent,
-          input: stateInput as any,
-          value: snapshot.value,
-          self: actorScope.self,
-          system: actorScope.system,
-          parent: actorScope.self._parent,
-          children: snapshot.children
-        },
+        withActorScope(
+          {
+            context: context ?? snapshot.context,
+            event: event as TEvent,
+            input: stateInput as any,
+            value: snapshot.value,
+            children: snapshot.children
+          },
+          actorScope
+        ),
         enq
       );
       if (result?.context !== undefined) {
@@ -489,16 +490,16 @@ export function createFSM<
       const transition = Array.isArray(transitionsConfig)
         ? transitionsConfig[i]
         : transitionsConfig;
-      const args = {
-        context: snapshot.context,
-        event,
-        input: snapshot.input,
-        value: snapshot.value,
-        self: actorScope.self,
-        system: actorScope.system,
-        parent: actorScope.self._parent,
-        children: snapshot.children
-      };
+      const args = withActorScope(
+        {
+          context: snapshot.context,
+          event,
+          input: snapshot.input,
+          value: snapshot.value,
+          children: snapshot.children
+        },
+        actorScope
+      );
 
       if (typeof transition === 'function') {
         const actions: AnyAction[] = [];
@@ -610,19 +611,31 @@ export function createFSM<
       } else {
         const hasContext = directTransition.context !== undefined;
         const hasInput = directTransition.input !== undefined;
-        const resolvedContext = resolveTransitionContext(
-          directTransition.context,
-          {
-            context: snapshot.context,
-            event,
-            input: snapshot.input,
-            value: snapshot.value,
-            self: actorScope.self,
-            system: actorScope.system,
-            parent: actorScope.self._parent,
-            children: snapshot.children
-          }
-        );
+        const resolvedContext = !isLazyActorScope(actorScope)
+          ? resolveTransitionContext(directTransition.context, {
+              context: snapshot.context,
+              event,
+              input: snapshot.input,
+              value: snapshot.value,
+              self: actorScope.self,
+              system: actorScope.system,
+              parent: actorScope.self._parent,
+              children: snapshot.children
+            })
+          : typeof directTransition.context === 'function'
+            ? directTransition.context(
+                withActorScope(
+                  {
+                    context: snapshot.context,
+                    event,
+                    input: snapshot.input,
+                    value: snapshot.value,
+                    children: snapshot.children
+                  },
+                  actorScope
+                )
+              )
+            : directTransition.context;
         const context =
           hasContext && resolvedContext
             ? mergeContextPatch(snapshot.context, resolvedContext)
@@ -654,16 +667,16 @@ export function createFSM<
       !stateConfig?.exit
     ) {
       const result = directTransition(
-        {
-          context: snapshot.context,
-          event,
-          input: snapshot.input,
-          value: snapshot.value,
-          self: actorScope.self,
-          system: actorScope.system,
-          parent: actorScope.self._parent,
-          children: snapshot.children
-        },
+        withActorScope(
+          {
+            context: snapshot.context,
+            event,
+            input: snapshot.input,
+            value: snapshot.value,
+            children: snapshot.children
+          },
+          actorScope
+        ),
         undefined as any
       );
       if (result) {

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -193,6 +193,7 @@ function createMaterializedInertActorScope<T extends AnyActorLogic>(
   // Reuse the branch actor's scope while keeping planning transactional.
   return Object.create((self as any)._actorScope, {
     defer: { value: () => {} },
+    stopChild: { value: (child: AnyActor) => (child as any)._stop() },
     actionExecutor: { value: () => {} }
   });
 }

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -52,8 +52,7 @@ export function isInertActorScope(actorScope: AnyActorScope): boolean {
 }
 
 /** @internal */
-export function attachSnapshotActorRef<T extends AnyActorLogic, TSnapshot>(
-  _actorLogic: T,
+export function attachSnapshotActorRef<TSnapshot>(
   actorScope: AnyActorScope,
   snapshot: TSnapshot
 ): TSnapshot {
@@ -191,17 +190,11 @@ function createMaterializedInertActorScope<T extends AnyActorLogic>(
     (self as any)._snapshot = currentSnapshot;
   }
 
-  return {
-    self: self as any,
-    defer: () => {},
-    id: self.id,
-    logger: self.system._logger,
-    sessionId: self.sessionId,
-    stopChild: (child) => (child as any)._stop(),
-    system: self.system,
-    emit: (event) => self.system.emitEvent(self, event),
-    actionExecutor: () => {}
-  };
+  // Reuse the branch actor's scope while keeping planning transactional.
+  return Object.create((self as any)._actorScope, {
+    defer: { value: () => {} },
+    actionExecutor: { value: () => {} }
+  });
 }
 
 /** @internal */
@@ -344,5 +337,5 @@ export function getNextSnapshot<T extends AnyActorLogic>(
   setInertActorScopeSnapshot(actorScope, nextSnapshot, false);
   return nextSnapshot === snapshot
     ? nextSnapshot
-    : attachSnapshotActorRef(actorLogic, actorScope, nextSnapshot);
+    : attachSnapshotActorRef(actorScope, nextSnapshot);
 }

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -1,11 +1,13 @@
 import { createActor } from './createActor.ts';
 import { isMachineSnapshot } from './State.ts';
 import {
-  copySnapshotActorRef,
   createSnapshotSystem,
   getSnapshotActorRef,
+  getSnapshotActorRefProvider,
+  peekSnapshotActorRef,
   setLazySnapshotActorRef,
-  setSnapshotActorRef
+  setSnapshotActorRef,
+  type SnapshotActorRef
 } from './snapshotActorRef.ts';
 import {
   ActorScope,
@@ -57,39 +59,32 @@ export function attachSnapshotActorRef<T extends AnyActorLogic, TSnapshot>(
 ): TSnapshot {
   setInertActorScopeSnapshot(actorScope, snapshot, false);
   const lazyState = getLazyInertActorState(actorScope);
-  if (
-    lazyState &&
-    !lazyState.materialized &&
-    lazyState.sourceSnapshot &&
-    typeof lazyState.sourceSnapshot === 'object' &&
-    copySnapshotActorRef(
-      lazyState.sourceSnapshot as Snapshot<unknown>,
-      snapshot as Snapshot<unknown>
-    )
-  ) {
-    snapshotActorScopes.set(
-      snapshot as object,
-      lazyState.sourceScope ?? actorScope
-    );
-    return snapshot;
-  }
   snapshotActorScopes.set(snapshot as object, actorScope);
-  setLazySnapshotActorRef(snapshot as Snapshot<unknown>, () => {
+  const create = () => {
     setSnapshotActorRef(
       snapshot as Snapshot<unknown>,
       actorScope.self,
       actorScope.system
     );
     return getSnapshotActorRef(snapshot as Snapshot<unknown>)!;
-  });
+  };
+  if (lazyState) {
+    if (lazyState.materialized) {
+      lazyState.identityProvider = create;
+    } else {
+      lazyState.identityProvider ??= create;
+    }
+  }
+  setLazySnapshotActorRef(snapshot as Snapshot<unknown>, create);
   return snapshot;
 }
 
 type LazyInertActorState = {
-  sourceSnapshot: unknown;
   snapshot: unknown;
   materialized?: AnyActorScope;
-  sourceScope?: AnyActorScope;
+  sourceRef?: () => SnapshotActorRef;
+  sourceChildren: Record<string, AnyActor | undefined>;
+  identityProvider?: () => SnapshotActorRef;
   parent?: AnyActor;
   parentKnown: boolean;
   materialize: () => AnyActorScope;
@@ -159,23 +154,20 @@ export function setInertActorMaterializationObserver(
 
 function createMaterializedInertActorScope<T extends AnyActorLogic>(
   actorLogic: T,
-  sourceSnapshot: SnapshotFrom<T> | undefined,
+  sourceRef: (() => SnapshotActorRef) | undefined,
+  sourceChildren: Record<string, AnyActor | undefined>,
   currentSnapshot: SnapshotFrom<T> | undefined,
   sourceSelf?: AnyActor
 ): AnyActorScope {
   inertActorMaterializationObserver?.();
-  const snapshotRef = sourceSnapshot
-    ? getSnapshotActorRef(sourceSnapshot)
-    : undefined;
+  const snapshotRef = sourceRef?.();
   const previousSelf = sourceSelf ?? snapshotRef?.actor;
   const baseSystem = previousSelf?.system;
   const system =
     previousSelf && baseSystem
       ? createSnapshotSystem(
           baseSystem,
-          isMachineSnapshot(sourceSnapshot)
-            ? (sourceSnapshot as any).children
-            : {},
+          sourceChildren,
           sourceSelf ? undefined : snapshotRef?.systemState
         )
       : undefined;
@@ -197,14 +189,6 @@ function createMaterializedInertActorScope<T extends AnyActorLogic>(
   }
   if (currentSnapshot) {
     (self as any)._snapshot = currentSnapshot;
-    if (currentSnapshot !== sourceSnapshot) {
-      setSnapshotActorRef(
-        currentSnapshot as Snapshot<unknown>,
-        self,
-        self.system,
-        sourceSnapshot as Snapshot<unknown> | undefined
-      );
-    }
   }
 
   return {
@@ -224,29 +208,75 @@ function createMaterializedInertActorScope<T extends AnyActorLogic>(
 export function createInertActorScope<T extends AnyActorLogic>(
   actorLogic: T,
   snapshot?: SnapshotFrom<T>,
-  sourceSelf?: AnyActor
+  sourceSelf?: AnyActor,
+  sourceActorScope?: AnyActorScope
 ): AnyActorScope {
   const sourceScope =
-    snapshot && typeof snapshot === 'object'
+    sourceActorScope ??
+    (snapshot && typeof snapshot === 'object'
       ? snapshotActorScopes.get(snapshot as object)
-      : undefined;
+      : undefined);
   const sourceState = sourceScope
     ? getLazyInertActorState(sourceScope)
     : undefined;
+  const eagerSourceRef =
+    snapshot && typeof snapshot === 'object'
+      ? peekSnapshotActorRef(snapshot as Snapshot<unknown>)
+      : undefined;
+  const sourceRef =
+    sourceState?.identityProvider ??
+    (snapshot && typeof snapshot === 'object'
+      ? getSnapshotActorRefProvider(snapshot as Snapshot<unknown>)
+      : undefined);
   const state = {
-    sourceSnapshot: snapshot,
     snapshot,
-    sourceScope,
-    parent: sourceSelf?._parent ?? sourceState?.parent,
-    parentKnown: !!sourceSelf || !!sourceState?.parentKnown || !snapshot
+    sourceRef,
+    sourceChildren: isMachineSnapshot(snapshot)
+      ? (snapshot as any).children
+      : {},
+    identityProvider: sourceState?.identityProvider ?? sourceRef,
+    parent:
+      sourceSelf?._parent ??
+      sourceState?.parent ??
+      eagerSourceRef?.actor._parent,
+    parentKnown:
+      !!sourceSelf ||
+      !!sourceState?.parentKnown ||
+      !!eagerSourceRef ||
+      !snapshot
   } as LazyInertActorState;
   state.materialize = () =>
     (state.materialized ??= createMaterializedInertActorScope(
       actorLogic,
-      state.sourceSnapshot as SnapshotFrom<T>,
+      state.sourceRef,
+      state.sourceChildren,
       state.snapshot as SnapshotFrom<T>,
       sourceSelf
     ));
+  if (!state.identityProvider && !snapshot) {
+    const identitySnapshot = {} as Snapshot<unknown>;
+    const identitySourceRef = state.sourceRef;
+    const identitySourceChildren = state.sourceChildren;
+    let identityRef: SnapshotActorRef | undefined;
+    state.identityProvider = () => {
+      if (identityRef) {
+        return identityRef;
+      }
+      const identityScope = createMaterializedInertActorScope(
+        actorLogic,
+        identitySourceRef,
+        identitySourceChildren,
+        undefined,
+        sourceSelf
+      );
+      setSnapshotActorRef(
+        identitySnapshot,
+        identityScope.self,
+        identityScope.system
+      );
+      return (identityRef = getSnapshotActorRef(identitySnapshot)!);
+    };
+  }
   const actorScope = Object.create(lazyInertActorScopePrototype) as ActorScope<
     SnapshotFrom<T>,
     EventFromLogic<T>,

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -1,8 +1,10 @@
 import { createActor } from './createActor.ts';
 import { isMachineSnapshot } from './State.ts';
 import {
+  copySnapshotActorRef,
   createSnapshotSystem,
   getSnapshotActorRef,
+  setLazySnapshotActorRef,
   setSnapshotActorRef
 } from './snapshotActorRef.ts';
 import {
@@ -13,6 +15,7 @@ import {
   EmittedFrom,
   EventFromLogic,
   InputFrom,
+  Snapshot,
   SnapshotFrom
 } from './types.ts';
 
@@ -22,7 +25,15 @@ export function setInertActorScopeSnapshot<T>(
   snapshot: T,
   attachActorRef = true
 ): T {
-  (actorScope.self as any)._snapshot = snapshot;
+  const lazyState = lazyInertActorScopes.get(actorScope);
+  if (lazyState) {
+    lazyState.snapshot = snapshot;
+    if (lazyState.materialized) {
+      (lazyState.materialized.self as any)._snapshot = snapshot;
+    }
+  } else {
+    (actorScope.self as any)._snapshot = snapshot;
+  }
   if (attachActorRef && snapshot && typeof snapshot === 'object') {
     setSnapshotActorRef(snapshot as any, actorScope.self);
   }
@@ -31,37 +42,87 @@ export function setInertActorScopeSnapshot<T>(
 
 /** @internal */
 export function isInertActorScope(actorScope: AnyActorScope): boolean {
-  return !!(actorScope.self as any).options?._inert;
+  return (
+    lazyInertActorScopes.has(actorScope) ||
+    !!(actorScope.self as any).options?._inert
+  );
 }
 
 /** @internal */
 export function attachSnapshotActorRef<T extends AnyActorLogic, TSnapshot>(
-  actorLogic: T,
+  _actorLogic: T,
   actorScope: AnyActorScope,
   snapshot: TSnapshot
 ): TSnapshot {
-  const snapshotScope = createInertActorScope(
-    actorLogic,
-    snapshot as SnapshotFrom<T>,
-    actorScope.self
-  );
-  return setInertActorScopeSnapshot(snapshotScope, snapshot);
+  setInertActorScopeSnapshot(actorScope, snapshot, false);
+  const lazyState = lazyInertActorScopes.get(actorScope);
+  if (
+    lazyState &&
+    !lazyState.materialized &&
+    lazyState.sourceSnapshot &&
+    typeof lazyState.sourceSnapshot === 'object' &&
+    copySnapshotActorRef(
+      lazyState.sourceSnapshot as Snapshot<unknown>,
+      snapshot as Snapshot<unknown>
+    )
+  ) {
+    snapshotActorScopes.set(
+      snapshot as object,
+      lazyState.sourceScope ?? actorScope
+    );
+    return snapshot;
+  }
+  snapshotActorScopes.set(snapshot as object, actorScope);
+  setLazySnapshotActorRef(snapshot as Snapshot<unknown>, () => {
+    setSnapshotActorRef(
+      snapshot as Snapshot<unknown>,
+      actorScope.self,
+      actorScope.system
+    );
+    return getSnapshotActorRef(snapshot as Snapshot<unknown>)!;
+  });
+  return snapshot;
 }
 
-/** @internal */
-export function createInertActorScope<T extends AnyActorLogic>(
+type LazyInertActorState = {
+  sourceSnapshot: unknown;
+  snapshot: unknown;
+  materialized?: AnyActorScope;
+  sourceScope?: AnyActorScope;
+  parent?: AnyActor;
+  parentKnown: boolean;
+};
+
+const lazyInertActorScopes = new WeakMap<AnyActorScope, LazyInertActorState>();
+const snapshotActorScopes = new WeakMap<object, AnyActorScope>();
+let inertActorMaterializationObserver: (() => void) | undefined;
+
+/** Test-only allocation instrumentation. @internal */
+export function setInertActorMaterializationObserver(
+  observer: (() => void) | undefined
+): void {
+  inertActorMaterializationObserver = observer;
+}
+
+function createMaterializedInertActorScope<T extends AnyActorLogic>(
   actorLogic: T,
-  snapshot?: SnapshotFrom<T>,
+  sourceSnapshot: SnapshotFrom<T> | undefined,
+  currentSnapshot: SnapshotFrom<T> | undefined,
   sourceSelf?: AnyActor
 ): AnyActorScope {
-  const snapshotRef = snapshot ? getSnapshotActorRef(snapshot) : undefined;
+  inertActorMaterializationObserver?.();
+  const snapshotRef = sourceSnapshot
+    ? getSnapshotActorRef(sourceSnapshot)
+    : undefined;
   const previousSelf = sourceSelf ?? snapshotRef?.actor;
   const baseSystem = previousSelf?.system;
   const system =
     previousSelf && baseSystem
       ? createSnapshotSystem(
           baseSystem,
-          isMachineSnapshot(snapshot) ? (snapshot as any).children : {},
+          isMachineSnapshot(sourceSnapshot)
+            ? (sourceSnapshot as any).children
+            : {},
           sourceSelf ? undefined : snapshotRef?.systemState
         )
       : undefined;
@@ -81,16 +142,17 @@ export function createInertActorScope<T extends AnyActorLogic>(
   if (previousSelf?._parent) {
     self._parent = previousSelf._parent;
   }
-  if (snapshot) {
-    (self as any)._snapshot = snapshot;
+  if (currentSnapshot) {
+    (self as any)._snapshot = currentSnapshot;
+    setSnapshotActorRef(
+      currentSnapshot as Snapshot<unknown>,
+      self,
+      self.system,
+      sourceSnapshot as Snapshot<unknown> | undefined
+    );
   }
 
-  const actorScope: ActorScope<
-    SnapshotFrom<T>,
-    EventFromLogic<T>,
-    any,
-    EmittedFrom<T>
-  > = {
+  return {
     self: self as any,
     defer: () => {},
     id: self.id,
@@ -101,6 +163,103 @@ export function createInertActorScope<T extends AnyActorLogic>(
     emit: (event) => self.system.emitEvent(self, event),
     actionExecutor: () => {}
   };
+}
+
+/** @internal */
+export function createInertActorScope<T extends AnyActorLogic>(
+  actorLogic: T,
+  snapshot?: SnapshotFrom<T>,
+  sourceSelf?: AnyActor
+): AnyActorScope {
+  const sourceScope =
+    snapshot && typeof snapshot === 'object'
+      ? snapshotActorScopes.get(snapshot as object)
+      : undefined;
+  const sourceState = sourceScope
+    ? lazyInertActorScopes.get(sourceScope)
+    : undefined;
+  const state: LazyInertActorState = {
+    sourceSnapshot: snapshot,
+    snapshot,
+    sourceScope,
+    parent: sourceSelf?._parent ?? sourceState?.parent,
+    parentKnown: !!sourceSelf || !!sourceState?.parentKnown || !snapshot
+  };
+  const materialize = () =>
+    (state.materialized ??= createMaterializedInertActorScope(
+      actorLogic,
+      state.sourceSnapshot as SnapshotFrom<T>,
+      state.snapshot as SnapshotFrom<T>,
+      sourceSelf
+    ));
+  const actorScope = {} as ActorScope<
+    SnapshotFrom<T>,
+    EventFromLogic<T>,
+    any,
+    EmittedFrom<T>
+  >;
+  const systemProxy = new Proxy({} as AnyActor['system'], {
+    get: (_, key) => {
+      if (key === '_hasInspectionObservers') {
+        return () => false;
+      }
+      if (key === '_sendInspectionEvent') {
+        return () => {};
+      }
+      const system = materialize().system as any;
+      return Reflect.get(system, key, system);
+    },
+    set: (_, key, value) => {
+      const system = materialize().system as any;
+      return Reflect.set(system, key, value, system);
+    }
+  });
+  const selfProxy = new Proxy({} as AnyActor, {
+    get: (_, key) => {
+      if (key === '_parent' && state.parentKnown) {
+        return state.parent;
+      }
+      if (key === 'system') {
+        return systemProxy;
+      }
+      const self = materialize().self as any;
+      return Reflect.get(self, key, self);
+    },
+    set: (_, key, value) => {
+      const self = materialize().self as any;
+      return Reflect.set(self, key, value, self);
+    },
+    has: (_, key) => {
+      if (key === 'system' || (key === '_parent' && state.parentKnown)) {
+        return true;
+      }
+      return key in materialize().self;
+    },
+    ownKeys: () => Reflect.ownKeys(materialize().self),
+    getOwnPropertyDescriptor: (_, key) => {
+      const descriptor = Reflect.getOwnPropertyDescriptor(
+        materialize().self,
+        key
+      );
+      return descriptor ? { ...descriptor, configurable: true } : undefined;
+    }
+  });
+  Object.defineProperties(actorScope, {
+    _isInert: { value: true },
+    self: { enumerable: true, value: selfProxy },
+    defer: { enumerable: true, get: () => materialize().defer },
+    id: { enumerable: true, get: () => materialize().id },
+    logger: { enumerable: true, get: () => materialize().logger },
+    sessionId: { enumerable: true, get: () => materialize().sessionId },
+    stopChild: { enumerable: true, get: () => materialize().stopChild },
+    system: { enumerable: true, value: systemProxy },
+    emit: { enumerable: true, get: () => materialize().emit },
+    actionExecutor: {
+      enumerable: true,
+      get: () => materialize().actionExecutor
+    }
+  });
+  lazyInertActorScopes.set(actorScope, state);
   return actorScope;
 }
 

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -18,6 +18,7 @@ import {
   Snapshot,
   SnapshotFrom
 } from './types.ts';
+import { lazyActorScope } from './actorScope.ts';
 
 /** @internal */
 export function setInertActorScopeSnapshot<T>(
@@ -25,7 +26,7 @@ export function setInertActorScopeSnapshot<T>(
   snapshot: T,
   attachActorRef = true
 ): T {
-  const lazyState = lazyInertActorScopes.get(actorScope);
+  const lazyState = getLazyInertActorState(actorScope);
   if (lazyState) {
     lazyState.snapshot = snapshot;
     if (lazyState.materialized) {
@@ -43,7 +44,7 @@ export function setInertActorScopeSnapshot<T>(
 /** @internal */
 export function isInertActorScope(actorScope: AnyActorScope): boolean {
   return (
-    lazyInertActorScopes.has(actorScope) ||
+    !!getLazyInertActorState(actorScope) ||
     !!(actorScope.self as any).options?._inert
   );
 }
@@ -55,7 +56,7 @@ export function attachSnapshotActorRef<T extends AnyActorLogic, TSnapshot>(
   snapshot: TSnapshot
 ): TSnapshot {
   setInertActorScopeSnapshot(actorScope, snapshot, false);
-  const lazyState = lazyInertActorScopes.get(actorScope);
+  const lazyState = getLazyInertActorState(actorScope);
   if (
     lazyState &&
     !lazyState.materialized &&
@@ -91,11 +92,63 @@ type LazyInertActorState = {
   sourceScope?: AnyActorScope;
   parent?: AnyActor;
   parentKnown: boolean;
+  materialize: () => AnyActorScope;
 };
 
-const lazyInertActorScopes = new WeakMap<AnyActorScope, LazyInertActorState>();
+const lazyInertActorState = Symbol();
+type LazyInertActorScope = AnyActorScope & {
+  [lazyInertActorState]?: LazyInertActorState;
+};
 const snapshotActorScopes = new WeakMap<object, AnyActorScope>();
 let inertActorMaterializationObserver: (() => void) | undefined;
+
+function getLazyInertActorState(
+  actorScope: AnyActorScope
+): LazyInertActorState | undefined {
+  return (actorScope as LazyInertActorScope)[lazyInertActorState];
+}
+
+function materializeInertActorScope(actorScope: AnyActorScope): AnyActorScope {
+  return getLazyInertActorState(actorScope)!.materialize();
+}
+
+const lazyInertActorScopePrototype = {
+  [lazyActorScope]: true,
+  get _parent() {
+    const actorScope = this as AnyActorScope;
+    const state = getLazyInertActorState(actorScope)!;
+    return state.parentKnown
+      ? state.parent
+      : materializeInertActorScope(actorScope).self._parent;
+  },
+  get self() {
+    return materializeInertActorScope(this as AnyActorScope).self;
+  },
+  get defer() {
+    return materializeInertActorScope(this as AnyActorScope).defer;
+  },
+  get id() {
+    return materializeInertActorScope(this as AnyActorScope).id;
+  },
+  get logger() {
+    return materializeInertActorScope(this as AnyActorScope).logger;
+  },
+  get sessionId() {
+    return materializeInertActorScope(this as AnyActorScope).sessionId;
+  },
+  get stopChild() {
+    return materializeInertActorScope(this as AnyActorScope).stopChild;
+  },
+  get system() {
+    return materializeInertActorScope(this as AnyActorScope).system;
+  },
+  get emit() {
+    return materializeInertActorScope(this as AnyActorScope).emit;
+  },
+  get actionExecutor() {
+    return materializeInertActorScope(this as AnyActorScope).actionExecutor;
+  }
+};
 
 /** Test-only allocation instrumentation. @internal */
 export function setInertActorMaterializationObserver(
@@ -176,90 +229,29 @@ export function createInertActorScope<T extends AnyActorLogic>(
       ? snapshotActorScopes.get(snapshot as object)
       : undefined;
   const sourceState = sourceScope
-    ? lazyInertActorScopes.get(sourceScope)
+    ? getLazyInertActorState(sourceScope)
     : undefined;
-  const state: LazyInertActorState = {
+  const state = {
     sourceSnapshot: snapshot,
     snapshot,
     sourceScope,
     parent: sourceSelf?._parent ?? sourceState?.parent,
     parentKnown: !!sourceSelf || !!sourceState?.parentKnown || !snapshot
-  };
-  const materialize = () =>
+  } as LazyInertActorState;
+  state.materialize = () =>
     (state.materialized ??= createMaterializedInertActorScope(
       actorLogic,
       state.sourceSnapshot as SnapshotFrom<T>,
       state.snapshot as SnapshotFrom<T>,
       sourceSelf
     ));
-  const actorScope = {} as ActorScope<
+  const actorScope = Object.create(lazyInertActorScopePrototype) as ActorScope<
     SnapshotFrom<T>,
     EventFromLogic<T>,
     any,
     EmittedFrom<T>
   >;
-  const systemProxy = new Proxy({} as AnyActor['system'], {
-    get: (_, key) => {
-      if (key === '_hasInspectionObservers') {
-        return () => false;
-      }
-      if (key === '_sendInspectionEvent') {
-        return () => {};
-      }
-      const system = materialize().system as any;
-      return Reflect.get(system, key, system);
-    },
-    set: (_, key, value) => {
-      const system = materialize().system as any;
-      return Reflect.set(system, key, value, system);
-    }
-  });
-  const selfProxy = new Proxy({} as AnyActor, {
-    get: (_, key) => {
-      if (key === '_parent' && state.parentKnown) {
-        return state.parent;
-      }
-      if (key === 'system') {
-        return systemProxy;
-      }
-      const self = materialize().self as any;
-      return Reflect.get(self, key, self);
-    },
-    set: (_, key, value) => {
-      const self = materialize().self as any;
-      return Reflect.set(self, key, value, self);
-    },
-    has: (_, key) => {
-      if (key === 'system' || (key === '_parent' && state.parentKnown)) {
-        return true;
-      }
-      return key in materialize().self;
-    },
-    ownKeys: () => Reflect.ownKeys(materialize().self),
-    getOwnPropertyDescriptor: (_, key) => {
-      const descriptor = Reflect.getOwnPropertyDescriptor(
-        materialize().self,
-        key
-      );
-      return descriptor ? { ...descriptor, configurable: true } : undefined;
-    }
-  });
-  Object.defineProperties(actorScope, {
-    _isInert: { value: true },
-    self: { enumerable: true, value: selfProxy },
-    defer: { enumerable: true, get: () => materialize().defer },
-    id: { enumerable: true, get: () => materialize().id },
-    logger: { enumerable: true, get: () => materialize().logger },
-    sessionId: { enumerable: true, get: () => materialize().sessionId },
-    stopChild: { enumerable: true, get: () => materialize().stopChild },
-    system: { enumerable: true, value: systemProxy },
-    emit: { enumerable: true, get: () => materialize().emit },
-    actionExecutor: {
-      enumerable: true,
-      get: () => materialize().actionExecutor
-    }
-  });
-  lazyInertActorScopes.set(actorScope, state);
+  (actorScope as LazyInertActorScope)[lazyInertActorState] = state;
   return actorScope;
 }
 

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -251,23 +251,29 @@ export function createInertActorScope<T extends AnyActorLogic>(
     const identitySnapshot = {} as Snapshot<unknown>;
     const identitySourceRef = state.sourceRef;
     const identitySourceChildren = state.sourceChildren;
+    let identityScope: AnyActorScope | undefined;
     let identityRef: SnapshotActorRef | undefined;
-    state.identityProvider = () => {
-      if (identityRef) {
-        return identityRef;
-      }
-      const identityScope = createMaterializedInertActorScope(
+    const getIdentityScope = () =>
+      (identityScope ??= createMaterializedInertActorScope(
         actorLogic,
         identitySourceRef,
         identitySourceChildren,
         undefined,
         sourceSelf
-      );
-      setSnapshotActorRef(
-        identitySnapshot,
-        identityScope.self,
-        identityScope.system
-      );
+      ));
+    state.materialize = () => {
+      const scope = getIdentityScope();
+      if (state.snapshot !== undefined) {
+        (scope.self as any)._snapshot = state.snapshot;
+      }
+      return (state.materialized = scope);
+    };
+    state.identityProvider = () => {
+      if (identityRef) {
+        return identityRef;
+      }
+      const scope = getIdentityScope();
+      setSnapshotActorRef(identitySnapshot, scope.self, scope.system);
       return (identityRef = getSnapshotActorRef(identitySnapshot)!);
     };
   }

--- a/packages/core/src/getNextSnapshot.ts
+++ b/packages/core/src/getNextSnapshot.ts
@@ -197,12 +197,14 @@ function createMaterializedInertActorScope<T extends AnyActorLogic>(
   }
   if (currentSnapshot) {
     (self as any)._snapshot = currentSnapshot;
-    setSnapshotActorRef(
-      currentSnapshot as Snapshot<unknown>,
-      self,
-      self.system,
-      sourceSnapshot as Snapshot<unknown> | undefined
-    );
+    if (currentSnapshot !== sourceSnapshot) {
+      setSnapshotActorRef(
+        currentSnapshot as Snapshot<unknown>,
+        self,
+        self.system,
+        sourceSnapshot as Snapshot<unknown> | undefined
+      );
+    }
   }
 
   return {

--- a/packages/core/src/snapshotActorRef.ts
+++ b/packages/core/src/snapshotActorRef.ts
@@ -16,6 +16,7 @@ interface SnapshotSystemState {
 }
 
 const snapshotActorRefs = new WeakMap<object, SnapshotActorRef>();
+const lazySnapshotActorRefs = new WeakMap<object, () => SnapshotActorRef>();
 const emptyKeyedActors = new Map<PropertyKey, AnyActor | undefined>();
 
 function copyRegisteredActors(
@@ -162,7 +163,26 @@ export function createSnapshotSystem(
 export function getSnapshotActorRef(
   snapshot: Snapshot<unknown>
 ): SnapshotActorRef | undefined {
-  return snapshotActorRefs.get(snapshot);
+  const existing = snapshotActorRefs.get(snapshot);
+  if (existing) {
+    return existing;
+  }
+  const create = lazySnapshotActorRefs.get(snapshot);
+  if (!create) {
+    return undefined;
+  }
+  const created = create();
+  snapshotActorRefs.set(snapshot, created);
+  lazySnapshotActorRefs.delete(snapshot);
+  return created;
+}
+
+/** Defers actor/system identity allocation until a snapshot capability is used. @internal */
+export function setLazySnapshotActorRef(
+  snapshot: Snapshot<unknown>,
+  create: () => SnapshotActorRef
+): void {
+  lazySnapshotActorRefs.set(snapshot, create);
 }
 
 /**
@@ -173,11 +193,18 @@ export function getSnapshotActorRef(
 export function copySnapshotActorRef(
   source: Snapshot<unknown>,
   target: Snapshot<unknown>
-): void {
-  const ref = getSnapshotActorRef(source);
+): boolean {
+  const ref = snapshotActorRefs.get(source);
   if (ref) {
     snapshotActorRefs.set(target, ref);
+    return true;
   }
+  const create = lazySnapshotActorRefs.get(source);
+  if (create) {
+    lazySnapshotActorRefs.set(target, create);
+    return true;
+  }
+  return false;
 }
 
 /**
@@ -192,6 +219,7 @@ export function setSnapshotActorRef(
   baseSystem: AnyActor['system'] = actor.system,
   previousSnapshot?: Snapshot<unknown>
 ): void {
+  lazySnapshotActorRefs.delete(snapshot);
   const sourceVersion = getSystemSnapshotVersion(baseSystem);
   const previousRef = previousSnapshot
     ? getSnapshotActorRef(previousSnapshot)

--- a/packages/core/src/snapshotActorRef.ts
+++ b/packages/core/src/snapshotActorRef.ts
@@ -182,6 +182,7 @@ export function setLazySnapshotActorRef(
   snapshot: Snapshot<unknown>,
   create: () => SnapshotActorRef
 ): void {
+  snapshotActorRefs.delete(snapshot);
   lazySnapshotActorRefs.set(snapshot, create);
 }
 

--- a/packages/core/src/snapshotActorRef.ts
+++ b/packages/core/src/snapshotActorRef.ts
@@ -177,6 +177,21 @@ export function getSnapshotActorRef(
   return created;
 }
 
+/** Reads an already materialized snapshot association without creating one. @internal */
+export function peekSnapshotActorRef(
+  snapshot: Snapshot<unknown>
+): SnapshotActorRef | undefined {
+  return snapshotActorRefs.get(snapshot);
+}
+
+/** Returns the existing identity provider without resolving it. @internal */
+export function getSnapshotActorRefProvider(
+  snapshot: Snapshot<unknown>
+): (() => SnapshotActorRef) | undefined {
+  const existing = snapshotActorRefs.get(snapshot);
+  return existing ? () => existing : lazySnapshotActorRefs.get(snapshot);
+}
+
 /** Defers actor/system identity allocation until a snapshot capability is used. @internal */
 export function setLazySnapshotActorRef(
   snapshot: Snapshot<unknown>,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -63,6 +63,11 @@ import {
 import { parseDurationToMilliseconds } from './delay.ts';
 import { transitionEffectSignal, transitionEffectTargets } from './system.ts';
 import { isInertActorScope } from './getNextSnapshot.ts';
+import {
+  getActorScopeParent,
+  isLazyActorScope,
+  withActorScope
+} from './actorScope.ts';
 
 type AnyStateNodeIterable = Iterable<AnyStateNode>;
 
@@ -952,16 +957,21 @@ export function transitionNode<
     any // TStateSchema
   >,
   event: TEvent,
-  self: AnyActor,
+  actorScope: AnyActorScope,
   selectionResults?: TransitionSelectionResults
 ): Array<TransitionDefinition<TContext, TEvent>> | undefined {
   // leaf node
   if (typeof stateValue === 'string') {
     const childStateNode = getStateNode(stateNode, stateValue);
-    const next = childStateNode.next(snapshot, event, self, selectionResults);
+    const next = childStateNode.next(
+      snapshot,
+      event,
+      actorScope,
+      selectionResults
+    );
 
     if (!next || !next.length) {
-      return stateNode.next(snapshot, event, self, selectionResults);
+      return stateNode.next(snapshot, event, actorScope, selectionResults);
     }
 
     return next;
@@ -977,12 +987,12 @@ export function transitionNode<
       stateValue[subStateKey]!,
       snapshot,
       event,
-      self,
+      actorScope,
       selectionResults
     );
 
     if (!next || !next.length) {
-      return stateNode.next(snapshot, event, self, selectionResults);
+      return stateNode.next(snapshot, event, actorScope, selectionResults);
     }
 
     return next;
@@ -1003,7 +1013,7 @@ export function transitionNode<
       subStateValue,
       snapshot,
       event,
-      self,
+      actorScope,
       selectionResults
     );
     if (innerTransitions) {
@@ -1012,7 +1022,7 @@ export function transitionNode<
   }
 
   if (!allInnerTransitions.length) {
-    return stateNode.next(snapshot, event, self, selectionResults);
+    return stateNode.next(snapshot, event, actorScope, selectionResults);
   }
 
   return allInnerTransitions;
@@ -1388,22 +1398,34 @@ function microstep(
           true
         );
 
-        const res = transitionFn(
-          {
-            context,
-            event,
-            parent: actorScope.self._parent,
-            self: actorScope.self,
-            children,
-            system: actorScope.system,
-            actions: currentSnapshot.machine.sources.actions,
-            actors: currentSnapshot.machine.sources.actors,
-            guards: currentSnapshot.machine.sources.guards,
-            delays: currentSnapshot.machine.sources.delays,
-            input
-          },
-          enqueue
-        );
+        const args = isLazyActorScope(actorScope)
+          ? withActorScope(
+              {
+                context,
+                event,
+                children,
+                actions: currentSnapshot.machine.sources.actions,
+                actors: currentSnapshot.machine.sources.actors,
+                guards: currentSnapshot.machine.sources.guards,
+                delays: currentSnapshot.machine.sources.delays,
+                input
+              },
+              actorScope
+            )
+          : {
+              context,
+              event,
+              parent: actorScope.self._parent,
+              self: actorScope.self,
+              children,
+              system: actorScope.system,
+              actions: currentSnapshot.machine.sources.actions,
+              actors: currentSnapshot.machine.sources.actors,
+              guards: currentSnapshot.machine.sources.guards,
+              delays: currentSnapshot.machine.sources.delays,
+              input
+            };
+        const res = transitionFn(args, enqueue);
 
         if (res?.context !== undefined) {
           updatedContext = mergeContextPatch(context, res.context);
@@ -2086,21 +2108,39 @@ export function getTransitionResult(
   internalEvents: EventObject[] | undefined;
   input: Record<string, unknown> | undefined;
 } {
-  const transitionArgs = {
-    context: snapshot.context,
-    event,
-    output: getEventOutput(event),
-    value: snapshot.value,
-    children: snapshot.children,
-    system: actorScope.system,
-    parent: actorScope.self._parent,
-    self: actorScope.self,
-    actions: snapshot.machine.sources.actions,
-    actors: snapshot.machine.sources.actors,
-    guards: snapshot.machine.sources.guards,
-    delays: snapshot.machine.sources.delays,
-    input: getStateInput(snapshot, transition.source.id)
-  };
+  let transitionArgs: any;
+  const getTransitionArgs = () =>
+    (transitionArgs ??= isLazyActorScope(actorScope)
+      ? withActorScope(
+          {
+            context: snapshot.context,
+            event,
+            output: getEventOutput(event),
+            value: snapshot.value,
+            children: snapshot.children,
+            actions: snapshot.machine.sources.actions,
+            actors: snapshot.machine.sources.actors,
+            guards: snapshot.machine.sources.guards,
+            delays: snapshot.machine.sources.delays,
+            input: getStateInput(snapshot, transition.source.id)
+          },
+          actorScope
+        )
+      : {
+          context: snapshot.context,
+          event,
+          output: getEventOutput(event),
+          value: snapshot.value,
+          children: snapshot.children,
+          system: actorScope.system,
+          parent: actorScope.self._parent,
+          self: actorScope.self,
+          actions: snapshot.machine.sources.actions,
+          actors: snapshot.machine.sources.actors,
+          guards: snapshot.machine.sources.guards,
+          delays: snapshot.machine.sources.delays,
+          input: getStateInput(snapshot, transition.source.id)
+        });
 
   if (transition.to) {
     const actions: AnyAction[] = [];
@@ -2108,7 +2148,7 @@ export function getTransitionResult(
     const res = options?.selectionResult?.reusable
       ? options.selectionResult.result
       : transition.to(
-          transitionArgs,
+          getTransitionArgs(),
           createTransitionEnqueue(
             actorScope,
             actions,
@@ -2153,7 +2193,7 @@ export function getTransitionResult(
       : transition.input;
   const resolvedContext =
     typeof transition.context === 'function'
-      ? transition.context(transitionArgs)
+      ? transition.context(getTransitionArgs())
       : transition.context;
 
   return {
@@ -2244,8 +2284,9 @@ export function macrostep(
     // collect microsteps; surfaced on the enclosing '@xstate.transition' event
     // via its `microsteps[]` facet (there is no standalone microstep event)
     if (
-      (event.type === XSTATE_INIT && !isInertActorScope(actorScope)) ||
-      (actorScope.system._hasInspectionObservers?.() ?? true)
+      !isInertActorScope(actorScope) &&
+      (event.type === XSTATE_INIT ||
+        (actorScope.system._hasInspectionObservers?.() ?? true))
     ) {
       const collectedMicrosteps =
         ((actorScope.self as any)._collectedMicrosteps as any[]) || [];
@@ -2307,7 +2348,7 @@ export function macrostep(
     const transitions = nextSnapshot.machine.getTransitionData(
       nextSnapshot as any,
       currentEvent,
-      actorScope.self,
+      actorScope,
       selectionResults
     );
 
@@ -2392,7 +2433,7 @@ export function macrostep(
       enabledTransitions = nextSnapshot.machine.getTransitionData(
         nextSnapshot as any,
         nextEvent,
-        actorScope.self,
+        actorScope,
         selectionResults
       );
     }
@@ -2434,7 +2475,7 @@ export function hasEffect(
   context: MachineContext,
   event: EventObject,
   snapshot: AnyMachineSnapshot,
-  self: AnyActor
+  actorScope: AnyActorScope
 ): boolean {
   if (transition.to) {
     return evaluateTransitionFunction(
@@ -2442,7 +2483,7 @@ export function hasEffect(
       context,
       event,
       snapshot,
-      self,
+      actorScope,
       snapshot.machine.sources,
       transition.source.id
     ).enabled;
@@ -2475,33 +2516,33 @@ function evaluateTransitionFunction(
   context: MachineContext,
   event: EventObject,
   snapshot: AnyMachineSnapshot,
-  self: AnyActor,
+  actorScope: AnyActorScope,
   sources: AnyMachineSnapshot['machine']['sources'],
   sourceId: string
 ): TransitionSelectionResult {
   let res;
-  const parent = self._parent;
+  const parent = getActorScopeParent(actorScope);
   if (parent) {
     transitionEffectTargets.push(parent);
   }
 
   try {
     res = transitionTo(
-      {
-        context,
-        event,
-        output: getEventOutput(event),
-        self,
-        system: self.system,
-        value: snapshot.value,
-        children: snapshot.children,
-        parent,
-        actions: sources.actions,
-        actors: sources.actors,
-        guards: sources.guards,
-        delays: sources.delays,
-        input: getStateInput(snapshot, sourceId)
-      },
+      withActorScope(
+        {
+          context,
+          event,
+          output: getEventOutput(event),
+          value: snapshot.value,
+          children: snapshot.children,
+          actions: sources.actions,
+          actors: sources.actors,
+          guards: sources.guards,
+          delays: sources.delays,
+          input: getStateInput(snapshot, sourceId)
+        },
+        actorScope
+      ),
       getTransitionEffectEnqueue()
     );
   } catch (err) {
@@ -2575,13 +2616,7 @@ function selectEventlessTransitions(
       }
       for (const transition of stateNode.always) {
         if (
-          evaluateCandidate(
-            transition,
-            event,
-            snapshot,
-            stateNode,
-            actorScope.self
-          )
+          evaluateCandidate(transition, event, snapshot, stateNode, actorScope)
         ) {
           enabledTransitionSet.add(transition);
           break loop;
@@ -2603,7 +2638,7 @@ export function evaluateCandidate(
   event: EventObject,
   snapshot: AnyMachineSnapshot,
   stateNode: AnyStateNode,
-  self: AnyActor,
+  actorScope: AnyActorScope,
   selectionResults?: TransitionSelectionResults
 ): boolean {
   if (candidate.matches && !matchesEvent(event, candidate.matches)) {
@@ -2615,19 +2650,20 @@ export function evaluateCandidate(
   }
 
   if (candidate.guard) {
-    const guardArgs = {
-      context: snapshot.context,
-      event,
-      output: getEventOutput(event),
-      self,
-      parent: self._parent,
-      children: snapshot.children,
-      actions: stateNode.machine.sources.actions,
-      actors: stateNode.machine.sources.actors,
-      guards: stateNode.machine.sources.guards,
-      delays: stateNode.machine.sources.delays,
-      _snapshot: snapshot
-    };
+    const guardArgs = withActorScope(
+      {
+        context: snapshot.context,
+        event,
+        output: getEventOutput(event),
+        children: snapshot.children,
+        actions: stateNode.machine.sources.actions,
+        actors: stateNode.machine.sources.actors,
+        guards: stateNode.machine.sources.guards,
+        delays: stateNode.machine.sources.delays,
+        _snapshot: snapshot
+      },
+      actorScope
+    );
     if (!(candidate.guard as (args: typeof guardArgs) => boolean)(guardArgs)) {
       return false;
     }
@@ -2639,7 +2675,7 @@ export function evaluateCandidate(
       snapshot.context,
       event,
       snapshot,
-      self,
+      actorScope,
       stateNode.machine.sources,
       candidate.source.id
     );

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -62,6 +62,7 @@ import {
 } from './transitionActions.ts';
 import { parseDurationToMilliseconds } from './delay.ts';
 import { transitionEffectSignal, transitionEffectTargets } from './system.ts';
+import { isInertActorScope } from './getNextSnapshot.ts';
 
 type AnyStateNodeIterable = Iterable<AnyStateNode>;
 
@@ -2243,7 +2244,7 @@ export function macrostep(
     // collect microsteps; surfaced on the enclosing '@xstate.transition' event
     // via its `microsteps[]` facet (there is no standalone microstep event)
     if (
-      event.type === XSTATE_INIT ||
+      (event.type === XSTATE_INIT && !isInertActorScope(actorScope)) ||
       (actorScope.system._hasInspectionObservers?.() ?? true)
     ) {
       const collectedMicrosteps =

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -66,6 +66,7 @@ import { isInertActorScope } from './getNextSnapshot.ts';
 import {
   getActorScopeParent,
   isLazyActorScope,
+  withActorSelfAndParent,
   withActorScope
 } from './actorScope.ts';
 
@@ -1437,7 +1438,24 @@ function microstep(
       // For 1-argument actions, wrap them to include input
       // Preserve _special flag if present (for entry/exit actions)
       const wrappedAction = Object.assign(
-        (args: any, enqueue: any) => transitionFn({ ...args, input }, enqueue),
+        (args: any, enqueue: any) =>
+          transitionFn(
+            isLazyActorScope(actorScope)
+              ? withActorScope(
+                  {
+                    context: args.context,
+                    event: args.event,
+                    output: args.output,
+                    children: args.children,
+                    actions: args.actions,
+                    actors: args.actors,
+                    input
+                  },
+                  actorScope
+                )
+              : { ...args, input },
+            enqueue
+          ),
         '_special' in transitionFn ? { _special: true } : {}
       );
       return [[wrappedAction], undefined, undefined];
@@ -2650,7 +2668,7 @@ export function evaluateCandidate(
   }
 
   if (candidate.guard) {
-    const guardArgs = withActorScope(
+    const guardArgs = withActorSelfAndParent(
       {
         context: snapshot.context,
         event,

--- a/packages/core/src/transition.ts
+++ b/packages/core/src/transition.ts
@@ -43,7 +43,7 @@ function attachMicrostepActorRefs(
   const finalSnapshot = result.at(-1)![0];
   setInertActorScopeSnapshot(actorScope, finalSnapshot, false);
   if (finalSnapshot !== inputSnapshot) {
-    attachSnapshotActorRef(finalSnapshot.machine, actorScope, finalSnapshot);
+    attachSnapshotActorRef(actorScope, finalSnapshot);
   }
   for (const [snapshot] of result) {
     if (snapshot !== inputSnapshot && snapshot !== finalSnapshot) {
@@ -53,7 +53,7 @@ function attachMicrostepActorRefs(
         undefined,
         actorScope
       );
-      attachSnapshotActorRef(snapshot.machine, snapshotScope, snapshot);
+      attachSnapshotActorRef(snapshotScope, snapshot);
     }
   }
   return result;
@@ -85,7 +85,7 @@ export function transition<T extends AnyActorLogic>(
   const returnedSnapshot =
     nextSnapshot === snapshot
       ? nextSnapshot
-      : attachSnapshotActorRef(logic, actorScope, nextSnapshot);
+      : attachSnapshotActorRef(actorScope, nextSnapshot);
   return [returnedSnapshot, effects as ExecutableActionObjectFromLogic<T>[]];
 }
 
@@ -111,11 +111,7 @@ export function initialTransition<T extends AnyActorLogic>(
   );
 
   setInertActorScopeSnapshot(actorScope, nextSnapshot, false);
-  const returnedSnapshot = attachSnapshotActorRef(
-    logic,
-    actorScope,
-    nextSnapshot
-  );
+  const returnedSnapshot = attachSnapshotActorRef(actorScope, nextSnapshot);
   return [
     returnedSnapshot,
     executableActions as ExecutableActionObjectFromLogic<T>[]

--- a/packages/core/src/transition.ts
+++ b/packages/core/src/transition.ts
@@ -42,9 +42,18 @@ function attachMicrostepActorRefs(
   const result = microsteps.slice();
   const finalSnapshot = result.at(-1)![0];
   setInertActorScopeSnapshot(actorScope, finalSnapshot, false);
+  if (finalSnapshot !== inputSnapshot) {
+    attachSnapshotActorRef(finalSnapshot.machine, actorScope, finalSnapshot);
+  }
   for (const [snapshot] of result) {
-    if (snapshot !== inputSnapshot) {
-      attachSnapshotActorRef(snapshot.machine, actorScope, snapshot);
+    if (snapshot !== inputSnapshot && snapshot !== finalSnapshot) {
+      const snapshotScope = createInertActorScope(
+        snapshot.machine,
+        snapshot,
+        undefined,
+        actorScope
+      );
+      attachSnapshotActorRef(snapshot.machine, snapshotScope, snapshot);
     }
   }
   return result;

--- a/packages/core/src/transitionActions.ts
+++ b/packages/core/src/transitionActions.ts
@@ -9,6 +9,7 @@ import {
 import { XSTATE_SPAWN, XSTATE_START, XSTATE_TERMINATE } from './constants.ts';
 import { createErrorPlatformEvent } from './eventUtils.ts';
 import type { ActorSystemRuntime } from './system.ts';
+import { isLazyActorScope, withActorScope } from './actorScope.ts';
 import { getEventOutput } from './utils.ts';
 import type {
   Action,
@@ -661,17 +662,29 @@ export function resolveActionsWithContext(
   const executableActions: ExecutableActionObject[] = [];
 
   for (const action of actions) {
-    const actionArgs = {
-      context: intermediateSnapshot.context,
-      event,
-      output: getEventOutput(event),
-      self: actorScope.self,
-      system: actorScope.system,
-      children: intermediateSnapshot.children,
-      parent: actorScope.self._parent,
-      actions: currentSnapshot.machine.sources.actions,
-      actors: currentSnapshot.machine.sources.actors
-    };
+    const actionArgs = isLazyActorScope(actorScope)
+      ? withActorScope(
+          {
+            context: intermediateSnapshot.context,
+            event,
+            output: getEventOutput(event),
+            children: intermediateSnapshot.children,
+            actions: currentSnapshot.machine.sources.actions,
+            actors: currentSnapshot.machine.sources.actors
+          },
+          actorScope
+        )
+      : {
+          context: intermediateSnapshot.context,
+          event,
+          output: getEventOutput(event),
+          self: actorScope.self,
+          system: actorScope.system,
+          parent: actorScope.self._parent,
+          children: intermediateSnapshot.children,
+          actions: currentSnapshot.machine.sources.actions,
+          actors: currentSnapshot.machine.sources.actors
+        };
 
     const isInline = typeof action === 'function';
     const actionRecord = getTransitionActionRecord(action);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1118,7 +1118,7 @@ export interface AnyStateMachine extends AnyActorLogic {
   getTransitionData(
     snapshot: any,
     event: any,
-    actor: AnyActorRef,
+    actorScope: AnyActorScope,
     selectionResults?: Map<AnyTransitionDefinition, unknown>
   ): AnyTransitionDefinition[];
   /** @internal */

--- a/packages/core/test/getNextSnapshot.test.ts
+++ b/packages/core/test/getNextSnapshot.test.ts
@@ -1,4 +1,6 @@
 import {
+  type ActorLogic,
+  type AnyActor,
   createLogic,
   createMachine,
   transition,
@@ -22,6 +24,33 @@ describe('transition', () => {
     expect(s1.context.count).toEqual(1);
     const [s2] = transition(logic, s1, { type: 'next' });
     expect(s2.context.count).toEqual(2);
+  });
+  it('stops children from custom logic during a pure transition', () => {
+    const stop = vi.fn();
+    const child = {
+      id: 'child',
+      _parent: {},
+      _stop: stop
+    } as unknown as AnyActor;
+    const snapshot = {
+      status: 'active' as const,
+      output: undefined,
+      error: undefined,
+      child
+    };
+    const logic: ActorLogic<typeof snapshot, { type: 'stop' }> = {
+      initialTransition: () => [snapshot, []],
+      transition: (currentSnapshot, _, actorScope) => {
+        actorScope.stopChild(currentSnapshot.child);
+        return [currentSnapshot, []];
+      },
+      getInitialSnapshot: () => snapshot,
+      getPersistedSnapshot: (currentSnapshot) => currentSnapshot
+    };
+
+    transition(logic, snapshot, { type: 'stop' });
+
+    expect(stop).toHaveBeenCalledOnce();
   });
   it('should calculate the next snapshot for machine logic', () => {
     const machine = createMachine({

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -128,9 +128,68 @@ describe('transition function', () => {
 
       expect(checkingSnapshot.context.found).toBe(false);
       expect(materializations).toBe(2);
+
+      materializations = 0;
+      const livePlanningMachine = createMachine({
+        context: { count: 0 },
+        on: {
+          INCREMENT: ({ context }) => ({
+            context: { count: context.count + 1 }
+          })
+        }
+      });
+      const liveActor = createActor(livePlanningMachine).start();
+      transition(livePlanningMachine, liveActor.getSnapshot(), {
+        type: 'INCREMENT'
+      });
+      expect(materializations).toBe(0);
+
+      const entryMachine = createMachine({
+        context: { count: 0 },
+        entry: ({ context }) => ({ context })
+      });
+      initialTransition(entryMachine);
+      expect(materializations).toBe(0);
     } finally {
       setInertActorMaterializationObserver(undefined);
     }
+  });
+
+  it('preserves callback argument surfaces while planning lazily', () => {
+    let contextKeys: string[] = [];
+    let guardKeys: string[] = [];
+    const machine = createMachine({
+      context: (args: any) => {
+        contextKeys = Object.keys(args).sort();
+        return { initialized: true };
+      },
+      on: {
+        CHECK: {
+          guard: (args: any) => {
+            guardKeys = Object.keys(args).sort();
+            return true;
+          }
+        }
+      }
+    } as any);
+
+    const [snapshot] = initialTransition(machine);
+    transition(machine, snapshot, { type: 'CHECK' });
+
+    expect(contextKeys).toEqual(['actors', 'input', 'self', 'spawn']);
+    expect(guardKeys).toEqual([
+      '_snapshot',
+      'actions',
+      'actors',
+      'children',
+      'context',
+      'delays',
+      'event',
+      'guards',
+      'output',
+      'parent',
+      'self'
+    ]);
   });
 
   it('does not repeatedly resolve a selected transition during a microstep', () => {
@@ -1611,6 +1670,50 @@ describe('transition function', () => {
       expect(branchRef.actor.getSnapshot()).toBe(nextSnapshot);
       expect(actor.getSnapshot()).toBe(liveSnapshot);
       expect(getSnapshotActorRef(liveSnapshot)!.actor).toBe(actor);
+    });
+
+    it('gives every planned snapshot its own current owner snapshot', () => {
+      const machine = createMachine({
+        context: { count: 0 },
+        on: {
+          INCREMENT: ({ context }) => ({
+            context: { count: context.count + 1 }
+          })
+        }
+      });
+      const liveActor = createActor(machine).start();
+      const liveSnapshot = liveActor.getSnapshot();
+      const [first] = transition(machine, liveSnapshot, {
+        type: 'INCREMENT'
+      });
+      const [second] = transition(machine, first, { type: 'INCREMENT' });
+
+      expect(getSnapshotActorRef(first)!.actor.getSnapshot()).toBe(first);
+      expect(getSnapshotActorRef(second)!.actor.getSnapshot()).toBe(second);
+      expect(getSnapshotActorRef(liveSnapshot)!.actor).toBe(liveActor);
+    });
+
+    it('gives every microstep its own current owner snapshot', () => {
+      const machine = createMachine({
+        initial: 'a',
+        states: {
+          a: { on: { NEXT: { target: 'b' } } },
+          b: { always: { target: 'c' } },
+          c: {}
+        }
+      });
+      const [initial] = initialTransition(machine);
+      const microsteps = getMicrosteps(machine, initial, { type: 'NEXT' });
+
+      expect(microsteps).toHaveLength(2);
+      for (const [snapshot] of microsteps) {
+        expect(getSnapshotActorRef(snapshot)!.actor.getSnapshot()).toBe(
+          snapshot
+        );
+      }
+      expect(getSnapshotActorRef(microsteps[0][0])!.actor).not.toBe(
+        getSnapshotActorRef(microsteps[1][0])!.actor
+      );
     });
 
     it('appends deferred starts to the final microstep', () => {

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -1586,6 +1586,33 @@ describe('transition function', () => {
       expect(actor.getSnapshot().value).toBe('a');
     });
 
+    it('replaces inherited live identity after materializing a pure branch', () => {
+      let branchSelf: AnyActor | undefined;
+      const machine = createMachine({
+        context: { count: 0 },
+        on: {
+          INCREMENT: ({ context, self, system }) => {
+            branchSelf = self;
+            system.get('missing');
+            return { context: { count: context.count + 1 } };
+          }
+        }
+      });
+      const actor = createActor(machine).start();
+      const liveSnapshot = actor.getSnapshot();
+
+      const [nextSnapshot] = transition(machine, liveSnapshot, {
+        type: 'INCREMENT'
+      });
+      const branchRef = getSnapshotActorRef(nextSnapshot)!;
+
+      expect(branchSelf).not.toBe(actor);
+      expect(branchRef.actor).toBe(branchSelf);
+      expect(branchRef.actor.getSnapshot()).toBe(nextSnapshot);
+      expect(actor.getSnapshot()).toBe(liveSnapshot);
+      expect(getSnapshotActorRef(liveSnapshot)!.actor).toBe(actor);
+    });
+
     it('appends deferred starts to the final microstep', () => {
       const machine = createMachine({
         entry: (_, enq) => enq.spawn(listener, { id: 'child' })

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -25,6 +25,7 @@ import { listenerLogic } from '../src/actors/listener';
 import { subscriptionLogic } from '../src/actors/subscription';
 import { XSTATE_SPAWN, XSTATE_START, XSTATE_STOP } from '../src/constants';
 import { getSnapshotActorRef } from '../src/snapshotActorRef';
+import { setInertActorMaterializationObserver } from '../src/getNextSnapshot';
 import { z } from 'zod';
 
 const isEffect =
@@ -86,6 +87,52 @@ function describeEffects(effects: ExecutableActionObject[]): string[] {
 }
 
 describe('transition function', () => {
+  it('does not materialize actors or systems for context-only planning', () => {
+    let materializations = 0;
+    setInertActorMaterializationObserver(() => materializations++);
+    try {
+      const machine = createMachine({
+        context: { count: 0 },
+        on: {
+          INCREMENT: ({ context }) => ({
+            context: { count: context.count + 1 }
+          })
+        }
+      });
+
+      let [snapshot] = initialTransition(machine);
+      for (let index = 0; index < 100; index++) {
+        [snapshot] = transition(machine, snapshot, { type: 'INCREMENT' });
+      }
+
+      expect(snapshot.context.count).toBe(100);
+      expect(materializations).toBe(0);
+
+      const checkingMachine = createMachine({
+        context: { found: false },
+        on: {
+          CHECK: ({ system }) => ({
+            context: { found: !!system.get('missing') }
+          })
+        }
+      });
+      let [checkingSnapshot] = initialTransition(checkingMachine);
+      for (let index = 0; index < 100; index++) {
+        [checkingSnapshot] = transition(checkingMachine, checkingSnapshot, {
+          type: 'UNKNOWN'
+        });
+      }
+      [checkingSnapshot] = transition(checkingMachine, checkingSnapshot, {
+        type: 'CHECK'
+      });
+
+      expect(checkingSnapshot.context.found).toBe(false);
+      expect(materializations).toBe(2);
+    } finally {
+      setInertActorMaterializationObserver(undefined);
+    }
+  });
+
   it('does not repeatedly resolve a selected transition during a microstep', () => {
     const update = vi.fn(({ context }: { context: { count: number } }) => ({
       context: { count: context.count + 1 }

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -192,6 +192,31 @@ describe('transition function', () => {
     ]);
   });
 
+  it('keeps materialized pure scopes effect-free', () => {
+    let deferred = false;
+    let executed = false;
+    const snapshot = {
+      status: 'active',
+      output: undefined,
+      error: undefined
+    };
+    const logic = {
+      initialTransition: (_input: unknown, actorScope: any) => {
+        actorScope.defer(() => (deferred = true));
+        actorScope.actionExecutor({ exec: () => (executed = true) });
+        return [snapshot, []];
+      },
+      transition: () => [snapshot, []],
+      getInitialSnapshot: () => snapshot,
+      getPersistedSnapshot: (value: unknown) => value
+    } as any;
+
+    initialTransition(logic);
+
+    expect(deferred).toBe(false);
+    expect(executed).toBe(false);
+  });
+
   it('does not repeatedly resolve a selected transition during a microstep', () => {
     const update = vi.fn(({ context }: { context: { count: number } }) => ({
       context: { count: context.count + 1 }

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -1718,6 +1718,43 @@ describe('transition function', () => {
       expect(getSnapshotActorRef(liveSnapshot)!.actor).toBe(liveActor);
     });
 
+    it('keeps one session identity across a plan started from scratch', () => {
+      const machine = createMachine({
+        context: { count: 0 },
+        on: {
+          INCREMENT: ({ context }) => ({
+            context: { count: context.count + 1 }
+          })
+        }
+      });
+      const [initial] = initialTransition(machine);
+      const [next] = transition(machine, initial, { type: 'INCREMENT' });
+
+      expect(getSnapshotActorRef(next)!.actor.sessionId).toBe(
+        getSnapshotActorRef(initial)!.actor.sessionId
+      );
+    });
+
+    it('keeps one session identity across initial microsteps', () => {
+      const machine = createMachine({
+        initial: 'a',
+        states: {
+          a: { always: { target: 'b' } },
+          b: {}
+        }
+      });
+      const microsteps = getInitialMicrosteps(machine);
+
+      expect(microsteps).toHaveLength(2);
+      expect(
+        new Set(
+          microsteps.map(
+            ([snapshot]) => getSnapshotActorRef(snapshot)!.actor.sessionId
+          )
+        )
+      ).toHaveLength(1);
+    });
+
     it('gives every microstep its own current owner snapshot', () => {
       const machine = createMachine({
         initial: 'a',

--- a/scripts/bench-core-memory.mjs
+++ b/scripts/bench-core-memory.mjs
@@ -23,6 +23,7 @@ if (!scenarioName) {
     'invoked child',
     'observed invoked child',
     'active mailbox actor',
+    'pure context planning',
     'flat machine actor',
     'compound machine actor',
     'parallel machine actor'
@@ -77,8 +78,9 @@ if (typeof global.gc !== 'function') {
 }
 
 const require = createRequire(import.meta.url);
-const { createActor, createMachine } = require(
-  join(root, 'packages/core/dist/xstate.development.cjs.js')
+const { createActor, createMachine, initialTransition, transition } = require(
+  process.env.XSTATE_BUNDLE ??
+    join(root, 'packages/core/dist/xstate.development.cjs.js')
 );
 const noop = () => {};
 const idleMachine = createMachine({});
@@ -89,6 +91,14 @@ const spawnedMachine = createMachine({
   entry: (_, enq) => enq.spawn(idleMachine, { id: 'child' })
 });
 const activeMailboxMachine = createMachine({ on: { PING: {} } });
+const pureContextMachine = createMachine({
+  context: { count: 0 },
+  on: {
+    INCREMENT: ({ context }) => ({
+      context: { count: context.count + 1 }
+    })
+  }
+});
 const flatMachine = createMachine({
   initial: 'one',
   states: { one: {}, two: {}, three: {} }
@@ -162,6 +172,15 @@ const factories = {
       actor.send({ type: 'PING' });
     }
     return actor;
+  },
+  'pure context planning': () => {
+    let [snapshot] = initialTransition(pureContextMachine);
+    for (let index = 0; index < 10; index++) {
+      [snapshot] = transition(pureContextMachine, snapshot, {
+        type: 'INCREMENT'
+      });
+    }
+    return snapshot;
   },
   'flat machine actor': () => createActor(flatMachine).start(),
   'compound machine actor': () => createActor(compoundMachine).start(),

--- a/scripts/bench-core-runtime.mjs
+++ b/scripts/bench-core-runtime.mjs
@@ -8,14 +8,23 @@ import { fileURLToPath } from 'node:url';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
-const { createActor, createFSM, createMachine } = require(
-  join(root, 'packages/core/dist/xstate.development.cjs.js')
-);
-
 const args = process.argv.slice(2);
+const xstateArg = args.find((arg) => arg.startsWith('--xstate='));
+const xstatePath = xstateArg
+  ? xstateArg.slice('--xstate='.length)
+  : join(root, 'packages/core/dist/xstate.development.cjs.js');
+const {
+  createActor,
+  createFSM,
+  createMachine,
+  initialTransition,
+  transition
+} = require(xstatePath);
+
 const timeArg = args.find((arg) => arg.startsWith('--time='));
 const warmupArg = args.find((arg) => arg.startsWith('--warmup='));
 const dunkyArg = args.find((arg) => arg.startsWith('--dunky='));
+const filterArg = args.find((arg) => arg.startsWith('--filter='));
 const json = args.includes('--json');
 const measureMemory = args.includes('--memory');
 
@@ -23,6 +32,9 @@ const measureMs = timeArg ? Number(timeArg.slice('--time='.length)) : 500;
 const warmupMs = warmupArg ? Number(warmupArg.slice('--warmup='.length)) : 100;
 const batchSize = 1_000;
 const dunkySpecifier = dunkyArg?.slice('--dunky='.length);
+const filter = filterArg
+  ? new RegExp(filterArg.slice('--filter='.length))
+  : undefined;
 
 if (!Number.isFinite(measureMs) || measureMs <= 0) {
   throw new Error('--time must be a positive number of milliseconds');
@@ -67,6 +79,9 @@ function runFor(ms, fn) {
 }
 
 function bench(name, fn) {
+  if (filter && !filter.test(name)) {
+    return undefined;
+  }
   runFor(warmupMs, fn);
   const [elapsedMs, count] = runFor(measureMs, fn);
   return {
@@ -258,6 +273,14 @@ function makeRawTransitionBench(makeLogic, event) {
   };
 }
 
+function makePublicTransitionBench(makeLogic, event) {
+  const logic = makeLogic();
+  let [snapshot] = initialTransition(logic);
+  return () => {
+    [snapshot] = transition(logic, snapshot, event);
+  };
+}
+
 function makeActorSendBench(makeLogic, event) {
   const actor = createActor(makeLogic()).start();
   return () => {
@@ -335,6 +358,30 @@ if (dunkyModule) {
 
 const results = [
   bench(
+    'createFSM public transition: { target }',
+    makePublicTransitionBench(makeFSMTarget, { type: 'next' })
+  ),
+  bench(
+    'createMachine public transition: { target }',
+    makePublicTransitionBench(makeMachineTarget, { type: 'next' })
+  ),
+  bench(
+    'createFSM public transition: { context }',
+    makePublicTransitionBench(makeFSMContext, { type: 'hit' })
+  ),
+  bench(
+    'createMachine public transition: { context }',
+    makePublicTransitionBench(makeMachineContext, { type: 'hit' })
+  ),
+  bench(
+    'createFSM public transition: function context',
+    makePublicTransitionBench(makeFSMFunctionContext, { type: 'hit' })
+  ),
+  bench(
+    'createMachine public transition: function context',
+    makePublicTransitionBench(makeMachineFunctionContext, { type: 'hit' })
+  ),
+  bench(
     'createFSM raw transition: { target }',
     makeRawTransitionBench(makeFSMTarget, { type: 'next' })
   ),
@@ -377,7 +424,7 @@ const results = [
   benchConstruction('construct createFSM', makeFSMTarget),
   benchConstruction('construct createMachine', makeMachineTarget),
   ...dunkyResults
-];
+].filter(Boolean);
 
 const memoryResults = measureMemory
   ? [

--- a/scripts/bench-core-runtime.mjs
+++ b/scripts/bench-core-runtime.mjs
@@ -78,10 +78,11 @@ function runFor(ms, fn) {
   return [performance.now() - start, count];
 }
 
-function bench(name, fn) {
+function bench(name, setup) {
   if (filter && !filter.test(name)) {
     return undefined;
   }
+  const fn = setup();
   runFor(warmupMs, fn);
   const [elapsedMs, count] = runFor(measureMs, fn);
   return {
@@ -289,7 +290,7 @@ function makeActorSendBench(makeLogic, event) {
 }
 
 function benchConstruction(name, makeLogic) {
-  return bench(name, makeLogic);
+  return bench(name, () => makeLogic);
 }
 
 function memoryPerInstance(name, makeLogic, count = 10_000) {
@@ -330,97 +331,57 @@ if (dunkyModule) {
     );
   }
   dunkyResults.push(
-    bench(
-      'Dunky send: { target }',
-      makeDunkySendBench(() => makeDunkyTarget(machine), { type: 'next' })
-    ),
-    bench(
-      'Dunky send: static context action',
+    bench('Dunky send: { target }', () =>
+      makeDunkySendBench(() => makeDunkyTarget(machine), { type: 'next' })),
+    bench('Dunky send: static context action', () =>
       makeDunkySendBench(() => makeDunkyStaticContext(machine, act), {
         type: 'hit'
-      })
-    ),
-    bench(
-      'Dunky send: function context action',
+      })),
+    bench('Dunky send: function context action', () =>
       makeDunkySendBench(() => makeDunkyFunctionContext(machine, act), {
         type: 'hit'
-      })
-    ),
-    bench(
-      'Dunky send: function action',
+      })),
+    bench('Dunky send: function action', () =>
       makeDunkySendBench(() => makeDunkyFunctionAction(machine), {
         type: 'hit'
-      })
-    ),
+      })),
     benchConstruction('construct Dunky', () => makeDunkyTarget(machine))
   );
 }
 
 const results = [
-  bench(
-    'createFSM public transition: { target }',
-    makePublicTransitionBench(makeFSMTarget, { type: 'next' })
-  ),
-  bench(
-    'createMachine public transition: { target }',
-    makePublicTransitionBench(makeMachineTarget, { type: 'next' })
-  ),
-  bench(
-    'createFSM public transition: { context }',
-    makePublicTransitionBench(makeFSMContext, { type: 'hit' })
-  ),
-  bench(
-    'createMachine public transition: { context }',
-    makePublicTransitionBench(makeMachineContext, { type: 'hit' })
-  ),
-  bench(
-    'createFSM public transition: function context',
-    makePublicTransitionBench(makeFSMFunctionContext, { type: 'hit' })
-  ),
-  bench(
-    'createMachine public transition: function context',
-    makePublicTransitionBench(makeMachineFunctionContext, { type: 'hit' })
-  ),
-  bench(
-    'createFSM raw transition: { target }',
-    makeRawTransitionBench(makeFSMTarget, { type: 'next' })
-  ),
-  bench(
-    'createMachine raw transition: { target }',
-    makeRawTransitionBench(makeMachineTarget, { type: 'next' })
-  ),
-  bench(
-    'createFSM actor.send: { target }',
-    makeActorSendBench(makeFSMTarget, { type: 'next' })
-  ),
-  bench(
-    'createMachine actor.send: { target }',
-    makeActorSendBench(makeMachineTarget, { type: 'next' })
-  ),
-  bench(
-    'createFSM actor.send: { context }',
-    makeActorSendBench(makeFSMContext, { type: 'hit' })
-  ),
-  bench(
-    'createMachine actor.send: { context }',
-    makeActorSendBench(makeMachineContext, { type: 'hit' })
-  ),
-  bench(
-    'createFSM actor.send: function context',
-    makeActorSendBench(makeFSMFunctionContext, { type: 'hit' })
-  ),
-  bench(
-    'createMachine actor.send: function context',
-    makeActorSendBench(makeMachineFunctionContext, { type: 'hit' })
-  ),
-  bench(
-    'createFSM actor.send: function enq',
-    makeActorSendBench(makeFSMEnq, { type: 'hit' })
-  ),
-  bench(
-    'createMachine actor.send: function enq',
-    makeActorSendBench(makeMachineEnq, { type: 'hit' })
-  ),
+  bench('createFSM public transition: { target }', () =>
+    makePublicTransitionBench(makeFSMTarget, { type: 'next' })),
+  bench('createMachine public transition: { target }', () =>
+    makePublicTransitionBench(makeMachineTarget, { type: 'next' })),
+  bench('createFSM public transition: { context }', () =>
+    makePublicTransitionBench(makeFSMContext, { type: 'hit' })),
+  bench('createMachine public transition: { context }', () =>
+    makePublicTransitionBench(makeMachineContext, { type: 'hit' })),
+  bench('createFSM public transition: function context', () =>
+    makePublicTransitionBench(makeFSMFunctionContext, { type: 'hit' })),
+  bench('createMachine public transition: function context', () =>
+    makePublicTransitionBench(makeMachineFunctionContext, { type: 'hit' })),
+  bench('createFSM raw transition: { target }', () =>
+    makeRawTransitionBench(makeFSMTarget, { type: 'next' })),
+  bench('createMachine raw transition: { target }', () =>
+    makeRawTransitionBench(makeMachineTarget, { type: 'next' })),
+  bench('createFSM actor.send: { target }', () =>
+    makeActorSendBench(makeFSMTarget, { type: 'next' })),
+  bench('createMachine actor.send: { target }', () =>
+    makeActorSendBench(makeMachineTarget, { type: 'next' })),
+  bench('createFSM actor.send: { context }', () =>
+    makeActorSendBench(makeFSMContext, { type: 'hit' })),
+  bench('createMachine actor.send: { context }', () =>
+    makeActorSendBench(makeMachineContext, { type: 'hit' })),
+  bench('createFSM actor.send: function context', () =>
+    makeActorSendBench(makeFSMFunctionContext, { type: 'hit' })),
+  bench('createMachine actor.send: function context', () =>
+    makeActorSendBench(makeMachineFunctionContext, { type: 'hit' })),
+  bench('createFSM actor.send: function enq', () =>
+    makeActorSendBench(makeFSMEnq, { type: 'hit' })),
+  bench('createMachine actor.send: function enq', () =>
+    makeActorSendBench(makeMachineEnq, { type: 'hit' })),
   benchConstruction('construct createFSM', makeFSMTarget),
   benchConstruction('construct createMachine', makeMachineTarget),
   ...dunkyResults


### PR DESCRIPTION
## Summary

- replace eager inert actor/runtime-system construction in public pure transitions with a lazy branch-local scope
- defer snapshot actor/system metadata and reuse untouched identity providers without retaining transition history
- keep pure microstep inspection bookkeeping local until actor capabilities are actually needed
- add allocation instrumentation plus public-planning runtime and retained-memory benchmark scenarios

## Impact

Five alternating-order, fresh-process samples from the checked-in runtime harness, comparing merged PR #5630 (`d888163069`) with this branch. The eager baseline's 1,000-operation batches overshoot the requested sample window, so ranges and coefficient of variation are included:

| Public planning scenario | Baseline median (range; CV) | Branch median (range; CV) | Change |
| --- | ---: | ---: | ---: |
| createMachine target | 333/s (71-374; 48.8%) | 707,302/s (651,946-724,660; 5.3%) | 2,124x |
| createMachine static context | 247/s (97-343; 38.1%) | 507,321/s (278,621-1,194,890; 55.5%) | 2,054x |
| createMachine function context | 272/s (83-418; 49.9%) | 371,631/s (41,649-420,636; 54.6%) | 1,366x |
| createFSM target | 306/s (84-401; 42.1%) | 491,735/s (409,097-1,014,418; 42.0%) | 1,607x |
| createFSM static context | 979,794/s (580,132-1,105,074; 24.6%) | 8,337,994/s (6,320,884-8,853,401; 12.9%) | 8.5x |
| createFSM function context | 353/s (102-390; 39.5%) | 471,861/s (221,966-498,157; 27.2%) | 1,337x |

Nine alternating-order, isolated managed-runtime samples remained close: FSM function context +5.8%, FSM function enqueue -1.6%, machine function context -0.9%, and machine function enqueue -1.5%. Seven isolated target samples measured createFSM at -0.3%; createMachine target/static-context samples remained within the harness's normal variance.

Five fresh-process, forced-GC retained-memory samples (5,000 instances):

| Scenario | Baseline median (range) | Branch median (range) | Change |
| --- | ---: | ---: | ---: |
| Idle actor | 1,951 B (1,951-1,951) | 1,950 B (1,950-1,950) | -1 B |
| Parent-child family | 3,867 B (3,858-3,867) | 3,868 B (3,820-3,871) | +1 B |
| Active mailbox actor | 2,105 B (2,091-2,105) | 2,102 B (2,097-2,102) | -3 B |
| Retained 10-step context plan | 40,621 B (40,621-40,622) | 1,453 B (1,451-1,453) | -96.4% |

The allocation regression test executes 100 context-only public transitions with zero Actor/RuntimeSystem materializations, then verifies that accessing `system` lazily materializes only the identity anchor and current branch. Review hardening also verifies that every planned snapshot and returned microstep owns its exact current snapshot, without mutating a live source snapshot's association.

Final five-process external-harness medians: XState v6 planning 530,856 transitions/s (3.7% process MAD), terminal-fenced runtime 933,128 increments/s (4.0% MAD), observed runtime 894,189 increments/s (3.2% MAD), and child lookup/send 859,904 increments/s (3.4% MAD). Planning was 1.98x the matched comparison implementation's 268,606 transitions/s.

The corrected per-snapshot identity metadata raises the retained 10-step context-plan median from the earlier unsafe 1,453 B to 2,685 B, still 93.4% below the eager baseline's 40,832 B. Five fresh forced-GC samples after unifying scratch-plan session identity measured [2,685, 2,685, 2,685, 2,685, 2,685] B.

Minified+gzip bundle impact against the PR base is +661 B (+3.18%) for minimal machine, +331 B (+3.51%) for minimal FSM, +703 B (+3.16%) for machine+actors, +678 B (+3.03%) for validated machine, and +798 B (+2.39%) for the kitchen sink. Cleanup reuses the materialized actor's runtime scope and removes an unused attachment parameter, recovering 38-46 B from machine profiles without changing FSM size. The checked-in size thresholds already fail on the PR base and the standard CI job does not invoke `bench:size`; this PR does not update those unrelated stale thresholds.

## Validation

- `pnpm test:core` - 2,132 passed, 32 skipped, 3 todo
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- focused transition, custom-runtime, inspection, child lifecycle, timers, termination, branch identity, and topology-isolation coverage
- repeated neutral/interleaved runtime and fresh-process forced-GC memory harnesses
