### PR TITLE
Simplify typed snapshot migrations

### DIFF
--- a/.changeset/soft-snapshots-migrate.md
+++ b/.changeset/soft-snapshots-migrate.md
@@ -1,0 +1,19 @@
+---
+'xstate': minor
+---
+
+Migrate persisted snapshots directly from `unknown` values with
+`machineVersions().migrateSnapshot()`. Exact version handlers are typed from
+retained machines, while `'*'` handles unversioned, unrecognized, or
+shape-detected snapshots. All migration handlers may be asynchronous.
+
+```ts
+const versions = machineVersions([checkoutV1, checkoutV2]);
+const snapshot = await versions.migrateSnapshot(persisted, {
+  to: '2',
+  migrations: {
+    '1': async (snapshot) => migrateV1(snapshot),
+    '*': async (snapshot, source) => migrateUnknown(snapshot, source)
+  }
+});
+```

--- a/docs/reference/persistence.md
+++ b/docs/reference/persistence.md
@@ -30,29 +30,53 @@ Persisted snapshots record current state. Event sourcing records the events that
 
 <!-- machine version parsing and migration APIs from packages/core/src/machineVersions.ts -->
 
-Keep the old machines whose persisted data you still support. `machineVersions()`
-uses their schemas to parse persisted snapshots. Each machine must have the same
-stable `id` and its own `version`.
+Register the machine versions whose persisted data you want parsed and typed.
+Each machine must have the same stable `id` and its own `version`.
 
 ```ts
 const checkoutVersions = machineVersions([checkoutV1, checkoutV2]);
-const source = await checkoutVersions.parseSnapshot(
-  JSON.parse(localStorage.getItem('checkout')!)
+const snapshot = await checkoutVersions.migrateSnapshot(
+  JSON.parse(localStorage.getItem('checkout')!),
+  {
+    to: '2',
+    migrations: {
+      '1': async (snapshot) => ({
+        ...snapshot,
+        context: { total: snapshot.context.count }
+      })
+    }
+  }
 );
-
-const snapshot = await migrateSnapshot(source, checkoutV2, {
-  '1': (snapshot) => ({
-    ...snapshot,
-    context: { total: snapshot.context.count }
-  })
-});
 
 const actor = createActor(checkoutV2, { snapshot }).start();
 ```
 
-The source version narrows the migration callback to that machine's context type.
-Migration is direct to the target machine. You do not need to define every
-intermediate version.
+Exact version keys narrow the callback to that retained machine's snapshot type.
+Migration is direct to the target machine and may be asynchronous. You do not
+need to define every intermediate version.
+
+Use `'*'` to handle any snapshot that cannot use an exact retained version. The
+snapshot is `unknown`, so the migration can inspect its shape or load an old
+schema only when needed:
+
+```ts
+const checkoutVersions = machineVersions([checkoutV2]);
+const snapshot = await checkoutVersions.migrateSnapshot(persisted, {
+  to: '2',
+  migrations: {
+    '*': async (snapshot, source) => {
+      const { checkoutV1Snapshot, migrateV1 } = await import(
+        './checkout-v1-migration'
+      );
+      return migrateV1(await checkoutV1Snapshot.parseAsync(snapshot));
+    }
+  }
+});
+```
+
+An exact version migration runs before `'*'`. If neither matches, migration
+throws. The target context schema validates the result before its machine
+identity and version are stamped.
 
 When adopting versioning for snapshots that were already persisted without a
 version, retain the old machine definition as an explicit version and configure it
