### PR TITLE
Add typed event history adaptation

### DIFF
--- a/.changeset/young-events-adapt.md
+++ b/.changeset/young-events-adapt.md
@@ -1,0 +1,17 @@
+---
+'xstate': minor
+---
+
+Add `machineVersions().adaptEvents()` for adapting complete event histories
+between machine versions. Exact retained-version adapters infer source and
+target event types, while an async `'*'` adapter can handle unknown histories.
+
+```ts
+const events = await versions.adaptEvents(storedEvents, {
+  from: { id: 'checkout', version: '1' },
+  to: '2',
+  adapters: {
+    '1': (events) => events.map(toV2Event)
+  }
+});
+```

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -28,7 +28,7 @@ Persisted snapshots record current state. Event sourcing records the events that
 
 ## Migrate machine versions
 
-<!-- machine version parsing and migration APIs from packages/core/src/machineVersions.ts -->
+<!-- snapshot migration and event adaptation APIs from packages/core/src/machineVersions.ts -->
 
 Register the machine versions whose persisted data you want parsed and typed.
 Each machine must have the same stable `id` and its own `version`.
@@ -94,6 +94,44 @@ with `'*'`.
 
 Use a runtime Standard Schema such as Zod to reject invalid persisted data.
 `types<T>()` provides TypeScript inference only and does not validate at runtime.
+
+## Adapt event histories
+
+Event adaptation is separate from snapshot migration. Pass the source identity
+once for the stream; events do not need version envelopes or metadata.
+
+```ts
+const events = await checkoutVersions.adaptEvents(storedEvents, {
+  from: { id: 'checkout', version: '1' },
+  to: '2',
+  adapters: {
+    '1': async (events) => [
+      {
+        type: 'totalChanged',
+        amount: events.reduce(
+          (total, event) => total + event.amount,
+          0
+        )
+      }
+    ]
+  }
+});
+```
+
+Adapters receive and return whole arrays, so they may insert, drop, combine or
+reorder events. Exact retained-version adapters receive typed source events and
+must return target events. `'*'` receives `unknown[]` plus the caller-provided
+source identity, allowing lazy schema imports or shape-based adaptation.
+
+An exact adapter takes precedence over `'*'`. A matching target version needs no
+adapter. Source histories are validated before exact adapters when a source
+event schema is available; unrecognized histories may fall through to `'*'`.
+Every result, including a same-version history, is validated against available
+target event schemas. If no applicable adapter exists, adaptation throws. An
+exact adapter's error propagates instead of falling through to `'*'`.
+
+`adaptEvents()` only adapts a materialized history. It does not store or replay
+events and does not produce a snapshot.
 
 ## Persistence cheatsheet
 

--- a/migration.md
+++ b/migration.md
@@ -973,7 +973,7 @@ These exports have been **added**:
 - `ActorSystemRuntime`
 - `ActorTermination`
 - Persistence/versioning surface: `machineVersions` and its related snapshot
-  migration types
+  migration and event adaptation types
 - Executable effect types: `BaseExecutableActionObject`, `CustomExecutableActionObject`, `ExecutableActionObject`, `ExecutableActionObjectFromLogic`, `BuiltInExecutableActionObject`, `SpecialExecutableAction`, `StartExecutableActionObject`, `RaiseExecutableActionObject`, `SendToExecutableActionObject`, `CancelExecutableActionObject`, `StopExecutableActionObject`, `TerminateExecutableActionObject`
 - `ActorLogic.start(snapshot, scope, options?)` receives `options.restored` so logic can distinguish restoration from a fresh start.
 - `actor.select(selector)` - derived, subscribable views
@@ -1116,6 +1116,12 @@ definition as a version and pass `{ unversioned: '<old-version>' }` to
 `machineVersions()`. This fallback applies only to snapshots without version
 metadata. `parseSnapshot()` rejects explicit unknown versions;
 `migrateSnapshot()` may handle them with `'*'`.
