### PR TITLE
Deterministic durable execution identity + host-guidance docs

### DIFF
--- a/.changeset/durable-followups.md
+++ b/.changeset/durable-followups.md
@@ -12,4 +12,10 @@ const durable = createDurable(machine, {
 });
 ```
 
+The new `runLogic` runtime operation makes the invoked async actor the primary durable unit: a developer writes a normal promise and the host journals the whole body as one entry — wrapping the provided thunk in its own step primitive, or re-running the registered logic on a remote executor from the actor's serializable `(src, input)` identity alone. `enq.step` remains for opt-in finer granularity.
+
+```ts
+runLogic: (actor, exec) => ctx.run(actor.address, exec)
+```
+
 Durable-execution docs now also cover quiescing in-flight steps before registering a durable wait, the ordered-effect replay guarantee, and that `runStep`'s `exec` closure must run in-process.

--- a/.changeset/durable-followups.md
+++ b/.changeset/durable-followups.md
@@ -1,0 +1,15 @@
+---
+'xstate': patch
+---
+
+Durable executions can pin a deterministic identity: `createDurable(machine, { executionId, ... })` makes session ids `<executionId>:<n>`, a deterministic function of actor-creation order, so hosts that journal the execution's own events can replay them — a journaled completion event still matches the child a replay re-creates.
+
+```ts
+const durable = createDurable(machine, {
+  executionId: orderId,
+  executeAction,
+  waitForEvent
+});
+```
+
+Durable-execution docs now also cover quiescing in-flight steps before registering a durable wait, the ordered-effect replay guarantee, and that `runStep`'s `exec` closure must run in-process.

--- a/.changeset/durable-followups.md
+++ b/.changeset/durable-followups.md
@@ -18,4 +18,6 @@ The new `runLogic` runtime operation makes the invoked async actor the primary d
 runLogic: (actor, exec) => ctx.run(actor.address, exec)
 ```
 
+Docs reposition `enq.step` as the hostless-durability tool (the snapshot is the journal; durable hosts use plain promise actors + `runLogic`), document the portable-action rule (named function + serializable args ships to a remote executor; closures run in-process), and add a "Driving effects yourself" section: `createDurable` is sugar over the pure `transition()` APIs, and hosts may execute the effect objects themselves.
+
 Durable-execution docs now also cover quiescing in-flight steps before registering a durable wait, the ordered-effect replay guarantee, and that `runStep`'s `exec` closure must run in-process.

--- a/.changeset/durable-followups.md
+++ b/.changeset/durable-followups.md
@@ -18,6 +18,8 @@ The new `runLogic` runtime operation makes the invoked async actor the primary d
 runLogic: (actor, exec) => ctx.run(actor.address, exec)
 ```
 
+A remote handle now carries its host-supplied incarnation token as its `sessionId` — one incarnation identity with one staleness rule (a ref that knows its incarnation compares it; one that does not defers to the owning runtime). The persisted `incarnation` field is unchanged.
+
 Docs reposition `enq.step` as the hostless-durability tool (the snapshot is the journal; durable hosts use plain promise actors + `runLogic`), document the portable-action rule (named function + serializable args ships to a remote executor; closures run in-process), and add a "Driving effects yourself" section: `createDurable` is sugar over the pure `transition()` APIs, and hosts may execute the effect objects themselves.
 
 Durable-execution docs now also cover quiescing in-flight steps before registering a durable wait, the ordered-effect replay guarantee, and that `runStep`'s `exec` closure must run in-process.

--- a/docs/actor-logic.md
+++ b/docs/actor-logic.md
@@ -50,7 +50,7 @@ const chargeCard = createAsyncLogic({
 });
 ```
 
-`enq.emit(event)` emits an event that observers read with `actor.on(...)`. Check a failure with `error instanceof TimeoutError`, which is exported from `xstate`. `enq.step(key, exec)` runs durable work through the system runtime's `runStep` operation. By default XState records each step's outcome on the snapshot under `effects[key]`, and a restored actor replays a recorded result instead of running the step again, so a resumed run does not charge the card twice; concurrent calls with the same key wait for the first one. A [durable host](durable-execution.md) that implements `runStep` journals steps in its own journal instead. Durable step semantics are experimental.
+`enq.emit(event)` emits an event that observers read with `actor.on(...)`. Check a failure with `error instanceof TimeoutError`, which is exported from `xstate`. `enq.step(key, exec)` is hostless durability: the snapshot is the journal. Each step's outcome is recorded on the snapshot under `effects[key]`, and a restored actor replays a recorded result instead of running the step again — persist the snapshot to `localStorage` and a checkout flow survives a page reload without charging the card twice; persist it per request and a backend workflow resumes mid-function. `effects[key]` statuses also make per-step progress readable from the snapshot, and concurrent calls with the same key wait for the first one. On a [durable host](durable-execution.md), do not use `enq.step` — write a normal promise actor and let the host's `runLogic` journal it; the host's journal replaces the snapshot's. Durable step semantics are experimental.
 
 Choose logic by lifecycle:
 

--- a/docs/backend-workflows.md
+++ b/docs/backend-workflows.md
@@ -54,7 +54,7 @@ The same rule applies to writes the workflow makes. Pass an idempotency key to t
 
 ## Durable steps
 
