### PR TITLE
feat: type setup state completion outputs

### DIFF
--- a/.changeset/typed-state-output.md
+++ b/.changeset/typed-state-output.md
@@ -1,0 +1,5 @@
+---
+'xstate': minor
+---
+
+Add setup state-local output schemas for typed final-state output and nested completion contracts.

--- a/docs/final-states.md
+++ b/docs/final-states.md
@@ -125,7 +125,7 @@ Because of this, transitions declared on a top-level final state are unreachable
 
 ## TypeScript
 
-`output` on a final state and on the machine root are typed against `schemas.output`. The root mapper's `output` argument is typed as the completing state's output. `onDone` handlers receive `DoneStateEvent`, whose `output` is the completed state's output and whose `stateId` is a string. See [input and output](input-output.md).
+`output` on a final state and on the machine root are typed against `schemas.output`. With `setup({ states })`, a state can additionally declare `schemas.output` for its own completion value; its parent's `onDone` receives that local type. The root mapper's `output` argument is typed as the completing state's output. `onDone` handlers receive `DoneStateEvent`, whose `output` is the completed state's output and whose `stateId` is a string. See [input and output](input-output.md).
 
 ## Final states cheatsheet
 

--- a/docs/parallel-states.md
+++ b/docs/parallel-states.md
@@ -127,7 +127,7 @@ Common uses: a media player with independent playback, volume and subtitle regio
 
 ## TypeScript
 
-Region keys are inferred from `states`, so `snapshot.value` and `matches` are typed against the real region structure and a misspelled region is a type error. `onDone` on a parallel state receives a done event whose `output` is an object keyed by region, with each region's final output type.
+Region keys are inferred from `states`, so `snapshot.value` and `matches` are typed against the real region structure and a misspelled region is a type error. `onDone` on a parallel state receives a done event whose `output` is an object keyed by region. With `setup({ states })`, declare the aggregate explicitly with the parallel state's `schemas.output` when the region contract needs to be available before the machine config is written.
 
 ## Parallel states cheatsheet
 

