### PR TITLE
docs: synchronize recent audit findings

### DIFF
--- a/docs/actions.md
+++ b/docs/actions.md
@@ -13,6 +13,8 @@ entry: ({ context }, enq) => {
 
 ## Built-in actions
 
+<!-- enqueue methods and supported call sites from packages/core/src/types.ts and packages/core/src/stateUtils.ts -->
+
 | Method | Purpose |
 | --- | --- |
 | `enq(...)` | Enqueue an effect function. |
@@ -23,8 +25,8 @@ entry: ({ context }, enq) => {
 | `enq.cancel(...)` | Cancel a delayed event. |
 | `enq.log(...)` | Log values. |
 | `enq.emit(...)` | Emit an [actor event](emitted-events.md). |
-| `enq.listen(...)` | Map another actor's [emitted events](listen-and-subscribe.md) to events for this machine. Entry and exit only. |
-| `enq.subscribeTo(...)` | Map another actor's [snapshots and outcomes](listen-and-subscribe.md) to events for this machine. Entry and exit only. |
+| `enq.listen(...)` | Map another actor's [emitted events](listen-and-subscribe.md) to events for this machine. |
+| `enq.subscribeTo(...)` | Map another actor's [snapshots and outcomes](listen-and-subscribe.md) to events for this machine. |
 
 Provide reusable named action sources through `setup(...)`.
 

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -138,6 +138,8 @@ See [guards](guards.md).
 
 ## Enqueue effects
 
+<!-- enqueue methods and supported call sites from packages/core/src/types.ts and packages/core/src/stateUtils.ts -->
+
 ```ts
 entry: ({ context, children, actions }, enq) => {
   enq(() => startEffect());              // any effect function
@@ -152,7 +154,8 @@ entry: ({ context, children, actions }, enq) => {
 };
 ```
 
-`enq.listen(...)` and `enq.subscribeTo(...)` are available in `entry` and `exit` only:
+`enq.listen(...)` and `enq.subscribeTo(...)` are available in transition,
+`entry` and `exit` functions:
 
 ```ts
 entry: (_, enq) => {

--- a/docs/create-actor.md
+++ b/docs/create-actor.md
@@ -47,6 +47,24 @@ const actor = createActor(machine, { input: { userId: 'u_1' } });
 
 There is no `systemId` option in v6. Use `registryKey`, which is typed against the machine's system registry.
 
+## Custom clocks
+
+<!-- Clock and ActorOptions.clock from packages/core/src/system.ts and packages/core/src/types.ts -->
+
+Provide `clock` to control delayed events and transitions. `setTimeout` and
+`clearTimeout` are required. Add `now()` when persisting and restoring timers so
+XState calculates remaining delays from the same time source.
+
+```ts
+const actor = createActor(machine, {
+  clock: {
+    now: () => currentTime,
+    setTimeout: (callback, delay) => schedule(callback, delay),
+    clearTimeout: (handle) => cancel(handle)
+  }
+});
+```
+
 ## Actor members
 
 | Member | Description |

--- a/docs/listen-and-subscribe.md
+++ b/docs/listen-and-subscribe.md
@@ -3,7 +3,11 @@ title: Listen and subscribe to actors
 description: Turn another actor's events and snapshots into events for this machine.
 ---
 
-`enq.listen(...)` and `enq.subscribeTo(...)` wire another actor into the current machine. Both map what the other actor produces into an event this machine handles. They are available in `entry` and `exit` functions, not in transition functions.
+<!-- enq.listen and enq.subscribeTo behavior from packages/core/src/stateUtils.ts and packages/core/src/transitionActions.ts -->
+
+`enq.listen(...)` and `enq.subscribeTo(...)` wire another actor into the current
+machine. Both map what the other actor produces into an event this machine
+handles. Use them in transition, `entry` or `exit` functions.
 
 Use them for actors this machine does not [invoke](invoke.md): [spawned](spawn.md) children, children passed in through input, or long-lived actors from a [system](systems.md). Invoked actors already have `onDone`, `onError` and `onSnapshot`.
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -34,11 +34,11 @@ Register lightweight schema descriptors for historical versions and retain an
 actual machine for each version that may be a target. Every entry must have the
 same stable `id` and its own `version`.
 
-Every entry satisfies one `MachineVersionDescriptor` contract:
-`{ id, version, snapshotSchema?, eventSchema? }`. Versioned machines expose
-`snapshotSchema` and `eventSchema` themselves, so `machineVersions()` uses the
-same schema path for machines and lightweight historical descriptors. It only
-checks whether an entry is executable when resolving `to`.
+Every lightweight entry satisfies `MachineVersionDescriptor`: `{ id, version }`
+plus at least one of `snapshotSchema` or `eventSchema`. Versioned machines expose
+both schemas themselves, so `machineVersions()` uses the same schema path for
+machines and historical descriptors. It only checks whether an entry is
+executable when resolving `to`.
 
 ```ts
 const checkoutVersions = machineVersions([

--- a/docs/spawn.md
+++ b/docs/spawn.md
@@ -139,7 +139,12 @@ entry: (_, enq) => {
 };
 ```
 
-`enq.listen(...)` maps [emitted events](emitted-events.md), `enq.subscribeTo(...)` maps snapshots and outcomes. Both return an actor that can be stopped with `enq.stop(...)`, and both are available in `entry` and `exit` functions. See [listen and subscribe](listen-and-subscribe.md).
+<!-- enq.listen and enq.subscribeTo behavior from packages/core/src/stateUtils.ts and packages/core/src/transitionActions.ts -->
+
+`enq.listen(...)` maps [emitted events](emitted-events.md), while
+`enq.subscribeTo(...)` maps snapshots and outcomes. Both return an actor that
+can be stopped with `enq.stop(...)`, and both work in transition, `entry` and
+`exit` functions. See [listen and subscribe](listen-and-subscribe.md).
 
 `syncSnapshot: true` is the lower-level alternative: the parent then receives `xstate.snapshot.actor` events that it can handle with `matches: { actorId }`.
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -3,7 +3,7 @@ title: TypeScript
 description: Define schemas and derive XState types.
 ---
 
-Define runtime schemas with `setup(...)`. XState infers context, events, input and output from them.
+Define schemas with `setup(...)`. XState infers context, events, input and output from them.
 
 Enable TypeScript's `strict` mode. Keep schemas next to actor logic so runtime validation and inferred types describe the same contract.
 
@@ -43,6 +43,47 @@ on: {
 ```
 
 Use `assertEvent(...)` only when shared code must narrow a union to one or more known event types.
+
+## Runtime validation
+
+<!-- runtime validation API and boundaries from packages/core/src/validation.types.ts, packages/core/src/validation/index.ts, and packages/core/src/setup.ts -->
+
+Runtime validation is opt-in. Install the Standard Schema validator from the
+separate `xstate/validation` entry point:
+
+```ts
+import { setup } from 'xstate';
+import { standardSchemaValidator } from 'xstate/validation';
+import { z } from 'zod';
+
+const machine = setup({
+  validator: standardSchemaValidator(),
+  schemas: {
+    input: z.object({ initialCount: z.number() }),
+    context: z.object({ count: z.number() }),
+    events: {
+      increment: z.object({ by: z.number() })
+    }
+  }
+}).createMachine({
+  context: ({ input }) => ({ count: input.initialCount })
+});
+```
+
+The validator checks input and public events before calculation, then checks
+stable context, active state schemas, child slots, delayed raised events,
+emitted events and final output before effects run. Invalid values throw an
+`ActorValidationError`.
+
+Validation is synchronous and assertion-only: schema transformations and async
+validation are rejected. Unknown events and emitted events are errors when a
+corresponding schema map exists; use `unknownEvents: 'ignore'` or
+`unknownEmitted: 'ignore'` for open protocols.
+
+Derived setups inherit the validator. Replace it or use `validator: undefined`
+to disable it. Persistence, restoration, immediate raised events, action and
+guard parameters, static meta and tags, and `snapshot.can()` are not validation
+boundaries.
 
 ## Type helpers
 

--- a/docs/xstate-v5-to-v6.md
+++ b/docs/xstate-v5-to-v6.md
@@ -969,7 +969,7 @@ These exports have been **removed** from `xstate`:
 These exports have been **added**:
 
 - `setup` (reshaped - see §4) and `createSystem(...).setup(...)` for typed system registries
-- `createFSM` and its related `FSMActorLogic`/`FSMConfig`/`FSMSnapshot` types for flat, actor-compatible finite state machines. A state with `type: 'final'` completes the actor.
+- `createFSM` and its related `FSMActorLogic`/`FSMConfig`/`FSMSnapshot` types for flat, actor-compatible finite state machines
 - `createStateConfig`
 - `checkStateIn`
 - `createLogic`, `createAsyncLogic`, `createCallbackLogic`, `createObservableLogic`, `createListenerLogic`, `createSubscriptionLogic`

--- a/docs/xstate-v5-to-v6.md
+++ b/docs/xstate-v5-to-v6.md
@@ -969,7 +969,7 @@ These exports have been **removed** from `xstate`:
 These exports have been **added**:
 
 - `setup` (reshaped - see §4) and `createSystem(...).setup(...)` for typed system registries
-- `createFSM` and its related `FSMActorLogic`/`FSMConfig`/`FSMSnapshot` types for flat, actor-compatible finite state machines
+- `createFSM` and its related `FSMActorLogic`/`FSMConfig`/`FSMSnapshot` types for flat, actor-compatible finite state machines. A state with `type: 'final'` completes the actor.
 - `createStateConfig`
 - `checkStateIn`
 - `createLogic`, `createAsyncLogic`, `createCallbackLogic`, `createObservableLogic`, `createListenerLogic`, `createSubscriptionLogic`


### PR DESCRIPTION
## Summary
- consolidate recent v6 action, actor, persistence, TypeScript, and migration documentation audits
- align custom clock and machine-version contracts with current core source

## Validation
- source-contract assertions
- `git diff --check`
- docs paths are excluded by the repository Oxfmt configuration