### PR TITLE
Fix `invoke.onDone` inference for logic-value `src` with heterogeneous actor maps

### DIFF
--- a/.changeset/tidy-lions-brush.md
+++ b/.changeset/tidy-lions-brush.md
@@ -1,0 +1,30 @@
+---
+'xstate': patch
+---
+
+Fixed `invoke.onDone` transition argument inference when actor logic is passed directly as `src` in a machine with two or more differently-typed registered actors. Previously, the transition function's arguments collapsed to `any` (`event.output` was unusable without annotations); now `event.output` is inferred from the invoked actor's output type.
+
+```ts
+const fetchUser = createAsyncLogic({ run: async () => ({ name: 'David' }) });
+const fetchCount = createAsyncLogic({ run: async () => 42 });
+
+setup({
+  actors: { fetchUser, fetchCount }
+}).createMachine({
+  initial: 'loading',
+  states: {
+    loading: {
+      invoke: {
+        src: fetchUser,
+        onDone: ({ event }) => {
+          event.output.name; // string
+          return { target: 'done' };
+        }
+      }
+    },
+    done: {}
+  }
+});
+```
+
+Note: when actors are registered, invoking *unregistered* inline logic now only supports the object/target forms of `onDone` (not the transition function form). Register the actor to get fully-typed function-form transitions.

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1300,21 +1300,52 @@ type SetupInvokeConfig<
           TInvoke,
           'onDone' | 'onError' | 'onSnapshot' | 'onTimeout'
         > & {
-          onDone?: StateTransitionConfigOrTarget<
-            TStateSchemas,
-            TContext,
-            TContextShape,
-            InvokeDoneEvent<TInvoke>,
-            TEvent,
-            TEmitted,
-            TChildren,
-            TMeta,
-            TActionMap,
-            TActorMap,
-            TGuardMap,
-            TDelayMap,
-            TSystemRegistry
-          >;
+          // Inline (unregistered-logic) invoke branches have no function-form
+          // `onDone` when actors are registered (see InlineInvokeOnDone), and
+          // that must be preserved when rebuilding `onDone` here: when a
+          // registered logic value is passed as `src`, TypeScript narrows the
+          // invoke union to the matching registered branch plus the inline
+          // branch, and contextual typing of `onDone` callbacks (and their
+          // per-actor `event.output`) only works if the registered branch
+          // provides the union's only call signature.
+          onDone?: TInvoke extends {
+            onDone?: infer TOnDone;
+          }
+            ? [
+                Extract<NonNullable<TOnDone>, (...args: any[]) => unknown>
+              ] extends [never]
+              ?
+                  | undefined
+                  | StateTransitionObjectConfig<
+                      TStateSchemas,
+                      TContext,
+                      TContextShape,
+                      DoneActorEvent,
+                      TChildren,
+                      TMeta,
+                      TActionMap,
+                      TActorMap,
+                      TGuardMap,
+                      TDelayMap,
+                      TSystemRegistry,
+                      false
+                    >
+              : StateTransitionConfigOrTarget<
+                  TStateSchemas,
+                  TContext,
+                  TContextShape,
+                  InvokeDoneEvent<TInvoke>,
+                  TEvent,
+                  TEmitted,
+                  TChildren,
+                  TMeta,
+                  TActionMap,
+                  TActorMap,
+                  TGuardMap,
+                  TDelayMap,
+                  TSystemRegistry
+                >
+            : never;
           onError?: StateTransitionConfigOrTarget<
             TStateSchemas,
             TContext,
@@ -1422,7 +1453,8 @@ type StateTransitionObjectConfig<
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TAllowContextMapper extends boolean = true
 > =
   | (StateTransitionResult<
       TStateSchemas,
@@ -1436,14 +1468,14 @@ type StateTransitionObjectConfig<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      true
+      TAllowContextMapper
     > & {
       description?: string;
     })
   | {
       target: SetupStateTarget<TStateSchemas>[];
       context?: StateTransitionContext<
-        true,
+        TAllowContextMapper,
         TContext,
         TContextShape,
         TContextShape,

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -434,6 +434,71 @@ type LogicForChildRef<TActorRef> =
     ? ActorLogic<TSnapshot, TEvent, any, any, TEmitted>
     : never;
 
+/**
+ * The `onDone` config for inline (unregistered-logic) invoke branches.
+ *
+ * When the actor map has registered sources, this deliberately has no
+ * function forms (no transition function, no context mapper): passing a
+ * registered logic value as `src` makes TypeScript narrow the invoke union to
+ * the matching registered branch plus the inline branch, and per-actor
+ * `event.output` inference in `onDone` callbacks only survives if the
+ * registered branch contributes the union's only call signature. Inline
+ * (unregistered) logic in such setups can use the object/target forms, or be
+ * registered to get function-form transitions.
+ *
+ * With no registered sources (empty or permissive maps) there is no competing
+ * branch, so the full transition config is allowed.
+ */
+type InlineInvokeOnDone<
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  TEmitted extends EventObject,
+  TActionMap extends Sources['actions'],
+  TActorMap extends Sources['actors'],
+  TGuardMap extends Sources['guards'],
+  TDelayMap extends Sources['delays'],
+  TMeta extends MetaObject
+> = [keyof TActorMap & string] extends [never]
+  ? Next_TransitionConfigOrTarget<
+      TContext,
+      DoneActorEvent<any>,
+      TEvent,
+      TEmitted,
+      TActionMap,
+      TActorMap,
+      TGuardMap,
+      TDelayMap,
+      TMeta
+    >
+  : string extends keyof TActorMap
+    ? Next_TransitionConfigOrTarget<
+        TContext,
+        DoneActorEvent<OutputFrom<TActorMap[keyof TActorMap & string]>>,
+        TEvent,
+        TEmitted,
+        TActionMap,
+        TActorMap,
+        TGuardMap,
+        TDelayMap,
+        TMeta
+      >
+    :
+        | undefined
+        | {
+            matches?: EventPayloadPattern<DoneActorEvent>;
+            target?: string | string[];
+            context?: TransitionContextPatch<TContext>;
+            description?: string;
+            reenter?: boolean;
+            meta?: TMeta;
+            input?:
+              | Record<string, unknown>
+              | ((args: {
+                  context: any;
+                  event: any;
+                }) => Record<string, unknown>);
+          };
+
 type InlineChildInvokeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
@@ -446,18 +511,31 @@ type InlineChildInvokeConfig<
   TMeta extends MetaObject,
   TSystemRegistry extends SystemRegistry
 > = Values<{
-  [K in keyof TChildren & string]: Next_InvokeConfigBase<
-    TContext,
-    TEvent,
-    TEmitted,
-    TChildren,
-    TActionMap,
-    TActorMap,
-    TGuardMap,
-    TDelayMap,
-    TMeta,
-    TSystemRegistry
+  [K in keyof TChildren & string]: Omit<
+    Next_InvokeConfigBase<
+      TContext,
+      TEvent,
+      TEmitted,
+      TChildren,
+      TActionMap,
+      TActorMap,
+      TGuardMap,
+      TDelayMap,
+      TMeta,
+      TSystemRegistry
+    >,
+    'onDone'
   > & {
+    onDone?: InlineInvokeOnDone<
+      TContext,
+      TEvent,
+      TEmitted,
+      TActionMap,
+      TActorMap,
+      TGuardMap,
+      TDelayMap,
+      TMeta
+    >;
     id: K;
     src: LogicForChildRef<TChildren[K]>;
     input?:
@@ -493,18 +571,31 @@ type InlineInvokeConfig<
         TMeta,
         TSystemRegistry
       >
-    : Next_InvokeConfigBase<
-        TContext,
-        TEvent,
-        TEmitted,
-        TChildren,
-        TActionMap,
-        TActorMap,
-        TGuardMap,
-        TDelayMap,
-        TMeta,
-        TSystemRegistry
+    : Omit<
+        Next_InvokeConfigBase<
+          TContext,
+          TEvent,
+          TEmitted,
+          TChildren,
+          TActionMap,
+          TActorMap,
+          TGuardMap,
+          TDelayMap,
+          TMeta,
+          TSystemRegistry
+        >,
+        'onDone'
       > & {
+        onDone?: InlineInvokeOnDone<
+          TContext,
+          TEvent,
+          TEmitted,
+          TActionMap,
+          TActorMap,
+          TGuardMap,
+          TDelayMap,
+          TMeta
+        >;
         src: AnyActorLogic;
         input?:
           | ((

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -6387,3 +6387,138 @@ it('createSystem registry keys typecheck registryKey usage', () => {
     app.createActor(other, { registryKey: 'receiver' });
   }
 });
+
+describe('invoke onDone inference with heterogeneous actor maps', () => {
+  const numberLogic = createAsyncLogic({ run: async () => 42 });
+  const stringLogic = createAsyncLogic({ run: async () => 'hello' });
+
+  it('should infer per-actor event.output for a string src', () => {
+    setup({
+      actors: { numberLogic, stringLogic }
+    }).createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: 'numberLogic',
+            onDone: ({ event }) => {
+              event.output satisfies number;
+              // @ts-expect-error output is a number
+              event.output satisfies string;
+              return {};
+            }
+          }
+        },
+        b: {
+          invoke: {
+            src: 'stringLogic',
+            onDone: ({ event }) => {
+              event.output satisfies string;
+              return {};
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should infer per-actor event.output for a logic value src', () => {
+    setup({
+      actors: { numberLogic, stringLogic }
+    }).createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: numberLogic,
+            onDone: ({ event }) => {
+              event.output satisfies number;
+              // @ts-expect-error output is a number
+              event.output satisfies string;
+              return {};
+            }
+          }
+        },
+        b: {
+          invoke: {
+            src: stringLogic,
+            onDone: ({ event }) => {
+              event.output satisfies string;
+              return {};
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should infer event.output for a logic value src in a single-actor map', () => {
+    setup({
+      actors: { numberLogic }
+    }).createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: numberLogic,
+            onDone: ({ event }) => {
+              event.output satisfies number;
+              return {};
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should infer per-actor event.output for a logic value src in plain createMachine', () => {
+    createMachine({
+      actors: { numberLogic, stringLogic },
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: numberLogic,
+            onDone: ({ event }) => {
+              event.output satisfies number;
+              return {};
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('should accept object-form onDone for a logic value src', () => {
+    setup({
+      actors: { numberLogic, stringLogic }
+    }).createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: numberLogic,
+            onDone: { target: ['b'] }
+          }
+        },
+        b: {}
+      }
+    });
+  });
+
+  it('should keep function-form onDone for inline logic when no actors are registered', () => {
+    const inlineLogic = createAsyncLogic({ run: async () => true });
+
+    setup({}).createMachine({
+      initial: 'a',
+      states: {
+        a: {
+          invoke: {
+            src: inlineLogic,
+            onDone: () => ({})
+          }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
## What changed

Registered actor logic passed directly as `invoke.src` in a machine with two or more differently-typed actors collapsed `onDone` transition-function args to `any` (TS7031). String-key `src` was unaffected. Now `event.output` is inferred per-actor for logic-value `src` in both `setup().createMachine` and plain `createMachine({ actors })`.

## Why it happened

TypeScript discriminates the invoke config union by `src`. A logic value matches both its registered branch and the inline catch-all branch (`src: AnyActorLogic`). Contextual typing of a lambda against a union requires all constituent call signatures to be identical (constituents *without* a call signature are skipped) — with heterogeneous actors the two branches' function-form `onDone` signatures differ, so params went implicit-`any`.

## How it's fixed

- `types.v6.ts`: new `InlineInvokeOnDone` — when the actor map has registered sources, the inline (unregistered-logic) branch's `onDone` only offers object/target forms (no transition function, no context mapper), so the registered branch contributes the union's only call signature. Empty/permissive maps keep the full config unchanged.
- `setup.ts`: `SetupInvokeConfig` rebuilds `onDone` per constituent; it now detects the inline branch by the absence of a function form and preserves the signature-free shape (`StateTransitionObjectConfig` gained a `TAllowContextMapper` flag).

## Reviewer notes

- **Deliberate tradeoff** (in the changeset): invoking *unregistered* inline logic in a setup that registers actors now rejects function-form `onDone` with a clear error (object/target forms still work). Previously it silently mistyped `event.output` as the union of registered outputs. Registering the actor restores full typing.
- Resolver `src: ({ actors }) => ...` + function `onDone` remains broken for heterogeneous maps (function expressions can't act as discriminant values in TS) — pre-existing, not addressed here.
- Verified: repo-wide `pnpm typecheck`, `pnpm test:core` (2159 passed), lint + format. Six new type tests in `types.test.ts`.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->