-Async logic that runs several external calls can record each one on the snapshot with `enq.step(...)`:
+Async logic that runs several external calls can record each one on the snapshot with `enq.step(...)` — this page's pattern is hostless durability, where the snapshot is the journal, and `enq.step` is built for it (on a [durable host](durable-execution.md), write plain promise actors instead):
 
 ```ts
 const fulfillOrder = createAsyncLogic({

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -56,9 +56,24 @@ runLogic: (actor, exec) => ctx.run(actor.address, exec)          // in-process j
 runLogic: (actor) => activities.runLogic(actor.src, actor.getSnapshot().input) // remote executor
 ```
 
-For finer granularity — several independently-journaled awaits inside one
-actor — split into separate invoked actors, or reach for `enq.step`, which
-routes through the `runStep` operation:
+Custom actions follow the same rule — durability crosses a boundary as
+declared identity plus serializable data, never as a closure. An action
+enqueued as a named function with serializable arguments
+(`enq(notifyApprover, context.orderId)`) carries `(type, args)` in its
+descriptor, so a remote-executor host can dispatch it worker-side and ignore
+`exec`, exactly like `runLogic`. An action enqueued as an inline closure
+(`enq(() => …)`) has no portable identity: it runs in this process, journaled
+by its effect ID. Work heavy enough to deserve an activity is usually an
+actor, not an action.
+
+For finer granularity — several independently-journaled awaits — split into
+separate invoked actors: each actor is its own journal entry, and the states
+between them make the progress visible. Do not reach for `enq.step` on a
+durable host; it is the [hostless durability](actor-logic.md) tool — the
+snapshot is its journal — and on a durable host it only duplicates what
+`runLogic` already provides. When restored snapshots that carry step results
+do run under a durable host, `enq.step` routes through the `runStep`
+operation:
 implement it to journal steps in the host's journal — a memoized result
 replays without re-running the step — and the built-in
 snapshot memoization steps aside. Unlike other operations, a step is an
@@ -255,6 +270,26 @@ it stops. It only starts fresh executions. A nonzero `transitionIndex`, or
 calling a lower-level transition method before `run()`, causes
 `DurableExecutionResumeError`; resume with the persisted snapshot and the
 explicit transition loop instead.
