### PR TITLE
Fix runtime validation types in createSystem setup

### DIFF
--- a/.changeset/tidy-ravens-validate.md
+++ b/.changeset/tidy-ravens-validate.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Fixed `createSystem(...).setup(...)` to preserve runtime validator types alongside typed actor registries. Validated setups now reject unsupported transforming schemas and carry validation into derived setups.

--- a/.changeset/tidy-ravens-validate.md
+++ b/.changeset/tidy-ravens-validate.md
@@ -3,3 +3,15 @@
 ---
 
 Fixed `createSystem(...).setup(...)` to preserve runtime validator types alongside typed actor registries. Validated setups now reject unsupported transforming schemas and carry validation into derived setups.
+
+Runtime validation can now also be installed on a derived setup when its inherited schemas are compatible:
+
+```ts
+import { setup } from 'xstate';
+import { standardSchemaValidator } from 'xstate/validation';
+import { z } from 'zod';
+
+const validated = setup({
+  schemas: { input: z.object({ id: z.string() }) }
+}).extend({ validator: standardSchemaValidator() });
+```

--- a/docs/setup-and-provide.md
+++ b/docs/setup-and-provide.md
@@ -30,6 +30,28 @@ const orderMachine = orderSetup.createMachine({
 
 Use `setup(...).extend(...)` to build a more specific setup from a shared one, merging schemas and sources.
 
+## Runtime validation
+
+<!-- runtime validation behavior from packages/core/src/setup.ts and packages/core/src/validation/index.ts -->
+
+Schemas provide type inference by default. Install `standardSchemaValidator()` to check actor inputs, events, snapshots and outputs at runtime:
+
+```ts
+import { setup } from 'xstate';
+import { standardSchemaValidator } from 'xstate/validation';
+import { z } from 'zod';
+
+const base = setup({
+  schemas: { input: z.object({ orderId: z.string() }) }
+});
+
+const validated = base.extend({
+  validator: standardSchemaValidator()
+});
+```
+
+Validation can be installed, replaced or disabled by a derived setup. Installing it checks inherited and new schemas for compatibility. Runtime validation is assertion-only, so schemas that transform one type into another are rejected; disable validation with `validator: undefined` when transformations are required.
+
 ## Sources on the machine
 
 `actions`, `guards`, `actors` and `delays` can be declared directly on `createMachine(...)` instead of on `setup(...)`. Use `setup(...)` when several machines share the same sources or when state schemas are needed.

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -165,6 +165,16 @@ type RuntimeValidationConstraint<TSchemas, TStates, TValidator> = [
     }
   : unknown;
 
+type RuntimeValidationCompatibility<TSchemas, TStates, TValidator> = [
+  TValidator
+] extends [ActorLogicValidator]
+  ? [TSchemas] extends [ValidateSetupSchemas<TSchemas>]
+    ? [TStates] extends [ValidateSetupStates<TStates>]
+      ? unknown
+      : RuntimeValidationDoesNotSupportTransformingSchemas
+    : RuntimeValidationDoesNotSupportTransformingSchemas
+  : unknown;
+
 declare const inheritedValidator: unique symbol;
 type InheritedValidator = typeof inheritedValidator;
 
@@ -203,10 +213,7 @@ type SetupExtensionConfig<
   'validator'
 > &
   ExtendValidatorConfig<TExtendValidator> &
-  (TBaseValidator extends ActorLogicValidator
-    ? unknown
-    : { validator?: never }) &
-  RuntimeValidationConstraint<
+  RuntimeValidationCompatibility<
     NoInfer<TBaseSchemas>,
     NoInfer<TBaseStates>,
     ResolveExtendedValidator<TBaseValidator, TExtendValidator>
@@ -2130,6 +2137,64 @@ export type SetupReturnFromConfig<
     : undefined
 >;
 
+type SetupFunction<TSystemRegistry extends SystemRegistry = SystemRegistry> = {
+  (): SetupReturn<
+    Record<string, SetupStateSchema>,
+    {},
+    {},
+    {},
+    {},
+    {},
+    never,
+    TSystemRegistry
+  >;
+  <
+    const TSchemas extends SetupSchemas = {},
+    const TStates extends Record<string, SetupStateSchema> = Record<
+      string,
+      SetupStateSchema
+    >,
+    TActionMap extends Sources['actions'] = {},
+    TActorMap extends Sources['actors'] = {},
+    TGuardMap extends Sources['guards'] = {},
+    TDelayMap extends Sources['delays'] = {},
+    const TValidator extends ActorLogicValidator | undefined = undefined
+  >(
+    config: SetupConfig<
+      TSchemas,
+      TStates,
+      TActionMap,
+      TActorMap,
+      TGuardMap,
+      TDelayMap,
+      TValidator
+    > &
+      RuntimeValidationConstraint<
+        NoInfer<TSchemas>,
+        NoInfer<TStates>,
+        TValidator
+      >
+  ): SetupReturn<
+    TStates,
+    TSchemas,
+    TActionMap,
+    TActorMap,
+    TGuardMap,
+    TDelayMap,
+    Extract<keyof TDelayMap, string>,
+    TSystemRegistry,
+    TValidator
+  >;
+  <const TConfig extends AnySetupConfig>(
+    config: TConfig &
+      RuntimeValidationConstraint<
+        NoInfer<SetupConfigSchemas<TConfig>>,
+        NoInfer<SetupConfigStates<TConfig>>,
+        TConfig extends { validator: infer TValidator } ? TValidator : undefined
+      >
+  ): SetupReturnFromConfig<TConfig, TSystemRegistry>;
+};
+
 /**
  * Sets up a state machine with state input schemas and other configuration.
  *
@@ -2166,49 +2231,7 @@ export type SetupReturnFromConfig<
  * });
  * ```
  */
-export function setup(): SetupReturn;
-export function setup<
-  const TSchemas extends SetupSchemas = {},
-  const TStates extends Record<string, SetupStateSchema> = Record<
-    string,
-    SetupStateSchema
-  >,
-  TActionMap extends Sources['actions'] = {},
-  TActorMap extends Sources['actors'] = {},
-  TGuardMap extends Sources['guards'] = {},
-  TDelayMap extends Sources['delays'] = {},
-  const TValidator extends ActorLogicValidator | undefined = undefined
->(
-  config: SetupConfig<
-    TSchemas,
-    TStates,
-    TActionMap,
-    TActorMap,
-    TGuardMap,
-    TDelayMap,
-    TValidator
-  > &
-    RuntimeValidationConstraint<NoInfer<TSchemas>, NoInfer<TStates>, TValidator>
-): SetupReturn<
-  TStates,
-  TSchemas,
-  TActionMap,
-  TActorMap,
-  TGuardMap,
-  TDelayMap,
-  Extract<keyof TDelayMap, string>,
-  SystemRegistry,
-  TValidator
->;
-export function setup<const TConfig extends AnySetupConfig>(
-  config: TConfig &
-    RuntimeValidationConstraint<
-      NoInfer<SetupConfigSchemas<TConfig>>,
-      NoInfer<SetupConfigStates<TConfig>>,
-      TConfig extends { validator: infer TValidator } ? TValidator : undefined
-    >
-): SetupReturnFromConfig<TConfig>;
-export function setup<
+export const setup = function setupImplementation<
   const TSchemas extends SetupSchemas = {},
   const TStates extends Record<string, SetupStateSchema> = Record<
     string,
@@ -2322,7 +2345,7 @@ export function setup<
     states,
     schemas: schemas ?? ({} as TSchemas)
   };
-}
+} as SetupFunction;
 
 type SystemBuilder<TSystemRegistry extends SystemRegistry> = {
   createActor<TLogic extends AnyActorLogic>(
@@ -2340,61 +2363,7 @@ type SystemBuilder<TSystemRegistry extends SystemRegistry> = {
       | Observer<InspectionEvent>
       | ((inspectionEvent: InspectionEvent) => void)
   ): Subscription;
-  setup(): SetupReturn<
-    Record<string, SetupStateSchema>,
-    {},
-    {},
-    {},
-    {},
-    {},
-    never,
-    TSystemRegistry
-  >;
-  setup<
-    const TSchemas extends SetupSchemas = {},
-    const TStates extends Record<string, SetupStateSchema> = Record<
-      string,
-      SetupStateSchema
-    >,
-    TActionMap extends Sources['actions'] = {},
-    TActorMap extends Sources['actors'] = {},
-    TGuardMap extends Sources['guards'] = {},
-    TDelayMap extends Sources['delays'] = {},
-    const TValidator extends ActorLogicValidator | undefined = undefined
-  >(
-    config: SetupConfig<
-      TSchemas,
-      TStates,
-      TActionMap,
-      TActorMap,
-      TGuardMap,
-      TDelayMap,
-      TValidator
-    > &
-      RuntimeValidationConstraint<
-        NoInfer<TSchemas>,
-        NoInfer<TStates>,
-        TValidator
-      >
-  ): SetupReturn<
-    TStates,
-    TSchemas,
-    TActionMap,
-    TActorMap,
-    TGuardMap,
-    TDelayMap,
-    Extract<keyof TDelayMap, string>,
-    TSystemRegistry,
-    TValidator
-  >;
-  setup<const TConfig extends AnySetupConfig>(
-    config: TConfig &
-      RuntimeValidationConstraint<
-        NoInfer<SetupConfigSchemas<TConfig>>,
-        NoInfer<SetupConfigStates<TConfig>>,
-        TConfig extends { validator: infer TValidator } ? TValidator : undefined
-      >
-  ): SetupReturnFromConfig<TConfig, TSystemRegistry>;
+  setup: SetupFunction<TSystemRegistry>;
 };
 
 export function createSystem<const TSystemRegistry extends SystemRegistry = {}>(
@@ -2457,9 +2426,7 @@ export function createSystem<const TSystemRegistry extends SystemRegistry = {}>(
         }
       };
     },