+
+Event history adaptation is a separate operation. Use
+`machineVersions().adaptEvents(events, { from, to, adapters })` to transform a
+whole source history into target-version events. Exact retained-version
+adapters are typed; `'*'` receives unknown events. Adaptation validates target
+event schemas when available but does not replay events or create a snapshot.
 
 ### Durable timers
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,9 @@ export {
 export { mapState } from './mapState.ts';
 export {
   machineVersions,
+  type AdaptEventsOptions,
+  type EventAdapterHandlers,
+  type EventHistorySource,
   type MigrateSnapshotOptions,
   type MachineVersionsOptions,
   type ParsedPersistedSnapshot,

--- a/packages/core/src/machineVersions.ts
+++ b/packages/core/src/machineVersions.ts
@@ -3,6 +3,8 @@ import type { AnyMachineSchemas } from './types.v6.ts';
 import type {
   AnyStateMachine,
   ContextFrom,
+  EventFrom,
+  EventObject,
   PersistedSnapshotFor,
   Snapshot
 } from './types.ts';
@@ -96,6 +98,37 @@ export type MigrateSnapshotOptions<
   >;
 };
 
+export type EventHistorySource = {
+  id?: string;
+  version?: string;
+};
+
+export type EventAdapterHandlers<
+  TMachines extends readonly VersionedStateMachine[],
+  TTarget extends VersionedStateMachine
+> = {
+  [TVersion in Exclude<MachineVersion<TMachines>, TTarget['version']>]?: (
+    events: readonly EventFrom<MachineForVersion<TMachines, TVersion>>[]
+  ) => MaybePromise<readonly EventFrom<TTarget>[]>;
+} & {
+  '*'?: (
+    events: readonly unknown[],
+    source: EventHistorySource
+  ) => MaybePromise<readonly EventFrom<TTarget>[]>;
+};
+
+export type AdaptEventsOptions<
+  TMachines extends readonly VersionedStateMachine[],
+  TTargetVersion extends MachineVersion<TMachines>
+> = {
+  from: EventHistorySource;
+  to: TTargetVersion;
+  adapters: EventAdapterHandlers<
+    TMachines,
+    MachineForVersion<TMachines, TTargetVersion>
+  >;
+};
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object';
 }
@@ -155,7 +188,39 @@ async function finalizeSnapshot<TTarget extends VersionedStateMachine>(
   } as unknown as PersistedSnapshotFrom<TTarget>;
 }
 
