### PR TITLE
Preserve optional payload fields from `types()` and structurally type `snapshot.value`

### DIFF
--- a/.changeset/optional-typed-event-payloads.md
+++ b/.changeset/optional-typed-event-payloads.md
@@ -1,0 +1,22 @@
+---
+'xstate': patch
+---
+
+Optional event payload fields declared with `types()` are now preserved instead of being made required:
+
+```ts
+const machine = setup({
+  schemas: {
+    events: {
+      submit: types<{ email: string; referrer?: string }>()
+    }
+  }
+}).createMachine({
+  // ...
+});
+
+// referrer can now be omitted
+actor.send({ type: 'submit', email: 'a@b.co' });
+```
+
+Payloads inferred from validator libraries (e.g. Zod) are still wrapped in `Required<>`.

--- a/.changeset/structured-state-value-type.md
+++ b/.changeset/structured-state-value-type.md
@@ -1,0 +1,18 @@
+---
+'xstate': patch
+---
+
+`snapshot.value` is now structurally typed from the machine config instead of the generic `StateValue` type. Flat machines get a union of state keys, and parallel machines get an object type with a key per region:
+
+```ts
+const machine = createMachine({
+  type: 'parallel',
+  states: {
+    bold: { initial: 'off', states: { off: {}, on: {} } },
+    italic: { initial: 'off', states: { off: {}, on: {} } }
+  }
+});
+
+const value = createActor(machine).getSnapshot().value;
+// { bold: 'off' | 'on'; italic: 'off' | 'on' }
+```

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -7,7 +7,7 @@ import {
   Cast,
   MachineContext,
   ProvidedActor,
-  StateValue,
+  StateValueFromStateSchema,
   ToChildren,
   MetaObject,
   StateSchema,
@@ -168,7 +168,7 @@ export function createMachine<
     MergeChildren<InferChildren<TChildrenSchemaMap>, TActor>,
     Record<string, AnyActorRef | undefined>
   >,
-  StateValue,
+  StateValueFromStateSchema<TSS>,
   TTag & string,
   TInput,
   InferOutput<TOutputSchema, unknown>,
@@ -271,7 +271,7 @@ export function createMachine<
     MergeChildren<InferChildren<TChildrenSchemaMap>, TActor>,
     Record<string, AnyActorRef | undefined>
   >,
-  StateValue,
+  StateValueFromStateSchema<TSS>,
   TTag & string,
   TInput,
   InferOutput<TOutputSchema, unknown>,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -20,6 +20,7 @@ import {
   RoutableStateId,
   StateSchema,
   StateValue,
+  StateValueFromStateSchema,
   ToChildren,
   MetaObject,
   Cast,
@@ -1970,7 +1971,12 @@ export interface SetupReturn<
       MergeChildren<SetupChildren<TSchemas, TChildrenSchemaMap>, TActor>,
       Record<string, AnyActorRef | undefined>
     >,
-    StateValue,
+    StateValueFromStateSchema<
+      MergeStateSchema<
+        Cast<TConfig, StateSchema>,
+        SetupStatesToStateSchema<TStates>
+      >
+    >,
     TTag & string,
     [SetupSchema<TSchemas, 'input'>] extends [never]
       ? TInput

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1249,13 +1249,14 @@ export type StateFrom<
     ? StateSnapshotFromMachine<ReturnType<T>>
     : never;
 
-type StateValueFromStateSchema<T extends StateSchema> = StateSchema extends T
-  ? StateValue
-  : ToStateValue<T> extends infer TStateValue
-    ? TStateValue extends StateValue
-      ? TStateValue
-      : StateValue
-    : StateValue;
+export type StateValueFromStateSchema<T extends StateSchema> =
+  StateSchema extends T
+    ? StateValue
+    : ToStateValue<T> extends infer TStateValue
+      ? TStateValue extends StateValue
+        ? TStateValue
+        : StateValue
+      : StateValue;
 
 type MatchingStateValueForStateFrom<
   TStateValue extends StateValue,

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -1,4 +1,8 @@
-import { SetupStateSchemas, StandardSchemaV1 } from './schema.types.ts';
+import {
+  SetupStateSchemas,
+  StandardSchemaV1,
+  TypeSchema
+} from './schema.types.ts';
 import { MachineSnapshot } from './State';
 import {
   Action,
@@ -50,7 +54,9 @@ export type InferOutput<T extends StandardSchemaV1, U> = Compute<
 /**
  * Event payloads from schemas (e.g. Zod) are often inferred as optional in
  * output types. Wrapping in Required<> ensures properties defined in the schema
- * are required on the event.
+ * are required on the event. Type-only schemas created with the `types()`
+ * helper are exempt: their declared type is authoritative, so optional
+ * properties stay optional.
  */
 export type InferEvents<
   TEventSchemaMap extends Record<string, StandardSchemaV1>
@@ -67,10 +73,17 @@ export type InferEvents<
           : string extends keyof O
             ? [O[string]] extends [never]
               ? { type: K }
-              : Required<O> & { type: K }
-            : Required<O> & { type: K }
+              : NormalizeEventPayload<TEventSchemaMap[K], O> & { type: K }
+            : NormalizeEventPayload<TEventSchemaMap[K], O> & { type: K }
     : never;
 }>;
+
+/**
+ * Keeps a type-only schema's payload verbatim; applies Required<> to payloads
+ * from validator libraries (see {@link InferEvents}).
+ */
+type NormalizeEventPayload<TSchema extends StandardSchemaV1, O> =
+  TSchema extends TypeSchema<any> ? O : Required<O>;
 
 export type InferChildren<
   TChildrenSchemaMap extends Record<string, StandardSchemaV1>

--- a/packages/core/test/typeSchemas.test.ts
+++ b/packages/core/test/typeSchemas.test.ts
@@ -31,6 +31,36 @@ describe('type-only schemas (`types`)', () => {
     expect(actor.getSnapshot().context.count).toBe(0);
   });
 
+  it('preserves optional payload fields declared via types()', () => {
+    const machine = setup({
+      schemas: {
+        events: {
+          submit: types<{ email: string; referrer?: string }>()
+        }
+      }
+    }).createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            submit: ({ event }) => {
+              event.email satisfies string;
+              event.referrer satisfies string | undefined;
+              // @ts-expect-error - referrer may be undefined
+              event.referrer satisfies string;
+              return {};
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    // optional field must be omittable
+    actor.send({ type: 'submit', email: 'a@b.co' });
+    actor.send({ type: 'submit', email: 'a@b.co', referrer: 'x' });
+  });
+
   it('does not validate at runtime (identity passthrough)', () => {
     const schema = types<{ a: number }>();
     expect(isTypeSchema(schema)).toBe(true);

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -874,6 +874,43 @@ describe('states', () => {
     });
   });
 
+  it('types snapshot.value structurally, including parallel states', () => {
+    const machine = createMachine({
+      type: 'parallel',
+      states: {
+        bold: {
+          initial: 'off',
+          states: { off: {}, on: {} }
+        },
+        italic: {
+          initial: 'off',
+          states: { off: {}, on: {} }
+        }
+      }
+    });
+
+    const value = createActor(machine).getSnapshot().value;
+    value satisfies {
+      bold: 'off' | 'on';
+      italic: 'off' | 'on';
+    };
+    value.bold satisfies 'off' | 'on';
+    // @ts-expect-error - may also be 'on'
+    value.bold satisfies 'off';
+  });
+
+  it('types snapshot.value as a string union for flat machines', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: { a: {}, b: {} }
+    });
+
+    const value = createActor(machine).getSnapshot().value;
+    value satisfies 'a' | 'b';
+    // @ts-expect-error - c is not a state
+    value satisfies 'c';
+  });
+
   // technically it wouldn't be a big problem accepting this, such transitions would just never be selected
   // it's not worth complicating our types to support this though unless a strong argument is made in favor for this
   it('should not accept a state handling an event type outside of the events accepted by the machine', () => {

--- a/packages/xstate-solid/test/useActor.test.tsx
+++ b/packages/xstate-solid/test/useActor.test.tsx
@@ -1238,11 +1238,7 @@ describe('useActor', () => {
       const [state, send] = useActor(machine);
       return (
         <div>
-          <div data-testid="result">
-            {typeof state.value === 'string'
-              ? state.value
-              : state.value.toString()}
-          </div>
+          <div data-testid="result">{String(state.value)}</div>
           <button role="button" onclick={() => send({ type: 'EV' })} />
         </div>
       );


### PR DESCRIPTION
## What changed

**1. Optional event payload fields declared with `types()` are preserved.**

`InferEvents` wrapped every schema payload in `Required<>` (a workaround for validator-library output quirks), which also stripped intentional optionality from type-only schemas:

```ts
setup({
  schemas: {
    events: { submit: types<{ email: string; referrer?: string }>() }
  }
})
// before: send required referrer; after: referrer stays optional
```

Since `types()` returns the branded `TypeSchema` (vendor `'xstate.types'`), a new `NormalizeEventPayload` helper keeps those payloads verbatim while still applying `Required<>` to validator-library payloads (e.g. Zod).

**2. `snapshot.value` is structurally typed from the machine config.**

`createMachine` / `setup().createMachine` passed the bare `StateValue` type into the returned `StateMachine`, even though `ToStateValue` / `StateValueFromStateSchema` already existed (used by `StateFrom`). Wiring them in gives flat machines a key union (`'a' | 'b'`) and parallel machines a structured object (`{ bold: 'off' | 'on'; italic: 'off' | 'on' }`).

## Notes for reviewers

- One xstate-solid test had a now-dead `state.value.toString()` branch (the non-string arm became `never` under the improved typing); simplified to `String(state.value)`.
- Found while probing a related report: transition-function return targets are not validated at all — `return { target: 'nope' }` compiles silently (`ValidateStateTargets` only checks literal config targets). Not addressed here; flagging as a known gap.

## Verification

- `pnpm typecheck`: 0 errors
- Core suite: 2156 passed; xstate-solid useActor: 37 passed
- `pnpm lint` / `pnpm format:check`: clean
- Type tests added in `typeSchemas.test.ts` (optional payload) and `types.test.ts` (flat + parallel value typing); changesets included
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5649" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->