### PR TITLE
Reduce actor runtime overhead

### DIFF
--- a/.changeset/calm-actors-run.md
+++ b/.changeset/calm-actors-run.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Reduce actor runtime memory usage and improve actor startup performance.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -539,9 +539,23 @@ export class StateMachine<
 
   private _attachPureActorRef<TSnapshot extends AnyMachineSnapshot>(
     snapshot: TSnapshot,
-    actorScope: AnyActorScope
+    actorScope: AnyActorScope,
+    skipInitializingActor = false
   ): TSnapshot {
     if (isInertActorScope(actorScope)) {
+      return snapshot;
+    }
+    if (
+      skipInitializingActor &&
+      (
+        actorScope.self as AnyActor & {
+          _actorScope?: AnyActorScope;
+          _snapshot?: unknown;
+        }
+      )._actorScope === actorScope &&
+      (actorScope.self as AnyActor & { _snapshot?: unknown })._snapshot ===
+        undefined
+    ) {
       return snapshot;
     }
     setSnapshotActorRef(snapshot, actorScope.self, actorScope.system);
@@ -969,7 +983,7 @@ export class StateMachine<
       }
       const returnedSnapshot = usesInertScope
         ? attachSnapshotActorRef(resolvedActorScope, macroState)
-        : this._attachPureActorRef(macroState, resolvedActorScope);
+        : this._attachPureActorRef(macroState, resolvedActorScope, true);
       const effects = this._collectEffects(microsteps);
       if (this.validator) {
         assertValid(this.validator, {
@@ -1046,9 +1060,12 @@ export class StateMachine<
     if (!snapshot?.children) {
       return;
     }
-    for (const child of Object.values(
-      snapshot.children as unknown as Record<string, AnyActor>
-    )) {
+    const children = snapshot.children as unknown as Record<string, AnyActor>;
+    for (const childId in children) {
+      if (!Object.hasOwn(children, childId)) {
+        continue;
+      }
+      const child = children[childId];
       if (
         (child as any)._rehydrated &&
         (child as any).getSnapshot?.().status === 'active'

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -59,7 +59,10 @@ import {
 } from './types.ts';
 import { toObserver } from './utils.ts';
 import { finalizeTransitionResult } from './transitionActions.ts';
-import { setSnapshotActorRef } from './snapshotActorRef.ts';
+import {
+  refreshSnapshotActorRefRoot,
+  setSnapshotActorRef
+} from './snapshotActorRef.ts';
 
 export const $$ACTOR_TYPE = 1;
 
@@ -72,7 +75,7 @@ export enum ProcessingStatus {
   Stopped = 2
 }
 
-const defaultOptions = {
+const defaultOptions = Object.freeze({
   clock: {
     setTimeout: (fn, ms) => {
       return setTimeout(fn, ms);
@@ -82,7 +85,7 @@ const defaultOptions = {
     }
   } as Clock,
   logger: console.log.bind(console)
-};
+});
 
 function safeCall<T>(fn: ((arg: T) => void) | undefined, arg?: T) {
   try {
@@ -110,62 +113,6 @@ function createActorRef(
   options: ActorOptions<AnyActorLogic>
 ): AnyActor {
   return new Actor(logic, options);
-}
-
-class RuntimeActorScope<TLogic extends AnyActorLogic> implements ActorScope<
-  SnapshotFrom<TLogic>,
-  EventFromLogic<TLogic>,
-  AnyActorSystem,
-  EmittedFrom<TLogic>,
-  SendableEventFromLogic<TLogic>
-> {
-  private _defer?: (fn: () => void) => void;
-  private _stopChild?: (child: AnyActor) => void;
-  private _emit?: (event: EmittedFrom<TLogic>) => void | PromiseLike<void>;
-  private _actionExecutor?: (action: ExecutableActionObject) => void;
-
-  constructor(private actor: Actor<TLogic>) {}
-
-  public get self(): Actor<TLogic> {
-    return this.actor;
-  }
-
-  public get id(): string {
-    return this.actor.id;
-  }
-
-  public get sessionId(): string {
-    return this.actor.sessionId;
-  }
-
-  public get logger(): ActorScope<
-    SnapshotFrom<TLogic>,
-    EventFromLogic<TLogic>
-  >['logger'] {
-    return this.actor._getLogger();
-  }
-
-  public get system(): AnyActorSystem {
-    return this.actor.system;
-  }
-
-  public get defer(): (fn: () => void) => void {
-    return (this._defer ??= (fn) => this.actor._defer(fn));
-  }
-
-  public get stopChild(): (child: AnyActor) => void {
-    return (this._stopChild ??= (child) => this.actor._stopChild(child));
-  }
-
-  public get emit(): (event: EmittedFrom<TLogic>) => void | PromiseLike<void> {
-    return (this._emit ??= (event) =>
-      this.actor.system.emitEvent(this.actor, event));
-  }
-
-  public get actionExecutor(): (action: ExecutableActionObject) => void {
-    return (this._actionExecutor ??= (action) =>
-      this.actor._executeAction(action));
-  }
 }
 
 /**
@@ -290,10 +237,9 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     public logic: TLogic,
     options?: ActorOptions<TLogic>
   ) {
-    const resolvedOptions = {
-      ...defaultOptions,
-      ...options
-    };
+    const resolvedOptions = (
+      options ? { ...defaultOptions, ...options } : defaultOptions
+    ) as ActorOptions<TLogic> & typeof defaultOptions;
 
     const { clock, logger, parent, syncSnapshot, id, registryKey, inspect } =
       resolvedOptions;
@@ -331,7 +277,7 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
       typeof defaultOptions;
     this.src = resolvedOptions.src ?? logic;
     this.ref = this;
-    this._actorScope = new RuntimeActorScope(this);
+    this._actorScope = this as unknown as typeof this._actorScope;
 
     if (registryKey) {
       this.registryKey = registryKey;
@@ -360,7 +306,7 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
           this.logic.initialTransition(this.options?.input, this._actorScope)
         );
         this._setSnapshot(snapshot);
-        this._initialEffects = effects;
+        this._initialEffects = effects.length ? effects : undefined;
       }
     } catch (err) {
       // if we get here then it means that we assign a value to this._snapshot that is not of the correct type
@@ -411,6 +357,36 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     EventFromLogic<TLogic>
   >['logger'] {
     return this.logger;
+  }
+
+  private get self(): Actor<TLogic> {
+    return this;
+  }
+
+  private get defer(): (fn: () => void) => void {
+    const defer = (fn: () => void) => this._defer(fn);
+    Object.defineProperty(this, 'defer', { value: defer });
+    return defer;
+  }
+
+  private get stopChild(): (child: AnyActor) => void {
+    const stopChild = (child: AnyActor) => this._stopChild(child);
+    Object.defineProperty(this, 'stopChild', { value: stopChild });
+    return stopChild;
+  }
+
+  private get emit(): (event: EmittedFrom<TLogic>) => void | PromiseLike<void> {
+    const emit = (event: EmittedFrom<TLogic>) =>
+      this.system.emitEvent(this, event);
+    Object.defineProperty(this, 'emit', { value: emit });
+    return emit;
+  }
+
+  private get actionExecutor(): (action: ExecutableActionObject) => void {
+    const actionExecutor = (action: ExecutableActionObject) =>
+      this._executeAction(action);
+    Object.defineProperty(this, 'actionExecutor', { value: actionExecutor });
+    return actionExecutor;
   }
 
   /** @internal */
@@ -595,7 +571,7 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
   }
 
   private _flushInitialEffects(): boolean {
-    if (!this._initialEffects) {
+    if (!this._initialEffects?.length) {
       return true;
     }
     this._forceDeferredActions = true;
@@ -810,10 +786,9 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     }
     this._processingStatus = ProcessingStatus.Running;
 
-    // TODO: this isn't correct when rehydrating
-    const initEvent = createInitEvent(this.options.input);
-    // remember source of init as parent for unified transition event
-    this._lastSourceRef = this._parent;
+    if (this._parent) {
+      this._lastSourceRef = this._parent;
+    }
 
     const status = (this._snapshot as Snapshot<unknown>).status;
 
@@ -834,7 +809,9 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
         }
         this.update(
           this._snapshot,
-          initEvent as unknown as EventFromLogic<TLogic>
+          createInitEvent(
+            this.options.input
+          ) as unknown as EventFromLogic<TLogic>
         );
         // TODO: rethink cleanup of observers, mailbox, etc
         return this;
@@ -863,10 +840,23 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
       }
     }
 
-    // TODO: this notifies all subscribers but usually this is redundant
-    // there is no real change happening here
-    // we need to rethink if this needs to be refactored
-    this.update(this._snapshot, initEvent as unknown as EventFromLogic<TLogic>);
+    if (
+      !this._restored &&
+      !this._deferred?.length &&
+      !this.observers?.size &&
+      !(this.system._hasInspectionObservers?.() ?? true)
+    ) {
+      // Starting changes the registered system view associated with the
+      // snapshot, even when there is nothing to publish or execute.
+      if (!refreshSnapshotActorRefRoot(this._snapshot, this, this.system)) {
+        this._setSnapshot(this._snapshot);
+      }
+    } else {
+      this.update(
+        this._snapshot,
+        createInitEvent(this.options.input) as unknown as EventFromLogic<TLogic>
+      );
+    }
 
     if (this._restored) {
       const timers: Record<string, { id: string; delay: number }> =

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -786,9 +786,7 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     }
     this._processingStatus = ProcessingStatus.Running;
 
-    if (this._parent) {
-      this._lastSourceRef = this._parent;
-    }
+    this._lastSourceRef = this._parent;
 
     const status = (this._snapshot as Snapshot<unknown>).status;
 
@@ -851,6 +849,9 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
       if (!refreshSnapshotActorRefRoot(this._snapshot, this, this.system)) {
         this._setSnapshot(this._snapshot);
       }
+      this._collectedMicrosteps = undefined;
+      this._collectedActions = undefined;
+      this._collectedSent = undefined;
     } else {
       this.update(
         this._snapshot,

--- a/packages/core/src/snapshotActorRef.ts
+++ b/packages/core/src/snapshotActorRef.ts
@@ -230,16 +230,18 @@ export function refreshSnapshotActorRefRoot(
   system: AnyActor['system']
 ): boolean {
   const ref = snapshotActorRefs.get(snapshot);
+  const sourceVersion = getSystemSnapshotVersion(system);
   if (
     ref?.actor !== actor ||
     ref.systemState.sourceSystem !== system ||
+    ref.systemState.sourceVersion + 1 !== sourceVersion ||
     system._getRootActor?.() !== actor ||
     system._peekChildren?.()
   ) {
     return false;
   }
   ref.systemState.root = actor;
-  ref.systemState.sourceVersion = getSystemSnapshotVersion(system);
+  ref.systemState.sourceVersion = sourceVersion;
   return true;
 }
 

--- a/packages/core/src/snapshotActorRef.ts
+++ b/packages/core/src/snapshotActorRef.ts
@@ -223,6 +223,26 @@ export function copySnapshotActorRef(
   return false;
 }
 
+/** Refreshes the only topology change made by an otherwise idle root start. */
+export function refreshSnapshotActorRefRoot(
+  snapshot: Snapshot<unknown>,
+  actor: AnyActor,
+  system: AnyActor['system']
+): boolean {
+  const ref = snapshotActorRefs.get(snapshot);
+  if (
+    ref?.actor !== actor ||
+    ref.systemState.sourceSystem !== system ||
+    system._getRootActor?.() !== actor ||
+    system._peekChildren?.()
+  ) {
+    return false;
+  }
+  ref.systemState.root = actor;
+  ref.systemState.sourceVersion = getSystemSnapshotVersion(system);
+  return true;
+}
+
 /**
  * Associates a transition snapshot with an actor and an immutable system view.
  * The internal association is excluded from enumeration and persistence.

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -36,14 +36,15 @@ interface Scheduler {
   cancelAll(actor: AnyActor): void;
 }
 
-let nextFallbackSystemId = 0;
+let systemIdPrefix: string | undefined;
+let nextSystemId = 0;
 
 /** @internal */
 export const transitionEffectSignal = new Error('Transition effect');
 /** @internal */
 export const transitionEffectTargets: AnyActor[] = [];
 
-function createSystemId(): string {
+function createSystemIdPrefix(): string {
   let crypto: Crypto | undefined;
   try {
     crypto = globalThis.crypto;
@@ -51,19 +52,21 @@ function createSystemId(): string {
     // Use the process-local fallback below.
   }
 
-  if (crypto?.randomUUID) {
-    try {
-      return crypto.randomUUID();
-    } catch {
-      // Try getRandomValues next.
-    }
-  }
-
   if (crypto?.getRandomValues) {
     try {
       const values = new Uint32Array(4);
       crypto.getRandomValues(values);
-      return Array.from(values, (value) => value.toString(36)).join('-');
+      return Array.from(values, (value) =>
+        value.toString(36).padStart(7, '0')
+      ).join('');
+    } catch {
+      // Try randomUUID next.
+    }
+  }
+
+  if (crypto?.randomUUID) {
+    try {
+      return crypto.randomUUID().replaceAll('-', '');
     } catch {
       // Use the process-local fallback below.
     }
@@ -71,7 +74,12 @@ function createSystemId(): string {
 
   return `xstate-${Date.now().toString(36)}-${Math.random()
     .toString(36)
-    .slice(2)}-${nextFallbackSystemId++}`;
+    .slice(2)}`;
+}
+
+function createSystemId(): string {
+  systemIdPrefix ??= createSystemIdPrefix();
+  return `${systemIdPrefix}:${(nextSystemId++).toString(36)}`;
 }
 
 /** @internal */
@@ -147,6 +155,10 @@ export interface ActorSystemRuntime {
 }
 
 type ScheduledTimerId = string & { __scheduledTimerId: never };
+
+const emptyScheduledTimers = Object.freeze(
+  {}
+) as ActorSystem<any>['_snapshot']['_scheduledTimers'];
 
 function createScheduledTimerId(actor: AnyActor, id: string): ScheduledTimerId {
   return `${actor.sessionId}.${id}` as ScheduledTimerId;
@@ -227,10 +239,17 @@ export interface ActorSystem<
 
 export type AnyActorSystem = ActorSystem<any>;
 
+// These optional lazy fields intentionally have no emitted initializers.
+// oxlint-disable-next-line typescript/no-unsafe-declaration-merging
+interface RuntimeSystem<T extends ActorSystemInfo> {
+  _children?: Map<string, AnyActor>;
+  _keyedActors?: Map<keyof T['actors'], AnyActor | undefined>;
+  _reverseKeyedActors?: WeakMap<AnyActor, keyof T['actors']>;
+  _inspectionObservers?: Set<Observer<InspectionEvent>>;
+  _timerMap?: { [id: ScheduledTimerId]: number };
+}
+
 class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
-  private _children?: Map<string, AnyActor>;
-  private _keyedActors?: Map<keyof T['actors'], AnyActor | undefined>;
-  private _reverseKeyedActors?: WeakMap<AnyActor, keyof T['actors']>;
   public _identity = {
     systemId: createSystemId(),
     nextSessionId: 0
@@ -241,9 +260,6 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
   public _clock: Clock;
   public _logger: (...args: any[]) => void;
   public createActorRef: ActorSystem<T>['createActorRef'];
-
-  private _inspectionObservers?: Set<Observer<InspectionEvent>>;
-  private _timerMap?: { [id: ScheduledTimerId]: number };
 
   public get children(): Map<string, AnyActor> {
     const children = (this._children ??= new Map());
@@ -308,7 +324,7 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
     this._logger = options.logger;
     this.createActorRef = options.createActorRef;
     this._snapshot = {
-      _scheduledTimers: restoredSnapshot?.scheduler ?? {},
+      _scheduledTimers: restoredSnapshot?.scheduler ?? emptyScheduledTimers,
       _nextActorId: restoredSnapshot?._nextActorId ?? 0
     };
   }
@@ -360,6 +376,9 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
       dueAt: scheduledAt + delay
     };
     const scheduledTimerId = createScheduledTimerId(source, id);
+    if (this._snapshot._scheduledTimers === emptyScheduledTimers) {
+      this._snapshot._scheduledTimers = {};
+    }
     this._snapshot._scheduledTimers[scheduledTimerId] = scheduledTimer;
     markSystemSnapshotDirty(this);
 
@@ -383,7 +402,9 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
     if (this._timerMap) {
       delete this._timerMap[scheduledTimerId];
     }
-    delete this._snapshot._scheduledTimers[scheduledTimerId];
+    if (this._snapshot._scheduledTimers !== emptyScheduledTimers) {
+      delete this._snapshot._scheduledTimers[scheduledTimerId];
+    }
     markSystemSnapshotDirty(this);
 
     if (timeout !== undefined) {
@@ -589,8 +610,12 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
 
   public start(): void {
     const scheduledTimers = this._snapshot._scheduledTimers;
-    this._snapshot._scheduledTimers = {};
+    let resetScheduledTimers = true;
     for (const scheduledId in scheduledTimers) {
+      if (resetScheduledTimers) {
+        this._snapshot._scheduledTimers = {};
+        resetScheduledTimers = false;
+      }
       const { source, dueAt, id } =
         scheduledTimers[scheduledId as ScheduledTimerId];
       this.scheduleTimer(

--- a/packages/core/test/clock.test.ts
+++ b/packages/core/test/clock.test.ts
@@ -27,13 +27,15 @@ describe('clock', () => {
     const setTimeoutSpy = vi.spyOn(clock, 'setTimeout');
     const actor = createActor(createMachine({}), { clock });
 
-    (actor.system._snapshot._scheduledTimers as any).restored = {
-      source: actor,
-      id: 'restored',
-      delay: 100,
-      scheduledAt: 950,
-      dueAt: 1_050
-    };
+    actor.system._snapshot._scheduledTimers = {
+      restored: {
+        source: actor,
+        id: 'restored',
+        delay: 100,
+        scheduledAt: 950,
+        dueAt: 1_050
+      }
+    } as any;
 
     actor.start();
 

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -75,7 +75,7 @@ describe('inspect', () => {
     );
   });
 
-  it('falls back without failing when Web Crypto is unusable', () => {
+  it('falls back without failing when Web Crypto is unusable', async () => {
     vi.stubGlobal('crypto', {
       randomUUID: () => {
         throw new Error('unavailable');
@@ -87,15 +87,19 @@ describe('inspect', () => {
     const sessionIds: string[] = [];
 
     try {
+      vi.resetModules();
+      const isolatedXState = await import('../src/index.ts');
       sessionIds.push(
-        createActor(createMachine({})).sessionId,
-        createActor(createMachine({})).sessionId
+        isolatedXState.createActor(isolatedXState.createMachine({})).sessionId,
+        isolatedXState.createActor(isolatedXState.createMachine({})).sessionId
       );
     } finally {
       vi.unstubAllGlobals();
+      vi.resetModules();
     }
 
     expect(new Set(sessionIds).size).toBe(2);
+    expect(sessionIds.every((id) => id.startsWith('xstate-'))).toBe(true);
   });
 
   it('uses new globally unique session IDs when restoring the same snapshot', () => {

--- a/packages/core/test/inspect.test.ts
+++ b/packages/core/test/inspect.test.ts
@@ -599,6 +599,53 @@ describe('inspect', () => {
     expect(initialTransition.microsteps).toHaveLength(1);
   });
 
+  it('clears a pre-start event source before inspecting initialization', () => {
+    const actor = createActor(createMachine({}));
+    const sender = createActor(createMachine({}), { parent: actor });
+    const events: InspectionEvent[] = [];
+
+    actor.system._relay(sender, actor, { type: 'QUEUED' });
+    actor.system.inspect((event) => events.push(event));
+    actor.start();
+
+    const initialTransition = events.find(
+      (event) =>
+        event.type === '@xstate.transition' && event.event.type === XSTATE_INIT
+    );
+    expect(initialTransition?.type).toBe('@xstate.transition');
+    if (initialTransition?.type !== '@xstate.transition') {
+      throw new Error('Initial transition was not inspected.');
+    }
+    expect(initialTransition.sourceRef).toBeUndefined();
+  });
+
+  it('does not retain uninspected initialization steps for the first event', () => {
+    const actor = createActor(
+      createMachine({
+        initial: 'a',
+        states: {
+          a: { always: { target: 'b' } },
+          b: {}
+        }
+      })
+    );
+    const events: InspectionEvent[] = [];
+
+    actor.start();
+    actor.system.inspect((event) => events.push(event));
+    actor.send({ type: 'PING' });
+
+    const transition = events.find(
+      (event) =>
+        event.type === '@xstate.transition' && event.event.type === 'PING'
+    );
+    expect(transition?.type).toBe('@xstate.transition');
+    if (transition?.type !== '@xstate.transition') {
+      throw new Error('PING transition was not inspected.');
+    }
+    expect(transition.microsteps).toHaveLength(0);
+  });
+
   it('actor.system.inspect(…) can inspect actors (observer)', () => {
     const actor = createActor(createMachine({}));
     const events: InspectionEvent[] = [];

--- a/packages/core/test/memory.test.ts
+++ b/packages/core/test/memory.test.ts
@@ -3,7 +3,8 @@ import {
   AnyActorSystem,
   createActor,
   createMachine,
-  Snapshot
+  Snapshot,
+  transition
 } from '../src';
 
 describe('runtime allocation lifecycle', () => {
@@ -51,11 +52,23 @@ describe('runtime allocation lifecycle', () => {
   });
 
   it('keeps the running root inline until registered actors are requested', () => {
-    const actor = createActor(createMachine({})).start();
+    let transitionSawRoot = false;
+    let actor: ReturnType<typeof createActor>;
+    const machine = createMachine({
+      on: {
+        CHECK: ({ system }) => {
+          transitionSawRoot = system.children.get(actor.sessionId) === actor;
+        }
+      }
+    });
+    actor = createActor(machine).start();
     const runtimeSystem = actor.system as typeof actor.system & {
       _children?: Map<string, unknown>;
     };
 
+    expect(runtimeSystem._children).toBeUndefined();
+    transition(machine, actor.getSnapshot(), { type: 'CHECK' });
+    expect(transitionSawRoot).toBe(true);
     expect(runtimeSystem._children).toBeUndefined();
     expect(actor.system.children.get(actor.sessionId)).toBe(actor);
     expect(runtimeSystem._children?.size).toBe(1);
@@ -69,11 +82,20 @@ describe('runtime allocation lifecycle', () => {
     expect(Object.hasOwn(first.system, 'sendEvent')).toBe(false);
   });
 
+  it('shares enumerable default actor options but copies explicit options', () => {
+    const logic = createMachine({});
+    const first = createActor(logic);
+    const second = createActor(logic);
+    const explicit = createActor(logic, {});
+
+    expect(first.options).toBe(second.options);
+    expect(Object.keys(first.options)).toEqual(['clock', 'logger']);
+    expect(explicit.options).not.toBe(first.options);
+    expect(Object.keys(explicit.options)).toEqual(['clock', 'logger']);
+  });
+
   it('keeps detachable actor-scope operations lazy', () => {
     type ScopeMethods = {
-      _defer?: (fn: () => void) => void;
-      _stopChild?: (child: never) => void;
-      _actionExecutor?: (action: never) => void;
       defer: (fn: () => void) => void;
       stopChild: (child: never) => void;
       actionExecutor: (action: never) => void;
@@ -86,15 +108,64 @@ describe('runtime allocation lifecycle', () => {
     const secondScope = (second as unknown as { _actorScope: ScopeMethods })
       ._actorScope;
 
-    expect(firstScope._defer).toBeUndefined();
-    expect(firstScope._stopChild).toBeUndefined();
-    expect(firstScope._actionExecutor).toBeUndefined();
+    expect(Object.hasOwn(firstScope, 'defer')).toBe(false);
+    expect(Object.hasOwn(firstScope, 'stopChild')).toBe(false);
+    expect(Object.hasOwn(firstScope, 'actionExecutor')).toBe(false);
 
     const detachedDefer = firstScope.defer;
     detachedDefer(() => {});
 
-    expect(firstScope._defer).toBe(detachedDefer);
-    expect(secondScope._defer).toBeUndefined();
+    expect(firstScope.defer).toBe(detachedDefer);
+    expect(Object.hasOwn(firstScope, 'defer')).toBe(true);
+    expect(Object.hasOwn(secondScope, 'defer')).toBe(false);
+  });
+
+  it('keeps detached actor-scope operations callable asynchronously', async () => {
+    const childLogic = createMachine({});
+    const actor = createActor(
+      createMachine({
+        invoke: { id: 'child', src: childLogic },
+        on: { FLUSH: {} }
+      })
+    ).start();
+    const child = actor.getSnapshot().children.child!;
+    const scope = (
+      actor as unknown as {
+        _actorScope: {
+          defer: (fn: () => void) => void;
+          emit: (event: { type: string }) => void;
+          stopChild: (child: typeof actor) => void;
+          actionExecutor: (action: unknown) => void;
+        };
+      }
+    )._actorScope;
+    const { defer, emit, stopChild, actionExecutor } = scope;
+    let deferred = false;
+    let emitted = false;
+    let executed = false;
+
+    actor.on('scope-event' as never, () => {
+      emitted = true;
+    });
+    await Promise.resolve();
+    defer(() => {
+      deferred = true;
+    });
+    emit({ type: 'scope-event' });
+    actionExecutor({
+      type: 'scope-action',
+      params: undefined,
+      exec: () => {
+        executed = true;
+      }
+    });
+    actor.send({ type: 'FLUSH' });
+    stopChild(child as typeof actor);
+
+    expect(deferred).toBe(true);
+    expect(emitted).toBe(true);
+    expect(executed).toBe(true);
+    expect(child.getSnapshot().status).toBe('stopped');
   });
 
   it('shares frozen empty snapshot records', () => {

--- a/packages/core/test/system.test.ts
+++ b/packages/core/test/system.test.ts
@@ -2,6 +2,7 @@ import { of } from 'rxjs';
 import { z } from 'zod';
 import { createCallbackLogic } from '../src/actors/callback.ts';
 import {
+  AnyActor,
   ActorRef,
   Snapshot,
   createActor,
@@ -10,7 +11,8 @@ import {
   createSystem,
   createEventObservableLogic,
   createObservableLogic,
-  createAsyncLogic
+  createAsyncLogic,
+  transition
 } from '../src/index.ts';
 import { ActorSystem } from '../src/system.ts';
 
@@ -91,6 +93,27 @@ describe('system', () => {
       .children.grandchild;
 
     expect(actor.system.get('grandchild')).toBe(grandchild);
+  });
+
+  it('refreshes registry changes made before the root actor starts', () => {
+    let registeredActor: AnyActor | undefined;
+    const machine = createMachine({
+      on: {
+        CHECK: ({ system }) => {
+          registeredActor = system.get('child');
+        }
+      }
+    });
+    const actor = createActor(machine);
+    const child = createActor(createMachine({}), {
+      parent: actor,
+      registryKey: 'child'
+    });
+
+    actor.start();
+    transition(machine, actor.getSnapshot(), { type: 'CHECK' });
+
+    expect(registeredActor).toBe(child);
   });
 
   it('createSystem should own the runtime actor system', () => {


### PR DESCRIPTION
## Summary

- reduce idle actor retention through shared defaults, direct actor scopes, and compact root-system state
- add a semantics-preserving cold-start path for unobserved machines
- preserve detached scope operations, inspection, restoration, timers, children, and pure-transition behavior

## Benchmarks

- exact external retained-memory harness: 2199.88 B to 1559.15 B per idle actor (7 fresh-process forced-GC samples; 640.74 B reduction)
- exact lifecycle loop: 185742/s to 217035/s median wall throughput (+16.85%); CPU throughput +27.38% across 11 alternating samples
- narrow Tinybench lifecycle task: 347826/s to 380952/s (+9.52%) across 7 alternating fresh processes
- managed-runtime CPU throughput: +5.66%; no regression
- pure planning: 563380 transitions/s; retained plan remains effectively unchanged

Wall throughput was measured under unusually high host load, so medians, MAD, and ranges—not individual runs—were used.

## Validation

- pnpm test:core (2131 passed, 32 skipped, 3 todo)
- pnpm typecheck
- pnpm lint
- pnpm format:check
- pnpm build

Stacked on #5632.