### PR TITLE
feat(core): add separate internal event schemas

### DIFF
--- a/.changeset/private-event-schemas.md
+++ b/.changeset/private-event-schemas.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Add separately declared internal event schemas with `schemas.internalEvents`. Internal events remain fully typed inside machines while staying out of the public actor event protocol. The existing top-level `internalEvents` list remains supported for migration.

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -423,8 +423,13 @@ See [final](final-states.md), [history](history-states.md), [parallel](parallel-
 
 ```ts
 createMachine({
-  schemas: { events: { start: z.object({}), tick: z.object({}) } },
-  internalEvents: ['tick', 'change.*'] as const,
+  schemas: {
+    events: { start: z.object({}) },
+    internalEvents: {
+      tick: z.object({}),
+      'change.*': z.object({ value: z.string() })
+    }
+  },
   initial: 'idle',
   states: {
     idle: {
@@ -438,7 +443,8 @@ createMachine({
 });
 ```
 
-Listed types can be raised inside the machine but throw when sent from outside. See [internal events](internal-events.md).
+Types declared in `schemas.internalEvents` can be raised inside the machine
+but throw when sent from outside. See [internal events](internal-events.md).
 
 ## Setup and provide
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,8 +36,8 @@ The root of a machine is a state node. It accepts everything a [state node](#sta
 | `onDone` | transition | Taken when a final child state is reached. See [final states](final-states.md). |
 | `onError` | transition | Taken on `xstate.error.*` raised below this node. See [errors](lifecycle-and-errors.md). |
 | `output` | value or `({ context, event }) => value` | [Output](input-output.md) produced on completion. |
-| `schemas` | `{ context, events, emitted, input, output, meta, tags, children, actions, guards }` | Standard Schema definitions. See [TypeScript](typescript.md). |
-| `internalEvents` | `readonly EventType[]` | Events the machine may raise but no one may send in. See [internal events](internal-events.md). |
+| `schemas` | `{ context, events, internalEvents, emitted, input, output, meta, tags, children, actions, guards }` | Standard Schema definitions. See [TypeScript](typescript.md). |
+| `internalEvents` | `readonly EventType[]` | Deprecated compatibility list for events declared in `schemas.events`; use `schemas.internalEvents` instead. See [internal events](internal-events.md). |
 | `actions` | `Record<string, (params, args) => void>` | Named action sources. See [setup and provide](setup-and-provide.md). |
 | `guards` | `Record<string, (params, args) => boolean>` | Named guard sources. See [guards](guards.md). |
 | `actors` | `Record<string, ActorLogic>` | Named actor logic sources. See [invoke](invoke.md). |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -33,7 +33,7 @@ description: Terms used throughout the XState documentation.
 
 **Input**: Data provided when an actor is created, or to a state via a transition's `input`.
 
-**Internal event**: An event listed in `internalEvents` that can be raised inside the machine but rejected when sent from outside the actor.
+**Internal event**: An event declared in `schemas.internalEvents` that is fully typed inside the machine but rejected by the public actor event protocol. The legacy top-level `internalEvents` list is supported for migration.
 
 **Invoked actor**: A child actor whose lifecycle belongs to a state.
 

--- a/docs/internal-events.md
+++ b/docs/internal-events.md
@@ -3,23 +3,26 @@ title: Internal events
 description: Declare events that the machine may raise but no one may send in.
 ---
 
-`internalEvents` lists event types that the machine can raise to itself but that cannot be sent from outside the actor.
+Declare private event payload schemas in `schemas.internalEvents`. These events
+are part of the machine's internal event union, but are excluded from the
+public `actor.send(...)` and `actor.trigger` protocols.
 
 ```ts
 const machine = createMachine({
   schemas: {
     events: {
-      start: z.object({}),
-      tick: z.object({})
+      start: z.object({})
+    },
+    internalEvents: {
+      tick: z.object({ count: z.number() })
     }
   },
-  internalEvents: ['tick'] as const,
   initial: 'idle',
   states: {
     idle: {
       on: {
         start: (_, enq) => {
-          enq.raise({ type: 'tick' });
+          enq.raise({ type: 'tick', count: 1 });
         },
         tick: { target: 'done' }
       }
@@ -40,21 +43,30 @@ actor.send({ type: 'tick' });
 
 The actor's state is unchanged, because the throw happens before the event is delivered.
 
-Internal events are still ordinary events in every other respect. They need a schema entry, they appear in `on` handlers, and they are raised with `enq.raise` like any other event.
+Internal events are still ordinary events in every other respect. They appear
+in `on` handlers and are raised with `enq.raise` like any other event. They do
+not need a duplicate entry in `schemas.events`.
 
 ## Wildcard patterns
 
 Entries may use a `.`-segment wildcard, which covers every event type under that prefix.
 
 ```ts
-internalEvents: ['change.*'] as const
+schemas: {
+  internalEvents: {
+    'change.*': z.object({ value: z.string() })
+  }
+}
 ```
 
 With that in place, `change.value`, `change.status` and any other `change.*` event can be raised internally but is rejected from outside.
 
 ## What counts as "outside"
 
-The check compares the sender to the receiver. An actor raising or sending an event to itself is allowed. Anything else throws: `actor.send` from application code, a parent sending to a child, or a sibling actor.
+The check compares the sender to the receiver. An internally executed
+self-targeted effect such as `enq.raise(...)` or `enq.sendTo(self, ...)` is
+allowed. Anything else throws: `actor.send` from application code, a parent
+sending to a child, or a sibling actor.
 
 > **Warning:** the error is thrown synchronously at the call site, not routed to the actor's error handling. Treat internal events as a private surface, and if application code needs to reach that behavior, expose a public event that raises the internal one.
 
@@ -66,7 +78,21 @@ Use internal events for:
 
 ## TypeScript
 
-Declaring `internalEvents` with `as const` narrows the actor's send type: listed types, and types matched by a wildcard, are removed from what `actor.send` accepts, so an invalid send is a type error rather than a runtime throw. The types must still exist in the events schema, and they remain fully typed inside the machine for `on` handlers, `enq.raise` and [transitions](transitions.md).
+The keys in `schemas.internalEvents` narrow the actor's public protocol: those
+types, and types matched by a wildcard, are removed from what `actor.send` and
+`actor.trigger` accept. They remain fully typed inside the machine for `on`
+handlers, guards, actions, `enq.raise` and [transitions](transitions.md).
+
+The legacy top-level form remains supported for migration:
+
+```ts
+schemas: { events: { tick: z.object({}) } },
+internalEvents: ['tick'] as const
+```
+
+It is deprecated; move each listed event to `schemas.internalEvents`. The
+legacy list is useful when a machine's existing public event schemas are being
+split incrementally.
 
 ## Internal events cheatsheet
 
@@ -74,12 +100,13 @@ Declaring `internalEvents` with `as const` narrows the actor's send type: listed
 createMachine({
   schemas: {
     events: {
-      start: z.object({}),
+      start: z.object({})
+    },
+    internalEvents: {
       tick: z.object({}),
-      'change.value': z.object({ value: z.string() })
+      'change.*': z.object({ value: z.string() })
     }
   },
-  internalEvents: ['tick', 'change.*'] as const,
   initial: 'idle',
   states: {
     idle: {

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -24,7 +24,7 @@ Use machine-as-data for cases such as:
 
 ## What survives serialization
 
-States, transitions, targets, serialized action objects, guard references, string actor `src` names, `after` delays, `timeout`/`onTimeout`, `meta`, `description`, `tags`, `output`, `context` values, `internalEvents`, `version`, and any other JSON-safe data on the config all survive.
+States, transitions, targets, serialized action objects, guard references, string actor `src` names, `after` delays, `timeout`/`onTimeout`, `meta`, `description`, `tags`, `output`, `context` values, the legacy top-level `internalEvents` list, `version`, and any other JSON-safe data on the config all survive.
 
 Inline functions become code expressions:
 
@@ -41,6 +41,7 @@ These values are omitted rather than serialized:
 
 - actor logic objects, including inline `invoke.src` logic (the whole `invoke` is dropped when its `src` cannot be named)
 - runtime schemas such as Zod schemas in `schemas`
+- `schemas.internalEvents` declarations; restore those schemas when reviving if runtime validation is needed
 - root `actions`, `guards`, `actors` and `delays` sources that are functions
 - class instances, `Date`s, `bigint` and `symbol` values, including inside arrays
 

--- a/docs/setup-and-provide.md
+++ b/docs/setup-and-provide.md
@@ -9,7 +9,8 @@ description: Declare typed sources with setup(...) and swap implementations with
 const orderSetup = setup({
   schemas: {
     context: z.object({ total: z.number() }),
-    events: { submit: z.object({}) }
+    events: { submit: z.object({}) },
+    internalEvents: { recalculate: z.object({}) }
   },
   actions: {
     logTotal: (params: { total: number }) => console.log(params.total)

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -17,6 +17,9 @@ const machine = setup({
     events: {
       increment: z.object({})
     },
+    internalEvents: {
+      tick: z.object({ count: z.number() })
+    },
     input: z.object({ initialCount: z.number() })
   }
 }).createMachine({
@@ -26,7 +29,8 @@ const machine = setup({
 });
 ```
 
-Schema event keys also create typed methods on `actor.trigger`.
+Public schema event keys create typed methods on `actor.trigger`; internal
+schema keys do not appear in the public trigger namespace.
 
 ```ts
 actor.trigger.increment();
@@ -63,6 +67,9 @@ const machine = setup({
     context: z.object({ count: z.number() }),
     events: {
       increment: z.object({ by: z.number() })
+    },
+    internalEvents: {
+      tick: z.object({ count: z.number() })
     }
   }
 }).createMachine({
@@ -70,7 +77,7 @@ const machine = setup({
 });
 ```
 
-The validator checks input and public events before calculation, then checks
+The validator checks input and public or internal events before calculation, then checks
 stable context, active state schemas, child slots, delayed raised events,
 emitted events and final output before effects run. Invalid values throw an
 `ActorValidationError`.

--- a/docs/xstate-v5-to-v6.md
+++ b/docs/xstate-v5-to-v6.md
@@ -45,13 +45,13 @@ Beyond simplifying the action/guard surface, v6 introduces a number of features 
 | Feature                                                                           | What it gives you                                                                                                                                                                                 |
 | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Inline function transitions](#1-inline-functions-replace-action-creators)        | Transitions and actions are plain functions; `enq` queues side effects.                                                                                                                           |
-| [Standard Schema definitions](#3-createmachine-schemas-replace-types)             | `schemas.context`/`events`/`input`/`output`/`emitted`/`meta`/`tags` accept Zod (or any [Standard Schema](https://standardschema.dev)) for TypeScript inference and runtime-readable metadata.     |
+| [Standard Schema definitions](#3-createmachine-schemas-replace-types)             | `schemas.context`/`events`/`internalEvents`/`input`/`output`/`emitted`/`meta`/`tags` accept Zod (or any [Standard Schema](https://standardschema.dev)) for TypeScript inference and runtime-readable metadata.     |
 | [State input](#5-state-input)                                                     | State nodes may declare a typed `input` payload that callers must provide on transition.                                                                                                          |
 | [`actor.trigger.X()`](#6-typed-actortrigger)                                      | Type-safe event dispatcher generated from `schemas.events` - no event-object boilerplate.                                                                                                         |
 | [`createAsyncLogic`](#7-async-actors-frompromise--createasynclogic)               | `fromPromise` rebuilt with `id`, `timeout`, `AbortSignal`, durable `enq.step()`, and event emission.                                                                                              |
 | [`createLogic`](#8-createlogic-stateful-actor-logic)                              | New stateful actor logic creator - like a small state machine defined as a single transition function with `enq`.                                                                                 |
 | [`enq.listen` / `enq.subscribeTo`](#9-enqlisten-and-enqsubscribeto)               | Declaratively wire child-actor emitted events or snapshot streams back to the parent.                                                                                                             |
-| [Internal events](#12-internal-events)                                            | `internalEvents: ['tick', 'change.*']` - events that can be raised inside the machine but rejected when sent from outside.                                                                        |
+| [Internal events](#12-internal-events)                                            | `schemas.internalEvents: { tick, 'change.*' }` - events that can be raised inside the machine but rejected by the public actor protocol.                                                          |
 | [Choice states](#13-choice-states)                                                | First-class `type: 'choice'` for declarative branch routing (replaces transient `always` chains).                                                                                                 |
 | [State timeouts](#14-state-and-async-timeouts)                                    | `timeout` + `onTimeout` per state - independent of `after`; auto-cancelled on exit.                                                                                                               |
 | [Duration strings](#14-state-and-async-timeouts)                                  | `'250ms'`, `'5s'` / `'1.5s'`, and ISO 8601 (`'PT1M30S'`, `'P1DT12H'`) accepted by state timeouts and async-logic timeouts.                                                                        |
@@ -378,6 +378,7 @@ const m = createMachine({
 schemas: {
   context:  ZodSchema,
   events:   { [eventType: string]: ZodSchema },        // map, not union
+  internalEvents: { [eventType: string]: ZodSchema },  // private event map
   actions:  { [actionType: string]: { params: ZodSchema } },
   guards:   { [guardType: string]: { params: ZodSchema } },
   emitted:  { [eventType: string]: ZodSchema },
@@ -391,11 +392,10 @@ schemas: {
 
 `events` and `emitted` are now **maps keyed by event type**, not unions. Each value is the schema for the event payload (excluding `type`).
 
-> **Note:** `schemas` drive **TypeScript inference only**. Runtime validation
-> of context/events/input against the schemas is **not** performed in this
-> release - do not rely on `schemas` to reject malformed events at runtime
-> (use `internalEvents` for inbound-event restriction, or validate at your
-> boundary).
+> **Note:** `schemas` drive TypeScript inference. Runtime validation is opt-in
+> through `standardSchemaValidator()` or the machine's event schema; ordinary
+> `actor.send(...)` calls do not automatically validate payloads. Internal
+> schemas also define the private event protocol.
 
 ### Machine output
 
@@ -824,18 +824,20 @@ on: {
 
 ## 12. Internal events
 
-Events listed in `internalEvents` can be **raised** internally but are **rejected** when sent from outside the actor. Wildcard patterns are supported.
+Events declared in `schemas.internalEvents` can be **raised** internally but
+are **rejected** by the public actor protocol. Wildcard patterns are supported.
 
 ```ts
 const machine = createMachine({
   schemas: {
     events: {
-      START: z.object({}),
+      START: z.object({})
+    },
+    internalEvents: {
       tick: z.object({}),
-      'change.value': z.object({ value: z.string() })
+      'change.*': z.object({ value: z.string() })
     }
   },
-  internalEvents: ['tick', 'change.*'] as const,
   initial: 'idle',
   states: {
     idle: {
@@ -853,6 +855,12 @@ const machine = createMachine({
 const actor = createActor(machine).start();
 actor.send({ type: 'tick' }); // throws: Internal event "tick" cannot be sent to actor "…" from outside.
 ```
+
+Raised, self-targeted and transition-handler event types include both schema
+maps. `actor.send(...)` and `actor.trigger` include only `schemas.events`.
+The previous top-level `internalEvents` descriptor list remains supported and
+deprecated; it can be migrated by moving each listed event's schema to
+`schemas.internalEvents`.
 
 ---
 

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -98,6 +98,24 @@ import type { PersistedMachineSnapshot } from './machineVersion.types.ts';
 
 const STATE_IDENTIFIER = '#';
 
+function findEventSchema(
+  schemas: Record<string, StandardSchemaV1> | undefined,
+  eventType: string
+): StandardSchemaV1 | undefined {
+  if (!schemas) {
+    return undefined;
+  }
+
+  if (Object.hasOwn(schemas, eventType)) {
+    return schemas[eventType];
+  }
+
+  const descriptor = Object.keys(schemas).find((key) =>
+    matchesEventDescriptor(eventType, key)
+  );
+  return descriptor === undefined ? undefined : schemas[descriptor];
+}
+
 let emptyCanActor: AnyActor | undefined;
 let emptyCanActorScope: AnyActorScope | undefined;
 
@@ -190,7 +208,8 @@ export class StateMachine<
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
-  TDelayMap extends Sources['delays']
+  TDelayMap extends Sources['delays'],
+  TInternalEvent extends EventObject = never
 > implements ActorLogic<
   MachineSnapshot<
     TContext,
@@ -207,6 +226,9 @@ export class StateMachine<
   AnyActorSystem,
   TEmitted
 > {
+  /** @internal Type-only marker for the actor's internal event protocol. */
+  declare readonly _internalEventType: TInternalEvent;
+
   /** The machine's own version. */
   public version?: string;
 
@@ -241,6 +263,7 @@ export class StateMachine<
   constructor(
     /** The raw config used to create the machine. */
     public config: Next_MachineConfig<
+      any,
       any,
       any,
       any,
@@ -377,14 +400,18 @@ export class StateMachine<
           }
           const event = value as EventObject;
           const eventSchemas = this.schemas?.events;
+          const internalEventSchemas = this.schemas?.internalEvents;
           const isFrameworkEvent =
             event.type.startsWith('xstate.') ||
             event.type.startsWith('@xstate.');
           const schema =
-            eventSchemas && Object.hasOwn(eventSchemas, event.type)
-              ? eventSchemas[event.type]
-              : undefined;
-          if (eventSchemas && !schema && !isFrameworkEvent) {
+            findEventSchema(internalEventSchemas, event.type) ??
+            findEventSchema(eventSchemas, event.type);
+          if (
+            (eventSchemas || internalEventSchemas) &&
+            !schema &&
+            !isFrameworkEvent
+          ) {
             return {
               issues: [
                 {
@@ -408,7 +435,10 @@ export class StateMachine<
         }
       }
     };
-    this.internalEventDescriptors = this.config.internalEvents ?? [];
+    this.internalEventDescriptors = [
+      ...Object.keys(this.schemas?.internalEvents ?? {}),
+      ...(this.config.internalEvents ?? [])
+    ];
     this.options = {
       maxIterations: Infinity,
       ...this.config.options

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -21,6 +21,7 @@ import {
   InferChildren,
   InferOutput,
   InferEvents,
+  InferInternalEvents,
   Next_MachineConfig,
   Next_StateNodeConfig,
   ValidateDelayReferences,
@@ -106,6 +107,7 @@ type _GroupTestValues<TTestValue extends string | TestValue> =
 export function createMachine<
   TContextSchema extends StandardSchemaV1,
   const TEventSchemaMap extends Record<string, StandardSchemaV1>,
+  const TInternalEventSchemaMap extends Record<string, StandardSchemaV1>,
   TEmittedSchemaMap extends Record<string, StandardSchemaV1>,
   TInputSchema extends StandardSchemaV1,
   const TOutputSchema extends StandardSchemaV1,
@@ -130,6 +132,7 @@ export function createMachine<
     Next_MachineConfig<
       TContextSchema,
       TEventSchemaMap,
+      TInternalEventSchemaMap,
       TEmittedSchemaMap,
       TInputSchema,
       TOutputSchema,
@@ -137,7 +140,8 @@ export function createMachine<
       TTagSchema,
       TChildrenSchemaMap,
       InferOutput<TContextSchema, MachineContext>,
-      InferEvents<TEventSchemaMap>,
+      | InferEvents<TEventSchemaMap>
+      | InferInternalEvents<TInternalEventSchemaMap>,
       Cast<
         MergeChildren<InferChildren<TChildrenSchemaMap>, TActor>,
         Record<string, AnyActorRef | undefined>
@@ -153,11 +157,15 @@ export function createMachine<
     } & ValidateTopLevelFinalOutputs<
       TSS,
       InferOutput<TContextSchema, MachineContext>,
-      InferEvents<TEventSchemaMap>
+      | InferEvents<TEventSchemaMap>
+      | InferInternalEvents<TInternalEventSchemaMap>
     >
 ): StateMachine<
   InferOutput<TContextSchema, MachineContext>,
-  | InferEvents<TEventSchemaMap>
+  | (
+      | InferEvents<TEventSchemaMap>
+      | InferInternalEvents<TInternalEventSchemaMap>
+    )
   | ([RoutableStateId<TSS>] extends [never]
       ? never
       : {
@@ -178,7 +186,8 @@ export function createMachine<
   TActionMap,
   TActorMap,
   TGuardMap,
-  DelayMapFromNames<TDelays, TDelayMap>
+  DelayMapFromNames<TDelays, TDelayMap>,
+  InferInternalEvents<TInternalEventSchemaMap>
 > & {
   states: TSS;
 } & MachineIdentity<TSS>;
@@ -202,6 +211,7 @@ export function createMachine<
     string,
     StandardSchemaV1
   >,
+  const TInternalEventSchemaMap extends Record<string, StandardSchemaV1> = {},
   _TEvent extends EventObject = EventObject,
   TActor extends ProvidedActor = ProvidedActor,
   TActionMap extends Sources['actions'] = Sources['actions'],
@@ -221,6 +231,7 @@ export function createMachine<
     Next_MachineConfig<
       StandardSchemaV1,
       TEventSchemaMap,
+      TInternalEventSchemaMap,
       TEmittedSchemaMap,
       TInputSchema,
       TOutputSchema,
@@ -228,7 +239,8 @@ export function createMachine<
       TTagSchema,
       TChildrenSchemaMap,
       WidenLiterals<TContext>,
-      InferEvents<TEventSchemaMap>,
+      | InferEvents<TEventSchemaMap>
+      | InferInternalEvents<TInternalEventSchemaMap>,
       Cast<
         MergeChildren<InferChildren<TChildrenSchemaMap>, TActor>,
         Record<string, AnyActorRef | undefined>
@@ -256,11 +268,15 @@ export function createMachine<
     } & ValidateTopLevelFinalOutputs<
       TSS,
       WidenLiterals<TContext>,
-      InferEvents<TEventSchemaMap>
+      | InferEvents<TEventSchemaMap>
+      | InferInternalEvents<TInternalEventSchemaMap>
     >
 ): StateMachine<
   WidenLiterals<TContext>,
-  | InferEvents<TEventSchemaMap>
+  | (
+      | InferEvents<TEventSchemaMap>
+      | InferInternalEvents<TInternalEventSchemaMap>
+    )
   | ([RoutableStateId<TSS>] extends [never]
       ? never
       : {
@@ -281,7 +297,8 @@ export function createMachine<
   TActionMap,
   TActorMap,
   TGuardMap,
-  DelayMapFromNames<TDelays, TDelayMap>
+  DelayMapFromNames<TDelays, TDelayMap>,
+  InferInternalEvents<TInternalEventSchemaMap>
 > & {
   states: TSS;
 } & MachineIdentity<TSS>;

--- a/packages/core/src/runtimeHelpers.ts
+++ b/packages/core/src/runtimeHelpers.ts
@@ -84,13 +84,30 @@ export function deliverEvent(
   target: AnyActor,
   event: AnyEventObject
 ): void {
+  assertEventCanBeSent(source, target, event);
   const runtimeTarget = target as AnyActor & {
     logic?: { isInternalEventType?: (eventType: string) => boolean };
     _lastSourceRef?: AnyActor;
     _send(event: AnyEventObject): void;
   };
-  // The same guard local delivery has always applied: internal events may
-  // only originate from the actor itself, whichever runtime delivers them.
+
+  runtimeTarget._lastSourceRef = source;
+  runtimeTarget._send(event);
+}
+
+/**
+ * Ensures internal events cannot cross an actor boundary from an external
+ * sender. Host runtimes must call this before taking ownership of delivery.
+ */
+export function assertEventCanBeSent(
+  source: AnyActor | undefined,
+  target: AnyActor,
+  event: AnyEventObject
+): void {
+  const runtimeTarget = target as AnyActor & {
+    logic?: { isInternalEventType?: (eventType: string) => boolean };
+  };
+
   if (
     source !== target &&
     runtimeTarget.logic?.isInternalEventType?.(event.type)
@@ -99,8 +116,6 @@ export function deliverEvent(
       `Internal event "${event.type}" cannot be sent to actor "${target.id}" from outside.`
     );
   }
-  runtimeTarget._lastSourceRef = source;
-  runtimeTarget._send(event);
 }
 
 /**

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -53,6 +53,7 @@ import {
   Sources,
   InferOutput,
   InferEvents,
+  InferInternalEvents,
   Next_MachineConfig,
   Next_InvokeConfig,
   Next_StateNodeConfig,
@@ -124,7 +125,11 @@ type ValidateSchemaMap<TMap> =
 
 type ValidateSetupSchemas<TSchemas> = TSchemas extends SetupSchemas
   ? {
-      [K in keyof TSchemas]: K extends 'events' | 'emitted' | 'children'
+      [K in keyof TSchemas]: K extends
+        | 'events'
+        | 'internalEvents'
+        | 'emitted'
+        | 'children'
         ? ValidateSchemaMap<TSchemas[K]>
         : K extends 'context' | 'input' | 'output'
           ? TSchemas[K] extends StandardSchemaV1
@@ -228,6 +233,7 @@ type SetupExtensionConfig<
 type InlineMachineSchemas<
   TContextSchema,
   TEventSchemaMap,
+  TInternalEventSchemaMap,
   TEmittedSchemaMap,
   TActionSchemaMap,
   TGuardSchemaMap,
@@ -239,6 +245,7 @@ type InlineMachineSchemas<
 > = {
   context?: TContextSchema;
   events?: TEventSchemaMap;
+  internalEvents?: TInternalEventSchemaMap;
   emitted?: TEmittedSchemaMap;
   actions?: TActionSchemaMap;
   guards?: TGuardSchemaMap;
@@ -366,6 +373,7 @@ export type { SetupStateSchemas };
 export type SetupSchemas = {
   context?: StandardSchemaV1;
   events?: Record<string, StandardSchemaV1>;
+  internalEvents?: Record<string, StandardSchemaV1>;
   actions?: ActionSchemas;
   guards?: GuardSchemas;
   emitted?: Record<string, StandardSchemaV1>;
@@ -393,7 +401,7 @@ type SetupSchema<
 
 type SetupSchemaMap<
   TSchemas,
-  TKey extends 'events' | 'emitted' | 'children'
+  TKey extends 'events' | 'internalEvents' | 'emitted' | 'children'
 > = TKey extends keyof TSchemas
   ? TSchemas[TKey] extends Record<string, StandardSchemaV1>
     ? TSchemas[TKey]
@@ -425,7 +433,7 @@ type SetupOrConfigSchema<
 
 type SetupOrConfigSchemaMap<
   TSchemas,
-  TKey extends 'events' | 'emitted' | 'children',
+  TKey extends 'events' | 'internalEvents' | 'emitted' | 'children',
   TConfigSchemaMap extends Record<string, StandardSchemaV1>
 > = [SetupSchemaMap<TSchemas, TKey>] extends [never]
   ? TConfigSchemaMap
@@ -572,12 +580,27 @@ type SetupContextRequired<TSchemas, TContextSchema extends StandardSchemaV1> = [
     : true
   : true;
 
-type SetupEvents<
+type SetupPublicEvents<
   TSchemas,
   TEventSchemaMap extends Record<string, StandardSchemaV1>
 > = [SetupSchemaMap<TSchemas, 'events'>] extends [never]
   ? InferEvents<TEventSchemaMap>
   : InferEvents<SetupSchemaMap<TSchemas, 'events'>>;
+
+type SetupInternalEvents<
+  TSchemas,
+  TInternalEventSchemaMap extends Record<string, StandardSchemaV1>
+> = [SetupSchemaMap<TSchemas, 'internalEvents'>] extends [never]
+  ? InferInternalEvents<TInternalEventSchemaMap>
+  : InferInternalEvents<SetupSchemaMap<TSchemas, 'internalEvents'>>;
+
+type SetupEvents<
+  TSchemas,
+  TEventSchemaMap extends Record<string, StandardSchemaV1>,
+  TInternalEventSchemaMap extends Record<string, StandardSchemaV1> = {}
+> =
+  | SetupPublicEvents<TSchemas, TEventSchemaMap>
+  | SetupInternalEvents<TSchemas, TInternalEventSchemaMap>;
 
 type SetupTags<TSchemas, TTagSchema extends StandardSchemaV1> = [
   SetupSchema<TSchemas, 'tags'>
@@ -831,6 +854,7 @@ type SetupMachineConfig<
   TSchemas extends SetupSchemas,
   TContextSchema extends StandardSchemaV1,
   TEventSchemaMap extends Record<string, StandardSchemaV1>,
+  TInternalEventSchemaMap extends Record<string, StandardSchemaV1>,
   TEmittedSchemaMap extends Record<string, StandardSchemaV1>,
   TInputSchema extends StandardSchemaV1,
   TOutputSchema extends StandardSchemaV1,
@@ -858,6 +882,7 @@ type SetupMachineConfig<
   Next_MachineConfig<
     SetupOrConfigSchema<TSchemas, 'context', TContextSchema>,
     SetupOrConfigSchemaMap<TSchemas, 'events', TEventSchemaMap>,
+    SetupOrConfigSchemaMap<TSchemas, 'internalEvents', TInternalEventSchemaMap>,
     SetupOrConfigSchemaMap<TSchemas, 'emitted', TEmittedSchemaMap>,
     SetupOrConfigSchema<TSchemas, 'input', TInputSchema>,
     SetupOrConfigSchema<TSchemas, 'output', TOutputSchema>,
@@ -1845,6 +1870,7 @@ export interface SetupReturn<
       string,
       StandardSchemaV1
     >,
+    const TInternalEventSchemaMap extends Record<string, StandardSchemaV1> = {},
     TEmittedSchemaMap extends Record<string, StandardSchemaV1> = Record<
       string,
       StandardSchemaV1
@@ -1878,6 +1904,7 @@ export interface SetupReturn<
       TSchemas,
       TContextSchema,
       TEventSchemaMap,
+      TInternalEventSchemaMap,
       TEmittedSchemaMap,
       TInputSchema,
       TOutputSchema,
@@ -1885,7 +1912,7 @@ export interface SetupReturn<
       TTagSchema,
       TChildrenSchemaMap,
       SetupContext<TSchemas, TContextSchema>,
-      SetupEvents<TSchemas, TEventSchemaMap>,
+      SetupEvents<TSchemas, TEventSchemaMap, TInternalEventSchemaMap>,
       Cast<
         MergeChildren<SetupChildren<TSchemas, TChildrenSchemaMap>, TActor>,
         Record<string, AnyActorRef | undefined>
@@ -1916,6 +1943,7 @@ export interface SetupReturn<
       TSchemas,
       TContextSchema,
       TEventSchemaMap,
+      TInternalEventSchemaMap,
       TEmittedSchemaMap,
       TInputSchema,
       TOutputSchema,
@@ -1923,7 +1951,7 @@ export interface SetupReturn<
       TTagSchema,
       TChildrenSchemaMap,
       SetupContext<TSchemas, TContextSchema>,
-      SetupEvents<TSchemas, TEventSchemaMap>,
+      SetupEvents<TSchemas, TEventSchemaMap, TInternalEventSchemaMap>,
       Cast<
         MergeChildren<SetupChildren<TSchemas, TChildrenSchemaMap>, TActor>,
         Record<string, AnyActorRef | undefined>
@@ -1953,6 +1981,7 @@ export interface SetupReturn<
     config: {
       schemas?: {
         events?: TEventSchemaMap;
+        internalEvents?: TInternalEventSchemaMap;
         context?: TContextSchema;
         emitted?: TEmittedSchemaMap;
         actions?: TActionSchemaMap;
@@ -1967,6 +1996,7 @@ export interface SetupReturn<
             InlineMachineSchemas<
               TContextSchema,
               TEventSchemaMap,
+              TInternalEventSchemaMap,
               TEmittedSchemaMap,
               TActionSchemaMap,
               TGuardSchemaMap,
@@ -1999,7 +2029,7 @@ export interface SetupReturn<
       >
   ): StateMachine<
     SetupContext<TSchemas, TContextSchema>,
-    | SetupEvents<TSchemas, TEventSchemaMap>
+    | SetupEvents<TSchemas, TEventSchemaMap, TInternalEventSchemaMap>
     | ([RoutableStateId<Cast<TConfig, StateSchema>>] extends [never]
         ? never
         : {
@@ -2039,7 +2069,8 @@ export interface SetupReturn<
     DelayMapFromNames<
       TSetupDelays | TDelays,
       MergeSourceMaps<TSetupDelayMap, TDelayMap>
-    >
+    >,
+    SetupInternalEvents<TSchemas, TInternalEventSchemaMap>
   > &
     MachineIdentity<TConfig>;
 
@@ -2309,7 +2340,7 @@ export const setup = function setupImplementation<
     ) {
       return setup(
         mergeSetupConfigs(config, extension as AnySetupConfig) as any
-      ) as SetupReturn<
+      ) as unknown as SetupReturn<
         MergeSourceMaps<TStates, TExtendStates>,
         MergeSourceMaps<TSchemas, TExtendSchemas>,
         MergeSourceMaps<TActionMap, TExtendActionMap>,
@@ -2455,6 +2486,7 @@ function mergeSchemas(
     ...left,
     ...right,
     events: mergeMaps(left?.events, right?.events),
+    internalEvents: mergeMaps(left?.internalEvents, right?.internalEvents),
     actions: mergeMaps(left?.actions, right?.actions),
     guards: mergeMaps(left?.guards, right?.guards),
     emitted: mergeMaps(left?.emitted, right?.emitted),

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -16,6 +16,7 @@ import { XSTATE_TIMER } from './constants.ts';
 import { toObserver } from './utils.ts';
 import { markSystemSnapshotDirty } from './snapshotActorRef.ts';
 import {
+  assertEventCanBeSent,
   deliverEvent,
   stopActor as stopActorLocally,
   terminateActor as terminateActorLocally,
@@ -758,6 +759,7 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
     target: AnyActor,
     event: AnyEventObject
   ): void | PromiseLike<void> {
+    assertEventCanBeSent(source, target, event);
     // Record for the inspection `sent[]` facet regardless of which runtime
     // delivers, so host runtimes keep inspection parity.
     this._recordSent(source, target, event);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -714,6 +714,31 @@ type ExcludeInternalEvents<
     : TEvent
   : never;
 
+type InternalEventDescriptorsFromConfig<
+  TEvent extends EventObject,
+  TConfig
+> = TConfig extends { internalEvents?: readonly EventDescriptor<TEvent>[] }
+  ? TConfig['internalEvents'] extends readonly (infer TDesc)[]
+    ? Extract<TDesc, string>
+    : never
+  : never;
+
+type InternalEventTypes<TInternalEvent extends EventObject> =
+  TInternalEvent extends any ? TInternalEvent['type'] : never;
+
+type SendableEventFromMachine<
+  TEvent extends EventObject,
+  TInternalEvent extends EventObject,
+  TConfig
+> =
+  IsAny<TInternalEvent> extends true
+    ? TEvent
+    : ExcludeInternalEvents<
+        TEvent,
+        | InternalEventTypes<TInternalEvent>
+        | InternalEventDescriptorsFromConfig<TEvent, TConfig>
+      >;
+
 export type IsLiteralString<T extends string> = string extends T ? false : true;
 
 type ActorsBySrc<TActor extends ProvidedActor> = {
@@ -1852,7 +1877,11 @@ export interface Subscribable<T> extends InteropSubscribable<T> {
 type EventDescriptorMatches<
   TEventType extends string,
   TNormalizedDescriptor
-> = TEventType extends TNormalizedDescriptor ? true : false;
+> = TEventType extends TNormalizedDescriptor
+  ? true
+  : TNormalizedDescriptor extends TEventType
+    ? true
+    : false;
 
 export type ExtractEvent<
   TEvent extends EventObject,
@@ -2019,47 +2048,24 @@ export type ActorRefFrom<T> =
     infer _TActionMap,
     infer _TActorMap,
     infer _TGuardMap,
-    infer _TDelayMap
+    infer _TDelayMap,
+    infer TInternalEvent
   >
-    ? TConfig extends {
-        internalEvents?: readonly EventDescriptor<TEvent>[];
-      }
-      ? ActorRef<
-          MachineSnapshot<
-            TContext,
-            TEvent,
-            TChildren,
-            TStateValue,
-            TTag,
-            TOutput,
-            TMeta,
-            any //TStateSchema
-          >,
+    ? ActorRef<
+        MachineSnapshot<
+          TContext,
           TEvent,
-          TEmitted,
-          ExcludeInternalEvents<
-            TEvent,
-            TConfig['internalEvents'] extends readonly EventDescriptor<TEvent>[]
-              ? TConfig['internalEvents'] extends readonly (infer TDesc)[]
-                ? Extract<TDesc, string>
-                : never
-              : never
-          >
-        >
-      : ActorRef<
-          MachineSnapshot<
-            TContext,
-            TEvent,
-            TChildren,
-            TStateValue,
-            TTag,
-            TOutput,
-            TMeta,
-            any //TStateSchema
-          >,
-          TEvent,
-          TEmitted
-        >
+          TChildren,
+          TStateValue,
+          TTag,
+          TOutput,
+          TMeta,
+          any //TStateSchema
+        >,
+        TEvent,
+        TEmitted,
+        SendableEventFromMachine<TEvent, TInternalEvent, TConfig>
+      >
     : T extends Promise<infer U>
       ? ActorRefFrom<AsyncActorLogic<U>>
       : T extends ActorLogic<
@@ -2087,20 +2093,10 @@ export type SendableEventFromLogic<TLogic extends AnyActorLogic> =
     infer _TActionMap,
     infer _TActorMap,
     infer _TGuardMap,
-    infer _TDelayMap
+    infer _TDelayMap,
+    infer TInternalEvent
   >
-    ? TConfig extends {
-        internalEvents?: readonly EventDescriptor<TEvent>[];
-      }
-      ? ExcludeInternalEvents<
-          TEvent,
-          TConfig['internalEvents'] extends readonly EventDescriptor<TEvent>[]
-            ? TConfig['internalEvents'] extends readonly (infer TDesc)[]
-              ? Extract<TDesc, string>
-              : never
-            : never
-        >
-      : TEvent
+    ? SendableEventFromMachine<TEvent, TInternalEvent, TConfig>
     : EventFromLogic<TLogic>;
 
 type OpaqueMachineSnapshot<TSnapshot extends Snapshot<unknown>> =

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -72,11 +72,26 @@ export type InferEvents<
           ? { type: K }
           : string extends keyof O
             ? [O[string]] extends [never]
-              ? { type: K }
-              : NormalizeEventPayload<TEventSchemaMap[K], O> & { type: K }
-            : NormalizeEventPayload<TEventSchemaMap[K], O> & { type: K }
+              ? { type: EventTypeFromSchemaKey<K> }
+              : NormalizeEventPayload<TEventSchemaMap[K], O> & {
+                  type: EventTypeFromSchemaKey<K>;
+                }
+            : NormalizeEventPayload<TEventSchemaMap[K], O> & {
+                type: EventTypeFromSchemaKey<K>;
+              }
     : never;
 }>;
+
+/** Infers internal events only from explicitly declared schema keys. */
+export type InferInternalEvents<
+  TEventSchemaMap extends Record<string, StandardSchemaV1>
+> = string extends keyof TEventSchemaMap ? never : InferEvents<TEventSchemaMap>;
+
+type EventTypeFromSchemaKey<TKey extends string> = TKey extends '*'
+  ? string
+  : TKey extends `${infer TLeading}.*`
+    ? `${TLeading}.${string}`
+    : TKey;
 
 /**
  * Keeps a type-only schema's payload verbatim; applies Required<> to payloads
@@ -213,6 +228,7 @@ export interface MachineOptions {
 type MachineSchemas<
   TContextSchema extends StandardSchemaV1,
   TEventSchemaMap extends Record<string, StandardSchemaV1>,
+  TInternalEventSchemaMap extends Record<string, StandardSchemaV1>,
   TEmittedSchemaMap extends Record<string, StandardSchemaV1>,
   TInputSchema extends StandardSchemaV1,
   TOutputSchema extends StandardSchemaV1,
@@ -221,6 +237,7 @@ type MachineSchemas<
   TChildrenSchemaMap extends Record<string, StandardSchemaV1>
 > = {
   events?: TEventSchemaMap;
+  internalEvents?: TInternalEventSchemaMap;
   actions?: ActionSchemas;
   guards?: GuardSchemas;
   context?: TContextSchema;
@@ -236,6 +253,7 @@ export type AnyMachineSchemas = MachineSchemas<
   StandardSchemaV1,
   Record<string, StandardSchemaV1>,
   Record<string, StandardSchemaV1>,
+  Record<string, StandardSchemaV1>,
   StandardSchemaV1,
   StandardSchemaV1,
   StandardSchemaV1,
@@ -246,6 +264,7 @@ export type AnyMachineSchemas = MachineSchemas<
 export type Next_MachineConfig<
   TContextSchema extends StandardSchemaV1,
   TEventSchemaMap extends Record<string, StandardSchemaV1>,
+  TInternalEventSchemaMap extends Record<string, StandardSchemaV1>,
   TEmittedSchemaMap extends Record<string, StandardSchemaV1>,
   TInputSchema extends StandardSchemaV1,
   TOutputSchema extends StandardSchemaV1,
@@ -253,7 +272,9 @@ export type Next_MachineConfig<
   TTagSchema extends StandardSchemaV1,
   TChildrenSchemaMap extends Record<string, StandardSchemaV1>,
   TContext extends MachineContext = InferOutput<TContextSchema, MachineContext>,
-  TEvent extends EventObject = InferEvents<TEventSchemaMap>,
+  TEvent extends EventObject =
+    | InferEvents<TEventSchemaMap>
+    | InferInternalEvents<TInternalEventSchemaMap>,
   TChildren extends Record<string, AnyActorRef | undefined> =
     InferChildren<TChildrenSchemaMap>,
   TDelays extends string = string,
@@ -269,7 +290,7 @@ export type Next_MachineConfig<
 > = (DistributiveOmit<
   Next_StateNodeConfig<
     TContext,
-    DoNotInfer<InferEvents<TEventSchemaMap>>,
+    DoNotInfer<TEvent>,
     DoNotInfer<TDelays>,
     DoNotInfer<StandardSchemaV1.InferOutput<TTagSchema> & string>,
     DoNotInfer<StandardSchemaV1.InferOutput<TOutputSchema>>,
@@ -287,12 +308,12 @@ export type Next_MachineConfig<
   >,
   'output' | 'schemas'
 > & {
-  internalEvents?: readonly InternalEventDescriptorFor<
-    InferEvents<TEventSchemaMap>
-  >[];
+  /** @deprecated Declare private event schemas in `schemas.internalEvents`. */
+  internalEvents?: readonly InternalEventDescriptorFor<TEvent>[];
   schemas?: MachineSchemas<
     TContextSchema,
     TEventSchemaMap,
+    TInternalEventSchemaMap,
     TEmittedSchemaMap,
     TInputSchema,
     TOutputSchema,

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -10,6 +10,7 @@ import type {
   AnyStateMachine,
   ExecutableActionObject
 } from '../types.ts';
+import { matchesEventDescriptor } from '../utils.ts';
 
 const actorValidationErrorSymbol = Symbol.for('xstate.actorValidationError');
 
@@ -91,6 +92,7 @@ interface ActorSchemas {
   input?: StandardSchemaV1;
   output?: StandardSchemaV1;
   events?: Record<string, StandardSchemaV1>;
+  internalEvents?: Record<string, StandardSchemaV1>;
   emitted?: Record<string, StandardSchemaV1>;
 }
 
@@ -141,15 +143,19 @@ export function standardSchemaValidator(
     eventOrigin: ActorValidationEventOrigin
   ) => {
     const schemas = getSchemas(logic);
-    if (
-      !schemas?.events ||
-      event.type.startsWith('xstate.') ||
-      event.type.startsWith('@xstate.')
-    ) {
+    if (event.type.startsWith('xstate.') || event.type.startsWith('@xstate.')) {
+      return undefined;
+    }
+    const eventSchemas = schemas?.events;
+    const internalEventSchemas = schemas?.internalEvents;
+    const schema =
+      findEventSchema(internalEventSchemas, event.type) ??
+      findEventSchema(eventSchemas, event.type);
+    if (!eventSchemas && !internalEventSchemas) {
       return undefined;
     }
     return checkTarget({
-      schema: schemas.events[event.type],
+      schema,
       value: getPayload(event),
       boundary: 'event',
       logicId: getLogicId(logic),
@@ -333,6 +339,24 @@ function getSchemas(logic: AnyActorLogic): ActorSchemas | undefined {
     return logic.schemas;
   }
   return (logic.config as { schemas?: ActorSchemas } | undefined)?.schemas;
+}
+
+function findEventSchema(
+  schemas: Record<string, StandardSchemaV1> | undefined,
+  eventType: string
+): StandardSchemaV1 | undefined {
+  if (!schemas) {
+    return undefined;
+  }
+
+  if (Object.hasOwn(schemas, eventType)) {
+    return schemas[eventType];
+  }
+
+  const descriptor = Object.keys(schemas).find((key) =>
+    matchesEventDescriptor(eventType, key)
+  );
+  return descriptor === undefined ? undefined : schemas[descriptor];
 }
 
 function getLogicId(logic: AnyActorLogic): string | undefined {

--- a/packages/core/test/internalEvents.test.ts
+++ b/packages/core/test/internalEvents.test.ts
@@ -2,6 +2,51 @@ import { createActor, createMachine } from '../src';
 import z from 'zod';
 
 describe('internalEvents', () => {
+  it('supports separately declared internal event schemas', async () => {
+    const machine = createMachine({
+      schemas: {
+        events: {
+          start: z.object({})
+        },
+        internalEvents: {
+          tick: z.object({ count: z.number() }),
+          'change.*': z.object({ value: z.string() })
+        }
+      },
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            start: (_, enq) => {
+              enq.raise({ type: 'tick', count: 1 });
+              enq.raise({ type: 'change.value', value: 'ready' });
+            },
+            tick: {},
+            'change.value': { target: 'done' }
+          }
+        },
+        done: {}
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'start' });
+
+    expect(actor.getSnapshot().value).toBe('done');
+    expect(
+      await machine.eventSchema['~standard'].validate({
+        type: 'change.value',
+        value: 'ready'
+      })
+    ).toEqual({
+      value: { type: 'change.value', value: 'ready' }
+    });
+    actor.system.runtime = { sendEvent: () => {} };
+    expect(() => actor.send({ type: 'tick', count: 2 } as any)).toThrow(
+      'Internal event "tick" cannot be sent to actor'
+    );
+  });
+
   it('allows raising internal events', () => {
     const machine = createMachine({
       schemas: {

--- a/packages/core/test/runtimeValidation.test.ts
+++ b/packages/core/test/runtimeValidation.test.ts
@@ -236,6 +236,30 @@ describe('runtime schema validation', () => {
     expect(guard).not.toHaveBeenCalled();
   });
 
+  it('validates separately declared internal event schemas', () => {
+    const machine = setup({
+      validator: standardSchemaValidator(),
+      schemas: {
+        events: { GO: z.object({}) },
+        internalEvents: { TICK: z.object({ count: z.number() }) }
+      }
+    }).createMachine({
+      initial: 'idle',
+      states: {
+        idle: { on: { TICK: { target: 'done' } } },
+        done: {}
+      }
+    });
+    const [snapshot] = initialTransition(machine);
+
+    expectValidationError(
+      getThrown(() =>
+        transition(machine, snapshot, { type: 'TICK', count: 'x' } as any)
+      ),
+      'event'
+    );
+  });
+
   it('is strict for unknown events by default and supports open protocols', () => {
     const create = (unknownEvents?: 'error' | 'ignore') =>
       setup({

--- a/packages/core/test/setup.test.ts
+++ b/packages/core/test/setup.test.ts
@@ -7,6 +7,9 @@ describe('setup', () => {
       events: {
         INC: types<{ value: number }>()
       },
+      internalEvents: {
+        TICK: types<{ count: number }>()
+      },
       actions: {
         track: {
           params: types<{ key: string }>()

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -337,6 +337,83 @@ describe('Raise events', () => {
 });
 
 describe('internalEvents', () => {
+  it('infers separate public and internal event schemas', () => {
+    const machine = createMachine({
+      schemas: {
+        events: {
+          start: z.object({}),
+          'change.value': z.object({ value: z.string() })
+        },
+        internalEvents: {
+          tick: z.object({ count: z.number() }),
+          'change.*': z.object({ value: z.string() })
+        }
+      },
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            start: (_, enq) => {
+              enq.raise({ type: 'tick', count: 1 });
+              enq.raise({ type: 'change.value', value: 'ready' });
+            },
+            tick: ({ event }) => {
+              ((_count: number) => {})(event.count);
+            },
+            'change.value': ({ event }) => {
+              ((_value: string) => {})(event.value);
+            }
+          }
+        }
+      }
+    });
+    const actor = createActor(machine);
+
+    actor.send({ type: 'start' });
+    actor.trigger.start();
+
+    function _expectInternalEventsRejected(a: typeof actor) {
+      // @ts-expect-error internal events are not part of the public protocol
+      a.send({ type: 'tick', count: 1 });
+      // @ts-expect-error internal wildcard takes precedence over public overlap
+      a.send({ type: 'change.value', value: 'ready' });
+      // @ts-expect-error internal events are not part of the public protocol
+      a.trigger.tick({ count: 1 });
+      // @ts-expect-error internal events are not part of the public protocol
+      a.trigger['change.value']({ value: 'ready' });
+    }
+    void _expectInternalEventsRejected;
+  });
+
+  it('supports separate event schemas declared in setup', () => {
+    const machine = setup({
+      schemas: {
+        events: { start: z.object({}) },
+        internalEvents: { tick: z.object({ count: z.number() }) }
+      }
+    }).createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            start: (_, enq) => enq.raise({ type: 'tick', count: 1 }),
+            tick: ({ event }) => {
+              ((_count: number) => {})(event.count);
+            }
+          }
+        }
+      }
+    });
+    const actor = createActor(machine);
+    actor.send({ type: 'start' });
+
+    function _expectInternalEventRejected(a: typeof actor) {
+      // @ts-expect-error internal events are not part of the public protocol
+      a.send({ type: 'tick', count: 1 });
+    }
+    void _expectInternalEventRejected;
+  });
+
   it('should allow raising internal and external events', () => {
     const machine = createMachine({
       schemas: {
@@ -2894,7 +2971,7 @@ describe('invoke', () => {
     const decorateSetup = <const TConfig extends AnySetupConfig>(
       config: TConfig
     ): SetupReturnFromConfig<TConfig> & { extra: true } => {
-      const s = setup(config) as SetupReturnFromConfig<TConfig>;
+      const s = setup(config) as unknown as SetupReturnFromConfig<TConfig>;
 
       return Object.assign(s, { extra: true as const });
     };


### PR DESCRIPTION
## Summary

- Add `schemas.internalEvents` as a first-class private event schema map.
- Keep `schemas.events` public and `schemas.emitted` distinct.
- Infer internal events across machine handlers, raises, actions, guards, and self-targeted effects while excluding them from `actor.send` and `actor.trigger`.
- Support exact and wildcard internal descriptors.
- Preserve the legacy top-level `internalEvents` list as deprecated compatibility.
- Enforce external-send restrictions before custom host runtime delivery.
- Update runtime validation, migration/docs guidance, tests, and changeset.

## Verification

- `pnpm test:core`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- Focused internal-event and runtime-validation tests