-    setup(config?: AnySetupConfig) {
-      return (config ? setup(config) : setup()) as any;
-    }
+    setup: setup as SetupFunction<TSystemRegistry>
   };
 }
 

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -2113,7 +2113,10 @@ type SetupConfigDelays<TConfig> = TConfig extends { delays?: infer TDelays }
     : {}
   : {};
 
-export type SetupReturnFromConfig<TConfig extends AnySetupConfig> = SetupReturn<
+export type SetupReturnFromConfig<
+  TConfig extends AnySetupConfig,
+  TSystemRegistry extends SystemRegistry = SystemRegistry
+> = SetupReturn<
   SetupConfigStates<TConfig>,
   SetupConfigSchemas<TConfig>,
   SetupConfigActions<TConfig>,
@@ -2121,7 +2124,7 @@ export type SetupReturnFromConfig<TConfig extends AnySetupConfig> = SetupReturn<
   SetupConfigGuards<TConfig>,
   SetupConfigDelays<TConfig>,
   Extract<keyof SetupConfigDelays<TConfig>, string>,
-  SystemRegistry,
+  TSystemRegistry,
   TConfig extends { validator: infer TValidator extends ActorLogicValidator }
     ? TValidator
     : undefined
@@ -2337,6 +2340,16 @@ type SystemBuilder<TSystemRegistry extends SystemRegistry> = {
       | Observer<InspectionEvent>
       | ((inspectionEvent: InspectionEvent) => void)
   ): Subscription;
