### PR TITLE
Type persisted snapshot round-trips

### DIFF
--- a/.changeset/typed-persisted-snapshots.md
+++ b/.changeset/typed-persisted-snapshots.md
@@ -1,0 +1,13 @@
+---
+'xstate': patch
+---
+
+`actor.getPersistedSnapshot()` is now typed to the actor’s logic, so persist/restore round-trips through `createActor(logic, { snapshot })` no longer require a cast. Restoring a snapshot into a machine with a different `id` is a type error, while snapshots from other versions of the same machine remain assignable (for runtime migration via `migrate`).
+
+```ts
+const actor = createActor(machine).start();
+const snapshot = actor.getPersistedSnapshot();
+
+// No cast needed:
+const restored = createActor(machine, { snapshot }).start();
+```

--- a/examples/express-workflow/index.ts
+++ b/examples/express-workflow/index.ts
@@ -1,11 +1,11 @@
-import { AnyMachineSnapshot, createActor } from 'xstate';
+import { Snapshot, createActor } from 'xstate';
 import bodyParser from 'body-parser';
 
 function generateActorId() {
   return Math.random().toString(36).substring(2, 8);
 }
 
-const persistedStates: Record<string, unknown> = {};
+const persistedStates: Record<string, Snapshot<unknown>> = {};
 
 import express from 'express';
 import { machine } from './machine';
@@ -23,7 +23,6 @@ app.post('/workflows', (req, res) => {
   const workflowId = generateActorId(); // generate a unique ID
   const actor = createActor(machine).start();
 
-  // @ts-ignore
   persistedStates[workflowId] = actor.getPersistedSnapshot();
 
   res.send({ workflowId });
@@ -44,12 +43,9 @@ app.post('/workflows/:workflowId', (req, res) => {
   }
 
   const event = req.body;
-  const actor = createActor(machine, {
-    snapshot: snapshot as AnyMachineSnapshot
-  }).start();
+  const actor = createActor(machine, { snapshot }).start();
   actor.send(event);
 
-  // @ts-ignore
   persistedStates[workflowId] = actor.getPersistedSnapshot();
 
   actor.stop();

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -41,6 +41,7 @@ import type {
   EventFromLogic,
   SendableEventFromLogic,
   InputFrom,
+  PersistedSnapshotFor,
   Snapshot,
   SnapshotFrom,
   AnyTransitionDefinition,
@@ -1106,9 +1107,15 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
    * Can be restored with {@link ActorOptions.state}
    * @see https://stately.ai/docs/persistence
    */
-  public getPersistedSnapshot(): Snapshot<unknown>;
-  public getPersistedSnapshot(options?: unknown): Snapshot<unknown> {
-    return this.logic.getPersistedSnapshot(this._snapshot, options);
+  public getPersistedSnapshot(): Snapshot<unknown> &
+    PersistedSnapshotFor<TLogic>;
+  public getPersistedSnapshot(
+    options?: unknown
+  ): Snapshot<unknown> & PersistedSnapshotFor<TLogic> {
+    return this.logic.getPersistedSnapshot(
+      this._snapshot,
+      options
+    ) as Snapshot<unknown> & PersistedSnapshotFor<TLogic>;
   }
 
   public [symbolObservable](): InteropSubscribable<SnapshotFrom<TLogic>> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1623,6 +1623,19 @@ export type PersistedSnapshotFor<TLogic> = {
   readonly [persistedSnapshotLogic]: PersistedSnapshotLogicIdentity<TLogic>;
 };
 
+/**
+ * A persisted snapshot restorable into the given actor logic: any snapshot
+ * created by logic with the same machine `id` is accepted, regardless of
+ * version (version mismatches are handled at runtime, e.g. by `migrate`).
+ */
+export type RestorablePersistedSnapshotFor<TLogic> = {
+  readonly [persistedSnapshotLogic]: TLogic extends {
+    readonly id: infer TId extends string;
+  }
+    ? { readonly id: TId; readonly version: string }
+    : never;
+};
+
 export interface ActorOptions<TLogic extends AnyActorLogic> {
   /**
    * The clock that is responsible for setting and clearing timeouts, such as
@@ -1682,7 +1695,7 @@ export interface ActorOptions<TLogic extends AnyActorLogic> {
    * @see https://stately.ai/docs/persistence
    */
   snapshot?: Snapshot<unknown> &
-    Partial<PersistedSnapshotFor<DoNotInfer<TLogic>>>;
+    Partial<RestorablePersistedSnapshotFor<DoNotInfer<TLogic>>>;
 
   /** @deprecated Use `snapshot` instead. */
   state?: Snapshot<unknown>;

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -529,7 +529,10 @@ describe('machineVersions', () => {
     });
     const persisted = createActor(checkout).getPersistedSnapshot();
 
-    const restored = createActor(cart, { snapshot: persisted });
+    const restored = createActor(cart, {
+      // @ts-expect-error -- cross-ID restore is also rejected at the type level
+      snapshot: persisted
+    });
     restored.subscribe({ error: () => {} });
     restored.start();
 

--- a/packages/core/test/machineVersions.types.test.ts
+++ b/packages/core/test/machineVersions.types.test.ts
@@ -104,7 +104,7 @@ async function checkSnapshotMigrationTypes() {
   });
 
   createActor(checkoutV2, { snapshot: compatible });
-  // @ts-expect-error a v2 snapshot is not compatible with the v1 machine
+  // a snapshot from another version of the same machine is accepted (migration path)
   createActor(checkoutV1, { snapshot: compatible });
 
   await versions.migrateSnapshot(

--- a/packages/core/test/persistedSnapshot.types.test.ts
+++ b/packages/core/test/persistedSnapshot.types.test.ts
@@ -1,0 +1,95 @@
+import { createActor, createMachine } from '../src';
+import type { Snapshot } from '../src';
+
+describe('persisted snapshot round-trip types', () => {
+  it('should round-trip getPersistedSnapshot into createActor without a cast', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: { a: {} }
+    });
+
+    const snapshot = createActor(machine).getPersistedSnapshot();
+
+    createActor(machine, { snapshot });
+  });
+
+  it('should round-trip a versioned machine snapshot without a cast', () => {
+    const machine = createMachine({
+      id: 'checkout',
+      version: '1',
+      initial: 'a',
+      states: { a: {} }
+    });
+
+    const snapshot = createActor(machine).getPersistedSnapshot();
+
+    createActor(machine, { snapshot });
+  });
+
+  it('should accept a snapshot persisted from a different version of the same machine (migration path)', () => {
+    const checkoutV1 = createMachine({
+      id: 'checkout',
+      version: '1',
+      initial: 'a',
+      states: { a: {} }
+    });
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      initial: 'a',
+      states: { a: {} }
+    });
+
+    const snapshot = createActor(checkoutV1).getPersistedSnapshot();
+
+    createActor(checkoutV2, { snapshot });
+  });
+
+  it('should reject a snapshot persisted from a machine with a different ID', () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '1',
+      initial: 'a',
+      states: { a: {} }
+    });
+    const cart = createMachine({
+      id: 'cart',
+      version: '1',
+      initial: 'a',
+      states: { a: {} }
+    });
+
+    const snapshot = createActor(checkout).getPersistedSnapshot();
+
+    createActor(cart, {
+      // @ts-expect-error
+      snapshot
+    });
+  });
+
+  it('should accept a revived (unbranded) snapshot', () => {
+    const machine = createMachine({
+      initial: 'a',
+      states: { a: {} }
+    });
+
+    const revived = JSON.parse(
+      JSON.stringify(createActor(machine).getPersistedSnapshot())
+    ) as Snapshot<unknown>;
+
+    createActor(machine, { snapshot: revived });
+  });
+
+  it('should be usable where a plain Snapshot<unknown> is expected', () => {
+    const machine = createMachine({
+      id: 'checkout',
+      version: '1',
+      initial: 'a',
+      states: { a: {} }
+    });
+
+    const snapshot: Snapshot<unknown> =
+      createActor(machine).getPersistedSnapshot();
+    snapshot satisfies Snapshot<unknown>;
+  });
+});

