### PR TITLE
Add schema-backed historical machine version descriptors

### DIFF
--- a/.changeset/old-squids-swim.md
+++ b/.changeset/old-squids-swim.md
@@ -4,7 +4,8 @@
 
 Represent historical machine versions with Standard Schema snapshot and event
 descriptors instead of retaining their executable machines. Versioned machines
-expose the same `snapshotSchema` and `eventSchema` interface.
+expose the same `snapshotSchema` and `eventSchema` interface. Machine-backed
+snapshot schemas default omitted history and timer records during migration.
 
 ```ts
 const versions = machineVersions([

--- a/.changeset/old-squids-swim.md
+++ b/.changeset/old-squids-swim.md
@@ -3,7 +3,8 @@
 ---
 
 Represent historical machine versions with Standard Schema snapshot and event
-descriptors instead of retaining their executable machines.
+descriptors instead of retaining their executable machines. Versioned machines
+expose the same `snapshotSchema` and `eventSchema` interface.
 
 ```ts
 const versions = machineVersions([

--- a/.changeset/old-squids-swim.md
+++ b/.changeset/old-squids-swim.md
@@ -1,0 +1,22 @@
+---
+'xstate': minor
+---
+
+Represent historical persisted machine versions with complete Standard Schema snapshot descriptors instead of retaining their executable machines.
+
+```ts
+const versions = machineVersions([
+  snapshotVersion({ id: 'checkout', version: '1', schema: checkoutV1Snapshot }),
+  checkoutV2
+]);
+
+const snapshot = await versions.migrateSnapshot(persisted, {
+  to: '2',
+  migrations: {
+    '1': (snapshot) => ({
+      ...snapshot,
+      context: { total: snapshot.context.count }
+    })
+  }
+});
+```

--- a/.changeset/old-squids-swim.md
+++ b/.changeset/old-squids-swim.md
@@ -2,11 +2,17 @@
 'xstate': minor
 ---
 
-Represent historical persisted machine versions with complete Standard Schema snapshot descriptors instead of retaining their executable machines.
+Represent historical machine versions with Standard Schema snapshot and event
+descriptors instead of retaining their executable machines.
 
 ```ts
 const versions = machineVersions([
-  snapshotVersion({ id: 'checkout', version: '1', schema: checkoutV1Snapshot }),
+  {
+    id: 'checkout',
+    version: '1',
+    snapshotSchema: checkoutV1Snapshot,
+    eventSchema: checkoutV1Event
+  },
   checkoutV2
 ]);
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -34,6 +34,12 @@ Register lightweight schema descriptors for historical versions and retain an
 actual machine for each version that may be a target. Every entry must have the
 same stable `id` and its own `version`.
 
+Every entry satisfies one `MachineVersionDescriptor` contract:
+`{ id, version, snapshotSchema?, eventSchema? }`. Versioned machines expose
+`snapshotSchema` and `eventSchema` themselves, so `machineVersions()` uses the
+same schema path for machines and lightweight historical descriptors. It only
+checks whether an entry is executable when resolving `to`.
+
 ```ts
 const checkoutVersions = machineVersions([
   {
@@ -88,8 +94,9 @@ need to retain old executable machines or define every intermediate version.
 A `snapshotSchema` describes the entire persisted contract, not only context:
 status/output/error, state value, context, children, history, timers, state
 inputs, counters and version metadata as applicable. Active state nodes are
-reconstructed from the state value, so `nodes` itself is not persisted. Existing
-versioned machines remain valid registry entries.
+reconstructed from the state value, so `nodes` itself is not persisted. A
+versioned machine's generated `snapshotSchema` validates this durable shape,
+its state value and its configured context schema.
 
 Use `'*'` to handle any snapshot that cannot use an exact retained version. The
 snapshot is `unknown`, so the migration can inspect its shape or load an old
@@ -176,7 +183,8 @@ An `eventSchema` validates each complete historical event object and infers the
 exact adapter's event union. A descriptor may provide `snapshotSchema`,
 `eventSchema` or both. If the relevant schema is absent, that operation may use
 its unknown `'*'` handler instead. Actual machines continue to work directly as
-entries and supply their existing snapshot and event types.
+entries. Their generated `eventSchema` turns the payload-oriented
+`schemas.events` map into a Standard Schema for complete event objects.
 
 Exact event and snapshot targets require actual machines. A schema descriptor
 describes historical data but cannot interpret restored state or receive events.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -96,7 +96,8 @@ status/output/error, state value, context, children, history, timers, state
 inputs, counters and version metadata as applicable. Active state nodes are
 reconstructed from the state value, so `nodes` itself is not persisted. A
 versioned machine's generated `snapshotSchema` validates this durable shape,
-its state value and its configured context schema.
+its state value and its configured context schema. It normalizes omitted
+`historyValue` and `timers` to empty records, matching restoration behavior.
 
 Use `'*'` to handle any snapshot that cannot use an exact retained version. The
 snapshot is `unknown`, so the migration can inspect its shape or load an old
@@ -185,6 +186,8 @@ exact adapter's event union. A descriptor may provide `snapshotSchema`,
 its unknown `'*'` handler instead. Actual machines continue to work directly as
 entries. Their generated `eventSchema` turns the payload-oriented
 `schemas.events` map into a Standard Schema for complete event objects.
+Without that schema or a `'*'` adapter, adaptation reports the missing event
+schema rather than treating the registered version as unknown.
 
 Exact event and snapshot targets require actual machines. A schema descriptor
 describes historical data but cannot interpret restored state or receive events.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -30,36 +30,41 @@ Persisted snapshots record current state. Event sourcing records the events that
 
 <!-- snapshot migration and event adaptation APIs from packages/core/src/machineVersions.ts -->
 
-Register lightweight snapshot descriptors for historical versions and retain an
-actual machine for each version that may be a restoration target. Every entry
-must have the same stable `id` and its own `version`.
+Register lightweight schema descriptors for historical versions and retain an
+actual machine for each version that may be a target. Every entry must have the
+same stable `id` and its own `version`.
 
 ```ts
-const checkoutV1 = snapshotVersion({
-  id: 'checkout',
-  version: '1',
-  // This version had no persisted children, history, timers or state inputs.
-  schema: z.object({
-    status: z.enum(['active', 'done', 'error', 'stopped']),
-    output: z.unknown().optional(),
-    error: z.unknown().optional(),
-    value: z.literal('active'),
-    context: z.object({ count: z.number() }),
-    children: z.object({}),
-    historyValue: z.object({}),
-    timers: z.object({}),
-    _nextActorId: z.number().optional(),
-    _nextTimerId: z.number(),
-    stateInputs: z.undefined().optional(),
-    machine: z.object({
-      id: z.literal('checkout'),
+const checkoutVersions = machineVersions([
+  {
+    id: 'checkout',
+    version: '1',
+    // This version had no persisted children, history, timers or state inputs.
+    snapshotSchema: z.object({
+      status: z.enum(['active', 'done', 'error', 'stopped']),
+      output: z.unknown().optional(),
+      error: z.unknown().optional(),
+      value: z.literal('active'),
+      context: z.object({ count: z.number() }),
+      children: z.object({}),
+      historyValue: z.object({}),
+      timers: z.object({}),
+      _nextActorId: z.number().optional(),
+      _nextTimerId: z.number(),
+      stateInputs: z.undefined().optional(),
+      machine: z.object({
+        id: z.literal('checkout'),
+        version: z.literal('1')
+      }),
       version: z.literal('1')
     }),
-    version: z.literal('1')
-  })
-});
-
-const checkoutVersions = machineVersions([checkoutV1, checkoutV2]);
+    eventSchema: z.discriminatedUnion('type', [
+      z.object({ type: z.literal('ADD'), value: z.number() }),
+      z.object({ type: z.literal('REMOVE'), value: z.number() })
+    ])
+  },
+  checkoutV2
+]);
 const snapshot = await checkoutVersions.migrateSnapshot(
   JSON.parse(localStorage.getItem('checkout')!),
   {
@@ -80,7 +85,7 @@ Exact version keys narrow the callback to that historical schema's output type.
 Migration is direct to the target machine and may be asynchronous. You do not
 need to retain old executable machines or define every intermediate version.
 
-A snapshot schema describes the entire persisted contract, not only context:
+A `snapshotSchema` describes the entire persisted contract, not only context:
 status/output/error, state value, context, children, history, timers, state
 inputs, counters and version metadata as applicable. Active state nodes are
 reconstructed from the state value, so `nodes` itself is not persisted. Existing
@@ -167,15 +172,14 @@ Every result, including a same-version history, is validated against available
 target event schemas. If no applicable adapter exists, adaptation throws. An
 exact adapter's error propagates instead of falling through to `'*'`.
 
-`snapshotVersion()` descriptors participate only in snapshot parsing and
-migration. Exact event adapters and event targets require actual machines, whose
-event schemas provide typing and runtime validation. Histories identified with a
-snapshot-only version may still use the unknown `'*'` adapter.
+An `eventSchema` validates each complete historical event object and infers the
+exact adapter's event union. A descriptor may provide `snapshotSchema`,
+`eventSchema` or both. If the relevant schema is absent, that operation may use
+its unknown `'*'` handler instead. Actual machines continue to work directly as
+entries and supply their existing snapshot and event types.
 
-The descriptor is intentionally named and scoped to snapshots rather than being
-a general `machineVersion({ snapshot, events })` bundle. This prevents a
-snapshot schema from implying event validation and leaves room for a separate
-event descriptor if one is needed later.
+Exact event and snapshot targets require actual machines. A schema descriptor
+describes historical data but cannot interpret restored state or receive events.
 
 `adaptEvents()` only adapts a materialized history. It does not store or replay
 events and does not produce a snapshot.

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -121,8 +121,9 @@ const snapshot = await checkoutVersions.migrateSnapshot(persisted, {
 An exact version migration runs before `'*'`. If neither matches, migration
 throws. Standard Schema validation may itself be asynchronous. There is no
 separate lazy-loader API: use an async Standard Schema or the existing `'*'`
-route when schema code must be imported conditionally. The target context schema
-validates the result before its machine identity and version are stamped.
+route when schema code must be imported conditionally. The target machine's
+snapshot schema validates the stamped result, so a migration must produce a
+valid `status`, a state value the target machine can resolve, and `children`.
 
 The `to` version must be backed by an actual machine, because it interprets the
 restored state. `machine.version` remains the compatibility stamp written to the

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -30,10 +30,35 @@ Persisted snapshots record current state. Event sourcing records the events that
 
 <!-- snapshot migration and event adaptation APIs from packages/core/src/machineVersions.ts -->
 
-Register the machine versions whose persisted data you want parsed and typed.
-Each machine must have the same stable `id` and its own `version`.
+Register lightweight snapshot descriptors for historical versions and retain an
+actual machine for each version that may be a restoration target. Every entry
+must have the same stable `id` and its own `version`.
 
 ```ts
+const checkoutV1 = snapshotVersion({
+  id: 'checkout',
+  version: '1',
+  // This version had no persisted children, history, timers or state inputs.
+  schema: z.object({
+    status: z.enum(['active', 'done', 'error', 'stopped']),
+    output: z.unknown().optional(),
+    error: z.unknown().optional(),
+    value: z.literal('active'),
+    context: z.object({ count: z.number() }),
+    children: z.object({}),
+    historyValue: z.object({}),
+    timers: z.object({}),
+    _nextActorId: z.number().optional(),
+    _nextTimerId: z.number(),
+    stateInputs: z.undefined().optional(),
+    machine: z.object({
+      id: z.literal('checkout'),
+      version: z.literal('1')
+    }),
+    version: z.literal('1')
+  })
+});
+
 const checkoutVersions = machineVersions([checkoutV1, checkoutV2]);
 const snapshot = await checkoutVersions.migrateSnapshot(
   JSON.parse(localStorage.getItem('checkout')!),
@@ -51,9 +76,15 @@ const snapshot = await checkoutVersions.migrateSnapshot(
 const actor = createActor(checkoutV2, { snapshot }).start();
 ```
 
-Exact version keys narrow the callback to that retained machine's snapshot type.
+Exact version keys narrow the callback to that historical schema's output type.
 Migration is direct to the target machine and may be asynchronous. You do not
-need to define every intermediate version.
+need to retain old executable machines or define every intermediate version.
+
+A snapshot schema describes the entire persisted contract, not only context:
+status/output/error, state value, context, children, history, timers, state
+inputs, counters and version metadata as applicable. Active state nodes are
+reconstructed from the state value, so `nodes` itself is not persisted. Existing
+versioned machines remain valid registry entries.
 
 Use `'*'` to handle any snapshot that cannot use an exact retained version. The
 snapshot is `unknown`, so the migration can inspect its shape or load an old
@@ -75,12 +106,18 @@ const snapshot = await checkoutVersions.migrateSnapshot(persisted, {
 ```
 
 An exact version migration runs before `'*'`. If neither matches, migration
-throws. The target context schema validates the result before its machine
-identity and version are stamped.
+throws. Standard Schema validation may itself be asynchronous. There is no
+separate lazy-loader API: use an async Standard Schema or the existing `'*'`
+route when schema code must be imported conditionally. The target context schema
+validates the result before its machine identity and version are stamped.
+
+The `to` version must be backed by an actual machine, because it interprets the
+restored state. `machine.version` remains the compatibility stamp written to the
+nested machine identity and legacy top-level `version` field.
 
 When adopting versioning for snapshots that were already persisted without a
-version, retain the old machine definition as an explicit version and configure it
-as `unversioned`:
+version, describe the old snapshot contract as an explicit version and configure
+it as `unversioned`:
 
 ```ts
 const checkoutVersions = machineVersions([checkoutV0, checkoutV1], {
@@ -129,6 +166,16 @@ event schema is available; unrecognized histories may fall through to `'*'`.
 Every result, including a same-version history, is validated against available
 target event schemas. If no applicable adapter exists, adaptation throws. An
 exact adapter's error propagates instead of falling through to `'*'`.
+
+`snapshotVersion()` descriptors participate only in snapshot parsing and
+migration. Exact event adapters and event targets require actual machines, whose
+event schemas provide typing and runtime validation. Histories identified with a
+snapshot-only version may still use the unknown `'*'` adapter.
+
+The descriptor is intentionally named and scoped to snapshots rather than being
+a general `machineVersion({ snapshot, events })` bundle. This prevents a
+snapshot schema from implying event validation and leaves room for a separate
+event descriptor if one is needed later.
 
 `adaptEvents()` only adapts a materialized history. It does not store or replay
 events and does not produce a snapshot.

--- a/docs/xstate-v5-to-v6.md
+++ b/docs/xstate-v5-to-v6.md
@@ -1114,13 +1114,16 @@ const persisted = actor.getPersistedSnapshot();
 
 Machines without a `version` produce snapshots with no `version` key.
 
-Keep old versioned machines when you need typed migration. `machineVersions()`
-parses stored snapshots with matching machine schemas and migrates raw snapshots
-directly to a retained target version. A `'*'` migration may asynchronously
-handle unknown snapshots without retaining old machines.
+Pass `{ id, version, snapshotSchema, eventSchema }` to retain Standard Schema
+contracts for a historical version without retaining its old executable machine.
+Either schema may be omitted when only one kind of historical data exists.
+`machineVersions()` infers exact snapshot migration and event adapter inputs from
+the corresponding schema. Targets must be backed by actual machines, which also
+remain supported directly as entries. A `'*'` handler may asynchronously handle
+unknown data.
 
-To migrate snapshots created before versioning was adopted, retain the old machine
-definition as a version and pass `{ unversioned: '<old-version>' }` to
+To migrate snapshots created before versioning was adopted, describe the old
+snapshot as a version and pass `{ unversioned: '<old-version>' }` to
 `machineVersions()`. This fallback applies only to snapshots without version
 metadata. `parseSnapshot()` rejects explicit unknown versions;
 `migrateSnapshot()` may handle them with `'*'`.
@@ -1130,6 +1133,8 @@ Event history adaptation is a separate operation. Use
 whole source history into target-version events. Exact retained-version
 adapters are typed; `'*'` receives unknown events. Adaptation validates target
 event schemas when available but does not replay events or create a snapshot.
+Descriptors with an `eventSchema` provide exact event adapters. The schema
+validates complete event objects rather than machine `schemas.events` payloads.
 
 ### Durable timers
 

--- a/docs/xstate-v5-to-v6.md
+++ b/docs/xstate-v5-to-v6.md
@@ -1122,6 +1122,10 @@ the corresponding schema. Targets must be backed by actual machines, which also
 remain supported directly as entries. A `'*'` handler may asynchronously handle
 unknown data.
 
+Versioned machines expose the same `snapshotSchema` and `eventSchema` fields as
+historical descriptors. `machineVersions()` therefore consumes one source
+interface; executable-machine detection is only used to constrain `to`.
+
 To migrate snapshots created before versioning was adopted, describe the old
 snapshot as a version and pass `{ unversioned: '<old-version>' }` to
 `machineVersions()`. This fallback applies only to snapshots without version

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -285,7 +285,11 @@ export class StateMachine<
           if (value === null || typeof value !== 'object') {
             return { issues: [{ message: 'Expected a persisted snapshot.' }] };
           }
-          const snapshot = value as Record<string, unknown>;
+          const snapshot: Record<string, unknown> = {
+            historyValue: {},
+            timers: {},
+            ...(value as Record<string, unknown>)
+          };
           const contextSchema = this.schemas?.context;
           let context = snapshot.context;
           if (contextSchema) {
@@ -301,12 +305,7 @@ export class StateMachine<
             }
             context = result.value;
           }
-          for (const key of [
-            'value',
-            'children',
-            'historyValue',
-            'timers'
-          ] as const) {
+          for (const key of ['value', 'children'] as const) {
             if (!(key in snapshot)) {
               return {
                 issues: [{ message: `Persisted snapshot is missing '${key}'.` }]

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -88,6 +88,8 @@ import {
 } from './utils.ts';
 import { assertValid } from './validation.ts';
 import type { ActorLogicValidator } from './validation.types.ts';
+import type { StandardSchemaV1 } from './schema.types.ts';
+import type { PersistedMachineSnapshot } from './machineVersion.types.ts';
 
 const STATE_IDENTIFIER = '#';
 
@@ -205,6 +207,15 @@ export class StateMachine<
 
   public schemas: AnyMachineSchemas | undefined;
 
+  /** Standard Schema for snapshots persisted by this machine version. */
+  public readonly snapshotSchema: StandardSchemaV1<
+    unknown,
+    Snapshot<unknown> & PersistedMachineSnapshot & { context: TContext }
+  >;
+
+  /** Standard Schema for complete events accepted by this machine version. */
+  public readonly eventSchema: StandardSchemaV1<unknown, TEvent>;
+
   public sources: Sources;
 
   /** Runtime options for machine execution. */
@@ -266,6 +277,133 @@ export class StateMachine<
     }
     this.version = this.config.version;
     this.schemas = this.config.schemas;
+    this.snapshotSchema = {
+      '~standard': {
+        version: 1,
+        vendor: 'xstate',
+        validate: async (value) => {
+          if (value === null || typeof value !== 'object') {
+            return { issues: [{ message: 'Expected a persisted snapshot.' }] };
+          }
+          const snapshot = value as Record<string, unknown>;
+          const contextSchema = this.schemas?.context;
+          let context = snapshot.context;
+          if (contextSchema) {
+            const result = await contextSchema['~standard'].validate(context);
+            if (result.issues) {
+              return {
+                issues: [
+                  {
+                    message: `Invalid context for machine '${this.id}' version '${this.version}': ${result.issues[0]?.message}`
+                  }
+                ]
+              };
+            }
+            context = result.value;
+          }
+          for (const key of [
+            'value',
+            'children',
+            'historyValue',
+            'timers'
+          ] as const) {
+            if (!(key in snapshot)) {
+              return {
+                issues: [{ message: `Persisted snapshot is missing '${key}'.` }]
+              };
+            }
+          }
+          if (
+            !['active', 'done', 'error', 'stopped'].includes(
+              snapshot.status as string
+            )
+          ) {
+            return {
+              issues: [{ message: 'Persisted snapshot has invalid status.' }]
+            };
+          }
+          for (const key of ['children', 'historyValue', 'timers'] as const) {
+            if (
+              snapshot[key] === null ||
+              typeof snapshot[key] !== 'object' ||
+              Array.isArray(snapshot[key])
+            ) {
+              return {
+                issues: [
+                  { message: `Persisted snapshot has invalid '${key}'.` }
+                ]
+              };
+            }
+          }
+          try {
+            this.resolveState({
+              value: snapshot.value as StateValue,
+              context
+            } as any);
+          } catch (error) {
+            return {
+              issues: [
+                {
+                  message:
+                    error instanceof Error
+                      ? error.message
+                      : 'Persisted snapshot has invalid state value.'
+                }
+              ]
+            };
+          }
+          return {
+            value: { ...snapshot, context } as Snapshot<unknown> &
+              PersistedMachineSnapshot & { context: TContext }
+          };
+        }
+      }
+    };
+    this.eventSchema = {
+      '~standard': {
+        version: 1,
+        vendor: 'xstate',
+        validate: async (value) => {
+          if (
+            value === null ||
+            typeof value !== 'object' ||
+            typeof (value as EventObject).type !== 'string'
+          ) {
+            return { issues: [{ message: 'Expected an event object.' }] };
+          }
+          const event = value as EventObject;
+          const eventSchemas = this.schemas?.events;
+          const isFrameworkEvent =
+            event.type.startsWith('xstate.') ||
+            event.type.startsWith('@xstate.');
+          const schema =
+            eventSchemas && Object.hasOwn(eventSchemas, event.type)
+              ? eventSchemas[event.type]
+              : undefined;
+          if (eventSchemas && !schema && !isFrameworkEvent) {
+            return {
+              issues: [
+                {
+                  message: `Unknown event '${event.type}' for machine '${this.id}' version '${this.version}'.`
+                }
+              ]
+            };
+          }
+          if (!schema) {
+            return { value: event as TEvent };
+          }
+          const { type, ...payload } = event;
+          const result = await schema['~standard'].validate(payload);
+          if (result.issues) {
+            return result;
+          }
+          if (result.value === null || typeof result.value !== 'object') {
+            return { issues: [{ message: 'Expected an event payload.' }] };
+          }
+          return { value: { ...result.value, type } as TEvent };
+        }
+      }
+    };
     this.internalEventDescriptors = this.config.internalEvents ?? [];
     this.options = {
       maxIterations: Infinity,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,7 @@ export {
 export { mapState } from './mapState.ts';
 export {
   machineVersions,
+  snapshotVersion,
   type AdaptEventsOptions,
   type EventAdapterHandlers,
   type EventHistorySource,
@@ -90,9 +91,11 @@ export {
   type MachineVersionsOptions,
   type ParsedPersistedSnapshot,
   type PersistedMachineIdentity,
+  type PersistedMachineSnapshot,
   type PersistedSnapshotDataFrom,
   type PersistedSnapshotSource,
   type SnapshotMigrationHandlers,
+  type SnapshotVersion,
   type PersistedSnapshotFrom
 } from './machineVersions.ts';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,19 +83,18 @@ export {
 export { mapState } from './mapState.ts';
 export {
   machineVersions,
-  snapshotVersion,
   type AdaptEventsOptions,
   type EventAdapterHandlers,
   type EventHistorySource,
   type MigrateSnapshotOptions,
   type MachineVersionsOptions,
+  type MachineVersionDescriptor,
   type ParsedPersistedSnapshot,
   type PersistedMachineIdentity,
   type PersistedMachineSnapshot,
   type PersistedSnapshotDataFrom,
   type PersistedSnapshotSource,
   type SnapshotMigrationHandlers,
-  type SnapshotVersion,
   type PersistedSnapshotFrom
 } from './machineVersions.ts';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,6 +87,8 @@ export {
   type EventAdapterHandlers,
   type EventHistorySource,
   type MigrateSnapshotOptions,
+  type MachineEventSchema,
+  type MachineSnapshotSchema,
   type MachineVersionsOptions,
   type MachineVersionDescriptor,
   type ParsedPersistedSnapshot,

--- a/packages/core/src/machineVersion.types.ts
+++ b/packages/core/src/machineVersion.types.ts
@@ -1,0 +1,44 @@
+import type { StandardSchemaV1 } from './schema.types.ts';
+import type { EventObject, Snapshot } from './types.ts';
+
+/** Durable machine snapshot fields that a historical snapshot schema describes. */
+export type PersistedMachineSnapshot = {
+  status: Snapshot<unknown>['status'];
+  output?: unknown;
+  error?: unknown;
+  value: unknown;
+  context: unknown;
+  children: Record<string, unknown>;
+  historyValue: Record<string, unknown>;
+  timers: Record<string, unknown>;
+  _nextActorId?: number;
+  _nextTimerId?: number;
+  stateInputs?: Record<string, Record<string, unknown>>;
+  machine?: { id: string; version: string };
+  version?: string;
+  [key: string]: unknown;
+};
+
+/** A Standard Schema for a complete persisted machine snapshot. */
+export type MachineSnapshotSchema = StandardSchemaV1<
+  unknown,
+  PersistedMachineSnapshot
+>;
+
+/** A Standard Schema for a complete persisted event object. */
+export type MachineEventSchema = StandardSchemaV1<unknown, EventObject>;
+
+/** Schema-backed capabilities for one machine version. */
+export type MachineVersionDescriptor = {
+  id: string;
+  version: string;
+} & (
+  | {
+      snapshotSchema: MachineSnapshotSchema;
+      eventSchema?: MachineEventSchema;
+    }
+  | {
+      snapshotSchema?: MachineSnapshotSchema;
+      eventSchema: MachineEventSchema;
+    }
+);

--- a/packages/core/src/machineVersions.ts
+++ b/packages/core/src/machineVersions.ts
@@ -39,29 +39,26 @@ export type PersistedMachineSnapshot = {
   [key: string]: unknown;
 };
 
-/** A schema-backed historical machine snapshot version. */
-export type SnapshotVersion<
-  TId extends string = string,
-  TVersion extends string = string,
-  TSchema extends StandardSchemaV1<unknown, PersistedMachineSnapshot> =
-    StandardSchemaV1<unknown, PersistedMachineSnapshot>
-> = {
-  kind: 'snapshot';
-  id: TId;
-  version: TVersion;
-  schema: TSchema;
-};
+/** A Standard Schema for a complete persisted machine snapshot. */
+type SnapshotSchema = StandardSchemaV1<unknown, PersistedMachineSnapshot>;
+type EventSchema = StandardSchemaV1<unknown, EventObject>;
 
-type VersionEntry = VersionedStateMachine | SnapshotVersion;
+/** Schema-backed capabilities for one historical machine version. */
+export type MachineVersionDescriptor = {
+  id: string;
+  version: string;
+} & (
+  | {
+      snapshotSchema: SnapshotSchema;
+      eventSchema?: EventSchema;
+    }
+  | {
+      snapshotSchema?: SnapshotSchema;
+      eventSchema: EventSchema;
+    }
+);
 
-/** Describes a historical persisted snapshot without retaining its machine. */
-export function snapshotVersion<
-  const TId extends string,
-  const TVersion extends string,
-  const TSchema extends StandardSchemaV1<unknown, PersistedMachineSnapshot>
->(descriptor: Omit<SnapshotVersion<TId, TVersion, TSchema>, 'kind'>) {
-  return { ...descriptor, kind: 'snapshot' as const };
-}
+type VersionEntry = VersionedStateMachine | MachineVersionDescriptor;
 
 export type PersistedSnapshotFrom<TMachine extends AnyStateMachine> =
   Snapshot<unknown> &
@@ -94,7 +91,7 @@ export type ParsedPersistedSnapshot<TEntries extends readonly VersionEntry[]> =
   }[number];
 
 export type MachineVersionsOptions<TEntries extends readonly VersionEntry[]> = {
-  unversioned?: TEntries[number]['version'];
+  unversioned?: SnapshotSourceVersion<TEntries>;
 };
 
 type MaybePromise<T> = T | PromiseLike<T>;
@@ -104,8 +101,21 @@ type MachineVersion<TEntries extends readonly VersionEntry[]> = Extract<
   VersionedStateMachine
 >['version'];
 
-type EntryVersion<TEntries extends readonly VersionEntry[]> =
-  TEntries[number]['version'];
+type SnapshotSourceVersion<TEntries extends readonly VersionEntry[]> = {
+  [K in keyof TEntries]: TEntries[K] extends
+    | VersionedStateMachine
+    | { snapshotSchema: SnapshotSchema }
+    ? TEntries[K]['version']
+    : never;
+}[number];
+
+type EventSourceVersion<TEntries extends readonly VersionEntry[]> = {
+  [K in keyof TEntries]: TEntries[K] extends
+    | VersionedStateMachine
+    | { eventSchema: EventSchema }
+    ? TEntries[K]['version']
+    : never;
+}[number];
 
 type MachineForVersion<
   TEntries extends readonly VersionEntry[],
@@ -118,23 +128,47 @@ type MachineForVersion<
     : never;
 }[number];
 
-type EntryForVersion<
+type SnapshotEntryForVersion<
   TEntries extends readonly VersionEntry[],
   TVersion extends string
 > = {
-  [K in keyof TEntries]: TEntries[K] extends VersionEntry
+  [K in keyof TEntries]: TEntries[K] extends
+    | VersionedStateMachine
+    | { snapshotSchema: SnapshotSchema }
     ? TEntries[K]['version'] extends TVersion
       ? TEntries[K]
       : never
     : never;
 }[number];
 
-type PersistedSnapshotFromEntry<TEntry extends VersionEntry> =
-  TEntry extends SnapshotVersion<string, string, infer TSchema>
-    ? StandardSchemaV1.InferOutput<TSchema>
-    : TEntry extends VersionedStateMachine
-      ? PersistedSnapshotFrom<TEntry>
-      : never;
+type EventEntryForVersion<
+  TEntries extends readonly VersionEntry[],
+  TVersion extends string
+> = {
+  [K in keyof TEntries]: TEntries[K] extends
+    | VersionedStateMachine
+    | { eventSchema: EventSchema }
+    ? TEntries[K]['version'] extends TVersion
+      ? TEntries[K]
+      : never
+    : never;
+}[number];
+
+type PersistedSnapshotFromEntry<TEntry extends VersionEntry> = TEntry extends {
+  snapshotSchema: infer TSchema extends SnapshotSchema;
+}
+  ? StandardSchemaV1.InferOutput<TSchema>
+  : TEntry extends VersionedStateMachine
+    ? PersistedSnapshotFrom<TEntry>
+    : never;
+
+type EventFromEntry<TEntry extends VersionEntry> = TEntry extends {
+  eventSchema: infer TSchema extends EventSchema;
+}
+  ? StandardSchemaV1.InferOutput<TSchema>
+  : TEntry extends VersionedStateMachine
+    ? EventFrom<TEntry>
+    : never;
 
 export type PersistedSnapshotSource = {
   id?: string;
@@ -145,8 +179,10 @@ export type SnapshotMigrationHandlers<
   TEntries extends readonly VersionEntry[],
   TTarget extends VersionedStateMachine
 > = {
-  [TVersion in Exclude<EntryVersion<TEntries>, TTarget['version']>]?: (
-    snapshot: PersistedSnapshotFromEntry<EntryForVersion<TEntries, TVersion>>
+  [TVersion in Exclude<SnapshotSourceVersion<TEntries>, TTarget['version']>]?: (
+    snapshot: PersistedSnapshotFromEntry<
+      SnapshotEntryForVersion<TEntries, TVersion>
+    >
   ) => MaybePromise<PersistedSnapshotDataFrom<TTarget>>;
 } & {
   '*'?: (
@@ -175,8 +211,8 @@ export type EventAdapterHandlers<
   TEntries extends readonly VersionEntry[],
   TTarget extends VersionedStateMachine
 > = {
-  [TVersion in Exclude<MachineVersion<TEntries>, TTarget['version']>]?: (
-    events: readonly EventFrom<MachineForVersion<TEntries, TVersion>>[]
+  [TVersion in Exclude<EventSourceVersion<TEntries>, TTarget['version']>]?: (
+    events: readonly EventFromEntry<EventEntryForVersion<TEntries, TVersion>>[]
   ) => MaybePromise<readonly EventFrom<TTarget>[]>;
 } & {
   '*'?: (
@@ -201,8 +237,25 @@ function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object';
 }
 
-function isSnapshotVersion(entry: VersionEntry): entry is SnapshotVersion {
-  return (entry as SnapshotVersion).kind === 'snapshot';
+function isVersionedStateMachine(
+  entry: VersionEntry
+): entry is VersionedStateMachine {
+  return (
+    'transition' in entry &&
+    typeof (entry as VersionedStateMachine).transition === 'function'
+  );
+}
+
+function hasSnapshotSchema(
+  entry: VersionEntry
+): entry is MachineVersionDescriptor & { snapshotSchema: SnapshotSchema } {
+  return 'snapshotSchema' in entry && entry.snapshotSchema !== undefined;
+}
+
+function hasEventSchema(
+  entry: VersionEntry
+): entry is MachineVersionDescriptor & { eventSchema: EventSchema } {
+  return 'eventSchema' in entry && entry.eventSchema !== undefined;
 }
 
 function getSnapshotSource(
@@ -298,6 +351,25 @@ async function validateEvents<TMachine extends VersionedStateMachine>(
   );
 }
 
+async function validateDescriptorEvents(
+  events: readonly unknown[],
+  descriptor: MachineVersionDescriptor & { eventSchema: EventSchema }
+): Promise<EventObject[]> {
+  return Promise.all(
+    events.map(async (event, index) => {
+      const validated = await validate(
+        descriptor.eventSchema,
+        event,
+        `event at index ${index} for machine '${descriptor.id}' version '${descriptor.version}'`
+      );
+      if (!isObject(validated) || typeof validated.type !== 'string') {
+        throw new Error(`Invalid event at index ${index}.`);
+      }
+      return validated as EventObject;
+    })
+  );
+}
+
 /** Creates migration and adaptation utilities for versions of one machine. */
 export function machineVersions<
   const TEntries extends readonly [VersionEntry, ...VersionEntry[]]
@@ -327,7 +399,7 @@ export function machineVersions<
       );
     }
     byIdentity.set(key, entry);
-    if (!isSnapshotVersion(entry)) {
+    if (isVersionedStateMachine(entry)) {
       machinesByIdentity.set(key, entry);
     }
   }
@@ -381,24 +453,31 @@ export function machineVersions<
       throw new Error(`Unknown machine identity '${id}' version '${version}'.`);
     }
 
-    const snapshot = isSnapshotVersion(source)
-      ? await validate(
-          source.schema,
-          raw,
-          `snapshot for machine '${id}' version '${version}'`
+    let snapshot: unknown;
+    if (hasSnapshotSchema(source)) {
+      snapshot = await validate(
+        source.snapshotSchema,
+        raw,
+        `snapshot for machine '${id}' version '${version}'`
+      );
+    } else if (isVersionedStateMachine(source)) {
+      snapshot = {
+        ...raw,
+        context: await validate(
+          source.schemas?.context,
+          raw.context,
+          `context for machine '${id}' version '${version}'`
         )
-      : {
-          ...raw,
-          context: await validate(
-            source.schemas?.context,
-            raw.context,
-            `context for machine '${id}' version '${version}'`
-          )
-        };
+      };
+    } else {
+      throw new Error(
+        `Machine version '${version}' does not define a snapshot schema.`
+      );
+    }
 
     return {
       source,
-      ...(!isSnapshotVersion(source) && { machine: source }),
+      ...(isVersionedStateMachine(source) && { machine: source }),
       snapshot: {
         ...(snapshot as Record<string, unknown>),
         machine: { id, version }
@@ -423,21 +502,25 @@ export function machineVersions<
       }
 
       const sourceId = adaptationOptions.from.id ?? machineId;
-      const source = machinesByIdentity.get(
+      const source = byIdentity.get(
         `${sourceId}\0${adaptationOptions.from.version}`
       );
       let sourceError: unknown;
       let sourceValidationFailed = false;
-      if (source) {
+      const hasTypedSource =
+        source && (isVersionedStateMachine(source) || hasEventSchema(source));
+      if (hasTypedSource) {
         let sourceEvents: EventObject[] | undefined;
         try {
-          sourceEvents = await validateEvents(events, source);
+          sourceEvents = isVersionedStateMachine(source)
+            ? await validateEvents(events, source)
+            : await validateDescriptorEvents(events, source);
         } catch (error) {
           sourceError = error;
           sourceValidationFailed = true;
         }
         if (sourceEvents) {
-          if (source === target) {
+          if (isVersionedStateMachine(source) && source === target) {
             return sourceEvents as EventFrom<TargetMachine>[];
           }
           const adapter = (
@@ -464,7 +547,7 @@ export function machineVersions<
           target
         );
       }
-      if (source) {
+      if (hasTypedSource) {
         if (sourceValidationFailed) {
           throw sourceError instanceof Error
             ? sourceError

--- a/packages/core/src/machineVersions.ts
+++ b/packages/core/src/machineVersions.ts
@@ -21,6 +21,48 @@ type VersionedStateMachine = AnyStateMachine & {
   schemas?: AnyMachineSchemas;
 };
 
+/** Durable machine snapshot fields that a historical snapshot schema describes. */
+export type PersistedMachineSnapshot = {
+  status: Snapshot<unknown>['status'];
+  output?: unknown;
+  error?: unknown;
+  value: unknown;
+  context: unknown;
+  children: Record<string, unknown>;
+  historyValue: Record<string, unknown>;
+  timers: Record<string, unknown>;
+  _nextActorId?: number;
+  _nextTimerId?: number;
+  stateInputs?: Record<string, Record<string, unknown>>;
+  machine?: { id: string; version: string };
+  version?: string;
+  [key: string]: unknown;
+};
+
+/** A schema-backed historical machine snapshot version. */
+export type SnapshotVersion<
+  TId extends string = string,
+  TVersion extends string = string,
+  TSchema extends StandardSchemaV1<unknown, PersistedMachineSnapshot> =
+    StandardSchemaV1<unknown, PersistedMachineSnapshot>
+> = {
+  kind: 'snapshot';
+  id: TId;
+  version: TVersion;
+  schema: TSchema;
+};
+
+type VersionEntry = VersionedStateMachine | SnapshotVersion;
+
+/** Describes a historical persisted snapshot without retaining its machine. */
+export function snapshotVersion<
+  const TId extends string,
+  const TVersion extends string,
+  const TSchema extends StandardSchemaV1<unknown, PersistedMachineSnapshot>
+>(descriptor: Omit<SnapshotVersion<TId, TVersion, TSchema>, 'kind'>) {
+  return { ...descriptor, kind: 'snapshot' as const };
+}
+
 export type PersistedSnapshotFrom<TMachine extends AnyStateMachine> =
   Snapshot<unknown> &
     PersistedSnapshotFor<TMachine> & {
@@ -35,38 +77,64 @@ export type PersistedSnapshotDataFrom<TMachine extends AnyStateMachine> =
     [key: string]: unknown;
   };
 
-export type ParsedPersistedSnapshot<
-  TMachines extends readonly AnyStateMachine[]
-> = {
-  [K in keyof TMachines]: TMachines[K] extends AnyStateMachine
-    ? {
-        machine: TMachines[K];
-        snapshot: PersistedSnapshotFrom<TMachines[K]>;
-      }
-    : never;
-}[number];
+export type ParsedPersistedSnapshot<TEntries extends readonly VersionEntry[]> =
+  {
+    [K in keyof TEntries]: TEntries[K] extends VersionEntry
+      ? TEntries[K] extends VersionedStateMachine
+        ? {
+            source: TEntries[K];
+            machine: TEntries[K];
+            snapshot: PersistedSnapshotFromEntry<TEntries[K]>;
+          }
+        : {
+            source: TEntries[K];
+            snapshot: PersistedSnapshotFromEntry<TEntries[K]>;
+          }
+      : never;
+  }[number];
 
-export type MachineVersionsOptions<
-  TMachines extends readonly AnyStateMachine[]
-> = {
-  unversioned?: NonNullable<TMachines[number]['version']>;
+export type MachineVersionsOptions<TEntries extends readonly VersionEntry[]> = {
+  unversioned?: TEntries[number]['version'];
 };
 
 type MaybePromise<T> = T | PromiseLike<T>;
 
-type MachineVersion<TMachines extends readonly VersionedStateMachine[]> =
-  TMachines[number]['version'];
+type MachineVersion<TEntries extends readonly VersionEntry[]> = Extract<
+  TEntries[number],
+  VersionedStateMachine
+>['version'];
+
+type EntryVersion<TEntries extends readonly VersionEntry[]> =
+  TEntries[number]['version'];
 
 type MachineForVersion<
-  TMachines extends readonly VersionedStateMachine[],
+  TEntries extends readonly VersionEntry[],
   TVersion extends string
 > = {
-  [K in keyof TMachines]: TMachines[K] extends VersionedStateMachine
-    ? TMachines[K]['version'] extends TVersion
-      ? TMachines[K]
+  [K in keyof TEntries]: TEntries[K] extends VersionedStateMachine
+    ? TEntries[K]['version'] extends TVersion
+      ? TEntries[K]
       : never
     : never;
 }[number];
+
+type EntryForVersion<
+  TEntries extends readonly VersionEntry[],
+  TVersion extends string
+> = {
+  [K in keyof TEntries]: TEntries[K] extends VersionEntry
+    ? TEntries[K]['version'] extends TVersion
+      ? TEntries[K]
+      : never
+    : never;
+}[number];
+
+type PersistedSnapshotFromEntry<TEntry extends VersionEntry> =
+  TEntry extends SnapshotVersion<string, string, infer TSchema>
+    ? StandardSchemaV1.InferOutput<TSchema>
+    : TEntry extends VersionedStateMachine
+      ? PersistedSnapshotFrom<TEntry>
+      : never;
 
 export type PersistedSnapshotSource = {
   id?: string;
@@ -74,11 +142,11 @@ export type PersistedSnapshotSource = {
 };
 
 export type SnapshotMigrationHandlers<
-  TMachines extends readonly VersionedStateMachine[],
+  TEntries extends readonly VersionEntry[],
   TTarget extends VersionedStateMachine
 > = {
-  [TVersion in Exclude<MachineVersion<TMachines>, TTarget['version']>]?: (
-    snapshot: PersistedSnapshotFrom<MachineForVersion<TMachines, TVersion>>
+  [TVersion in Exclude<EntryVersion<TEntries>, TTarget['version']>]?: (
+    snapshot: PersistedSnapshotFromEntry<EntryForVersion<TEntries, TVersion>>
   ) => MaybePromise<PersistedSnapshotDataFrom<TTarget>>;
 } & {
   '*'?: (
@@ -88,13 +156,13 @@ export type SnapshotMigrationHandlers<
 };
 
 export type MigrateSnapshotOptions<
-  TMachines extends readonly VersionedStateMachine[],
-  TTargetVersion extends MachineVersion<TMachines>
+  TEntries extends readonly VersionEntry[],
+  TTargetVersion extends MachineVersion<TEntries>
 > = {
   to: TTargetVersion;
   migrations: SnapshotMigrationHandlers<
-    TMachines,
-    MachineForVersion<TMachines, TTargetVersion>
+    TEntries,
+    MachineForVersion<TEntries, TTargetVersion>
   >;
 };
 
@@ -104,11 +172,11 @@ export type EventHistorySource = {
 };
 
 export type EventAdapterHandlers<
-  TMachines extends readonly VersionedStateMachine[],
+  TEntries extends readonly VersionEntry[],
   TTarget extends VersionedStateMachine
 > = {
-  [TVersion in Exclude<MachineVersion<TMachines>, TTarget['version']>]?: (
-    events: readonly EventFrom<MachineForVersion<TMachines, TVersion>>[]
+  [TVersion in Exclude<MachineVersion<TEntries>, TTarget['version']>]?: (
+    events: readonly EventFrom<MachineForVersion<TEntries, TVersion>>[]
   ) => MaybePromise<readonly EventFrom<TTarget>[]>;
 } & {
   '*'?: (
@@ -118,19 +186,23 @@ export type EventAdapterHandlers<
 };
 
 export type AdaptEventsOptions<
-  TMachines extends readonly VersionedStateMachine[],
-  TTargetVersion extends MachineVersion<TMachines>
+  TEntries extends readonly VersionEntry[],
+  TTargetVersion extends MachineVersion<TEntries>
 > = {
   from: EventHistorySource;
   to: TTargetVersion;
   adapters: EventAdapterHandlers<
-    TMachines,
-    MachineForVersion<TMachines, TTargetVersion>
+    TEntries,
+    MachineForVersion<TEntries, TTargetVersion>
   >;
 };
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object';
+}
+
+function isSnapshotVersion(entry: VersionEntry): entry is SnapshotVersion {
+  return (entry as SnapshotVersion).kind === 'snapshot';
 }
 
 function getSnapshotSource(
@@ -226,37 +298,38 @@ async function validateEvents<TMachine extends VersionedStateMachine>(
   );
 }
 
-/** Creates migration and adaptation utilities backed by retained versions of one machine. */
+/** Creates migration and adaptation utilities for versions of one machine. */
 export function machineVersions<
-  const TMachines extends readonly [
-    VersionedStateMachine,
-    ...VersionedStateMachine[]
-  ]
->(machines: TMachines, options?: MachineVersionsOptions<TMachines>) {
-  const byIdentity = new Map<string, VersionedStateMachine>();
-  const machineId = machines[0].id;
+  const TEntries extends readonly [VersionEntry, ...VersionEntry[]]
+>(entries: TEntries, options?: MachineVersionsOptions<TEntries>) {
+  const byIdentity = new Map<string, VersionEntry>();
+  const machinesByIdentity = new Map<string, VersionedStateMachine>();
+  const machineId = entries[0].id;
 
-  for (const machine of machines) {
-    if (machine.version === undefined) {
-      throw new Error(`Machine '${machine.id}' must define a version.`);
+  for (const entry of entries) {
+    if (entry.version === undefined) {
+      throw new Error(`Machine '${entry.id}' must define a version.`);
     }
-    if (machine.version === '*') {
+    if (entry.version === '*') {
       throw new Error(
         "Machine version '*' is reserved for wildcard migrations."
       );
     }
-    if (machine.id !== machineId) {
+    if (entry.id !== machineId) {
       throw new Error(
-        `Machine '${machine.id}' does not match machine ID '${machineId}'.`
+        `Machine '${entry.id}' does not match machine ID '${machineId}'.`
       );
     }
-    const key = `${machine.id}\0${machine.version}`;
+    const key = `${entry.id}\0${entry.version}`;
     if (byIdentity.has(key)) {
       throw new Error(
-        `Duplicate machine identity '${machine.id}' version '${machine.version}'.`
+        `Duplicate machine identity '${entry.id}' version '${entry.version}'.`
       );
     }
-    byIdentity.set(key, machine);
+    byIdentity.set(key, entry);
+    if (!isSnapshotVersion(entry)) {
+      machinesByIdentity.set(key, entry);
+    }
   }
 
   if (
@@ -270,7 +343,7 @@ export function machineVersions<
 
   const parseSnapshot = async (
     raw: unknown
-  ): Promise<ParsedPersistedSnapshot<TMachines>> => {
+  ): Promise<ParsedPersistedSnapshot<TEntries>> => {
     if (!isObject(raw)) {
       throw new Error('Persisted snapshot is missing machine identity.');
     }
@@ -303,45 +376,54 @@ export function machineVersions<
       );
     }
 
-    const machine = byIdentity.get(`${id}\0${version}`);
-    if (!machine) {
+    const source = byIdentity.get(`${id}\0${version}`);
+    if (!source) {
       throw new Error(`Unknown machine identity '${id}' version '${version}'.`);
     }
 
-    const context = await validate(
-      machine.schemas?.context,
-      raw.context,
-      `context for machine '${id}' version '${version}'`
-    );
+    const snapshot = isSnapshotVersion(source)
+      ? await validate(
+          source.schema,
+          raw,
+          `snapshot for machine '${id}' version '${version}'`
+        )
+      : {
+          ...raw,
+          context: await validate(
+            source.schemas?.context,
+            raw.context,
+            `context for machine '${id}' version '${version}'`
+          )
+        };
 
     return {
-      machine,
+      source,
+      ...(!isSnapshotVersion(source) && { machine: source }),
       snapshot: {
-        ...raw,
-        context,
+        ...(snapshot as Record<string, unknown>),
         machine: { id, version }
       }
-    } as ParsedPersistedSnapshot<TMachines>;
+    } as ParsedPersistedSnapshot<TEntries>;
   };
 
   return {
     parseSnapshot,
-    async adaptEvents<TTargetVersion extends MachineVersion<TMachines>>(
+    async adaptEvents<TTargetVersion extends MachineVersion<TEntries>>(
       events: readonly unknown[],
-      adaptationOptions: AdaptEventsOptions<TMachines, TTargetVersion>
-    ): Promise<EventFrom<MachineForVersion<TMachines, TTargetVersion>>[]> {
-      type TargetMachine = MachineForVersion<TMachines, TTargetVersion>;
-      const target = byIdentity.get(`${machineId}\0${adaptationOptions.to}`) as
-        | TargetMachine
-        | undefined;
+      adaptationOptions: AdaptEventsOptions<TEntries, TTargetVersion>
+    ): Promise<EventFrom<MachineForVersion<TEntries, TTargetVersion>>[]> {
+      type TargetMachine = MachineForVersion<TEntries, TTargetVersion>;
+      const target = machinesByIdentity.get(
+        `${machineId}\0${adaptationOptions.to}`
+      ) as TargetMachine | undefined;
       if (!target) {
         throw new Error(
-          `Target version '${adaptationOptions.to}' is not retained for machine '${machineId}'.`
+          `Target version '${adaptationOptions.to}' is not backed by a machine for '${machineId}'.`
         );
       }
 
       const sourceId = adaptationOptions.from.id ?? machineId;
-      const source = byIdentity.get(
+      const source = machinesByIdentity.get(
         `${sourceId}\0${adaptationOptions.from.version}`
       );
       let sourceError: unknown;
@@ -399,23 +481,23 @@ export function machineVersions<
         `Unknown event history source '${sourceId}' version '${adaptationOptions.from.version}'.`
       );
     },
-    async migrateSnapshot<TTargetVersion extends MachineVersion<TMachines>>(
+    async migrateSnapshot<TTargetVersion extends MachineVersion<TEntries>>(
       raw: unknown,
-      migrationOptions: MigrateSnapshotOptions<TMachines, TTargetVersion>
+      migrationOptions: MigrateSnapshotOptions<TEntries, TTargetVersion>
     ): Promise<
-      PersistedSnapshotFrom<MachineForVersion<TMachines, TTargetVersion>>
+      PersistedSnapshotFrom<MachineForVersion<TEntries, TTargetVersion>>
     > {
-      type TargetMachine = MachineForVersion<TMachines, TTargetVersion>;
-      const target = byIdentity.get(`${machineId}\0${migrationOptions.to}`) as
-        | TargetMachine
-        | undefined;
+      type TargetMachine = MachineForVersion<TEntries, TTargetVersion>;
+      const target = machinesByIdentity.get(
+        `${machineId}\0${migrationOptions.to}`
+      ) as TargetMachine | undefined;
       if (!target) {
         throw new Error(
-          `Target version '${migrationOptions.to}' is not retained for machine '${machineId}'.`
+          `Target version '${migrationOptions.to}' is not backed by a machine for '${machineId}'.`
         );
       }
 
-      let source: ParsedPersistedSnapshot<TMachines> | undefined;
+      let source: ParsedPersistedSnapshot<TEntries> | undefined;
       let parseError: unknown;
       try {
         source = await parseSnapshot(raw);
@@ -424,7 +506,7 @@ export function machineVersions<
       }
 
       if (source) {
-        if (source.machine.version === target.version) {
+        if (source.source.version === target.version) {
           return finalizeSnapshot(
             source.snapshot as PersistedSnapshotDataFrom<TargetMachine>,
             target
@@ -438,7 +520,7 @@ export function machineVersions<
               ) => MaybePromise<PersistedSnapshotDataFrom<TargetMachine>>)
             | undefined
           >
-        )[source.machine.version];
+        )[source.source.version];
         if (exactMigration) {
           return finalizeSnapshot(
             await exactMigration(source.snapshot),
@@ -451,7 +533,7 @@ export function machineVersions<
       if (!wildcardMigration) {
         if (source) {
           throw new Error(
-            `No snapshot migration from version '${source.machine.version}' to '${target.version}' for machine '${target.id}'.`
+            `No snapshot migration from version '${source.source.version}' to '${target.version}' for machine '${target.id}'.`
           );
         }
         throw parseError;

--- a/packages/core/src/machineVersions.ts
+++ b/packages/core/src/machineVersions.ts
@@ -1,5 +1,15 @@
 import type { StandardSchemaV1 } from './schema.types.ts';
-import type { AnyMachineSchemas } from './types.v6.ts';
+import type {
+  MachineEventSchema,
+  MachineSnapshotSchema,
+  MachineVersionDescriptor
+} from './machineVersion.types.ts';
+export type {
+  MachineEventSchema,
+  MachineSnapshotSchema,
+  MachineVersionDescriptor,
+  PersistedMachineSnapshot
+} from './machineVersion.types.ts';
 import type {
   AnyStateMachine,
   ContextFrom,
@@ -18,47 +28,11 @@ export type PersistedMachineIdentity<
 
 type VersionedStateMachine = AnyStateMachine & {
   version: string;
-  schemas?: AnyMachineSchemas;
+  snapshotSchema: MachineSnapshotSchema;
+  eventSchema: MachineEventSchema;
 };
 
-/** Durable machine snapshot fields that a historical snapshot schema describes. */
-export type PersistedMachineSnapshot = {
-  status: Snapshot<unknown>['status'];
-  output?: unknown;
-  error?: unknown;
-  value: unknown;
-  context: unknown;
-  children: Record<string, unknown>;
-  historyValue: Record<string, unknown>;
-  timers: Record<string, unknown>;
-  _nextActorId?: number;
-  _nextTimerId?: number;
-  stateInputs?: Record<string, Record<string, unknown>>;
-  machine?: { id: string; version: string };
-  version?: string;
-  [key: string]: unknown;
-};
-
-/** A Standard Schema for a complete persisted machine snapshot. */
-type SnapshotSchema = StandardSchemaV1<unknown, PersistedMachineSnapshot>;
-type EventSchema = StandardSchemaV1<unknown, EventObject>;
-
-/** Schema-backed capabilities for one historical machine version. */
-export type MachineVersionDescriptor = {
-  id: string;
-  version: string;
-} & (
-  | {
-      snapshotSchema: SnapshotSchema;
-      eventSchema?: EventSchema;
-    }
-  | {
-      snapshotSchema?: SnapshotSchema;
-      eventSchema: EventSchema;
-    }
-);
-
-type VersionEntry = VersionedStateMachine | MachineVersionDescriptor;
+type VersionEntry = MachineVersionDescriptor;
 
 export type PersistedSnapshotFrom<TMachine extends AnyStateMachine> =
   Snapshot<unknown> &
@@ -104,7 +78,7 @@ type MachineVersion<TEntries extends readonly VersionEntry[]> = Extract<
 type SnapshotSourceVersion<TEntries extends readonly VersionEntry[]> = {
   [K in keyof TEntries]: TEntries[K] extends
     | VersionedStateMachine
-    | { snapshotSchema: SnapshotSchema }
+    | { snapshotSchema: MachineSnapshotSchema }
     ? TEntries[K]['version']
     : never;
 }[number];
@@ -112,7 +86,7 @@ type SnapshotSourceVersion<TEntries extends readonly VersionEntry[]> = {
 type EventSourceVersion<TEntries extends readonly VersionEntry[]> = {
   [K in keyof TEntries]: TEntries[K] extends
     | VersionedStateMachine
-    | { eventSchema: EventSchema }
+    | { eventSchema: MachineEventSchema }
     ? TEntries[K]['version']
     : never;
 }[number];
@@ -134,7 +108,7 @@ type SnapshotEntryForVersion<
 > = {
   [K in keyof TEntries]: TEntries[K] extends
     | VersionedStateMachine
-    | { snapshotSchema: SnapshotSchema }
+    | { snapshotSchema: MachineSnapshotSchema }
     ? TEntries[K]['version'] extends TVersion
       ? TEntries[K]
       : never
@@ -147,7 +121,7 @@ type EventEntryForVersion<
 > = {
   [K in keyof TEntries]: TEntries[K] extends
     | VersionedStateMachine
-    | { eventSchema: EventSchema }
+    | { eventSchema: MachineEventSchema }
     ? TEntries[K]['version'] extends TVersion
       ? TEntries[K]
       : never
@@ -155,7 +129,7 @@ type EventEntryForVersion<
 }[number];
 
 type PersistedSnapshotFromEntry<TEntry extends VersionEntry> = TEntry extends {
-  snapshotSchema: infer TSchema extends SnapshotSchema;
+  snapshotSchema: infer TSchema extends MachineSnapshotSchema;
 }
   ? StandardSchemaV1.InferOutput<TSchema>
   : TEntry extends VersionedStateMachine
@@ -163,7 +137,7 @@ type PersistedSnapshotFromEntry<TEntry extends VersionEntry> = TEntry extends {
     : never;
 
 type EventFromEntry<TEntry extends VersionEntry> = TEntry extends {
-  eventSchema: infer TSchema extends EventSchema;
+  eventSchema: infer TSchema extends MachineEventSchema;
 }
   ? StandardSchemaV1.InferOutput<TSchema>
   : TEntry extends VersionedStateMachine
@@ -248,13 +222,15 @@ function isVersionedStateMachine(
 
 function hasSnapshotSchema(
   entry: VersionEntry
-): entry is MachineVersionDescriptor & { snapshotSchema: SnapshotSchema } {
+): entry is MachineVersionDescriptor & {
+  snapshotSchema: MachineSnapshotSchema;
+} {
   return 'snapshotSchema' in entry && entry.snapshotSchema !== undefined;
 }
 
 function hasEventSchema(
   entry: VersionEntry
-): entry is MachineVersionDescriptor & { eventSchema: EventSchema } {
+): entry is MachineVersionDescriptor & { eventSchema: MachineEventSchema } {
   return 'eventSchema' in entry && entry.eventSchema !== undefined;
 }
 
@@ -299,73 +275,45 @@ async function finalizeSnapshot<TTarget extends VersionedStateMachine>(
   snapshot: PersistedSnapshotDataFrom<TTarget>,
   target: TTarget
 ): Promise<PersistedSnapshotFrom<TTarget>> {
-  const context = await validate(
-    target.schemas?.context,
-    snapshot.context,
-    `context for machine '${target.id}' version '${target.version}'`
-  );
-
-  return {
-    ...snapshot,
-    context,
-    machine: { id: target.id, version: target.version },
-    version: target.version
-  } as unknown as PersistedSnapshotFrom<TTarget>;
+  return (await validate(
+    target.snapshotSchema,
+    {
+      ...snapshot,
+      machine: { id: target.id, version: target.version },
+      version: target.version
+    },
+    `snapshot for machine '${target.id}' version '${target.version}'`
+  )) as PersistedSnapshotFrom<TTarget>;
 }
 
-async function validateEvents<TMachine extends VersionedStateMachine>(
+async function validateEvents<
+  TSource extends MachineVersionDescriptor & {
+    eventSchema: MachineEventSchema;
+  }
+>(
   events: readonly unknown[],
-  machine: TMachine
-): Promise<EventFrom<TMachine>[]> {
+  source: TSource
+): Promise<EventFromEntry<TSource>[]> {
   return Promise.all(
     events.map(async (event, index) => {
-      if (!isObject(event) || typeof event.type !== 'string') {
-        throw new Error(`Invalid event at index ${index}.`);
-      }
-      const eventSchemas = machine.schemas?.events;
-      const isFrameworkEvent =
-        event.type.startsWith('xstate.') || event.type.startsWith('@xstate.');
-      const schema =
-        eventSchemas && Object.hasOwn(eventSchemas, event.type)
-          ? eventSchemas[event.type]
-          : undefined;
-      if (eventSchemas && !schema && !isFrameworkEvent) {
+      const result = await source.eventSchema['~standard'].validate(event);
+      if (result.issues) {
+        const message = result.issues[0]?.message;
+        if (message?.startsWith('Unknown event ')) {
+          throw new Error(message);
+        }
+        const type = isObject(event) ? event.type : undefined;
         throw new Error(
-          `Unknown event '${event.type}' for machine '${machine.id}' version '${machine.version}'.`
+          typeof type === 'string'
+            ? `Invalid event '${type}' at index ${index}${message ? `: ${message}` : '.'}`
+            : `Invalid event at index ${index}${message ? `: ${message}` : '.'}`
         );
       }
-      if (!schema) {
-        return event as EventFrom<TMachine>;
-      }
-      const { type, ...payload } = event;
-      const validatedPayload = await validate(
-        schema,
-        payload,
-        `event '${type}' at index ${index}`
-      );
-      if (!isObject(validatedPayload)) {
-        throw new Error(`Invalid event '${type}' at index ${index}.`);
-      }
-      return { ...validatedPayload, type } as EventFrom<TMachine>;
-    })
-  );
-}
-
-async function validateDescriptorEvents(
-  events: readonly unknown[],
-  descriptor: MachineVersionDescriptor & { eventSchema: EventSchema }
-): Promise<EventObject[]> {
-  return Promise.all(
-    events.map(async (event, index) => {
-      const validated = await validate(
-        descriptor.eventSchema,
-        event,
-        `event at index ${index} for machine '${descriptor.id}' version '${descriptor.version}'`
-      );
+      const validated = result.value;
       if (!isObject(validated) || typeof validated.type !== 'string') {
         throw new Error(`Invalid event at index ${index}.`);
       }
-      return validated as EventObject;
+      return validated as EventFromEntry<TSource>;
     })
   );
 }
@@ -453,27 +401,16 @@ export function machineVersions<
       throw new Error(`Unknown machine identity '${id}' version '${version}'.`);
     }
 
-    let snapshot: unknown;
-    if (hasSnapshotSchema(source)) {
-      snapshot = await validate(
-        source.snapshotSchema,
-        raw,
-        `snapshot for machine '${id}' version '${version}'`
-      );
-    } else if (isVersionedStateMachine(source)) {
-      snapshot = {
-        ...raw,
-        context: await validate(
-          source.schemas?.context,
-          raw.context,
-          `context for machine '${id}' version '${version}'`
-        )
-      };
-    } else {
+    if (!hasSnapshotSchema(source)) {
       throw new Error(
         `Machine version '${version}' does not define a snapshot schema.`
       );
     }
+    const snapshot = await validate(
+      source.snapshotSchema,
+      raw,
+      `snapshot for machine '${id}' version '${version}'`
+    );
 
     return {
       source,
@@ -507,20 +444,17 @@ export function machineVersions<
       );
       let sourceError: unknown;
       let sourceValidationFailed = false;
-      const hasTypedSource =
-        source && (isVersionedStateMachine(source) || hasEventSchema(source));
+      const hasTypedSource = source && hasEventSchema(source);
       if (hasTypedSource) {
         let sourceEvents: EventObject[] | undefined;
         try {
-          sourceEvents = isVersionedStateMachine(source)
-            ? await validateEvents(events, source)
-            : await validateDescriptorEvents(events, source);
+          sourceEvents = await validateEvents(events, source);
         } catch (error) {
           sourceError = error;
           sourceValidationFailed = true;
         }
         if (sourceEvents) {
-          if (isVersionedStateMachine(source) && source === target) {
+          if (source === target) {
             return sourceEvents as EventFrom<TargetMachine>[];
           }
           const adapter = (
@@ -535,7 +469,10 @@ export function machineVersions<
             >
           )[source.version];
           if (adapter) {
-            return validateEvents(await adapter(sourceEvents), target);
+            return validateEvents(
+              await adapter(sourceEvents),
+              target
+            ) as Promise<EventFrom<TargetMachine>[]>;
           }
         }
       }
@@ -545,7 +482,7 @@ export function machineVersions<
         return validateEvents(
           await wildcardAdapter(events, adaptationOptions.from),
           target
-        );
+        ) as Promise<EventFrom<TargetMachine>[]>;
       }
       if (hasTypedSource) {
         if (sourceValidationFailed) {

--- a/packages/core/src/machineVersions.ts
+++ b/packages/core/src/machineVersions.ts
@@ -497,6 +497,11 @@ export function machineVersions<
           `No event adapter from version '${source.version}' to '${target.version}' for machine '${target.id}'.`
         );
       }
+      if (source) {
+        throw new Error(
+          `Machine version '${source.version}' does not define an event schema; only the '*' adapter can handle its event history.`
+        );
+      }
       throw new Error(
         `Unknown event history source '${sourceId}' version '${adaptationOptions.from.version}'.`
       );

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1111,6 +1111,8 @@ export interface AnyStateMachine extends AnyActorLogic {
   config: any;
   version?: string;
   schemas?: import('./types.v6.ts').AnyMachineSchemas;
+  snapshotSchema: import('./machineVersion.types.ts').MachineSnapshotSchema;
+  eventSchema: import('./machineVersion.types.ts').MachineEventSchema;
   provide(sources: any): AnyStateMachine;
   resolveState(config: any): any;
   /** @internal */

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -2,6 +2,40 @@ import { z } from 'zod';
 import { createActor, createMachine, machineVersions, types } from '../src';
 
 describe('machineVersions', () => {
+  it('exposes the same version schemas on machines and descriptors', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '1',
+      schemas: {
+        context: z.object({ count: z.number() }),
+        events: { ADD: z.object({ value: z.number() }) }
+      },
+      context: { count: 0 },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const persisted = createActor(checkout).getPersistedSnapshot();
+
+    await expect(
+      checkout.snapshotSchema['~standard'].validate({
+        ...persisted,
+        context: { count: 1 }
+      })
+    ).resolves.toMatchObject({ value: { context: { count: 1 } } });
+    await expect(
+      checkout.eventSchema['~standard'].validate({
+        type: 'ADD',
+        value: 2
+      })
+    ).resolves.toEqual({ value: { type: 'ADD', value: 2 } });
+    await expect(
+      checkout.snapshotSchema['~standard'].validate({
+        ...persisted,
+        value: 'removed'
+      })
+    ).resolves.toHaveProperty('issues');
+  });
+
   it('migrates a historical snapshot validated by its complete schema', async () => {
     const checkoutV1 = {
       id: 'checkout',
@@ -817,9 +851,12 @@ describe('machineVersions', () => {
       states: { active: {} }
     });
     const versions = machineVersions([checkoutV1]);
+    const { machine: _, ...legacyPersisted } = createActor(
+      checkoutV1
+    ).getPersistedSnapshot() as Record<string, unknown>;
 
     const parsed = await versions.parseSnapshot({
-      version: '1',
+      ...legacyPersisted,
       context: { count: 2 }
     });
 

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -1,18 +1,12 @@
 import { z } from 'zod';
-import {
-  createActor,
-  createMachine,
-  machineVersions,
-  snapshotVersion,
-  types
-} from '../src';
+import { createActor, createMachine, machineVersions, types } from '../src';
 
 describe('machineVersions', () => {
   it('migrates a historical snapshot validated by its complete schema', async () => {
-    const checkoutV1 = snapshotVersion({
+    const checkoutV1 = {
       id: 'checkout',
       version: '1',
-      schema: z
+      snapshotSchema: z
         .object({
           status: z.literal('active'),
           output: z.undefined().optional(),
@@ -31,7 +25,7 @@ describe('machineVersions', () => {
           version: z.literal('1')
         })
         .passthrough()
-    });
+    } as const;
     const checkoutV2 = createMachine({
       id: 'checkout',
       version: '2',
@@ -51,7 +45,7 @@ describe('machineVersions', () => {
       _nextTimerId: 0,
       machine: { id: 'checkout', version: '1' },
       version: '1'
-    };
+    } as const;
 
     const compatible = await versions.migrateSnapshot(persisted, {
       to: '2',
@@ -81,10 +75,10 @@ describe('machineVersions', () => {
   });
 
   it('does not use a snapshot-only version as a restoration target', async () => {
-    const historical = snapshotVersion({
+    const historical = {
       id: 'checkout',
       version: '1',
-      schema: types<{
+      snapshotSchema: types<{
         status: 'active';
         value: 'active';
         context: {};
@@ -93,7 +87,7 @@ describe('machineVersions', () => {
         timers: {};
         _nextTimerId: number;
       }>()
-    });
+    } as const;
     const current = createMachine({
       id: 'checkout',
       version: '2',
@@ -110,10 +104,10 @@ describe('machineVersions', () => {
   });
 
   it('uses the unknown event adapter for snapshot-only source versions', async () => {
-    const historical = snapshotVersion({
+    const historical = {
       id: 'checkout',
       version: '1',
-      schema: types<{
+      snapshotSchema: types<{
         status: 'active';
         value: 'active';
         context: {};
@@ -122,7 +116,7 @@ describe('machineVersions', () => {
         timers: {};
         _nextTimerId: number;
       }>()
-    });
+    } as const;
     const current = createMachine({
       id: 'checkout',
       version: '2',
@@ -147,6 +141,95 @@ describe('machineVersions', () => {
         }
       })
     ).resolves.toEqual([{ type: 'CHANGE', delta: 2 }]);
+  });
+
+  it('adapts events from a historical event schema', async () => {
+    const historical = {
+      id: 'checkout',
+      version: '1',
+      eventSchema: z.discriminatedUnion('type', [
+        z.object({ type: z.literal('ADD'), value: z.number() }),
+        z.object({ type: z.literal('REMOVE'), value: z.number() })
+      ])
+    } as const;
+    const current = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: { CHANGE: z.object({ delta: z.number() }) }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([historical, current]);
+    const wildcard = vi.fn();
+
+    const events = await versions.adaptEvents(
+      [
+        { type: 'ADD', value: 5 },
+        { type: 'REMOVE', value: 2 }
+      ],
+      {
+        from: { version: '1' },
+        to: '2',
+        adapters: {
+          '1': (events) => [
+            {
+              type: 'CHANGE',
+              delta: events.reduce(
+                (total, event) =>
+                  total + (event.type === 'ADD' ? event.value : -event.value),
+                0
+              )
+            }
+          ],
+          '*': wildcard
+        }
+      }
+    );
+
+    expect(events).toEqual([{ type: 'CHANGE', delta: 3 }]);
+    expect(wildcard).not.toHaveBeenCalled();
+  });
+
+  it('routes invalid historical event-schema input to the wildcard', async () => {
+    const historical = {
+      id: 'checkout',
+      version: '1',
+      eventSchema: z.object({
+        type: z.literal('ADD'),
+        value: z.number()
+      })
+    } as const;
+    const current = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: { CHANGE: z.object({ delta: z.number() }) }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([historical, current]);
+    const exact = vi.fn();
+
+    const events = await versions.adaptEvents(
+      [{ type: 'ADD', value: 'invalid' }],
+      {
+        from: { version: '1' },
+        to: '2',
+        adapters: {
+          '1': exact,
+          '*': (events) => {
+            expect(events).toEqual([{ type: 'ADD', value: 'invalid' }]);
+            return [{ type: 'CHANGE', delta: 0 }];
+          }
+        }
+      }
+    );
+
+    expect(events).toEqual([{ type: 'CHANGE', delta: 0 }]);
+    expect(exact).not.toHaveBeenCalled();
   });
 
   it('adapts a whole event history through an async exact-version adapter', async () => {
@@ -804,10 +887,10 @@ describe('machineVersions', () => {
   });
 
   it('parses an unversioned snapshot through a historical schema', async () => {
-    const historical = snapshotVersion({
+    const historical = {
       id: 'checkout',
       version: '0',
-      schema: z.object({
+      snapshotSchema: z.object({
         status: z.literal('active'),
         output: z.undefined().optional(),
         error: z.undefined().optional(),
@@ -819,7 +902,7 @@ describe('machineVersions', () => {
         _nextActorId: z.number().optional(),
         _nextTimerId: z.number()
       })
-    });
+    } as const;
     const versions = machineVersions([historical], { unversioned: '0' });
 
     const parsed = await versions.parseSnapshot({

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -1,7 +1,154 @@
 import { z } from 'zod';
-import { createActor, createMachine, machineVersions, types } from '../src';
+import {
+  createActor,
+  createMachine,
+  machineVersions,
+  snapshotVersion,
+  types
+} from '../src';
 
 describe('machineVersions', () => {
+  it('migrates a historical snapshot validated by its complete schema', async () => {
+    const checkoutV1 = snapshotVersion({
+      id: 'checkout',
+      version: '1',
+      schema: z
+        .object({
+          status: z.literal('active'),
+          output: z.undefined().optional(),
+          error: z.undefined().optional(),
+          value: z.literal('active'),
+          context: z.object({ count: z.number() }),
+          children: z.record(z.string(), z.unknown()),
+          historyValue: z.record(z.string(), z.unknown()),
+          timers: z.record(z.string(), z.unknown()),
+          _nextActorId: z.number(),
+          _nextTimerId: z.number(),
+          machine: z.object({
+            id: z.literal('checkout'),
+            version: z.literal('1')
+          }),
+          version: z.literal('1')
+        })
+        .passthrough()
+    });
+    const checkoutV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      context: { total: 0 },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkoutV1, checkoutV2]);
+    const persisted = {
+      status: 'active',
+      value: 'active',
+      context: { count: 3 },
+      children: {},
+      historyValue: {},
+      timers: {},
+      _nextActorId: 0,
+      _nextTimerId: 0,
+      machine: { id: 'checkout', version: '1' },
+      version: '1'
+    };
+
+    const compatible = await versions.migrateSnapshot(persisted, {
+      to: '2',
+      migrations: {
+        '1': (snapshot) => ({
+          ...snapshot,
+          context: { total: snapshot.context.count }
+        })
+      }
+    });
+
+    expect(compatible.context).toEqual({ total: 3 });
+    await expect(
+      versions.migrateSnapshot(
+        { ...persisted, value: 'removed-state' },
+        {
+          to: '2',
+          migrations: {
+            '1': (snapshot) => ({
+              ...snapshot,
+              context: { total: snapshot.context.count }
+            })
+          }
+        }
+      )
+    ).rejects.toThrow("Invalid snapshot for machine 'checkout' version '1'");
+  });
+
+  it('does not use a snapshot-only version as a restoration target', async () => {
+    const historical = snapshotVersion({
+      id: 'checkout',
+      version: '1',
+      schema: types<{
+        status: 'active';
+        value: 'active';
+        context: {};
+        children: {};
+        historyValue: {};
+        timers: {};
+        _nextTimerId: number;
+      }>()
+    });
+    const current = createMachine({
+      id: 'checkout',
+      version: '2',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([historical, current]);
+
+    await expect(
+      versions.migrateSnapshot({}, { to: '1', migrations: {} } as any)
+    ).rejects.toThrow(
+      "Target version '1' is not backed by a machine for 'checkout'."
+    );
+  });
+
+  it('uses the unknown event adapter for snapshot-only source versions', async () => {
+    const historical = snapshotVersion({
+      id: 'checkout',
+      version: '1',
+      schema: types<{
+        status: 'active';
+        value: 'active';
+        context: {};
+        children: {};
+        historyValue: {};
+        timers: {};
+        _nextTimerId: number;
+      }>()
+    });
+    const current = createMachine({
+      id: 'checkout',
+      version: '2',
+      schemas: {
+        events: { CHANGE: z.object({ delta: z.number() }) }
+      },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([historical, current]);
+
+    await expect(
+      versions.adaptEvents([{ type: 'ADD', value: 2 }], {
+        from: { version: '1' },
+        to: '2',
+        adapters: {
+          '*': async (events, source) => {
+            expect(events).toEqual([{ type: 'ADD', value: 2 }]);
+            expect(source).toEqual({ version: '1' });
+            return [{ type: 'CHANGE', delta: 2 }];
+          }
+        }
+      })
+    ).resolves.toEqual([{ type: 'CHANGE', delta: 2 }]);
+  });
+
   it('adapts a whole event history through an async exact-version adapter', async () => {
     const checkoutV1 = createMachine({
       id: 'checkout',
@@ -654,6 +801,42 @@ describe('machineVersions', () => {
     const actor = createActor(checkoutV1, { snapshot: compatible }).start();
 
     expect(actor.getSnapshot().context).toEqual({ total: 2 });
+  });
+
+  it('parses an unversioned snapshot through a historical schema', async () => {
+    const historical = snapshotVersion({
+      id: 'checkout',
+      version: '0',
+      schema: z.object({
+        status: z.literal('active'),
+        output: z.undefined().optional(),
+        error: z.undefined().optional(),
+        value: z.literal('active'),
+        context: z.object({ count: z.number() }),
+        children: z.object({}),
+        historyValue: z.object({}),
+        timers: z.object({}),
+        _nextActorId: z.number().optional(),
+        _nextTimerId: z.number()
+      })
+    });
+    const versions = machineVersions([historical], { unversioned: '0' });
+
+    const parsed = await versions.parseSnapshot({
+      status: 'active',
+      value: 'active',
+      context: { count: 1 },
+      children: {},
+      historyValue: {},
+      timers: {},
+      _nextTimerId: 0
+    });
+
+    expect(parsed.source).toBe(historical);
+    expect(parsed.snapshot).toMatchObject({
+      context: { count: 1 },
+      machine: { id: 'checkout', version: '0' }
+    });
   });
 
   it('does not use the unversioned policy for an explicit unknown version', async () => {

--- a/packages/core/test/machineVersions.test.ts
+++ b/packages/core/test/machineVersions.test.ts
@@ -177,6 +177,38 @@ describe('machineVersions', () => {
     ).resolves.toEqual([{ type: 'CHANGE', delta: 2 }]);
   });
 
+  it('reports when a registered source has no event schema', async () => {
+    const historical = {
+      id: 'checkout',
+      version: '1',
+      snapshotSchema: types<{
+        status: 'active';
+        value: 'active';
+        context: {};
+        children: {};
+        historyValue: {};
+        timers: {};
+      }>()
+    } as const;
+    const current = createMachine({
+      id: 'checkout',
+      version: '2',
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([historical, current]);
+
+    await expect(
+      versions.adaptEvents([], {
+        from: { version: '1' },
+        to: '2',
+        adapters: {}
+      })
+    ).rejects.toThrow(
+      "Machine version '1' does not define an event schema; only the '*' adapter can handle its event history."
+    );
+  });
+
   it('adapts events from a historical event schema', async () => {
     const historical = {
       id: 'checkout',
@@ -669,6 +701,40 @@ describe('machineVersions', () => {
         }
       )
     ).rejects.toThrow("Invalid context for machine 'checkout' version '2'");
+  });
+
+  it('defaults restoration-optional bookkeeping in migration output', async () => {
+    const checkout = createMachine({
+      id: 'checkout',
+      version: '2',
+      context: { total: 0 },
+      initial: 'active',
+      states: { active: {} }
+    });
+    const versions = machineVersions([checkout]);
+
+    const compatible = await versions.migrateSnapshot(
+      {},
+      {
+        to: '2',
+        migrations: {
+          '*': () => ({
+            status: 'active',
+            output: undefined,
+            error: undefined,
+            value: 'active',
+            context: { total: 3 },
+            children: {}
+          })
+        }
+      }
+    );
+
+    expect(compatible).toMatchObject({ historyValue: {}, timers: {} });
+    expect(
+      createActor(checkout, { snapshot: compatible }).start().getSnapshot()
+        .context
+    ).toEqual({ total: 3 });
   });
 
   it('routes an unretained source version to the wildcard', async () => {

--- a/packages/core/test/machineVersions.types.test.ts
+++ b/packages/core/test/machineVersions.types.test.ts
@@ -2,7 +2,6 @@ import {
   createActor,
   createMachine,
   machineVersions,
-  snapshotVersion,
   setup,
   types
 } from '../src';
@@ -27,10 +26,10 @@ const checkoutV2 = createMachine({
   initial: 'active',
   states: { active: {} }
 });
-const checkoutV0 = snapshotVersion({
+const checkoutV0 = {
   id: 'checkout',
   version: '0',
-  schema: types<{
+  snapshotSchema: types<{
     status: 'active';
     output?: undefined;
     error?: undefined;
@@ -44,7 +43,7 @@ const checkoutV0 = snapshotVersion({
     machine: { id: 'checkout'; version: '0' };
     version: '0';
   }>()
-});
+} as const;
 
 const version: '1' = checkoutV1.version;
 const setupVersion: '1' = setup({}).createMachine({
@@ -86,13 +85,27 @@ const eventMachineV2 = createMachine({
   initial: 'active',
   states: { active: {} }
 });
+const eventVersionV0 = {
+  id: 'events',
+  version: '0',
+  eventSchema: types<
+    | { type: 'INCREMENT'; amount: number }
+    | { type: 'DECREMENT'; amount: number }
+  >()
+} as const;
 const eventVersions = machineVersions([eventMachineV1, eventMachineV2]);
+const eventDescriptorVersions = machineVersions([
+  eventVersionV0,
+  eventMachineV2
+]);
 
 if (false) {
   // @ts-expect-error version parsers require versioned machines
   machineVersions([unversioned]);
   // @ts-expect-error unversioned must reference a retained version
   machineVersions([checkoutV1, checkoutV2], { unversioned: '3' });
+  // @ts-expect-error event-only descriptors cannot parse unversioned snapshots
+  machineVersions([eventVersionV0, eventMachineV2], { unversioned: '0' });
 }
 
 async function checkSnapshotMigrationTypes() {
@@ -175,6 +188,30 @@ async function checkSnapshotMigrationTypes() {
 }
 
 async function checkEventAdaptationTypes() {
+  await eventDescriptorVersions.adaptEvents([], {
+    from: { id: 'events', version: '0' },
+    to: '2',
+    adapters: {
+      '0': (events) => {
+        const event = events[0];
+        if (event?.type === 'INCREMENT') {
+          const amount: number = event.amount;
+          // @ts-expect-error historical event schema has no delta
+          event.delta;
+          void amount;
+        }
+        return [{ type: 'CHANGE', delta: events.length }];
+      }
+    }
+  });
+
+  await eventDescriptorVersions.adaptEvents([], {
+    from: { id: 'events', version: '2' },
+    // @ts-expect-error schema-only versions cannot be event targets
+    to: '0',
+    adapters: {}
+  });
+
   await machineVersions([checkoutV0, eventMachineV2]).adaptEvents([], {
     from: { id: 'checkout', version: '0' },
     to: '2',

--- a/packages/core/test/machineVersions.types.test.ts
+++ b/packages/core/test/machineVersions.types.test.ts
@@ -1,6 +1,7 @@
 import {
   createActor,
   createMachine,
+  type MachineVersionDescriptor,
   machineVersions,
   setup,
   types
@@ -98,6 +99,8 @@ const eventDescriptorVersions = machineVersions([
   eventVersionV0,
   eventMachineV2
 ]);
+const machineVersionDescriptor: MachineVersionDescriptor = eventMachineV1;
+void machineVersionDescriptor;
 
 if (false) {
   // @ts-expect-error version parsers require versioned machines

--- a/packages/core/test/machineVersions.types.test.ts
+++ b/packages/core/test/machineVersions.types.test.ts
@@ -2,6 +2,7 @@ import {
   createActor,
   createMachine,
   machineVersions,
+  snapshotVersion,
   setup,
   types
 } from '../src';
@@ -26,6 +27,24 @@ const checkoutV2 = createMachine({
   initial: 'active',
   states: { active: {} }
 });
+const checkoutV0 = snapshotVersion({
+  id: 'checkout',
+  version: '0',
+  schema: types<{
+    status: 'active';
+    output?: undefined;
+    error?: undefined;
+    value: 'legacy';
+    context: { quantity: number };
+    children: Record<string, unknown>;
+    historyValue: Record<string, unknown>;
+    timers: Record<string, unknown>;
+    _nextActorId: number;
+    _nextTimerId: number;
+    machine: { id: 'checkout'; version: '0' };
+    version: '0';
+  }>()
+});
 
 const version: '1' = checkoutV1.version;
 const setupVersion: '1' = setup({}).createMachine({
@@ -35,6 +54,7 @@ const setupVersion: '1' = setup({}).createMachine({
   states: { active: {} }
 }).version;
 const versions = machineVersions([checkoutV1, checkoutV2]);
+const schemaVersions = machineVersions([checkoutV0, checkoutV2]);
 const versionsWithUnversioned = machineVersions([checkoutV1, checkoutV2], {
   unversioned: '1'
 });
@@ -76,6 +96,32 @@ if (false) {
 }
 
 async function checkSnapshotMigrationTypes() {
+  await schemaVersions.migrateSnapshot({} as unknown, {
+    to: '2',
+    migrations: {
+      '0': (snapshot) => {
+        const quantity: number = snapshot.context.quantity;
+        const value: 'legacy' = snapshot.value;
+        // @ts-expect-error descriptor schema output has no v2 context field
+        snapshot.context.total;
+        void value;
+        return {
+          ...snapshot,
+          context: { total: quantity }
+        };
+      }
+    }
+  });
+
+  await schemaVersions.migrateSnapshot(
+    {},
+    {
+      // @ts-expect-error snapshot-only versions cannot be migration targets
+      to: '0',
+      migrations: {}
+    }
+  );
+
   const compatible = await versions.migrateSnapshot({} as unknown, {
     to: '2',
     migrations: {
@@ -129,6 +175,15 @@ async function checkSnapshotMigrationTypes() {
 }
 
 async function checkEventAdaptationTypes() {
+  await machineVersions([checkoutV0, eventMachineV2]).adaptEvents([], {
+    from: { id: 'checkout', version: '0' },
+    to: '2',
+    adapters: {
+      // @ts-expect-error snapshot-only versions do not provide event typing
+      '0': () => [{ type: 'CHANGE', delta: 0 }]
+    }
+  });
+
   const adapted = await eventVersions.adaptEvents([], {
     from: { id: 'events', version: '1' },
     to: '2',


### PR DESCRIPTION
## Summary

- make versioned machines expose `snapshotSchema` and `eventSchema`, satisfying the same `MachineVersionDescriptor` contract as historical descriptors
- make `machineVersions()` consume only those Standard Schema fields for snapshot parsing and event adaptation
- infer exact snapshot migration inputs from `snapshotSchema` and exact event adapter inputs from `eventSchema`
- allow historical descriptors to provide either schema or both; the missing capability can still use the wildcard handler
- require actual machines only for `to` targets, where executable logic must interpret restored state or receive adapted events
- preserve machine ID/version stamping, unversioned snapshot policy, async handlers, wildcard precedence, and target validation
- update persistence/migration docs and the changeset

## API

```ts
const versions = machineVersions([
  {
    id: 'checkout',
    version: '1',
    snapshotSchema: checkoutV1Snapshot,
    eventSchema: checkoutV1Event
  },
  checkoutV2
]);
```

Every entry now has one source shape: `{ id, version, snapshotSchema?, eventSchema? }`. A versioned machine implements it directly with generated Standard Schemas. Its snapshot schema validates the durable snapshot shape, state value, and configured context schema. Its event schema adapts the payload-oriented `schemas.events` map into validation for complete event objects.

Only machine-backed versions are legal `to` targets. Descriptor-only versions remain lightweight historical source capabilities.

No dedicated lazy-loader layer was added. Standard Schema validation may already be async, and the wildcard handler remains the conditional-import path for unknown schemas.

## Validation

- `pnpm test:core` — 2,182 passed, 32 skipped, 3 todo
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm changeset status --since=origin/next`
- `git diff --check`