+  setup(): SetupReturn<
+    Record<string, SetupStateSchema>,
+    {},
+    {},
+    {},
+    {},
+    {},
+    never,
+    TSystemRegistry
+  >;
   setup<
     const TSchemas extends SetupSchemas = {},
     const TStates extends Record<string, SetupStateSchema> = Record<
@@ -2346,16 +2359,23 @@ type SystemBuilder<TSystemRegistry extends SystemRegistry> = {
     TActionMap extends Sources['actions'] = {},
     TActorMap extends Sources['actors'] = {},
     TGuardMap extends Sources['guards'] = {},
-    TDelayMap extends Sources['delays'] = {}
+    TDelayMap extends Sources['delays'] = {},
+    const TValidator extends ActorLogicValidator | undefined = undefined
   >(
-    config?: SetupConfig<
+    config: SetupConfig<
       TSchemas,
       TStates,
       TActionMap,
       TActorMap,
       TGuardMap,
-      TDelayMap
-    >
+      TDelayMap,
+      TValidator
+    > &
+      RuntimeValidationConstraint<
+        NoInfer<TSchemas>,
+        NoInfer<TStates>,
+        TValidator
+      >
   ): SetupReturn<
     TStates,
     TSchemas,
@@ -2364,8 +2384,17 @@ type SystemBuilder<TSystemRegistry extends SystemRegistry> = {
     TGuardMap,
     TDelayMap,
     Extract<keyof TDelayMap, string>,
-    TSystemRegistry
+    TSystemRegistry,
+    TValidator
   >;
+  setup<const TConfig extends AnySetupConfig>(
+    config: TConfig &
+      RuntimeValidationConstraint<
+        NoInfer<SetupConfigSchemas<TConfig>>,
+        NoInfer<SetupConfigStates<TConfig>>,
+        TConfig extends { validator: infer TValidator } ? TValidator : undefined
+      >
+  ): SetupReturnFromConfig<TConfig, TSystemRegistry>;
 };
 
 export function createSystem<const TSystemRegistry extends SystemRegistry = {}>(
@@ -2428,7 +2457,7 @@ export function createSystem<const TSystemRegistry extends SystemRegistry = {}>(
         }
       };
     },