@@ -64,8 +88,9 @@ const checkoutVersions = machineVersions([checkoutV0, checkoutV1], {
 });
 ```
 
-This policy applies only when version metadata is absent. An explicit unknown
-version is still rejected.
+This policy applies only when version metadata is absent. `parseSnapshot()`
+still rejects an explicit unknown version; `migrateSnapshot()` may handle it
+with `'*'`.
 
 Use a runtime Standard Schema such as Zod to reject invalid persisted data.
 `types<T>()` provides TypeScript inference only and does not validate at runtime.

--- a/migration.md
+++ b/migration.md
@@ -972,8 +972,8 @@ These exports have been **added**:
 - `executeEffects`
 - `ActorSystemRuntime`
 - `ActorTermination`
-- Persistence/versioning surface: `machineVersions`, `migrateSnapshot`, and their
-  related snapshot types
+- Persistence/versioning surface: `machineVersions` and its related snapshot
+  migration types
 - Executable effect types: `BaseExecutableActionObject`, `CustomExecutableActionObject`, `ExecutableActionObject`, `ExecutableActionObjectFromLogic`, `BuiltInExecutableActionObject`, `SpecialExecutableAction`, `StartExecutableActionObject`, `RaiseExecutableActionObject`, `SendToExecutableActionObject`, `CancelExecutableActionObject`, `StopExecutableActionObject`, `TerminateExecutableActionObject`
 - `ActorLogic.start(snapshot, scope, options?)` receives `options.restored` so logic can distinguish restoration from a fresh start.
 - `actor.select(selector)` - derived, subscribable views
@@ -1107,13 +1107,15 @@ const persisted = actor.getPersistedSnapshot();
 Machines without a `version` produce snapshots with no `version` key.
 
 Keep old versioned machines when you need typed migration. `machineVersions()`
-parses stored snapshots with the matching machine schemas. `migrateSnapshot()`
-converts directly to a target machine.
+parses stored snapshots with matching machine schemas and migrates raw snapshots
+directly to a retained target version. A `'*'` migration may asynchronously
+handle unknown snapshots without retaining old machines.
 
 To migrate snapshots created before versioning was adopted, retain the old machine
 definition as a version and pass `{ unversioned: '<old-version>' }` to
 `machineVersions()`. This fallback applies only to snapshots without version
-metadata; explicit unknown versions are rejected.
+metadata. `parseSnapshot()` rejects explicit unknown versions;
+`migrateSnapshot()` may handle them with `'*'`.
 
 ### Durable timers
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,11 +29,12 @@ export {
 export { mapState } from './mapState.ts';
 export {
   machineVersions,
-  migrateSnapshot,
+  type MigrateSnapshotOptions,
   type MachineVersionsOptions,
   type ParsedPersistedSnapshot,
   type PersistedMachineIdentity,
   type PersistedSnapshotDataFrom,
+  type PersistedSnapshotSource,
   type SnapshotMigrationHandlers,
   type PersistedSnapshotFrom
 } from './machineVersions.ts';

--- a/packages/core/src/machineVersions.ts
+++ b/packages/core/src/machineVersions.ts
@@ -50,38 +50,76 @@ export type MachineVersionsOptions<
   unversioned?: NonNullable<TMachines[number]['version']>;
 };
 
-type ParsedSnapshotSource = {
-  machine: VersionedStateMachine;
-  snapshot: Snapshot<unknown> & {
-    context: unknown;
-    machine: PersistedMachineIdentity;
-    [key: string]: unknown;
-  };
+type MaybePromise<T> = T | PromiseLike<T>;
+
+type MachineVersion<TMachines extends readonly VersionedStateMachine[]> =
+  TMachines[number]['version'];
+
+type MachineForVersion<
+  TMachines extends readonly VersionedStateMachine[],
+  TVersion extends string
+> = {
+  [K in keyof TMachines]: TMachines[K] extends VersionedStateMachine
+    ? TMachines[K]['version'] extends TVersion
+      ? TMachines[K]
+      : never
+    : never;
+}[number];
+
+export type PersistedSnapshotSource = {
+  id?: string;
+  version?: string;
 };
 
-type SourceVersion<TSource extends ParsedSnapshotSource> =
-  TSource extends unknown ? NonNullable<TSource['machine']['version']> : never;
-
-type SourceForVersion<
-  TSource extends ParsedSnapshotSource,
-  TVersion extends string
-> = TSource extends unknown
-  ? TSource['machine']['version'] extends TVersion
-    ? TSource
-    : never
-  : never;
-
 export type SnapshotMigrationHandlers<
-  TSource extends ParsedSnapshotSource,
-  TTarget extends AnyStateMachine
+  TMachines extends readonly VersionedStateMachine[],
+  TTarget extends VersionedStateMachine
 > = {
-  [TVersion in SourceVersion<TSource>]?: (
-    snapshot: SourceForVersion<TSource, TVersion>['snapshot']
-  ) => PersistedSnapshotDataFrom<TTarget>;
+  [TVersion in Exclude<MachineVersion<TMachines>, TTarget['version']>]?: (
+    snapshot: PersistedSnapshotFrom<MachineForVersion<TMachines, TVersion>>
+  ) => MaybePromise<PersistedSnapshotDataFrom<TTarget>>;
+} & {
+  '*'?: (
+    snapshot: unknown,
+    source: PersistedSnapshotSource
+  ) => MaybePromise<PersistedSnapshotDataFrom<TTarget>>;
+};
+
+export type MigrateSnapshotOptions<
+  TMachines extends readonly VersionedStateMachine[],
+  TTargetVersion extends MachineVersion<TMachines>
+> = {
+  to: TTargetVersion;
+  migrations: SnapshotMigrationHandlers<
+    TMachines,
+    MachineForVersion<TMachines, TTargetVersion>
+  >;
 };
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object';
+}
+
+function getSnapshotSource(
+  raw: unknown,
+  defaultId: string
+): PersistedSnapshotSource {
+  if (!isObject(raw)) {
+    return {};
+  }
+  if (isObject(raw.machine)) {
+    return {
+      id: typeof raw.machine.id === 'string' ? raw.machine.id : undefined,
+      version:
+        typeof raw.machine.version === 'string'
+          ? raw.machine.version
+          : undefined
+    };
+  }
+  return {
+    id: typeof raw.version === 'string' ? defaultId : undefined,
+    version: typeof raw.version === 'string' ? raw.version : undefined
+  };
 }
 
 async function validate(
@@ -99,6 +137,24 @@ async function validate(
   return result.value;
 }
 
+async function finalizeSnapshot<TTarget extends VersionedStateMachine>(
+  snapshot: PersistedSnapshotDataFrom<TTarget>,
+  target: TTarget
+): Promise<PersistedSnapshotFrom<TTarget>> {
+  const context = await validate(
+    target.schemas?.context,
+    snapshot.context,
+    `context for machine '${target.id}' version '${target.version}'`
+  );
+
+  return {
+    ...snapshot,
+    context,
+    machine: { id: target.id, version: target.version },
+    version: target.version
+  } as unknown as PersistedSnapshotFrom<TTarget>;
+}
+
 /** Creates parsers backed by retained versions of one machine. */
 export function machineVersions<
   const TMachines extends readonly [
@@ -112,6 +168,11 @@ export function machineVersions<
   for (const machine of machines) {
     if (machine.version === undefined) {
       throw new Error(`Machine '${machine.id}' must define a version.`);
+    }
+    if (machine.version === '*') {
+      throw new Error(
+        "Machine version '*' is reserved for wildcard migrations."
+      );
     }
     if (machine.id !== machineId) {
       throw new Error(
@@ -136,118 +197,127 @@ export function machineVersions<
     );
   }
 
+  const parseSnapshot = async (
+    raw: unknown
+  ): Promise<ParsedPersistedSnapshot<TMachines>> => {
+    if (!isObject(raw)) {
+      throw new Error('Persisted snapshot is missing machine identity.');
+    }
+
+    let id: string;
+    let version: string;
+    if (isObject(raw.machine)) {
+      ({ id, version } = raw.machine as { id: string; version: string });
+      if (typeof id !== 'string' || typeof version !== 'string') {
+        throw new Error('Persisted snapshot has an invalid machine identity.');
+      }
+    } else if (typeof raw.version === 'string') {
+      id = machineId;
+      version = raw.version;
+    } else if (
+      raw.version === undefined &&
+      options?.unversioned !== undefined
+    ) {
+      id = machineId;
+      version = options.unversioned;
+    } else {
+      throw new Error('Persisted snapshot is missing machine identity.');
+    }
+    if (raw.version !== undefined && typeof raw.version !== 'string') {
+      throw new Error('Persisted snapshot has an invalid version.');
+    }
+    if (raw.version !== undefined && raw.version !== version) {
+      throw new Error(
+        `Persisted snapshot version '${raw.version}' conflicts with machine version '${version}'.`
+      );
+    }
+
+    const machine = byIdentity.get(`${id}\0${version}`);
+    if (!machine) {
+      throw new Error(`Unknown machine identity '${id}' version '${version}'.`);
+    }
+
+    const context = await validate(
+      machine.schemas?.context,
+      raw.context,
+      `context for machine '${id}' version '${version}'`
+    );
+
+    return {
+      machine,
+      snapshot: {
+        ...raw,
+        context,
+        machine: { id, version }
+      }
+    } as ParsedPersistedSnapshot<TMachines>;
+  };
+
   return {
-    async parseSnapshot(
-      raw: unknown
-    ): Promise<ParsedPersistedSnapshot<TMachines>> {
-      if (!isObject(raw)) {
-        throw new Error('Persisted snapshot is missing machine identity.');
+    parseSnapshot,
+    async migrateSnapshot<TTargetVersion extends MachineVersion<TMachines>>(
+      raw: unknown,
+      migrationOptions: MigrateSnapshotOptions<TMachines, TTargetVersion>
+    ): Promise<
+      PersistedSnapshotFrom<MachineForVersion<TMachines, TTargetVersion>>
+    > {
+      type TargetMachine = MachineForVersion<TMachines, TTargetVersion>;
+      const target = byIdentity.get(`${machineId}\0${migrationOptions.to}`) as
+        | TargetMachine
+        | undefined;
+      if (!target) {
+        throw new Error(
+          `Target version '${migrationOptions.to}' is not retained for machine '${machineId}'.`
+        );
       }
 
-      let id: string;
-      let version: string;
-      if (isObject(raw.machine)) {
-        ({ id, version } = raw.machine as { id: string; version: string });
-        if (typeof id !== 'string' || typeof version !== 'string') {
-          throw new Error(
-            'Persisted snapshot has an invalid machine identity.'
+      let source: ParsedPersistedSnapshot<TMachines> | undefined;
+      let parseError: unknown;
+      try {
+        source = await parseSnapshot(raw);
+      } catch (error) {
+        parseError = error;
+      }
+
+      if (source) {
+        if (source.machine.version === target.version) {
+          return finalizeSnapshot(
+            source.snapshot as PersistedSnapshotDataFrom<TargetMachine>,
+            target
           );
         }
-      } else if (typeof raw.version === 'string') {
-        id = machineId;
-        version = raw.version;
-      } else if (
-        raw.version === undefined &&
-        options?.unversioned !== undefined
-      ) {
-        id = machineId;
-        version = options.unversioned;
-      } else {
-        throw new Error('Persisted snapshot is missing machine identity.');
-      }
-      if (raw.version !== undefined && typeof raw.version !== 'string') {
-        throw new Error('Persisted snapshot has an invalid version.');
-      }
-      if (raw.version !== undefined && raw.version !== version) {
-        throw new Error(
-          `Persisted snapshot version '${raw.version}' conflicts with machine version '${version}'.`
-        );
-      }
-
-      const machine = byIdentity.get(`${id}\0${version}`);
-      if (!machine) {
-        throw new Error(
-          `Unknown machine identity '${id}' version '${version}'.`
-        );
-      }
-
-      const context = await validate(
-        machine.schemas?.context,
-        raw.context,
-        `context for machine '${id}' version '${version}'`
-      );
-
-      return {
-        machine,
-        snapshot: {
-          ...raw,
-          context,
-          machine: { id, version }
+        const exactMigration = (
+          migrationOptions.migrations as unknown as Record<
+            string,
+            | ((
+                snapshot: unknown
+              ) => MaybePromise<PersistedSnapshotDataFrom<TargetMachine>>)
+            | undefined
+          >
+        )[source.machine.version];
+        if (exactMigration) {
+          return finalizeSnapshot(
+            await exactMigration(source.snapshot),
+            target
+          );
         }
-      } as ParsedPersistedSnapshot<TMachines>;
+      }
+
+      const wildcardMigration = migrationOptions.migrations['*'];
+      if (!wildcardMigration) {
+        if (source) {
+          throw new Error(
+            `No snapshot migration from version '${source.machine.version}' to '${target.version}' for machine '${target.id}'.`
+          );
+        }
+        throw parseError;
+      }
+
+      const snapshot = await wildcardMigration(
+        raw,
+        getSnapshotSource(raw, machineId)
+      );
+      return finalizeSnapshot(snapshot, target);
     }
   };
-}
-
-/** Migrates a parsed persisted snapshot directly to a target machine. */
-export async function migrateSnapshot<
-  TSource extends ParsedSnapshotSource,
-  TTarget extends VersionedStateMachine
->(
-  source: TSource,
-  target: TTarget,
-  migrations: SnapshotMigrationHandlers<TSource, TTarget>
-): Promise<PersistedSnapshotFrom<TTarget>> {
-  if (target.version === undefined) {
-    throw new Error(`Target machine '${target.id}' must define a version.`);
-  }
-  if (source.machine.id !== target.id) {
-    throw new Error(
-      `Cannot migrate machine '${source.machine.id}' to '${target.id}'.`
-    );
-  }
-
-  let snapshot: PersistedSnapshotDataFrom<TTarget>;
-  if (source.machine.version === target.version) {
-    snapshot = source.snapshot as PersistedSnapshotDataFrom<TTarget>;
-  } else {
-    const migrate = (
-      migrations as Record<
-        string,
-        | ((
-            snapshot: TSource['snapshot']
-          ) => PersistedSnapshotDataFrom<TTarget>)
-        | undefined
-      >
-    )[source.machine.version];
-    if (!migrate) {
-      throw new Error(
-        `No snapshot migration from version '${source.machine.version}' to '${target.version}' for machine '${target.id}'.`
-      );
-    }
-    snapshot = migrate(source.snapshot as never);
-  }
-
-  const context = await validate(
-    target.schemas?.context,
-    snapshot.context,
-    `context for machine '${target.id}' version '${target.version}'`
-  );
-
-  return {
-    ...snapshot,
-    context,
-    machine: { id: target.id, version: target.version },
-    version: target.version
-  } as unknown as PersistedSnapshotFrom<TTarget>;
 }

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -1,14 +1,114 @@
 import { z } from 'zod';
-import {
-  createActor,
-  createMachine,
-  machineVersions,
-  migrateSnapshot,
-  types
-} from '../src';
+import { createActor, createMachine, machineVersions, types } from '../src';
 
 describe('machineVersions', () => {
-  it('only exposes persisted snapshot parsing', () => {
+  it('migrates an unknown snapshot through an async wildcard handler', async () => {
+    const legacyCheckout = createMachine({
+      id: 'checkout',
+      context: { count: 2 },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        context: z.object({ total: z.number() })
+      },
+      context: { total: 0 },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const persisted = JSON.parse(
+      JSON.stringify(createActor(legacyCheckout).getPersistedSnapshot())
+    );
+    const versions = machineVersions([checkoutV2]);
+
+    const compatible = await versions.migrateSnapshot(persisted, {
+      to: '2',
+      migrations: {
+        '*': async (snapshot, source) => {
+          expect(snapshot).toEqual(persisted);
+          expect(source).toEqual({ id: undefined, version: undefined });
+          await Promise.resolve();
+          return {
+            ...(snapshot as Record<string, unknown>),
+            context: {
+              total: (snapshot as { context: { count: number } }).context.count
+            }
+          } as any;
+        }
+      }
+    });
+    const actor = createActor(checkoutV2, { snapshot: compatible }).start();
+
+    expect(actor.getSnapshot().context).toEqual({ total: 2 });
+  });
+
+  it('validates wildcard migration output against the target machine', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        context: z.object({ total: z.number() })
+      },
+      context: { total: 0 },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkout]);
+
+    await expect(
+      versions.migrateSnapshot(
+        {},
+        {
+          to: '2',
+          migrations: {
+            '*': () =>
+              ({
+                ...createActor(checkout).getPersistedSnapshot(),
+                context: { total: 'invalid' }
+              }) as any
+          }
+        }
+      )
+    ).rejects.toThrow("Invalid context for machine 'checkout' version '2'");
+  });
+
+  it('routes an unretained source version to the wildcard', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '2',
+      context: { total: 0 },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkout]);
+    const persisted = {
+      ...createActor(checkout).getPersistedSnapshot(),
+      machine: { id: 'checkout', version: '1' },
+      version: '1',
+      context: { count: 3 }
+    };
+
+    const compatible = await versions.migrateSnapshot(persisted, {
+      to: '2',
+      migrations: {
+        '*': (snapshot, source) => {
+          expect(snapshot).toBe(persisted);
+          expect(source).toEqual({ id: 'checkout', version: '1' });
+          return {
+            ...(snapshot as typeof persisted),
+            context: { total: 3 }
+          } as any;
+        }
+      }
+    });
+
+    expect(compatible.context).toEqual({ total: 3 });
+  });
+
+  it('exposes persisted snapshot parsing and migration', () => {
     const checkout = createMachine({
       id: 'checkout',
       version: '1',
@@ -17,7 +117,8 @@ describe('machineVersions', () => {
     });
 
     expect(machineVersions([checkout])).toEqual({
-      parseSnapshot: expect.any(Function)
+      parseSnapshot: expect.any(Function),
+      migrateSnapshot: expect.any(Function)
     });
   });
 
@@ -30,6 +131,19 @@ describe('machineVersions', () => {
 
     expect(() => machineVersions([unversionedMachine] as any)).toThrow(
       "Machine 'checkout' must define a version."
+    );
+  });
+
+  it("reserves '*' for wildcard migrations", () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '*',
+      initial: 'active',
+      states: { active: {} }
+    });
+
+    expect(() => machineVersions([checkout])).toThrow(
+      "Machine version '*' is reserved for wildcard migrations."
     );
   });
 
@@ -195,11 +309,14 @@ describe('machineVersions', () => {
       machine: { id: 'checkout', version: '0' }
     });
 
-    const compatible = await migrateSnapshot(parsed, checkoutV1, {
-      '0': (snapshot) => ({
-        ...snapshot,
-        context: { total: snapshot.context.count }
-      })
+    const compatible = await versions.migrateSnapshot(persisted, {
+      to: '1',
+      migrations: {
+        '0': (snapshot) => ({
+          ...snapshot,
+          context: { total: snapshot.context.count }
+        })
+      }
     });
     const actor = createActor(checkoutV1, { snapshot: compatible }).start();
 
@@ -288,7 +405,7 @@ describe('machineVersions', () => {
     ).rejects.toThrow("Invalid context for machine 'checkout' version '1'");
   });
 
-  it('migrates a parsed snapshot to a target machine', async () => {
+  it('prefers an async exact-version migration over the wildcard', async () => {
     const checkoutV1 = createMachine({
       id: 'checkout',
       version: '1',
@@ -310,15 +427,20 @@ describe('machineVersions', () => {
       states: { active: {} }
     });
     const versions = machineVersions([checkoutV1, checkoutV2]);
-    const source = await versions.parseSnapshot(
-      JSON.parse(JSON.stringify(createActor(checkoutV1).getPersistedSnapshot()))
+    const persisted = JSON.parse(
+      JSON.stringify(createActor(checkoutV1).getPersistedSnapshot())
     );
+    const wildcard = vi.fn();
 
-    const compatible = await migrateSnapshot(source, checkoutV2, {
-      '1': (snapshot) => ({
-        ...snapshot,
-        context: { total: snapshot.context.count }
-      })
+    const compatible = await versions.migrateSnapshot(persisted, {
+      to: '2',
+      migrations: {
+        '1': async (snapshot) => ({
+          ...snapshot,
+          context: { total: snapshot.context.count }
+        }),
+        '*': wildcard
+      }
     });
     const actor = createActor(checkoutV2, { snapshot: compatible }).start();
 
@@ -327,5 +449,6 @@ describe('machineVersions', () => {
       id: 'checkout',
       version: '2'
     });
+    expect(wildcard).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/test/machineVersions.types.test.ts
+++ b/packages/core/test/machineVersions.types.test.ts
@@ -2,7 +2,6 @@ import {
   createActor,
   createMachine,
   machineVersions,
-  migrateSnapshot,
   setup,
   types
 } from '../src';
@@ -53,23 +52,56 @@ if (false) {
 }
 
 async function checkSnapshotMigrationTypes() {
-  const source = await versions.parseSnapshot({} as unknown);
-
-  const compatible = await migrateSnapshot(source, checkoutV2, {
-    '1': (snapshot) => {
-      const count: number = snapshot.context.count;
-      // @ts-expect-error v1 context does not contain the v2 field
-      snapshot.context.total;
-      return {
-        ...snapshot,
-        context: { total: count }
-      };
+  const compatible = await versions.migrateSnapshot({} as unknown, {
+    to: '2',
+    migrations: {
+      '1': async (snapshot) => {
+        const count: number = snapshot.context.count;
+        // @ts-expect-error v1 context does not contain the v2 field
+        snapshot.context.total;
+        return {
+          ...snapshot,
+          context: { total: count }
+        };
+      },
+      '*': async (snapshot, source) => {
+        // @ts-expect-error wildcard snapshots are unknown
+        snapshot.context;
+        const id: string | undefined = source.id;
+        const version: string | undefined = source.version;
+        void id;
+        void version;
+        return {
+          ...createActor(checkoutV2).getPersistedSnapshot(),
+          context: { total: 0 }
+        };
+      }
     }
   });
 
   createActor(checkoutV2, { snapshot: compatible });
   // @ts-expect-error a v2 snapshot is not compatible with the v1 machine
   createActor(checkoutV1, { snapshot: compatible });
+
+  await versions.migrateSnapshot(
+    {},
+    {
+      // @ts-expect-error target version must be retained
+      to: '3',
+      migrations: {}
+    }
+  );
+
+  await versions.migrateSnapshot(
+    {},
+    {
+      to: '2',
+      migrations: {
+        // @ts-expect-error the target version is validated without migration
+        '2': (snapshot) => snapshot
+      }
+    }
+  );
 }
 
 void version;


### PR DESCRIPTION
## What changed

- add `machineVersions().migrateSnapshot(raw, { to, migrations })`
- strongly type exact-version migrations from retained machines
- add an async `'*'` fallback for unknown, unversioned, shape-detected, or lazily parsed snapshots
- validate migration output against the target context schema and stamp the target identity
- remove the detached `migrateSnapshot(source, target, migrations)` export
- update persistence docs, migration docs, tests, and the changeset

## Why

Persisted snapshots can outlive the machine code that created them. Migration should support both strongly typed retained versions and genuinely unknown snapshots without requiring every historical machine to remain loaded.

## Validation

- `pnpm test:core` — 2,127 passed, 32 skipped, 3 todo
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
