### PR TITLE
Throw descriptive error when persisted snapshot references a missing state

### DIFF
--- a/.changeset/wild-states-refuse.md
+++ b/.changeset/wild-states-refuse.md
@@ -2,7 +2,7 @@
 'xstate': patch
 ---
 
-Restoring a persisted snapshot whose state value references a state that no longer exists on the machine now throws a descriptive error instead of crashing deep in the interpreter, e.g.:
+Restoring a persisted snapshot whose state value references a state that no longer exists on the machine now throws a descriptive error, e.g.:
 
 ```
 Persisted snapshot references state 'reviewing' which does not exist on machine 'order-approval'.

--- a/.changeset/wild-states-refuse.md
+++ b/.changeset/wild-states-refuse.md
@@ -1,0 +1,11 @@
+---
+'xstate': patch
+---
+
+Restoring a persisted snapshot whose state value references a state that no longer exists on the machine now throws a descriptive error instead of crashing deep in the interpreter, e.g.:
+
+```
+Persisted snapshot references state 'reviewing' which does not exist on machine 'order-approval'.
+```
+
+Nested state values report the full state path (e.g. `'active.reviewing'`), and parallel state regions are validated as well.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -1306,6 +1306,35 @@ export class StateMachine<
     };
 
     const revivedHistoryValue = reviveHistoryValue(snapshotData.historyValue);
+
+    const validateStateValue = (
+      stateValue: StateValue,
+      node: AnyStateNode,
+      path: string[]
+    ): void => {
+      const missingStateError = (statePath: string[]) =>
+        new Error(
+          `Persisted snapshot references state '${statePath.join('.')}' which does not exist on machine '${this.id}'.`
+        );
+      if (typeof stateValue === 'string') {
+        if (!node.states[stateValue]) {
+          throw missingStateError(path.concat(stateValue));
+        }
+        return;
+      }
+      if (!stateValue || typeof stateValue !== 'object') {
+        return;
+      }
+      for (const key of Object.keys(stateValue)) {
+        const childNode = node.states[key];
+        if (!childNode) {
+          throw missingStateError(path.concat(key));
+        }
+        validateStateValue(stateValue[key]!, childNode, path.concat(key));
+      }
+    };
+    validateStateValue(snapshotData.value, this.root, []);
+
     const nodes = Array.from(
       getAllStateNodes(getStateNodes(this.root, snapshotData.value))
     );

--- a/packages/core/test/rehydration.test.ts
+++ b/packages/core/test/rehydration.test.ts
@@ -494,4 +494,169 @@ describe('rehydration', () => {
         .children.grandchild.getSnapshot().context.count
     ).toBe(1);
   });
+
+  describe('persisted state value validation', () => {
+    function restoreOnto(
+      machine: Parameters<typeof createActor>[0],
+      snapshot: ReturnType<
+        ReturnType<typeof createActor>['getPersistedSnapshot']
+      >
+    ) {
+      const restored = createActor(machine, { snapshot });
+      restored.subscribe({ error: () => {} });
+      restored.start();
+      return restored.getSnapshot();
+    }
+
+    it('should error with a descriptive message when the persisted state value references a top-level state that no longer exists', () => {
+      const machine = createMachine({
+        id: 'order-approval',
+        initial: 'reviewing',
+        states: { reviewing: {}, approved: {} }
+      });
+      const actorRef = createActor(machine).start();
+      const snapshot = actorRef.getPersistedSnapshot();
+      actorRef.stop();
+
+      const renamedMachine = createMachine({
+        id: 'order-approval',
+        initial: 'awaitingApproval',
+        states: { awaitingApproval: {}, approved: {} }
+      });
+
+      expect(restoreOnto(renamedMachine, snapshot)).toMatchObject({
+        status: 'error',
+        error: expect.objectContaining({
+          message:
+            "Persisted snapshot references state 'reviewing' which does not exist on machine 'order-approval'."
+        })
+      });
+    });
+
+    it('should error with the full state path when a nested state no longer exists', () => {
+      const machine = createMachine({
+        id: 'order-approval',
+        initial: 'active',
+        states: {
+          active: {
+            initial: 'reviewing',
+            states: { reviewing: {}, done: {} }
+          }
+        }
+      });
+      const actorRef = createActor(machine).start();
+      const snapshot = actorRef.getPersistedSnapshot();
+      actorRef.stop();
+
+      const renamedMachine = createMachine({
+        id: 'order-approval',
+        initial: 'active',
+        states: {
+          active: {
+            initial: 'awaitingApproval',
+            states: { awaitingApproval: {}, done: {} }
+          }
+        }
+      });
+
+      expect(restoreOnto(renamedMachine, snapshot)).toMatchObject({
+        status: 'error',
+        error: expect.objectContaining({
+          message:
+            "Persisted snapshot references state 'active.reviewing' which does not exist on machine 'order-approval'."
+        })
+      });
+    });
+
+    it('should error when a parent of a nested state value no longer exists', () => {
+      const machine = createMachine({
+        id: 'order-approval',
+        initial: 'active',
+        states: {
+          active: {
+            initial: 'reviewing',
+            states: { reviewing: {} }
+          }
+        }
+      });
+      const actorRef = createActor(machine).start();
+      const snapshot = actorRef.getPersistedSnapshot();
+      actorRef.stop();
+
+      const renamedMachine = createMachine({
+        id: 'order-approval',
+        initial: 'running',
+        states: {
+          running: {
+            initial: 'reviewing',
+            states: { reviewing: {} }
+          }
+        }
+      });
+
+      expect(restoreOnto(renamedMachine, snapshot)).toMatchObject({
+        status: 'error',
+        error: expect.objectContaining({
+          message:
+            "Persisted snapshot references state 'active' which does not exist on machine 'order-approval'."
+        })
+      });
+    });
+
+    it('should error when a region of a parallel state value no longer exists', () => {
+      const machine = createMachine({
+        id: 'order-approval',
+        type: 'parallel',
+        states: {
+          review: { initial: 'reviewing', states: { reviewing: {} } },
+          payment: { initial: 'pending', states: { pending: {} } }
+        }
+      });
+      const actorRef = createActor(machine).start();
+      const snapshot = actorRef.getPersistedSnapshot();
+      actorRef.stop();
+
+      const renamedMachine = createMachine({
+        id: 'order-approval',
+        type: 'parallel',
+        states: {
+          review: {
+            initial: 'awaitingApproval',
+            states: { awaitingApproval: {} }
+          },
+          payment: { initial: 'pending', states: { pending: {} } }
+        }
+      });
+
+      expect(restoreOnto(renamedMachine, snapshot)).toMatchObject({
+        status: 'error',
+        error: expect.objectContaining({
+          message:
+            "Persisted snapshot references state 'review.reviewing' which does not exist on machine 'order-approval'."
+        })
+      });
+    });
+
+    it('should restore successfully when the persisted state value is valid', () => {
+      const machine = createMachine({
+        id: 'order-approval',
+        type: 'parallel',
+        states: {
+          review: { initial: 'reviewing', states: { reviewing: {} } },
+          payment: { initial: 'pending', states: { pending: {} } }
+        }
+      });
+      const actorRef = createActor(machine).start();
+      const snapshot = actorRef.getPersistedSnapshot();
+      actorRef.stop();
+
+      const restored = createActor(machine, { snapshot }).start();
+
+      expect(restored.getSnapshot().status).toBe('active');
+      expect(restored.getSnapshot().value).toEqual({
+        review: 'reviewing',
+        payment: 'pending'
+      });
+    });
+  });
 });


### PR DESCRIPTION
## What changed

`restoreSnapshot` now validates the persisted state value against the machine's state nodes before rehydrating. If the state value references a state that no longer exists (e.g. a state was renamed between persist and restore), it throws a descriptive error naming the state path and machine:

```
Persisted snapshot references state 'reviewing' which does not exist on machine 'order-approval'.
```

Nested values report the full path (`'active.reviewing'`), and parallel regions are validated per-region.

## Why

Previously the failure surfaced as a generic error thrown from deep inside `getStateNodes` (`State 'reviewing' does not exist on 'order-approval'`), with no indication it came from restoring a persisted snapshot — and in some scenarios crashed with an unrelated `TypeError`. The new error flows through the existing restore-error channel (actor snapshot becomes `status: 'error'`), consistent with machine-ID and version mismatch errors.

## Notes for reviewers

- Validation is a pre-pass in `StateMachine.restoreSnapshot`; behavior for valid snapshots is unchanged.
- Tests added in `packages/core/test/rehydration.test.ts` (`persisted state value validation`): top-level rename, nested rename, renamed parent, renamed parallel-region child, and a valid-restore control.
- `pnpm test:core` (2180 passed), `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all clean. Changeset included (`xstate` patch).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5653" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->