-/** Creates parsers backed by retained versions of one machine. */
+async function validateEvents<TMachine extends VersionedStateMachine>(
+  events: readonly unknown[],
+  machine: TMachine
+): Promise<EventFrom<TMachine>[]> {
+  return Promise.all(
+    events.map(async (event, index) => {
+      if (!isObject(event) || typeof event.type !== 'string') {
+        throw new Error(`Invalid event at index ${index}.`);
+      }
+      const schema = machine.schemas?.events?.[event.type];
+      if (machine.schemas?.events && !schema) {
+        throw new Error(
+          `Unknown event '${event.type}' for machine '${machine.id}' version '${machine.version}'.`
+        );
+      }
+      if (!schema) {
+        return event as EventFrom<TMachine>;
+      }
+      const { type, ...payload } = event;
+      const validatedPayload = await validate(
+        schema,
+        payload,
+        `event '${type}' at index ${index}`
+      );
+      if (!isObject(validatedPayload)) {
+        throw new Error(`Invalid event '${type}' at index ${index}.`);
+      }
+      return { ...validatedPayload, type } as EventFrom<TMachine>;
+    })
+  );
+}
+
+/** Creates migration and adaptation utilities backed by retained versions of one machine. */
 export function machineVersions<
   const TMachines extends readonly [
     VersionedStateMachine,
@@ -255,6 +320,78 @@ export function machineVersions<
 
   return {
     parseSnapshot,
+    async adaptEvents<TTargetVersion extends MachineVersion<TMachines>>(
+      events: readonly unknown[],
+      adaptationOptions: AdaptEventsOptions<TMachines, TTargetVersion>
+    ): Promise<EventFrom<MachineForVersion<TMachines, TTargetVersion>>[]> {
+      type TargetMachine = MachineForVersion<TMachines, TTargetVersion>;
+      const target = byIdentity.get(`${machineId}\0${adaptationOptions.to}`) as
+        | TargetMachine
+        | undefined;
+      if (!target) {
+        throw new Error(
+          `Target version '${adaptationOptions.to}' is not retained for machine '${machineId}'.`
+        );
+      }
+
+      const source = byIdentity.get(
+        `${adaptationOptions.from.id}\0${adaptationOptions.from.version}`
+      );
+      let sourceError: unknown;
+      let sourceValidationFailed = false;
+      if (source) {
+        let sourceEvents: EventObject[] | undefined;
+        try {
+          sourceEvents = await validateEvents(events, source);
+        } catch (error) {
+          sourceError = error;
+          sourceValidationFailed = true;
+        }
+        if (sourceEvents) {
+          if (source === target) {
+            return sourceEvents as EventFrom<TargetMachine>[];
+          }
+          const adapter = (
+            adaptationOptions.adapters as Record<
+              string,
+              | ((
+                  events: readonly EventObject[]
+                ) =>
+                  | readonly EventFrom<TargetMachine>[]
+                  | PromiseLike<readonly EventFrom<TargetMachine>[]>)
+              | undefined
+            >
+          )[source.version];
+          if (adapter) {
+            return validateEvents(await adapter(sourceEvents), target);
+          }
+        }
+      }
+
+      const wildcardAdapter = adaptationOptions.adapters['*'];
+      if (wildcardAdapter) {
+        return validateEvents(
+          await wildcardAdapter(events, adaptationOptions.from),
+          target
+        );
+      }
+      if (source) {
+        if (sourceValidationFailed) {
+          throw sourceError instanceof Error
+            ? sourceError
+            : new Error(
+                `Unable to validate event history for machine '${source.id}' version '${source.version}'.`,
+                { cause: sourceError }
+              );
+        }
+        throw new Error(
+          `No event adapter from version '${source.version}' to '${target.version}' for machine '${target.id}'.`
+        );
+      }
+      throw new Error(
+        `Unknown event history source '${adaptationOptions.from.id}' version '${adaptationOptions.from.version}'.`
+      );
+    },
     async migrateSnapshot<TTargetVersion extends MachineVersion<TMachines>>(
       raw: unknown,
       migrationOptions: MigrateSnapshotOptions<TMachines, TTargetVersion>

--- a/packages/core/src/machineVersions.ts
+++ b/packages/core/src/machineVersions.ts
@@ -198,11 +198,13 @@ async function validateEvents<TMachine extends VersionedStateMachine>(
         throw new Error(`Invalid event at index ${index}.`);
       }
       const eventSchemas = machine.schemas?.events;
+      const isFrameworkEvent =
+        event.type.startsWith('xstate.') || event.type.startsWith('@xstate.');
       const schema =
         eventSchemas && Object.hasOwn(eventSchemas, event.type)
           ? eventSchemas[event.type]
           : undefined;
-      if (eventSchemas && !schema) {
+      if (eventSchemas && !schema && !isFrameworkEvent) {
         throw new Error(
           `Unknown event '${event.type}' for machine '${machine.id}' version '${machine.version}'.`
         );

--- a/packages/core/src/machineVersions.ts
+++ b/packages/core/src/machineVersions.ts
@@ -197,8 +197,12 @@ async function validateEvents<TMachine extends VersionedStateMachine>(
       if (!isObject(event) || typeof event.type !== 'string') {
         throw new Error(`Invalid event at index ${index}.`);
       }
-      const schema = machine.schemas?.events?.[event.type];
-      if (machine.schemas?.events && !schema) {
+      const eventSchemas = machine.schemas?.events;
+      const schema =
+        eventSchemas && Object.hasOwn(eventSchemas, event.type)
+          ? eventSchemas[event.type]
+          : undefined;
+      if (eventSchemas && !schema) {
         throw new Error(
           `Unknown event '${event.type}' for machine '${machine.id}' version '${machine.version}'.`
         );
@@ -334,8 +338,9 @@ export function machineVersions<
         );
       }
 
+      const sourceId = adaptationOptions.from.id ?? machineId;
       const source = byIdentity.get(
-        `${adaptationOptions.from.id}\0${adaptationOptions.from.version}`
+        `${sourceId}\0${adaptationOptions.from.version}`
       );
       let sourceError: unknown;
       let sourceValidationFailed = false;
@@ -389,7 +394,7 @@ export function machineVersions<
         );
       }
       throw new Error(
-        `Unknown event history source '${adaptationOptions.from.id}' version '${adaptationOptions.from.version}'.`
+        `Unknown event history source '${sourceId}' version '${adaptationOptions.from.version}'.`
       );
     },
     async migrateSnapshot<TTargetVersion extends MachineVersion<TMachines>>(

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -309,6 +309,31 @@ describe('machineVersions', () => {
     );
   });
 
+  it('preserves reserved framework events without schema validation', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: { CHANGE: z.object({ delta: z.number() }) }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkout]);
+    const events = [
+      { type: 'xstate.done.actor', actorId: 'child' },
+      { type: '@xstate.init' }
+    ];
+
+    await expect(
+      versions.adaptEvents(events, {
+        from: { id: 'checkout', version: '2' },
+        to: '2',
+        adapters: {}
+      })
+    ).resolves.toEqual(events);
+  });
+
   it('migrates an unknown snapshot through an async wildcard handler', async () => {
     const legacyCheckout = createMachine({
       id: 'checkout',

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -2,6 +2,264 @@ import { z } from 'zod';
 import { createActor, createMachine, machineVersions, types } from '../src';
 
 describe('machineVersions', () => {
+  it('adapts a whole event history through an async exact-version adapter', async () => {
+    const checkoutV1 = createMachine({
+      id: 'checkout',
+      version: '1',
+      schemas: {
+        events: {
+          ADD: z.object({ value: z.number() }),
+          REMOVE: z.object({ value: z.number() })
+        }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: {
+          CHANGE: z.object({ delta: z.number() })
+        }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkoutV1, checkoutV2]);
+    const wildcard = vi.fn();
+
+    const events = await versions.adaptEvents(
+      [
+        { type: 'ADD', value: 5 },
+        { type: 'REMOVE', value: 2 }
+      ],
+      {
+        from: { id: 'checkout', version: '1' },
+        to: '2',
+        adapters: {
+          '1': async (sourceEvents) => [
+            {
+              type: 'CHANGE',
+              delta: sourceEvents.reduce(
+                (total, event) =>
+                  total + (event.type === 'ADD' ? event.value : -event.value),
+                0
+              )
+            }
+          ],
+          '*': wildcard
+        }
+      }
+    );
+
+    expect(events).toEqual([{ type: 'CHANGE', delta: 3 }]);
+    expect(wildcard).not.toHaveBeenCalled();
+  });
+
+  it('adapts an unknown history through an async wildcard adapter', async () => {
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: {
+          CHANGE: z.object({ delta: z.number() })
+        }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkoutV2]);
+    const history = [{ kind: 'added', amount: 3 }];
+    const source = { id: 'legacy-checkout', version: 'draft' };
+
+    const events = await versions.adaptEvents(history, {
+      from: source,
+      to: '2',
+      adapters: {
+        '*': async (unknownEvents, actualSource) => {
+          expect(unknownEvents).toBe(history);
+          expect(actualSource).toBe(source);
+          await Promise.resolve();
+          return [
+            {
+              type: 'CHANGE',
+              delta: (unknownEvents[0] as { amount: number }).amount
+            }
+          ];
+        }
+      }
+    });
+
+    expect(events).toEqual([{ type: 'CHANGE', delta: 3 }]);
+  });
+
+  it('validates and returns same-version histories without calling adapters', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: {
+          CHANGE: z.object({ delta: z.number() })
+        }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkout]);
+    const wildcard = vi.fn();
+
+    const events = await versions.adaptEvents([{ type: 'CHANGE', delta: 3 }], {
+      from: { id: 'checkout', version: '2' },
+      to: '2',
+      adapters: { '*': wildcard }
+    });
+
+    expect(events).toEqual([{ type: 'CHANGE', delta: 3 }]);
+    expect(wildcard).not.toHaveBeenCalled();
+  });
+
+  it('routes invalid retained-source histories to the wildcard adapter', async () => {
+    const checkoutV1 = createMachine({
+      id: 'checkout',
+      version: '1',
+      schemas: {
+        events: { ADD: z.object({ value: z.number() }) }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: { CHANGE: z.object({ delta: z.number() }) }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkoutV1, checkoutV2]);
+    const history = [{ type: 'legacy-add', amount: 4 }];
+    const exact = vi.fn();
+
+    const events = await versions.adaptEvents(history, {
+      from: { id: 'checkout', version: '1' },
+      to: '2',
+      adapters: {
+        '1': exact,
+        '*': (unknownEvents) => [
+          {
+            type: 'CHANGE',
+            delta: (unknownEvents[0] as { amount: number }).amount
+          }
+        ]
+      }
+    });
+
+    expect(events).toEqual([{ type: 'CHANGE', delta: 4 }]);
+    expect(exact).not.toHaveBeenCalled();
+  });
+
+  it('rejects a retained source without an exact or wildcard adapter', async () => {
+    const checkoutV1 = createMachine({
+      id: 'checkout',
+      version: '1',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkoutV1, checkoutV2]);
+
+    await expect(
+      versions.adaptEvents([{ type: 'ADD' }], {
+        from: { id: 'checkout', version: '1' },
+        to: '2',
+        adapters: {}
+      })
+    ).rejects.toThrow(
+      "No event adapter from version '1' to '2' for machine 'checkout'."
+    );
+  });
+
+  it('propagates exact adapter errors without falling back to wildcard', async () => {
+    const checkoutV1 = createMachine({
+      id: 'checkout',
+      version: '1',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkoutV1, checkoutV2]);
+    const wildcard = vi.fn();
+
+    await expect(
+      versions.adaptEvents([], {
+        from: { id: 'checkout', version: '1' },
+        to: '2',
+        adapters: {
+          '1': async () => {
+            throw new Error('adapter failed');
+          },
+          '*': wildcard
+        }
+      })
+    ).rejects.toThrow('adapter failed');
+    expect(wildcard).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown source without a wildcard adapter', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '2',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkout]);
+
+    await expect(
+      versions.adaptEvents([], {
+        from: { id: 'checkout', version: 'unknown' },
+        to: '2',
+        adapters: {}
+      })
+    ).rejects.toThrow(
+      "Unknown event history source 'checkout' version 'unknown'."
+    );
+  });
+
+  it('validates adapted output against target event schemas', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: { CHANGE: z.object({ delta: z.number() }) }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkout]);
+
+    await expect(
+      versions.adaptEvents([], {
+        from: { version: 'legacy' },
+        to: '2',
+        adapters: {
+          '*': () => [{ type: 'CHANGE', delta: 'invalid' }] as any
+        }
+      })
+    ).rejects.toThrow("Invalid event 'CHANGE' at index 0");
+  });
+
   it('migrates an unknown snapshot through an async wildcard handler', async () => {
     const legacyCheckout = createMachine({
       id: 'checkout',
@@ -108,7 +366,7 @@ describe('machineVersions', () => {
     expect(compatible.context).toEqual({ total: 3 });
   });
 
-  it('exposes persisted snapshot parsing and migration', () => {
+  it('exposes snapshot migration and event adaptation separately', () => {
     const checkout = createMachine({
       id: 'checkout',
       version: '1',
@@ -118,6 +376,7 @@ describe('machineVersions', () => {
 
     expect(machineVersions([checkout])).toEqual({
       parseSnapshot: expect.any(Function),
+      adaptEvents: expect.any(Function),
       migrateSnapshot: expect.any(Function)
     });
   });

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -57,6 +57,32 @@ describe('machineVersions', () => {
     expect(wildcard).not.toHaveBeenCalled();
   });
 
+  it('defaults an omitted source ID to the retained machine ID', async () => {
+    const checkoutV1 = createMachine({
+      id: 'checkout',
+      version: '1',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkoutV1, checkoutV2]);
+
+    const events = await versions.adaptEvents([{ type: 'ADD' }], {
+      from: { version: '1' },
+      to: '2',
+      adapters: {
+        '1': () => [{ type: 'CHANGE' }]
+      }
+    });
+
+    expect(events).toEqual([{ type: 'CHANGE' }]);
+  });
+
   it('adapts an unknown history through an async wildcard adapter', async () => {
     const checkoutV2 = createMachine({
       id: 'checkout',
@@ -258,6 +284,29 @@ describe('machineVersions', () => {
         }
       })
     ).rejects.toThrow("Invalid event 'CHANGE' at index 0");
+  });
+
+  it('rejects inherited event schema keys as unknown events', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: { CHANGE: z.object({ delta: z.number() }) }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkout]);
+
+    await expect(
+      versions.adaptEvents([{ type: 'constructor' }], {
+        from: { id: 'checkout', version: '2' },
+        to: '2',
+        adapters: {}
+      })
+    ).rejects.toThrow(
+      "Unknown event 'constructor' for machine 'checkout' version '2'."
+    );
   });
 
   it('migrates an unknown snapshot through an async wildcard handler', async () => {

--- a/packages/core/test/machineVersions.types.test.ts
+++ b/packages/core/test/machineVersions.types.test.ts
@@ -43,6 +43,30 @@ const unversioned = createMachine({
   initial: 'active',
   states: { active: {} }
 });
+const eventMachineV1 = createMachine({
+  id: 'events',
+  version: '1',
+  schemas: {
+    events: {
+      ADD: types<{ value: number }>(),
+      REMOVE: types<{ value: number }>()
+    }
+  },
+  initial: 'active',
+  states: { active: {} }
+});
+const eventMachineV2 = createMachine({
+  id: 'events',
+  version: '2',
+  schemas: {
+    events: {
+      CHANGE: types<{ delta: number }>()
+    }
+  },
+  initial: 'active',
+  states: { active: {} }
+});
+const eventVersions = machineVersions([eventMachineV1, eventMachineV2]);
 
 if (false) {
   // @ts-expect-error version parsers require versioned machines
@@ -104,10 +128,59 @@ async function checkSnapshotMigrationTypes() {
   );
 }
 
+async function checkEventAdaptationTypes() {
+  const adapted = await eventVersions.adaptEvents([], {
+    from: { id: 'events', version: '1' },
+    to: '2',
+    adapters: {
+      '1': async (events) => {
+        const event = events[0];
+        if (event?.type === 'ADD') {
+          const value: number = event.value;
+          // @ts-expect-error v1 ADD events do not contain the v2 field
+          event.delta;
+          void value;
+        }
+        return [{ type: 'CHANGE', delta: events.length }];
+      },
+      '*': async (events, source) => {
+        // @ts-expect-error wildcard event values are unknown
+        events[0].type;
+        const id: string | undefined = source.id;
+        const version: string | undefined = source.version;
+        void id;
+        void version;
+        return [{ type: 'CHANGE', delta: 0 }];
+      }
+    }
+  });
+  const targetEvents: Array<{ type: 'CHANGE'; delta: number }> = adapted;
+  void targetEvents;
+
+  await eventVersions.adaptEvents([], {
+    from: { id: 'events', version: '1' },
+    to: '2',
+    adapters: {
+      // @ts-expect-error the target version is validated without adaptation
+      '2': (events) => events
+    }
+  });
+
+  await eventVersions.adaptEvents([], {
+    from: { id: 'events', version: '1' },
+    to: '2',
+    adapters: {
+      // @ts-expect-error adapters must return target-version events
+      '1': () => [{ type: 'ADD', value: 1 }]
+    }
+  });
+}
+
 void version;
 void setupVersion;
 void versionsWithUnversioned;
 void checkSnapshotMigrationTypes;
+void checkEventAdaptationTypes;
 
 describe('machine version types', () => {
   it('checks machine and migration versions at compile time', () => {


### PR DESCRIPTION
## What changed

- add `machineVersions().adaptEvents(events, { from, to, adapters })`
- adapt complete histories so handlers can insert, drop, combine, or reorder events
- infer exact retained-version source events and target-version output events
- support async `'*'` adapters over `readonly unknown[]` plus stream-level source metadata
- validate retained source histories before exact adapters and all results against target event schemas when available
- document event adaptation separately from snapshot migration and add a changeset

## Semantics

- matching source and target identity is validated identity; no adapter runs
- exact adapters take precedence over `'*'`
- unknown or source-schema-invalid histories may use `'*'`
- missing adapters, source validation failures without `'*'`, adapter errors, and target validation failures reject
- exact adapter errors propagate; `'*'` is selection fallback, not error recovery

This intentionally does not add event storage, replay, per-event metadata, or `AsyncIterable` support. The array-level async API leaves room for a later streaming overload or sibling API with explicit buffering semantics.

## Validation

- `pnpm test:core` — 2,149 passed, 32 skipped, 3 todo
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm changeset status`