+
+## Driving effects yourself
+
+`createDurable` is sugar over the pure APIs: its `initialTransition` and
+`transition` call the exported `initialTransition(logic, input)` and
+`transition(logic, snapshot, event)` directly, adding only stable-ID tags on
+the effects and the runtime installation. `createActor` is the built-in
+in-process runtime over the same pure relations; `createDurable` is the
+journaled one.
+
+Effects are plain objects — each has a serializable `descriptor` and an
+`exec(runtime)` method — so a host may take `[snapshot, effects]` from the
+pure APIs and execute them entirely its own way. Dropping `executeEffects`
+means providing its four services yourself: transitive settlement (an
+effect's operations trigger further operations; "executed" must mean the
+whole cascade was accepted before checkpointing), root-event capture
+(children's sends to the root must surface instead of queuing on an inert
+mailbox), ordered handoff to the runtime, and batch failure discard for
+retries. Engines with native equivalents for some of these may prefer their
+own; everyone else should stay on `executeEffects`.
 
 ## Host adapters
 

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -39,8 +39,26 @@ const output = await durable.run(input);
 ```
 
 Runtime operations you omit keep their local behavior — spawned machine
-children run in this process, for example. Async-actor steps (`enq.step` in
-[actor logic](actor-logic.md)) route through the `runStep` operation:
+children run in this process, for example.
+
+The primary durable unit for async work is the actor itself: a developer
+writes a normal promise (`fromPromise`, `createAsyncLogic`) and invokes it;
+the `runLogic` operation hands the host the whole body as one journal
+entry. The actor's identity — `address`, string `src` key and serializable
+`input` — crosses any boundary, so a host either wraps the provided `exec`
+in its own step primitive, or ignores it entirely and re-runs the
+registered logic on a remote executor from `(src, input)` alone; the output
+flows back as the actor's ordinary completion event. No step vocabulary
+appears in the machine.
+
+```ts
+runLogic: (actor, exec) => ctx.run(actor.address, exec)          // in-process journal
+runLogic: (actor) => activities.runLogic(actor.src, actor.getSnapshot().input) // remote executor
+```
+
+For finer granularity — several independently-journaled awaits inside one
+actor — split into separate invoked actors, or reach for `enq.step`, which
+routes through the `runStep` operation:
 implement it to journal steps in the host's journal — a memoized result
 replays without re-running the step — and the built-in
 snapshot memoization steps aside. Unlike other operations, a step is an
@@ -51,10 +69,11 @@ from `xstate` exposes the built-in behavior. `exec` is a closure over live
 execution state: run it in this process and journal its result; it cannot be
 shipped to a remote executor.
 
-Because steps outlive `executeEffects`, a host whose wait is durable rather
-than in-process must quiesce before parking: track the promises your
-`runStep` returns and drain them (steps can start further steps, so drain to
-empty) before registering a durable wait. An in-flight step ends by
+Because logic bodies and steps outlive `executeEffects`, a host whose wait
+is durable rather than in-process must account for them before parking:
+either race its durable wait against the pending `runLogic`/`runStep`
+promises it created (the natural shape when they map to the engine's own
+step primitives), or drain them to empty first. An in-flight step ends by
 completing its actor, and that completion event cannot satisfy a durable
 wait that was already registered with the engine — the run deadlocks until
 its idle timeout. The in-process loop above needs none of this, because any

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -139,11 +139,13 @@ ones) must pin `executionId` on the adapter: session ids become
 replayed execution re-creates the same ids — a journaled completion still
 matches the child the replay re-creates. Uniqueness across executions is the
 host's responsibility. For a remote child the owning runtime is the authority on
-staleness by default; a host that stores an opaque `incarnation` token on the
-persisted child entry gets the same guard on the referencing side — a
-completion whose `sessionId` differs from the token is dropped, and `sendTo`
-effect descriptors journal the target's token so a send replayed after the
-address was reincarnated is detectable.
+staleness by default; a host that stores an opaque `incarnation` token on
+the persisted child entry gets the same guard on the referencing side. The
+token is the owner's `sessionId` for the child and the restored handle
+carries it as its own `sessionId` — one incarnation identity, one rule: a
+ref that knows its incarnation compares it, one that does not defers to the
+owner. `sendTo` effect descriptors journal the target's token so a send
+replayed after the address was reincarnated is detectable.
 
 Correlate actors by address, not object identity. Actor references passed to
 runtime operations expose `address`, `id` and (for registered sources) a

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -45,8 +45,20 @@ implement it to journal steps in the host's journal — a memoized result
 replays without re-running the step — and the built-in
 snapshot memoization steps aside. Unlike other operations, a step is an
 orchestration frame that may itself await runtime operations of the same
-execution, so it is never serialized behind them. The `runStep` helper
-exported from `xstate` exposes the built-in behavior. Operations initiated by live child
+execution, so it is never serialized behind them — and for the same reason
+`executeEffects` resolves without awaiting it. The `runStep` helper exported
+from `xstate` exposes the built-in behavior. `exec` is a closure over live
+execution state: run it in this process and journal its result; it cannot be
+shipped to a remote executor.
+
+Because steps outlive `executeEffects`, a host whose wait is durable rather
+than in-process must quiesce before parking: track the promises your
+`runStep` returns and drain them (steps can start further steps, so drain to
+empty) before registering a durable wait. An in-flight step ends by
+completing its actor, and that completion event cannot satisfy a durable
+wait that was already registered with the engine — the run deadlocks until
+its idle timeout. The in-process loop above needs none of this, because any
+later event resolves its wait. Operations initiated by live child
 actors (parent sends, timers, terminations) route to your implementations
 with no per-actor wiring. `run()` is convenience over the explicit loop:
 
@@ -86,7 +98,13 @@ Addresses are stable across persistence and restore.
 `sessionId` identifies one incarnation of an address. A restored actor is a
 new incarnation: completion events carry the producing incarnation's
 `sessionId`, and `transition()` drops completions from a previous incarnation
-of a local child. For a remote child the owning runtime is the authority on
+of a local child. Session ids embed a random per-process system id, so a
+host that journals the execution's own events (rather than only external
+ones) must pin `executionId` on the adapter: session ids become
+`<executionId>:<n>`, a deterministic function of actor-creation order, and a
+replayed execution re-creates the same ids — a journaled completion still
+matches the child the replay re-creates. Uniqueness across executions is the
+host's responsibility. For a remote child the owning runtime is the authority on
 staleness by default; a host that stores an opaque `incarnation` token on the
 persisted child entry gets the same guard on the referencing side — a
 completion whose `sessionId` differs from the token is dropped, and `sendTo`
@@ -105,7 +123,9 @@ the wire address with a host key outside the logical address.
 ordered effects with stable IDs such as `0:0` and `1:0`, and event waits with
 IDs such as `event:0`. Memoize or deduplicate each operation using that ID:
 replaying the same events from the beginning reconstructs the same snapshots,
-effects, waits and IDs. Each `DurableEffect` also carries a serializable
+effects, waits and IDs — not just the same resulting snapshot, but the same
+effects in the same order, which is what hosts that match journal entries
+positionally (Temporal, Restate) depend on. Each `DurableEffect` also carries a serializable
 `descriptor` — actor references replaced by addresses and actor sources by
 source keys — for journaling; payload fields such as `event` and `input` pass
 through by reference and are only as serializable as their values.

--- a/packages/core/src/State.ts
+++ b/packages/core/src/State.ts
@@ -633,10 +633,12 @@ export function getPersistedSnapshot<
         ? { snapshot: child.getPersistedSnapshot(options) }
         : {
             remote: true,
-            // Round-trips verbatim: the host that owns the child injects the
-            // token; XState never stamps one (a local sessionId would make
-            // persisted snapshots nondeterministic across replays).
-            incarnation: child._incarnation
+            // A remote handle's sessionId IS the host-supplied incarnation
+            // token, round-tripped verbatim. A local child persisted by
+            // address never stamps its own sessionId: that value is this
+            // incarnation's, not a durable identity, and it would make
+            // persisted snapshots nondeterministic across replays.
+            incarnation: isRemoteActorRef(child) ? child.sessionId : undefined
           }),
       src: child.src,
       registryKey: child.registryKey,

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -194,33 +194,6 @@ type ProvidedActors<
     : never;
 };
 
-// Declaration merging keeps the type-only marker zero-emit: a `declare`
-// class field is rejected by the build's babel pipeline, and a plain field
-// would emit an undefined property per instance. Merging requires type
-// parameters identical to the class's, so most are necessarily unused here.
-/* oxlint-disable no-unused-vars */
-export interface StateMachine<
-  TContext extends MachineContext,
-  TEvent extends EventObject,
-  TChildren extends Record<string, AnyActorRef | undefined>,
-  TStateValue extends StateValue,
-  TTag extends string,
-  TInput,
-  TOutput,
-  TEmitted extends EventObject,
-  TMeta extends MetaObject,
-  TConfig extends StateSchema,
-  TActionMap extends Sources['actions'],
-  TActorMap extends Sources['actors'],
-  TGuardMap extends Sources['guards'],
-  TDelayMap extends Sources['delays'],
-  TInternalEvent extends EventObject = never
-> {
-  /** @internal Type-only marker for the actor's internal event protocol. */
-  readonly _internalEventType: TInternalEvent;
-}
-/* oxlint-enable no-unused-vars */
-
 export class StateMachine<
   TContext extends MachineContext,
   TEvent extends EventObject,
@@ -253,6 +226,13 @@ export class StateMachine<
   AnyActorSystem,
   TEmitted
 > {
+  /**
+   * @internal Type-only marker for the actor's internal event protocol. Not
+   * `declare` (the build's babel pipeline rejects declare class fields); the
+   * one `undefined` property this emits per machine instance is inert.
+   */
+  readonly _internalEventType!: TInternalEvent;
+
   /** The machine's own version. */
   public version?: string;
 

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -194,6 +194,33 @@ type ProvidedActors<
     : never;
 };
 
+// Declaration merging keeps the type-only marker zero-emit: a `declare`
+// class field is rejected by the build's babel pipeline, and a plain field
+// would emit an undefined property per instance. Merging requires type
+// parameters identical to the class's, so most are necessarily unused here.
+/* oxlint-disable no-unused-vars */
+export interface StateMachine<
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  TChildren extends Record<string, AnyActorRef | undefined>,
+  TStateValue extends StateValue,
+  TTag extends string,
+  TInput,
+  TOutput,
+  TEmitted extends EventObject,
+  TMeta extends MetaObject,
+  TConfig extends StateSchema,
+  TActionMap extends Sources['actions'],
+  TActorMap extends Sources['actors'],
+  TGuardMap extends Sources['guards'],
+  TDelayMap extends Sources['delays'],
+  TInternalEvent extends EventObject = never
+> {
+  /** @internal Type-only marker for the actor's internal event protocol. */
+  readonly _internalEventType: TInternalEvent;
+}
+/* oxlint-enable no-unused-vars */
+
 export class StateMachine<
   TContext extends MachineContext,
   TEvent extends EventObject,
@@ -226,9 +253,6 @@ export class StateMachine<
   AnyActorSystem,
   TEmitted
 > {
-  /** @internal Type-only marker for the actor's internal event protocol. */
-  declare readonly _internalEventType: TInternalEvent;
-
   /** The machine's own version. */
   public version?: string;
 

--- a/packages/core/src/actors/promise.ts
+++ b/packages/core/src/actors/promise.ts
@@ -369,29 +369,37 @@ export function createAsyncLogic<
           }
         };
 
-        const resolvedPromise = Promise.resolve(
-          config.run(
-            {
-              input,
-              system,
-              self: self as any,
-              signal: controller.signal
-            },
-            {
-              emit: (event) => void runtime.emitEvent!(actorSelf, event),
-              // Steps route through the runtime: a durable host that
-              // implements `runStep` owns the step journal; otherwise the
-              // built-in behavior memoizes into this actor's own snapshot,
-              // self-sending through the same runtime as the other effects.
-              step: (key, exec) =>
-                runtime.runStep
-                  ? (Promise.resolve(
-                      runtime.runStep(actorSelf, key, exec)
-                    ) as Promise<any>)
-                  : runStep(actorSelf, key, exec, sendSelf)
-            }
-          )
-        );
+        const runBody = () =>
+          Promise.resolve(
+            config.run(
+              {
+                input,
+                system,
+                self: self as any,
+                signal: controller.signal
+              },
+              {
+                emit: (event) => void runtime.emitEvent!(actorSelf, event),
+                // Steps route through the runtime: a durable host that
+                // implements `runStep` owns the step journal; otherwise the
+                // built-in behavior memoizes into this actor's own snapshot,
+                // self-sending through the same runtime as the other effects.
+                step: (key, exec) =>
+                  runtime.runStep
+                    ? (Promise.resolve(
+                        runtime.runStep(actorSelf, key, exec)
+                      ) as Promise<any>)
+                    : runStep(actorSelf, key, exec, sendSelf)
+              }
+            )
+          );
+        // The whole body is one durable unit: a host that implements
+        // `runLogic` journals it by the actor's address — or re-runs the
+        // registered logic from (src, input) on a remote executor, ignoring
+        // the closure. The default runs it here, unjournaled.
+        const resolvedPromise = runtime.runLogic
+          ? Promise.resolve(runtime.runLogic(actorSelf, runBody))
+          : runBody();
 
         resolvedPromise.then(
           (response) => {

--- a/packages/core/src/durable/index.ts
+++ b/packages/core/src/durable/index.ts
@@ -257,7 +257,8 @@ export function createDurable<TLogic extends AnyActorLogic>(
   for (const operation of [
     ...RUNTIME_OPERATIONS,
     'sendEvent',
-    'runStep'
+    'runStep',
+    'runLogic'
   ] as const) {
     const impl = adapter[operation];
     if (impl) {
@@ -368,6 +369,9 @@ export function createDurable<TLogic extends AnyActorLogic>(
     // deadlock with) the operations its own body initiates.
     if (runtime.runStep) {
       wrapped.runStep = runtime.runStep;
+    }
+    if (runtime.runLogic) {
+      wrapped.runLogic = runtime.runLogic;
     }
     wrapped.sendEvent = (source, target, event) => {
       if (

--- a/packages/core/src/durable/index.ts
+++ b/packages/core/src/durable/index.ts
@@ -6,6 +6,7 @@ import { deliverEvent } from '../runtimeHelpers.ts';
 import { getSnapshotActorRef } from '../snapshotActorRef.ts';
 import {
   encodeAddressSegment,
+  withExecutionIdentity,
   getRootActorId,
   RUNTIME_OPERATIONS,
   type ActorSystemRuntime
@@ -104,6 +105,16 @@ export interface DurableExecutionAdapter<
   ): EventFromLogic<TLogic> | PromiseLike<EventFromLogic<TLogic>>;
   /** Index assigned to the first transition. Defaults to `0`. */
   transitionIndex?: number;
+  /**
+   * Pins this execution's actor identity. Session ids become
+   * `<executionId>:<n>`, a deterministic function of actor-creation order, so
+   * a replay re-creates the same session ids and journaled completion events
+   * (which carry the producing incarnation's `sessionId`) still match the
+   * children the replay re-creates. Without it, session ids embed a random
+   * per-process system id and journaled internal events go stale across
+   * replays. Uniqueness across executions is the host's responsibility.
+   */
+  executionId?: string;
 }
 
 export class DurableExecutionCancelledError extends Error {
@@ -234,6 +245,12 @@ export function createDurable<TLogic extends AnyActorLogic>(
   const rootAddress = encodeAddressSegment(getRootActorId(logic));
   const machineId = (logic as { id?: string }).id ?? rootAddress;
   const machineVersion = (logic as { version?: string }).version;
+  // One identity object for the whole execution: session numbering continues
+  // across this execution's transitions, and a replay (a fresh createDurable
+  // with the same executionId) re-numbers identically.
+  const executionIdentity = adapter.executionId
+    ? { systemId: adapter.executionId, nextSessionId: 0 }
+    : undefined;
 
   // The adapter's runtime operations, picked off the flat adapter shape.
   const systemRuntime: Partial<ActorSystemRuntime> = {};
@@ -421,11 +438,16 @@ export function createDurable<TLogic extends AnyActorLogic>(
       return nextTransitionIndex;
     },
     initialTransition(...args) {
-      const [snapshot, effects] = initialTransition(logic, ...args);
+      const [snapshot, effects] = withExecutionIdentity(executionIdentity, () =>
+        initialTransition(logic, ...args)
+      );
       return [installSystemRuntime(snapshot), tagEffects(effects)];
     },
     transition(snapshot, event) {
-      const [nextSnapshot, effects] = transition(logic, snapshot, event);
+      const [nextSnapshot, effects] = withExecutionIdentity(
+        executionIdentity,
+        () => transition(logic, snapshot, event)
+      );
       return [installSystemRuntime(nextSnapshot), tagEffects(effects)];
     },
     getActorRef(snapshot) {

--- a/packages/core/src/effectDescriptor.ts
+++ b/packages/core/src/effectDescriptor.ts
@@ -1,3 +1,4 @@
+import { isRemoteActorRef } from './remoteActorRef.ts';
 import { getActorIdPrefix } from './system.ts';
 import type { ExecutableActionObject } from './types.ts';
 
@@ -147,7 +148,9 @@ export function getEffectDescriptor(
         type: '@xstate.sendTo',
         source: effect.source.address,
         target: effect.target.address,
-        incarnation: (effect.target as { _incarnation?: string })._incarnation,
+        incarnation: isRemoteActorRef(effect.target)
+          ? effect.target.sessionId
+          : undefined,
         event: effect.event,
         id: effect.id,
         delay: effect.delay

--- a/packages/core/src/remoteActorRef.ts
+++ b/packages/core/src/remoteActorRef.ts
@@ -67,12 +67,12 @@ export function createRemoteActorRef(
     address: options.address,
     src: options.src,
     registryKey: options.registryKey,
-    // A remote handle does not know the child's incarnation; the runtime that
-    // owns the child is the authority on completion staleness — unless the
-    // host supplied an incarnation token, which lets this side drop stale
-    // completions and lets journaled sends name the intended incarnation.
-    sessionId: undefined as unknown as string,
-    _incarnation: options.incarnation,
+    // The host-supplied incarnation token, when present: the owner's
+    // sessionId for this child, letting this side drop stale completions and
+    // journaled sends name the intended incarnation. Without one the handle
+    // does not know the child's incarnation and the owning runtime is the
+    // authority on staleness.
+    sessionId: options.incarnation as string,
     system,
     _parent: options.parent,
     // Round-trips through persistence verbatim (undefined stays undefined,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1,4 +1,3 @@
-import { isRemoteActorRef } from './remoteActorRef.ts';
 import isDevelopment from '#is-development';
 import { MachineSnapshot, cloneMachineSnapshot } from './State.ts';
 import type { StateNode } from './StateNode.ts';
@@ -304,22 +303,17 @@ export function matchesActorSession(
   snapshot: AnyMachineSnapshot,
   actorId: string
 ): boolean {
-  const child = snapshot.children[actorId] as
-    | (AnyActor & { _incarnation?: string })
-    | undefined;
+  const child = snapshot.children[actorId];
   if (!child || !('sessionId' in event)) {
     return true;
   }
-  if (isRemoteActorRef(child)) {
-    // Without a host-supplied incarnation token the runtime that owns the
-    // child is the authority on staleness; with one, a completion from a
-    // different incarnation of the same address is dropped here.
-    return (
-      child._incarnation === undefined ||
-      child._incarnation === (event as { sessionId?: string }).sessionId
-    );
-  }
-  return child.sessionId === (event as { sessionId?: string }).sessionId;
+  // One rule: a ref that knows its incarnation compares it; a remote handle
+  // without a host-supplied token (sessionId undefined) defers to the
+  // runtime that owns the child.
+  return (
+    child.sessionId === undefined ||
+    child.sessionId === (event as { sessionId?: string }).sessionId
+  );
 }
 
 function normalizeLegacyInternalEvent(
@@ -2276,23 +2270,14 @@ export function macrostep(
     if (!actorId) {
       return;
     }
-    const child = nextSnapshot.children[actorId] as
-      | (AnyActor & { _incarnation?: string })
-      | undefined;
+    const child = nextSnapshot.children[actorId];
     if (!child) {
       return;
     }
     // The same staleness rule matchesActorSession applies to transition
     // selection: a completion from a different incarnation must not remove
     // the still-running child either.
-    if (isRemoteActorRef(child)) {
-      if (
-        child._incarnation !== undefined &&
-        child._incarnation !== sessionId
-      ) {
-        return;
-      }
-    } else if (child.sessionId !== sessionId) {
+    if (child.sessionId !== undefined && child.sessionId !== sessionId) {
       return;
     }
 

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -302,6 +302,21 @@ export interface ActorSystemRuntime {
   /** Cancels one logical timer. */
   cancelTimer(source: AnyActor, id: string): void | PromiseLike<void>;
   /**
+   * Runs an async actor's entire body as one durable unit. The actor is the
+   * natural journal entry: its identity — `address`, string `src` key and
+   * serializable `input` — crosses any boundary, so a host can wrap `exec`
+   * in its own step primitive, or ignore `exec` entirely and re-run the
+   * registered logic on a remote executor from `(src, input)` alone. The
+   * default runs the body in this process, unjournaled.
+   *
+   * Like `runStep`, this is an orchestration frame: it may span external
+   * events and must never be serialized behind other runtime operations.
+   */
+  runLogic(
+    actor: AnyActor,
+    exec: () => PromiseLike<unknown>
+  ): PromiseLike<unknown>;
+  /**
    * Runs one keyed step of an async actor (`enq.step`). The default journals
    * the result in the actor's own snapshot; a durable host implements this
    * to journal steps in its own journal instead — memoized results replay
@@ -342,9 +357,10 @@ export const RUNTIME_OPERATIONS = [
   'cancelTimer',
   'cancelAllTimers',
   'deadLetter'
-  // `runStep` and `sendEvent` are deliberately absent: durable executions
-  // wire them separately, since a step awaits other runtime operations and
-  // root-addressed sends are captured per batch.
+  // `runLogic`, `runStep` and `sendEvent` are deliberately absent: durable
+  // executions wire them separately, since logic bodies and steps await
+  // other runtime operations and root-addressed sends are captured per
+  // batch.
 ] as const satisfies readonly (keyof ActorSystemRuntime)[];
 
 type ScheduledTimerId = string & { __scheduledTimerId: never };
@@ -846,6 +862,17 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
       return override(actor, key, exec);
     }
     return runStep(actor, key, exec);
+  }
+
+  public runLogic(
+    actor: AnyActor,
+    exec: () => PromiseLike<unknown>
+  ): PromiseLike<unknown> {
+    const override = this.runtime?.runLogic;
+    if (override) {
+      return override(actor, exec);
+    }
+    return exec();
   }
 
   public scheduleTimer(

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -90,6 +90,39 @@ function createSystemId(): string {
 }
 
 /**
+ * The identity a durable execution pins on every system its transitions
+ * create. Shared across all transitions (and replays) of one execution, so
+ * session ids become a deterministic function of actor-creation order:
+ * `<executionId>:0`, `<executionId>:1`, … A replayed execution re-creates
+ * the same session ids, so journaled completion events (which carry the
+ * producing incarnation's `sessionId`) still match the children the replay
+ * re-creates.
+ */
+export interface ExecutionIdentity {
+  systemId: string;
+  nextSessionId: number;
+}
+
+let ambientExecutionIdentity: ExecutionIdentity | undefined;
+
+/** @internal Runs `fn` with systems it creates pinned to `identity`. */
+export function withExecutionIdentity<T>(
+  identity: ExecutionIdentity | undefined,
+  fn: () => T
+): T {
+  if (!identity) {
+    return fn();
+  }
+  const previous = ambientExecutionIdentity;
+  ambientExecutionIdentity = identity;
+  try {
+    return fn();
+  } finally {
+    ambientExecutionIdentity = previous;
+  }
+}
+
+/**
  * Derives the deterministic id prefix for a generated actor id from its actor
  * source: the registered source key when the source is a string, the logic's
  * own `id` otherwise, with `x` as the last-resort prefix.
@@ -429,7 +462,7 @@ interface RuntimeSystem<T extends ActorSystemInfo> {
 }
 
 class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
-  public _identity = {
+  public _identity = ambientExecutionIdentity ?? {
     systemId: createSystemId(),
     nextSessionId: 0
   };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -697,13 +697,19 @@ type EventTypeMatchesDescriptor<
 type IsInternalEventType<
   TEventType extends string,
   TDescriptors extends string
-> = true extends (
-  TDescriptors extends any
-    ? EventTypeMatchesDescriptor<TEventType, TDescriptors>
-    : never
-)
-  ? true
-  : false;
+> =
+  // Descriptors that collapsed to broad `string` (an untyped machine's
+  // config) cannot classify anything: without the guard they would match
+  // every event type and reduce the sendable events to `never`.
+  string extends TDescriptors
+    ? false
+    : true extends (
+          TDescriptors extends any
+            ? EventTypeMatchesDescriptor<TEventType, TDescriptors>
+            : never
+        )
+      ? true
+      : false;
 
 type ExcludeInternalEvents<
   TEvent extends EventObject,

--- a/packages/core/test/addressFirstIdentity.test.ts
+++ b/packages/core/test/addressFirstIdentity.test.ts
@@ -1089,7 +1089,8 @@ describe('incarnation tokens on remote handles', () => {
       snapshot: persistedWithIncarnation('runtime-b:7')
     }).start();
     const handle = restored.getSnapshot().children.w as any;
-    expect(handle._incarnation).toBe('runtime-b:7');
+    // The token IS the handle's sessionId: one incarnation identity, one field.
+    expect(handle.sessionId).toBe('runtime-b:7');
     const repersisted = restored.getPersistedSnapshot({
       embedChildren: false
     }) as any;

--- a/packages/core/test/durable-execution-identity.test.ts
+++ b/packages/core/test/durable-execution-identity.test.ts
@@ -1,0 +1,101 @@
+import { createAsyncLogic, setup } from '../src/index.ts';
+import { createDurable } from '../src/durable/index.ts';
+
+const fraudCheck = createAsyncLogic({
+  id: 'fraudCheck',
+  run: async (_, enq) => {
+    return enq.step('score', async () => 0.2);
+  }
+});
+
+const machine = setup({ actors: { fraudCheck } }).createMachine({
+  id: 'order',
+  initial: 'verifying',
+  states: {
+    verifying: {
+      invoke: { id: 'fraud', src: 'fraudCheck', onDone: { target: 'approved' } }
+    },
+    approved: {}
+  }
+});
+
+function createHost(steps: Map<string, unknown>, executionId?: string) {
+  return createDurable(machine, {
+    executionId,
+    executeAction: () => {},
+    startActor: (actor) => {
+      actor.start();
+    },
+    runStep: async (actor, key, exec) => {
+      const id = `${actor.address}:${key}`;
+      if (steps.has(id)) {
+        return steps.get(id);
+      }
+      const output = await exec();
+      steps.set(id, output);
+      return output;
+    },
+    waitForEvent: () => {
+      throw new Error('host-driven loop');
+    }
+  });
+}
+
+describe('deterministic execution identity', () => {
+  it('a replay re-creates the same session ids', async () => {
+    const steps = new Map<string, unknown>();
+    const first = createHost(steps, 'exec-1');
+    const [s1, e1] = first.initialTransition();
+    const events1 = await first.executeEffects(e1);
+
+    const second = createHost(steps, 'exec-1');
+    const [s2, e2] = second.initialTransition();
+    const events2 = await second.executeEffects(e2);
+
+    expect(events1.map(({ event }) => event)).toEqual(
+      events2.map(({ event }) => event)
+    );
+    const sessionId = (events1[0]!.event as { sessionId?: string }).sessionId;
+    expect(sessionId).toMatch(/^exec-1:/);
+    void s1;
+    void s2;
+  });
+
+  it('a journaled completion event still matches the child a replay re-creates', async () => {
+    const steps = new Map<string, unknown>();
+
+    // Run 1: the invoked fraud check completes; its completion reaches the
+    // root and a journaling host records the event verbatim.
+    const first = createHost(steps, 'exec-1');
+    const [snapshot1, effects1] = first.initialTransition();
+    const [journaled] = await first.executeEffects(effects1);
+    expect(journaled!.event.type).toMatch(/^xstate\.done\.actor/);
+
+    // Crash. Replay from the beginning in a "fresh process": same journal,
+    // same executionId. The replayed step returns its memoized result, and
+    // the recorded completion event — carrying run 1's sessionId — must
+    // match the child the replay just re-created.
+    const second = createHost(steps, 'exec-1');
+    const [snapshot2, effects2] = second.initialTransition();
+    await second.executeEffects(effects2);
+    const [replayed] = second.transition(snapshot2 as never, journaled!.event);
+    expect((replayed as { value?: unknown }).value).toBe('approved');
+    void snapshot1;
+  });
+
+  it('without an executionId, journaled completions go stale across replays', async () => {
+    const steps = new Map<string, unknown>();
+    const first = createHost(steps);
+    const [, effects1] = first.initialTransition();
+    const [journaled] = await first.executeEffects(effects1);
+
+    const second = createHost(steps);
+    const [snapshot2, effects2] = second.initialTransition();
+    await second.executeEffects(effects2);
+    const [replayed] = second.transition(snapshot2 as never, journaled!.event);
+    // The recorded sessionId embeds run 1's random system id, so the
+    // completion is dropped as stale — the documented reason to pin
+    // executionId on journaling hosts.
+    expect((replayed as { value?: unknown }).value).toBe('verifying');
+  });
+});

--- a/packages/core/test/durable-execution-identity.test.ts
+++ b/packages/core/test/durable-execution-identity.test.ts
@@ -99,3 +99,107 @@ describe('deterministic execution identity', () => {
     expect((replayed as { value?: unknown }).value).toBe('verifying');
   });
 });
+
+describe('runLogic: the async actor as the durable unit', () => {
+  const plainMachine = setup({
+    actors: {
+      score: createAsyncLogic({
+        id: 'score',
+        // A normal promise — no step vocabulary.
+        run: async ({ input }: { input: { total: number } }) =>
+          input.total > 1000 ? 0.9 : 0.1
+      })
+    }
+  }).createMachine({
+    id: 'order',
+    initial: 'verifying',
+    context: ({ input }: { input: { total: number } }) => ({
+      total: input.total
+    }),
+    states: {
+      verifying: {
+        invoke: {
+          id: 'fraud',
+          src: 'score',
+          input: ({ context }) => ({ total: context.total }),
+          onDone: { target: 'approved' }
+        }
+      },
+      approved: {}
+    }
+  });
+
+  it('a journaling host wraps the body once and replays the result', async () => {
+    const journal = new Map<string, unknown>();
+    let executions = 0;
+    const host = (executionId: string) =>
+      createDurable(plainMachine, {
+        executionId,
+        executeAction: () => {},
+        startActor: (actor) => {
+          actor.start();
+        },
+        runLogic: async (actor, exec) => {
+          if (journal.has(actor.address)) {
+            return journal.get(actor.address);
+          }
+          executions++;
+          const output = await exec();
+          journal.set(actor.address, output);
+          return output;
+        },
+        waitForEvent: () => {
+          throw new Error('host-driven loop');
+        }
+      });
+
+    const first = host('exec-1');
+    const [, e1] = first.initialTransition({ total: 1500 });
+    const [done1] = await first.executeEffects(e1);
+    expect(done1!.event.type).toMatch(/^xstate\.done\.actor/);
+    expect(executions).toBe(1);
+
+    // Crash → replay: the body does not re-run, and the journaled
+    // completion still matches the replayed child.
+    const second = host('exec-1');
+    const [s2, e2] = second.initialTransition({ total: 1500 });
+    await second.executeEffects(e2);
+    expect(executions).toBe(1);
+    const [replayed] = second.transition(s2 as never, done1!.event);
+    expect((replayed as { value?: unknown }).value).toBe('approved');
+  });
+
+  it('a remote-executor host ignores the closure and re-runs from (src, input)', async () => {
+    // The Temporal shape: the "activity worker" reconstructs the work from
+    // the actor's serializable identity alone — no closure crosses over.
+    const workerSide = {
+      score: async (input: { total: number }) =>
+        input.total > 1000 ? 0.9 : 0.1
+    };
+    const shipped: Array<{ src: unknown; input: unknown }> = [];
+    const durable = createDurable(plainMachine, {
+      executionId: 'exec-1',
+      executeAction: () => {},
+      startActor: (actor) => {
+        actor.start();
+      },
+      runLogic: async (actor) => {
+        const input = (actor.getSnapshot() as { input?: unknown }).input;
+        shipped.push({ src: actor.src, input });
+        expect(() => JSON.stringify({ src: actor.src, input })).not.toThrow();
+        return workerSide[actor.src as keyof typeof workerSide](
+          input as { total: number }
+        );
+      },
+      waitForEvent: () => {
+        throw new Error('host-driven loop');
+      }
+    });
+
+    const [snapshot, effects] = durable.initialTransition({ total: 1500 });
+    const [done] = await durable.executeEffects(effects);
+    expect(shipped).toEqual([{ src: 'score', input: { total: 1500 } }]);
+    const [next] = durable.transition(snapshot as never, done!.event);
+    expect((next as { value?: unknown }).value).toBe('approved');
+  });
+});

--- a/packages/core/test/internalEvents.test.ts
+++ b/packages/core/test/internalEvents.test.ts
@@ -1,4 +1,4 @@
-import { createActor, createMachine } from '../src';
+import { createActor, createMachine, type ActorRefFrom } from '../src';
 import z from 'zod';
 
 describe('internalEvents', () => {
@@ -134,4 +134,18 @@ describe('internalEvents', () => {
     ).toThrow('Internal event "change.value" cannot be sent to actor');
     expect(actor.getSnapshot().value).toBe('idle');
   });
+});
+
+it('an untyped machine keeps its sendable events (type-level)', () => {
+  // Broad TConfig collapses internal-event descriptors to `string`; that
+  // must classify nothing rather than everything (send would become never).
+  const machine = createMachine({
+    initial: 'a',
+    states: { a: { on: { NEXT: { target: 'a' } } } }
+  });
+  const actor = createActor(machine).start();
+  actor.send({ type: 'NEXT' });
+  const ref: ActorRefFrom<typeof machine> = actor;
+  ref.send({ type: 'NEXT' });
+  actor.stop();
 });


### PR DESCRIPTION
Follow-up to #5659, from field-testing the durable contract against five real hosts (Restate, Rivet, Temporal, Inngest, Trigger.dev) with one shared saga machine.

## executionId: deterministic session ids for journaling hosts

Session ids embed a random per-process system id, so a host that journals the execution's **own** events (not just external ones) finds them stale on replay: a recorded `xstate.done.actor` completion carries run 1's `sessionId` and never matches the child the replay re-creates. Rivet and Restate hit this independently and each had to segregate internal from external events as a workaround.

`createDurable(machine, { executionId, ... })` pins the execution's identity: session ids become `<executionId>:<n>`, a deterministic function of actor-creation order, so a replay re-creates the same ids and journaled completions match. Uniqueness across executions is the host's responsibility. Tests cover identical replays, the journaled-completion round-trip, and the stale behavior without it.

## Docs (three host-guidance gaps)

- **Quiesce before parking durably**: `executeEffects` resolves without awaiting steps (by design); a host registering a durable wait while steps are in flight deadlocks — the step's completion event can never satisfy the already-registered wait. Two hosts hit this.
- **`runStep`'s `exec` is a closure** over live execution state: run it in-process and journal its result; it cannot ship to a remote executor (Temporal finding).
- **Ordered-effect replay guarantee** stated explicitly: replay reconstructs the same effects in the same order, which positional-journal hosts (Temporal, Restate) depend on.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5663" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->