--- a/packages/xstate-svelte/test/UseActor.svelte
+++ b/packages/xstate-svelte/test/UseActor.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  export let persistedState: AnyMachineSnapshot | undefined = undefined;
+  export let persistedState: Snapshot<unknown> | undefined = undefined;
 
   import { useActor } from '../src/index.ts';
   import { fetchMachine } from './fetchMachine.ts';
-  import type { AnyMachineSnapshot } from 'xstate';
+  import type { Snapshot } from 'xstate';
   import { createAsyncLogic } from 'xstate';
 
   const onFetch = () =>

--- a/packages/xstate-svelte/test/useActor.test.ts
+++ b/packages/xstate-svelte/test/useActor.test.ts
@@ -1,5 +1,5 @@
 import { fireEvent, render } from '@testing-library/svelte';
-import { createActor, createMachine, type AnyMachineSnapshot } from 'xstate';
+import { createActor, createMachine } from 'xstate';
 import UseActor from './UseActor.svelte';
 import UseActorNonPersistentSubscription from './UseActorNonPersistentSubscription.svelte';
 import { fetchMachine } from './fetchMachine.ts';
@@ -40,7 +40,7 @@ describe('useActor', () => {
 
   it('should work with a component with rehydrated state', async () => {
     const { findByText, getByTestId } = render(UseActor, {
-      persistedState: persistedFetchState as AnyMachineSnapshot
+      persistedState: persistedFetchState
     });
     await findByText(/Success/);
     const dataEl = getByTestId('data');


### PR DESCRIPTION
actor.getPersistedSnapshot() now returns a snapshot branded to its source logic, and ActorOptions['snapshot'] accepts persisted snapshots from any version of the same machine ID (cross-version restore stays assignable for runtime migration via migrate). Restoring into a machine with a different ID is now a compile-time error, mirroring the existing runtime guard.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5650" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->