### PR TITLE
Make root entry exports statically analyzable for CJS-lexed dev mode

### DIFF
--- a/.changeset/lazy-donuts-import.md
+++ b/.changeset/lazy-donuts-import.md
@@ -1,0 +1,9 @@
+---
+'xstate': patch
+---
+
+The root `xstate` entry now re-exports actor logic creators (`createAsyncLogic`, `createCallbackLogic`, `createObservableLogic`, etc.) and `SpecialTargets` by name instead of via `export *`. This fixes named imports such as `import { createAsyncLogic } from 'xstate'` failing with "does not provide an export named" in environments that load the package as CommonJS and rely on static named-export detection (for example `tsx` in development).
+
+```ts
+import { createAsyncLogic } from 'xstate'; // now works everywhere
+```

--- a/.changeset/lazy-donuts-import.md
+++ b/.changeset/lazy-donuts-import.md
@@ -2,7 +2,7 @@
 'xstate': patch
 ---
 
-The root `xstate` entry now re-exports actor logic creators (`createAsyncLogic`, `createCallbackLogic`, `createObservableLogic`, etc.) and `SpecialTargets` by name instead of via `export *`. This fixes named imports such as `import { createAsyncLogic } from 'xstate'` failing with "does not provide an export named" in environments that load the package as CommonJS and rely on static named-export detection (for example `tsx` in development).
+Named imports from the root `xstate` entry (such as the actor logic creators and `SpecialTargets`) now work in all environments, including tools that load the package as CommonJS.
 
 ```ts
 import { createAsyncLogic } from 'xstate'; // now works everywhere

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,58 @@
-export * from './actors/index.ts';
+// Explicit named re-exports (not `export *`): the root entry must stay
+// statically analyzable by Node's CJS export lexer, which loses names that
+// only flow through a star re-export when this file is compiled to CJS
+// (e.g. preconstruct dev mode under `tsx`).
+export {
+  createAsyncLogic,
+  createCallbackLogic,
+  createEmptyActor,
+  createEventObservableLogic,
+  createListenerLogic,
+  createLogic,
+  createObservableLogic,
+  createSubscriptionLogic,
+  listenerLogic,
+  subscriptionLogic,
+  TimeoutError,
+  type AsyncActorLogic,
+  type AsyncActorRef,
+  type AsyncLogicArgs,
+  type AsyncLogicConfig,
+  type AsyncLogicEnqueue,
+  type AsyncLogicFunction,
+  type AsyncSnapshot,
+  type CallbackActorLogic,
+  type CallbackActorRef,
+  type CallbackLogicConfig,
+  type CallbackLogicFunction,
+  type CallbackSnapshot,
+  type EventObservableLogicConfig,
+  type EventObservableLogicFunction,
+  type ListenerActorLogic,
+  type ListenerActorRef,
+  type ListenerInput,
+  type ListenerSnapshot,
+  type LogicActorLogic,
+  type LogicActorRef,
+  type LogicArgs,
+  type LogicConfig,
+  type LogicEffect,
+  type LogicEffectState,
+  type LogicEnqueue,
+  type LogicFunction,
+  type LogicPatch,
+  type LogicSnapshot,
+  type ObservableActorLogic,
+  type ObservableActorRef,
+  type ObservableLogicConfig,
+  type ObservableLogicFunction,
+  type ObservableSnapshot,
+  type SubscriptionActorLogic,
+  type SubscriptionActorRef,
+  type SubscriptionInput,
+  type SubscriptionMappers,
+  type SubscriptionSnapshot
+} from './actors/index.ts';
 export { assertEvent } from './assert.ts';
 export {
   Actor,
@@ -86,7 +140,8 @@ export type {
   AnyActorSystem
 } from './system.ts';
 export { toPromise } from './toPromise.ts';
-export * from './types.ts';
+export type * from './types.ts';
+export { SpecialTargets } from './types.ts';
 export type {
   Next_MachineConfig as MachineConfig,
   Next_StateNodeConfig as StateNodeConfig,


### PR DESCRIPTION
## What changed

- Replaced `export * from './actors/index.ts'` in `packages/core/src/index.ts` with an explicit named re-export list (runtime creators + types).
- Split `export * from './types.ts'` into `export type *` plus an explicit `export { SpecialTargets }` (the one runtime value in that module).

## Why

In preconstruct dev mode under `tsx --conditions=module`, the root entry resolves to the symlinked `src/index.ts`. Because `packages/core` is not `"type": "module"`, tsx compiles it to CommonJS, and star re-exports become dynamic `__reExport` calls that Node's cjs-module-lexer cannot statically detect — so `import { createAsyncLogic } from 'xstate'` failed with "does not provide an export named 'createAsyncLogic'" while directly-named exports worked. Explicit named exports keep the entry statically analyzable in any CJS-lexed path.

## Notes for reviewers

- Export surface is unchanged; only the re-export form differs. `pnpm typecheck` and `pnpm test:core` (2153 passed) are clean.
- Verified at runtime: named root imports now work under `tsx --conditions=module` against the workspace build; the `xstate/actors` workaround imports in the examples corpus branch have been reverted separately.
- Separate pre-existing issue (not addressed here): preconstruct dev's generated `dist/xstate.cjs.mjs` references `./dist/xstate.cjs.js` from inside `dist/`, breaking plain `tsx`/Node ESM without `--conditions=module`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5644" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->