--- a/docs/setup-and-provide.md
+++ b/docs/setup-and-provide.md
@@ -29,6 +29,30 @@ const orderMachine = orderSetup.createMachine({
 
 `setup(...)` also accepts `states`, where each state declares its own schemas. That is what types the `initial: { target, input }` form and transitions carrying [state input](state-input.md).
 
+State schemas can also declare `schemas.output` for the value emitted when that
+state completes. Final-state `output` functions and the parent state's `onDone`
+event use that local type. For a parallel state, declare the aggregate object on
+the parallel state itself:
+
+```ts
+const uploadSetup = setup({
+  states: {
+    processing: {
+      schemas: {
+        output: types<{
+          upload: { url: string };
+          scan: { safe: boolean };
+        }>()
+      }
+    }
+  }
+});
+```
+
+These local output schemas currently provide TypeScript contracts. Runtime
+validation still checks the machine's stable terminal output at the existing
+result boundary; it does not validate transient nested completion values.
+
 Use `setup(...).extend(...)` to build a more specific setup from a shared one, merging schemas and sources.
 
 ## Runtime validation

--- a/packages/core/src/schema.types.ts
+++ b/packages/core/src/schema.types.ts
@@ -8,6 +8,8 @@ export interface StandardSchemaV1<Input = unknown, Output = Input> {
 export type SetupStateSchemas = {
   context?: StandardSchemaV1;
   input?: StandardSchemaV1;
+  /** The output emitted when this state node completes. */
+  output?: StandardSchemaV1;
 };
 
 /** A type-only Standard Schema produced by {@link types}. */

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -384,7 +384,7 @@ export type SetupSchemas = {
   children?: Record<string, StandardSchemaV1>;
 };
 
-/** State schema with optional schemas.input and nested states */
+/** State schema with optional input/output schemas and nested states */
 export interface SetupStateSchema {
   schemas?: SetupStateSchemas;
   states?: Record<string, SetupStateSchema>;
@@ -722,6 +722,21 @@ type StateInput<TStateSchema extends SetupStateSchema> =
       : undefined
     : undefined;
 
+/** Extracts the completion output type from a state schema. */
+type StateOutput<
+  TStateSchema extends SetupStateSchema,
+  TFallback
+> = TStateSchema['schemas'] extends { output: infer TOutputSchema }
+  ? TOutputSchema extends StandardSchemaV1
+    ? StandardSchemaV1.InferOutput<TOutputSchema>
+    : TFallback
+  : TFallback;
+
+type StateCompletionOutput<TStateSchema extends SetupStateSchema> = StateOutput<
+  TStateSchema,
+  unknown
+>;
+
 type StateContext<
   TStateSchema extends SetupStateSchema,
   TFallbackContext extends MachineContext
@@ -776,6 +791,13 @@ type SetupStateSchemaToStateSchema<TSetupSchema extends SetupStateSchema> = {
       ? TContextSchema
       : undefined
     : undefined;
+  outputSchema: TSetupSchema['schemas'] extends {
+    output: infer TOutputSchema;
+  }
+    ? TOutputSchema extends StandardSchemaV1
+      ? TOutputSchema
+      : undefined
+    : undefined;
   states: TSetupSchema['states'] extends Record<string, SetupStateSchema>
     ? {
         [K in keyof TSetupSchema['states'] &
@@ -820,6 +842,19 @@ type StateSchemaContextSchema<
       : undefined
     : undefined;
 
+type StateSchemaOutputSchema<
+  TConfig extends StateSchema,
+  TSetup extends StateSchema
+> = TSetup extends { outputSchema: infer TOutputSchema }
+  ? TOutputSchema extends StandardSchemaV1
+    ? TOutputSchema
+    : undefined
+  : TConfig extends { outputSchema: infer TOutputSchema }
+    ? TOutputSchema extends StandardSchemaV1
+      ? TOutputSchema
+      : undefined
+    : undefined;
+
 type StateSchemaChild<
   TSetup extends StateSchema,
   K extends string
@@ -834,6 +869,7 @@ type MergeStateSchema<
   TSetup extends StateSchema
 > = Omit<TConfig, 'contextSchema' | 'input' | 'states'> & {
   contextSchema: StateSchemaContextSchema<TConfig, TSetup>;
+  outputSchema: StateSchemaOutputSchema<TConfig, TSetup>;
   input: StateSchemaInput<TConfig, TSetup>;
   states: TConfig extends { states: infer TStates }
     ? TStates extends Record<string, StateSchema>
@@ -1062,7 +1098,7 @@ type StateNodeConfigWithNestedInput<
       TEvent,
       TDelays,
       TTag,
-      TOutput,
+      StateOutput<TStateSchema, TOutput>,
       TEmitted,
       TMeta,
       TChildren,
@@ -1072,7 +1108,8 @@ type StateNodeConfigWithNestedInput<
       TDelayMap,
       StateInput<TStateSchema>,
       Record<string, unknown>,
-      TSystemRegistry
+      TSystemRegistry,
+      StateCompletionOutput<TStateSchema>
     >,
     | 'on'
     | 'always'
@@ -1150,7 +1187,7 @@ type StateNodeConfigWithNestedInput<
       TSiblingStateSchemas,
       StateContext<TStateSchema, TContext>,
       StateContextShape<TStateSchema, TContextShape>,
-      DoneStateEvent,
+      DoneStateEvent<StateCompletionOutput<TStateSchema>>,
       TEvent,
       TEmitted,
       TChildren,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2610,6 +2610,7 @@ export type StateSchema = {
   route?: unknown;
   states?: Record<string, StateSchema>;
   contextSchema?: StandardSchemaV1;
+  outputSchema?: StandardSchemaV1;
   input?: unknown;
 
   // Other types

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -1238,7 +1238,7 @@ interface Next_RegularStateNodeConfig<
    */
   onDone?: Next_TransitionConfigOrTarget<
     TContext,
-    DoneStateEvent,
+    DoneStateEvent<TChildOutput>,
     TEvent,
     TEmitted,
     TActionMap,

--- a/packages/core/test/typeSchemas.test.ts
+++ b/packages/core/test/typeSchemas.test.ts
@@ -238,4 +238,143 @@ describe('type-only schemas (`types`)', () => {
       output: ({ output }) => output
     });
   });
+
+  it('types final output from a setup state-local output schema', () => {
+    const s = setup({
+      states: {
+        done: {
+          schemas: {
+            output: types<{ status: 'ok' }>()
+          }
+        }
+      }
+    });
+
+    s.createMachine({
+      initial: 'done',
+      states: {
+        done: {
+          type: 'final',
+          output: ({}) => ({ status: 'ok' as const })
+        }
+      }
+    });
+
+    s.createMachine({
+      initial: 'done',
+      states: {
+        done: {
+          type: 'final',
+          // @ts-expect-error
+          output: { status: 'error' }
+        }
+      }
+    });
+  });
+
+  it('types nested onDone output from a setup state-local output schema', () => {
+    const s = setup({
+      states: {
+        workflow: {
+          schemas: {
+            output: types<{ receiptId: string }>()
+          },
+          states: {
+            done: {}
+          }
+        }
+      }
+    });
+
+    s.createMachine({
+      initial: 'workflow',
+      states: {
+        workflow: {
+          initial: 'done',
+          states: {
+            done: {
+              type: 'final',
+              output: { receiptId: 'receipt-1' }
+            }
+          },
+          onDone: ({ event }) => {
+            event.output.receiptId satisfies string;
+            // @ts-expect-error - the state-local output has no `status` field
+            event.output.status;
+            return { target: 'complete' };
+          }
+        },
+        complete: { type: 'final' }
+      }
+    });
+  });
+
+  it('types parallel aggregate output from a setup state-local output schema', () => {
+    const s = setup({
+      states: {
+        processing: {
+          schemas: {
+            output: types<{
+              upload: { url: string };
+              validate: { valid: boolean };
+            }>()
+          },
+          states: {
+            upload: {
+              states: {
+                done: {
+                  schemas: { output: types<{ url: string }>() }
+                }
+              }
+            },
+            validate: {
+              states: {
+                done: {
+                  schemas: { output: types<{ valid: boolean }>() }
+                }
+              }
+            }
+          }
+        },
+        complete: {}
+      }
+    });
+
+    s.createMachine({
+      initial: 'processing',
+      states: {
+        processing: {
+          type: 'parallel',
+          states: {
+            upload: {
+              initial: 'done',
+              states: {
+                done: {
+                  type: 'final',
+                  output: { url: '/file.png' }
+                }
+              }
+            },
+            validate: {
+              initial: 'done',
+              states: {
+                done: {
+                  type: 'final',
+                  output: { valid: true }
+                }
+              }
+            }
+          },
+          onDone: ({ event }) => {
+            event.output.upload.url satisfies string;
+            event.output.validate.valid satisfies boolean;
+            // @ts-expect-error - the aggregate has no top-level `url` field
+            event.output.url;
+            return { target: 'complete' };
+          }
+        },
+        complete: { type: 'final' }
+      }
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add setup state-local `schemas.output` contracts.
- Type final-state output and parent `onDone` completion values.
- Type declared parallel aggregate outputs.
- Document the compile-time-only runtime boundary.

## Verification

- `pnpm test:core -- packages/core/test/typeSchemas.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm changeset status`

Exhaustive invoke outcomes are intentionally not included.