### PR TITLE
Fix `enq.subscribeTo()` and `enq.listen()` being silent no-ops in transition functions

### DIFF
--- a/.changeset/fluffy-pandas-tell.md
+++ b/.changeset/fluffy-pandas-tell.md
@@ -1,0 +1,21 @@
+---
+'xstate': patch
+---
+
+Fixed a bug where `enq.subscribeTo(…)` and `enq.listen(…)` silently did nothing when called inside a transition function. They now work the same as in `entry` actions:
+
+```ts
+const machine = createMachine({
+  on: {
+    start: (_, enq) => {
+      const child = enq.spawn(childLogic);
+      enq.subscribeTo(child, {
+        done: (output) => ({ type: 'childDone', output })
+      });
+    },
+    childDone: ({ event }) => {
+      // event.output is the child's output
+    }
+  }
+});
+```

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -2523,7 +2523,9 @@ function getTransitionEffectEnqueue() {
       raise: triggerTransitionEffect,
       spawn: triggerTransitionEffect,
       sendTo: triggerTransitionEffect,
-      stop: triggerTransitionEffect
+      stop: triggerTransitionEffect,
+      listen: triggerTransitionEffect,
+      subscribeTo: triggerTransitionEffect
     },
     triggerTransitionEffect
   ));

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -2171,7 +2171,7 @@ export function getTransitionResult(
             actorScope,
             actions,
             internalEvents,
-            false,
+            true,
             options?.resolveActions ?? true
           )
         );

--- a/packages/core/src/transitionActions.ts
+++ b/packages/core/src/transitionActions.ts
@@ -359,6 +359,9 @@ export function createTransitionEnqueue(
   if (actorSubscriptions) {
     Object.assign(props, {
       listen: (actor: any, eventType: string, mapper: any) => {
+        if (!createActors) {
+          return { id: undefined } as unknown as AnyActor;
+        }
         const input: ListenerInput<any, any> = {
           actor,
           eventType,
@@ -376,6 +379,9 @@ export function createTransitionEnqueue(
         return listenerActor;
       },
       subscribeTo: (actor: any, mappers: any) => {
+        if (!createActors) {
+          return { id: undefined } as unknown as AnyActor;
+        }
         const normalizedMappers: SubscriptionMappers<any, any, any> =
           typeof mappers === 'function' ? { snapshot: mappers } : mappers;
 

--- a/packages/core/test/listen.test.ts
+++ b/packages/core/test/listen.test.ts
@@ -587,4 +587,93 @@ describe('enq.subscribeTo()', () => {
     // Should not have received done event
     expect(receivedDone).toBe(false);
   });
+
+  it('subscribes to done events from an actor spawned in a transition', async () => {
+    const childLogic = createAsyncLogic({
+      run: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return { result: 'success' };
+      }
+    });
+
+    const receivedEvents: any[] = [];
+
+    const parentMachine = createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            SPAWN: (_, enq) => {
+              const childRef = enq.spawn(childLogic, { id: 'child' });
+              enq.subscribeTo(childRef, {
+                done: (output) => ({
+                  type: 'CHILD_DONE',
+                  output
+                })
+              });
+            },
+            CHILD_DONE: ({ event }, enq) => {
+              enq(() => receivedEvents.push(event));
+              return { target: 'done' };
+            }
+          }
+        },
+        done: {
+          type: 'final'
+        }
+      }
+    });
+
+    const actor = createActor(parentMachine);
+    actor.start();
+    actor.send({ type: 'SPAWN' });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(actor.getSnapshot().value).toBe('done');
+    expect(receivedEvents).toHaveLength(1);
+    expect(receivedEvents[0].output).toEqual({ result: 'success' });
+  });
+
+  it('listens to emitted events from an actor spawned in a transition', async () => {
+    const childLogic = createCallbackLogic(({ emit }) => {
+      emit({ type: 'childEvent', value: 42 } as any);
+    });
+
+    const receivedEvents: any[] = [];
+
+    const parentMachine = createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            SPAWN: (_, enq) => {
+              const childRef = enq.spawn(childLogic, { id: 'child' });
+              enq.listen(
+                childRef,
+                'childEvent',
+                (emitted) =>
+                  ({
+                    type: 'FROM_CHILD',
+                    value: (emitted as any).value
+                  }) as any
+              );
+            },
+            FROM_CHILD: ({ event }, enq) => {
+              enq(() => receivedEvents.push(event));
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(parentMachine);
+    actor.start();
+    actor.send({ type: 'SPAWN' });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(receivedEvents).toHaveLength(1);
+    expect(receivedEvents[0].value).toBe(42);
+  });
 });

--- a/packages/core/test/listen.test.ts
+++ b/packages/core/test/listen.test.ts
@@ -635,6 +635,55 @@ describe('enq.subscribeTo()', () => {
     expect(receivedEvents[0].output).toEqual({ result: 'success' });
   });
 
+  it('subscribes to an existing child when the transition has no other effects', async () => {
+    const childLogic = createAsyncLogic({
+      run: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return { result: 'success' };
+      }
+    });
+
+    const receivedEvents: any[] = [];
+
+    const parentMachine = createMachine({
+      entry: (_, enq) => {
+        enq.spawn(childLogic, { id: 'child' });
+      },
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            SUBSCRIBE: ({ children }, enq) => {
+              enq.subscribeTo(children.child as AnyActor, {
+                done: (output) => ({
+                  type: 'CHILD_DONE',
+                  output
+                })
+              });
+            },
+            CHILD_DONE: ({ event }, enq) => {
+              enq(() => receivedEvents.push(event));
+              return { target: 'done' };
+            }
+          }
+        },
+        done: {
+          type: 'final'
+        }
+      }
+    });
+
+    const actor = createActor(parentMachine);
+    actor.start();
+    actor.send({ type: 'SUBSCRIBE' });
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(actor.getSnapshot().value).toBe('done');
+    expect(receivedEvents).toHaveLength(1);
+    expect(receivedEvents[0].output).toEqual({ result: 'success' });
+  });
+
   it('listens to emitted events from an actor spawned in a transition', async () => {
     const childLogic = createCallbackLogic(({ emit }) => {
       emit({ type: 'childEvent', value: 42 } as any);


### PR DESCRIPTION
## What changed

- `createTransitionEnqueue` was called with `actorSubscriptions: false` for transition functions (`transition.to`), so `enq.subscribeTo()` and `enq.listen()` fell through to the silent no-op stubs in `createEnqueueObject` — no error, no subscription actor, mappers never fired. Entry/exit actions passed `true`, which is why the same call worked in `entry`.
- Transitions now get `actorSubscriptions: true`. `listen`/`subscribeTo` additionally return an inert placeholder when `createActors` is false (mirroring `enq.spawn`), so speculative transition-selection passes (`resolveActions: false`, used by conflict resolution and `getNextSnapshot` previews) don't create real subscription actors.

## Repro (previously broken)

```ts
const machine = createMachine({
  on: {
    start: (_, enq) => {
      const child = enq.spawn(childLogic);
      enq.subscribeTo(child, {
        done: (output) => ({ type: 'childDone', output })
      });
    },
    childDone: ({ event }) => {
      // never reached before this fix
    }
  }
});
```

## Tests

Two regression tests in `packages/core/test/listen.test.ts` (`subscribeTo` done mapper and `listen` on a transition-spawned actor); both fail without the fix. Full core suite, typecheck, lint, and format pass. Changeset included.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5648" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->