-    setup(config) {
+    setup(config?: AnySetupConfig) {
       return (config ? setup(config) : setup()) as any;
     }
   };

--- a/packages/core/test/runtimeValidation.test.ts
+++ b/packages/core/test/runtimeValidation.test.ts
@@ -137,6 +137,21 @@ describe('runtime schema validation', () => {
     ).not.toThrow();
   });
 
+  it('can be installed by a derived setup', () => {
+    const validated = setup({
+      schemas: { input: z.object({ count: z.number() }) }
+    }).extend({ validator: standardSchemaValidator() });
+
+    expectValidationError(
+      getThrown(() =>
+        initialTransition(validated.createMachine({}), {
+          count: 'invalid'
+        } as any)
+      ),
+      'input'
+    );
+  });
+
   it('calls validators only at pure calculation boundaries', () => {
     const check = vi.fn<ActorLogicValidator['check']>(() => undefined);
     const machine = setup({ validator: { check } }).createMachine({

--- a/packages/core/test/runtimeValidation.test.ts
+++ b/packages/core/test/runtimeValidation.test.ts
@@ -8,6 +8,7 @@ import {
   createEventObservableLogic,
   createLogic,
   createMachine,
+  createSystem,
   createObservableLogic,
   initialTransition,
   setup,
@@ -39,6 +40,20 @@ function expectValidationError(
 }
 
 describe('runtime schema validation', () => {
+  it('validates setup schemas created through a system builder', () => {
+    const machine = createSystem()
+      .setup({
+        validator: standardSchemaValidator(),
+        schemas: { input: z.object({ count: z.number() }) }
+      })
+      .createMachine({});
+
+    expectValidationError(
+      getThrown(() => initialTransition(machine, { count: 'invalid' } as any)),
+      'input'
+    );
+  });
+
   it('validates input across actor logic creators', () => {
     const input = z.object({ count: z.number() });
     const validator = standardSchemaValidator();

--- a/packages/core/test/runtimeValidation.types.test.ts
+++ b/packages/core/test/runtimeValidation.types.test.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { setup } from '../src/index.ts';
+import {
+  type AnySetupConfig,
+  createCallbackLogic,
+  createSystem,
+  setup
+} from '../src/index.ts';
 import { standardSchemaValidator } from '../src/validation/index.ts';
 
 describe('runtime validation types', () => {
@@ -113,5 +118,51 @@ describe('runtime validation types', () => {
         validator: standardSchemaValidator()
       });
     }
+  });
+
+  it('preserves runtime validation types through createSystem().setup()', () => {
+    const transforming = z.string().transform((value) => value.length);
+    const receiver = createCallbackLogic<{ type: 'HELLO' }>(() => {});
+    const system = createSystem({ registry: { receiver } });
+
+    if (false) {
+      system.setup({
+        validator: standardSchemaValidator(),
+        // @ts-expect-error - runtime validation does not apply schema transforms
+        schemas: { input: transforming }
+      });
+    }
+
+    const validated = system.setup({
+      validator: standardSchemaValidator()
+    });
+
+    if (false) {
+      validated.extend({
+        schemas: {
+          // @ts-expect-error - extended schemas inherit runtime validation
+          input: transforming
+        }
+      });
+    }
+
+    validated.extend({ validator: standardSchemaValidator() });
+
+    const setupFromConfig = <const TConfig extends AnySetupConfig>(
+      config: TConfig
+    ) => system.setup(config);
+    setupFromConfig({ validator: standardSchemaValidator() }).extend({
+      validator: standardSchemaValidator()
+    });
+
+    validated.createMachine({
+      on: {
+        TEST: ({ system }) => {
+          system.get('receiver')?.send({ type: 'HELLO' });
+          // @ts-expect-error - registry actor only accepts HELLO
+          system.get('receiver')?.send({ type: 'OTHER' });
+        }
+      }
+    });
   });
 });

--- a/packages/core/test/runtimeValidation.types.test.ts
+++ b/packages/core/test/runtimeValidation.types.test.ts
@@ -108,15 +108,37 @@ describe('runtime validation types', () => {
     });
   });
 
-  it('requires validation to be installed by the root setup', () => {
+  it('can install validation on a compatible derived setup', () => {
     const transforming = z.string().transform((value) => value.length);
-    const base = setup({ schemas: { input: transforming } });
+    setup().extend({ validator: standardSchemaValidator() });
+    const validated = setup({ schemas: { input: z.string() } }).extend({
+      validator: standardSchemaValidator()
+    });
 
     if (false) {
-      base.extend({
-        // @ts-expect-error - validation must be installed by the root setup
+      validated.createMachine({
+        schemas: {
+          // @ts-expect-error - derived validation applies to inline schemas
+          output: transforming
+        }
+      });
+    }
+
+    const incompatible = setup({ schemas: { input: transforming } });
+
+    if (false) {
+      // @ts-expect-error - inherited schema transforms cannot be validated
+      incompatible.extend({
         validator: standardSchemaValidator()
       });
+
+      const incompatibleState = setup({
+        states: {
+          loading: { schemas: { input: transforming } }
+        }
+      });
+      // @ts-expect-error - inherited state schema transforms cannot be validated
+      incompatibleState.extend({ validator: standardSchemaValidator() });
     }
   });
 


### PR DESCRIPTION
## Summary

- define one registry-parameterized `SetupFunction` contract for standalone and system-bound setup authoring
- preserve runtime validator types alongside typed system registries
- reuse the standalone `setup` function directly from `createSystem`, eliminating the duplicated wrapper and overload surface that caused the drift
- allow compatible unvalidated setups to install a validator through `.extend({ validator })`
- reject validation opt-in when inherited root or state schemas contain unsupported type-changing transforms
- add runtime/type regression coverage, documentation, and a patch changeset

## Root cause

`SystemBuilder.setup()` manually duplicated the standalone `setup()` type surface. Runtime validation later updated only the standalone overloads, so builder-created setups still ran validation but silently lost its compile-time guarantees.

The fix makes `SetupFunction<TSystemRegistry>` the single public callable contract. Standalone `setup` uses the default registry, while `SystemBuilder.setup` binds the declared registry type. Both now share the same runtime function and cannot drift independently.

## Impact

Typed actor registries and typed runtime validation can be used together. Derived setups inherit validator typing, unsupported transforming schemas are rejected, and consumers can opt a compatible shared setup into runtime validation later.

## Validation

- `pnpm test:core` — 2,199 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- CJS and ESM named-export smoke tests for `setup`; verified `createSystem().setup === setup`

Fixes #5656