### PR TITLE
Durable execution DX: retained root events, inspection, address lookup, output inference

### DIFF
--- a/.changeset/durable-dx.md
+++ b/.changeset/durable-dx.md
@@ -1,0 +1,24 @@
+---
+'xstate': patch
+---
+
+Durable execution DX improvements:
+
+- The drive loop no longer routes root events by hand. `executeEffects` retains the root-addressed events it captures, and `execution.waitForEvent()` hands them out before deferring to the adapter, so the canonical loop is:
+
+  ```ts
+  let [state, effects] = execution.initialTransition(input);
+  await execution.executeEffects(effects);
+
+  while (state.status === 'active') {
+    [state, effects] = execution.transition(state, await execution.waitForEvent());
+    await execution.executeEffects(effects);
+  }
+  ```
+
+  (`executeEffects` now resolves with `void`.)
+
+- `createDurable(logic, adapter, { inspect })` observes the execution's inspection events (`@xstate.actor` / `@xstate.transition`) across the whole live actor tree, including transitions computed by the pure path — the host-side home for operation logs and instrumentation.
+- `execution.getActorRef(snapshot, address)` resolves a logical address against the snapshot's live actor tree, for hosts whose durable mailbox stores addresses as strings.
+- Machine `output` types infer from the config's `output` function when no `schemas.output` schema is declared; a declared schema stays authoritative.
+- `DurableSnapshot` keeps the `status`/`output`/`error` discriminant visible when `TLogic` is an unresolved type parameter, and adapter `waitForEvent` implementations may return plain event objects — generic host libraries no longer need casts.

--- a/.changeset/gentle-buttons-shake.md
+++ b/.changeset/gentle-buttons-shake.md
@@ -1,0 +1,20 @@
+---
+'xstate': patch
+---
+
+A machine's output type is now inferred from its `output` config when no `schemas.output` is declared. A declared `schemas.output` stays authoritative.
+
+```ts
+const machine = setup({}).createMachine({
+  context: { shipped: ['sku-1'] },
+  initial: 'done',
+  states: { done: { type: 'final' } },
+  output: ({ context }) => ({
+    status: 'shipped' as const,
+    skus: context.shipped
+  })
+});
+
+// OutputFrom<typeof machine> is now
+// { status: 'shipped'; skus: string[] } instead of {}
+```

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -98,15 +98,18 @@ with no per-actor wiring. `run()` is convenience over the explicit loop:
 
 ```ts
 let [state, effects] = durable.initialTransition(input);
-let rootEvents = await durable.executeEffects(effects);
+await durable.executeEffects(effects);
 
 while (state.status === 'active') {
-  const event =
-    rootEvents.shift()?.event ?? (await durable.waitForEvent());
-  [state, effects] = durable.transition(state, event);
-  rootEvents.push(...(await durable.executeEffects(effects)));
+  [state, effects] = durable.transition(state, await durable.waitForEvent());
+  await durable.executeEffects(effects);
 }
 ```
+
+`waitForEvent()` first hands out the root-addressed events prior
+`executeEffects` batches captured (an invoked actor completing, a child
+reporting up), and only when none are queued defers to the adapter's durable
+wait.
 
 Checkpoint with `getPersistedSnapshot(state)` after `executeEffects`
 resolves, and persist `durable.nextTransitionIndex` alongside; pass it as
@@ -202,9 +205,9 @@ deliver the same completion more than once (retries, replays), the host is
 responsible for deduplicating before handing it to the execution.
 
 Events addressed to the root actor do not reach `sendEvent` during
-`executeEffects`: the execution captures them and resolves them from that
-call as `{ event, source }` records for the loop to process before
-suspending. While the loop is parked in `waitForEvent()`, a root-addressed
+`executeEffects`: the execution captures and retains them, and
+`waitForEvent()` hands them out — in capture order — before deferring to the
+adapter. While the loop is parked in the adapter's wait, a root-addressed
 event reaches `sendEvent` like any other target and belongs in the host's
 mailbox; if the adapter implements no `sendEvent`, producing one there throws,
 since delivering it locally to the inert root would silently lose it.
@@ -265,6 +268,18 @@ persisted address verbatim — the owning runtime's identity for the child.
 
 `durable.getActorRef(snapshot)` returns the root actor reference behind a
 snapshot this execution produced, for addressing and inspection.
+`durable.getActorRef(snapshot, address)` resolves a logical address against
+the snapshot's live actor tree instead — the tool for hosts whose mailbox
+stores addresses as strings and must deliver to the actor behind one —
+returning `undefined` when no live actor has that address (a timer firing
+for an actor that already completed).
+
+`createDurable(logic, adapter, { inspect })` observes the execution's
+inspection events — the `@xstate.actor` / `@xstate.transition` protocol,
+across the whole live actor tree, including transitions computed by the pure
+path. This is host observability, not part of the durable contract: use it
+for operation logs, tracing and test instrumentation, and keep the adapter
+itself pure physics.
 
 `run()` resolves with the machine output when the machine is done, throws the
 machine error when it fails, and throws `DurableExecutionCancelledError` when
@@ -287,11 +302,12 @@ Effects are plain objects — each has a serializable `descriptor` and an
 pure APIs and execute them entirely its own way. Dropping `executeEffects`
 means providing its four services yourself: transitive settlement (an
 effect's operations trigger further operations; "executed" must mean the
-whole cascade was accepted before checkpointing), root-event capture
-(children's sends to the root must surface instead of queuing on an inert
-mailbox), ordered handoff to the runtime, and batch failure discard for
-retries. Engines with native equivalents for some of these may prefer their
-own; everyone else should stay on `executeEffects`.
+whole cascade was accepted before checkpointing), root-event capture and
+replay into `transition()` (children's sends to the root must surface
+instead of queuing on an inert mailbox), ordered handoff to the runtime, and
+batch failure discard for retries. Engines with native equivalents for some
+of these may prefer their own; everyone else should stay on
+`executeEffects`.
 
 ## Host adapters
 

--- a/docs/final-states.md
+++ b/docs/final-states.md
@@ -125,7 +125,7 @@ Because of this, transitions declared on a top-level final state are unreachable
 
 ## TypeScript
 
-`output` on a final state and on the machine root are typed against `schemas.output`. With `setup({ states })`, a state can additionally declare `schemas.output` for its own completion value; its parent's `onDone` receives that local type. The root mapper's `output` argument is typed as the completing state's output. `onDone` handlers receive `DoneStateEvent`, whose `output` is the completed state's output and whose `stateId` is a string. See [input and output](input-output.md).
+`output` on a final state and on the machine root are typed against `schemas.output`. Without `schemas.output`, the machine's output type is inferred from the root `output`: the mapper's return type, or the static value's type. With `setup({ states })`, a state can additionally declare `schemas.output` for its own completion value; its parent's `onDone` receives that local type. The root mapper's `output` argument is typed as the completing state's output. `onDone` handlers receive `DoneStateEvent`, whose `output` is the completed state's output and whose `stateId` is a string. See [input and output](input-output.md).
 
 ## Final states cheatsheet
 

--- a/docs/input-output.md
+++ b/docs/input-output.md
@@ -42,6 +42,22 @@ Actors that run indefinitely may never produce output.
 
 Declare input and output schemas when they cross actor boundaries.
 
+The output type is inferred from the root `output` when `schemas.output` is not declared. A declared `schemas.output` is authoritative and the root `output` is checked against it.
+
+```ts
+const machine = setup({}).createMachine({
+  context: { shipped: ['sku-1'] },
+  initial: 'done',
+  states: { done: { type: 'final' } },
+  output: ({ context }) => ({
+    status: 'shipped' as const,
+    skus: context.shipped
+  })
+});
+
+// OutputFrom<typeof machine> is { status: 'shipped'; skus: string[] }
+```
+
 ## Input and output cheatsheet
 
 ```ts

--- a/packages/core/src/createActor.ts
+++ b/packages/core/src/createActor.ts
@@ -574,7 +574,9 @@ export class Actor<TLogic extends AnyActorLogic> implements ActorInstance<
     this._inspectTransition(this._snapshot, event);
   }
 
-  private _inspectTransition(
+  /** @internal Emits the transition inspection event; used by the pure
+   * `transition()` path for snapshots driven outside a live actor. */
+  public _inspectTransition(
     snapshot: SnapshotFrom<TLogic>,
     event: EventObject
   ): void {

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -20,6 +20,7 @@ import {
   DelayMapFromNames,
   InferChildren,
   InferOutput,
+  SchemaOrConfigOutput,
   InferEvents,
   InferInternalEvents,
   Next_MachineConfig,
@@ -179,7 +180,7 @@ export function createMachine<
   StateValueFromStateSchema<TSS>,
   TTag & string,
   TInput,
-  InferOutput<TOutputSchema, unknown>,
+  SchemaOrConfigOutput<TOutputSchema, TSS>,
   WithDefault<InferEvents<TEmittedSchemaMap>, AnyEventObject>,
   InferOutput<TMetaSchema, MetaObject>, // TMeta
   TSS, // TStateSchema
@@ -290,7 +291,7 @@ export function createMachine<
   StateValueFromStateSchema<TSS>,
   TTag & string,
   TInput,
-  InferOutput<TOutputSchema, unknown>,
+  SchemaOrConfigOutput<TOutputSchema, TSS>,
   WithDefault<InferEvents<TEmittedSchemaMap>, AnyEventObject>,
   InferOutput<TMetaSchema, MetaObject>, // TMeta
   TSS, // TStateSchema

--- a/packages/core/src/durable/index.ts
+++ b/packages/core/src/durable/index.ts
@@ -7,10 +7,12 @@ import { getSnapshotActorRef } from '../snapshotActorRef.ts';
 import {
   encodeAddressSegment,
   withExecutionIdentity,
+  withSystemInspector,
   getRootActorId,
   RUNTIME_OPERATIONS,
   type ActorSystemRuntime
 } from '../system.ts';
+import type { InspectionEvent } from '../inspection.ts';
 import { initialTransition, transition } from '../transition.ts';
 import type {
   AnyActor,
@@ -70,10 +72,11 @@ export interface DurableEffect<TEffect> extends DurableEffectMetadata {
  * operations keep their default local behavior.
  *
  * Events addressed to this execution's root actor do not reach `sendEvent`
- * during `executeEffects`: the execution captures them and resolves them
- * from that call for the durable loop to process before suspending. While
- * the loop is parked, a root-addressed event reaches `sendEvent` like any
- * other target, so the host enqueues it in its own mailbox.
+ * during `executeEffects`: the execution captures and retains them, and the
+ * execution's `waitForEvent()` hands them out before deferring to this
+ * adapter. While the loop is parked, a root-addressed event reaches
+ * `sendEvent` like any other target, so the host enqueues it in its own
+ * mailbox.
  */
 export interface DurableExecutionAdapter<
   TLogic extends AnyActorLogic
@@ -99,10 +102,19 @@ export interface DurableExecutionAdapter<
     metadata: DurableEffectMetadata,
     effect: ExecutableActionObjectFromLogic<TLogic>
   ): Partial<ActorSystemRuntime>;
-  /** Waits durably for the next event addressed to this execution. */
+  /**
+   * Waits durably for the next event addressed to this execution. Typed to
+   * also accept plain event objects: an adapter written against
+   * `AnyActorLogic` (a generic host library) cannot produce
+   * `EventFromLogic<TLogic>`, and the events a host relays are runtime data
+   * anyway — the execution narrows at its own boundary.
+   */
   waitForEvent(
     metadata: DurableWaitMetadata
-  ): EventFromLogic<TLogic> | PromiseLike<EventFromLogic<TLogic>>;
+  ):
+    | EventFromLogic<TLogic>
+    | AnyEventObject
+    | PromiseLike<EventFromLogic<TLogic> | AnyEventObject>;
   /** Index assigned to the first transition. Defaults to `0`. */
   transitionIndex?: number;
   /**
@@ -133,6 +145,15 @@ export class DurableExecutionResumeError extends Error {
   }
 }
 
+/**
+ * The snapshot type a durable execution hands back: the logic's own snapshot,
+ * intersected with the base `Snapshot` union so the `status`/`output`/`error`
+ * discriminant stays visible even when `TLogic` is an unresolved type
+ * parameter (a generic host library), where `SnapshotFrom` alone is opaque.
+ */
+export type DurableSnapshot<TLogic extends AnyActorLogic> =
+  SnapshotFrom<TLogic> & Snapshot<OutputFrom<TLogic>>;
+
 export interface DurableExecution<TLogic extends AnyActorLogic> {
   /**
    * The logical address of this execution's root actor: the logic's own name,
@@ -155,14 +176,14 @@ export interface DurableExecution<TLogic extends AnyActorLogic> {
       ? [input?: InputFrom<TLogic>]
       : [input: InputFrom<TLogic>]
   ): [
-    snapshot: SnapshotFrom<TLogic>,
+    snapshot: DurableSnapshot<TLogic>,
     effects: DurableEffect<ExecutableActionObjectFromLogic<TLogic>>[]
   ];
   transition(
     snapshot: SnapshotFrom<TLogic>,
     event: EventFromLogic<TLogic>
   ): [
-    snapshot: SnapshotFrom<TLogic>,
+    snapshot: DurableSnapshot<TLogic>,
     effects: DurableEffect<ExecutableActionObjectFromLogic<TLogic>>[]
   ];
   /**
@@ -170,8 +191,16 @@ export interface DurableExecution<TLogic extends AnyActorLogic> {
    * for addressing and inspection. `undefined` for snapshots this execution
    * has not seen (for example a freshly deserialized checkpoint that has not
    * been passed through `transition()` yet).
+   *
+   * With an `address`, returns the live actor at that logical address in the
+   * snapshot's actor tree instead — the root itself, one of its transitive
+   * children, or `undefined` when no live actor has that address (for
+   * example a timer firing for an actor that already completed).
    */
-  getActorRef(snapshot: SnapshotFrom<TLogic>): AnyActor | undefined;
+  getActorRef(
+    snapshot: SnapshotFrom<TLogic>,
+    address?: string
+  ): AnyActor | undefined;
   /**
    * Executes effects and resolves only when every runtime operation they
    * transitively initiated — including operations from live child actors
@@ -179,14 +208,20 @@ export interface DurableExecution<TLogic extends AnyActorLogic> {
    * failed operation rejects it. Operations are handed to the runtime one at
    * a time, in initiation order.
    *
-   * Resolves with the events addressed to this execution's root actor that
-   * were produced along the way, in order. Feed them back through
-   * `transition()` (and execute their effects) before durably waiting for an
-   * external event; `run()` does this automatically.
+   * Events addressed to this execution's root actor that were produced along
+   * the way are retained, in order, and handed out by `waitForEvent()`
+   * before it defers to the adapter — so the drive loop is just
+   * `transition(snapshot, await waitForEvent())` + `executeEffects`.
    */
   executeEffects(
     effects: readonly DurableEffect<ExecutableActionObjectFromLogic<TLogic>>[]
-  ): Promise<DurableRootEvent<EventFromLogic<TLogic>>[]>;
+  ): Promise<void>;
+  /**
+   * Resolves with the next event addressed to this execution's root actor:
+   * an event a prior `executeEffects` batch captured (an invoked actor
+   * completing, a child reporting up), or — once none are queued — whatever
+   * the adapter's durable wait produces.
+   */
   waitForEvent(): Promise<EventFromLogic<TLogic>>;
   run(
     ...[input]: undefined extends InputFrom<TLogic>
@@ -204,9 +239,20 @@ export interface DurableExecution<TLogic extends AnyActorLogic> {
  *
  * @experimental
  */
+export interface DurableExecutionOptions {
+  /**
+   * Observes the execution's inspection events — actor lifecycle, event
+   * routing, transitions — across the whole live actor tree. The host-side
+   * home for operation logs and instrumentation, so adapters stay pure
+   * physics.
+   */
+  inspect?: (inspectionEvent: InspectionEvent) => void;
+}
+
 export function createDurable<TLogic extends AnyActorLogic>(
   logic: TLogic,
-  adapter: DurableExecutionAdapter<TLogic>
+  adapter: DurableExecutionAdapter<TLogic>,
+  options?: DurableExecutionOptions
 ): DurableExecution<TLogic> {
   let nextTransitionIndex = adapter.transitionIndex ?? 0;
   const startingTransitionIndex = nextTransitionIndex;
@@ -281,6 +327,10 @@ export function createDurable<TLogic extends AnyActorLogic>(
     pending: Set<Promise<void>>;
   }
   let currentBatch: Batch | undefined;
+
+  // Root-addressed events captured by settled batches, waiting for the drive
+  // loop to take them through `waitForEvent()`.
+  const pendingRootEvents: DurableRootEvent<AnyEventObject>[] = [];
 
   // Every inter-actor edge is an async handoff to the runtime, and every
   // handoff queues behind the last one: hosts whose step or activity model
@@ -410,11 +460,52 @@ export function createDurable<TLogic extends AnyActorLogic>(
     ? wrapRuntime(systemRuntime, true)
     : undefined;
 
+  // Depth-first walk of the live actor tree by logical address. Subtrees
+  // whose address is not a prefix of the target are pruned.
+  function findByAddress(
+    actor: AnyActor,
+    address: string
+  ): AnyActor | undefined {
+    if (actor.address === address) {
+      return actor;
+    }
+    if (!address.startsWith(`${actor.address}/`)) {
+      return undefined;
+    }
+    const children = (
+      actor.getSnapshot() as { children?: Record<string, AnyActor | undefined> }
+    ).children;
+    for (const child of Object.values(children ?? {})) {
+      const found = child && findByAddress(child, address);
+      if (found) {
+        return found;
+      }
+    }
+    return undefined;
+  }
+
+  const inspect = options?.inspect;
+
+  // Attaches the execution's inspector to a system that does not have it
+  // yet. Systems constructed inside a transition get it at construction (the
+  // ambient inspector); this covers systems materialized outside that window
+  // — a snapshot's system first touched here, or a restored child's foreign
+  // system. Observer presence doubles as the dedup check: this execution is
+  // the only thing attaching observers to its systems.
+  function wireInspection(system: AnyActor['system']): void {
+    if (inspect && !system._hasInspectionObservers?.()) {
+      system.inspect(inspect);
+    }
+  }
+
   function installSystemRuntime<TSnapshot>(snapshot: TSnapshot): TSnapshot {
-    if (wrappedSystemRuntime) {
+    if (wrappedSystemRuntime || inspect) {
       const ref = getSnapshotActorRef(snapshot as Snapshot<unknown>)?.actor;
       if (ref) {
-        ref.system.runtime = wrappedSystemRuntime;
+        if (wrappedSystemRuntime) {
+          ref.system.runtime = wrappedSystemRuntime;
+        }
+        wireInspection(ref.system);
       }
       // Children restored outside this execution (rehydrated actors and
       // remote handles) may carry a system created before this install.
@@ -426,7 +517,10 @@ export function createDurable<TLogic extends AnyActorLogic>(
           // Only restored/rehydrated children can carry a foreign system;
           // everything else shares the root's.
           if (child && child.system !== ref?.system) {
-            child.system.runtime = wrappedSystemRuntime;
+            if (wrappedSystemRuntime) {
+              child.system.runtime = wrappedSystemRuntime;
+            }
+            wireInspection(child.system);
           }
         }
       }
@@ -442,20 +536,27 @@ export function createDurable<TLogic extends AnyActorLogic>(
       return nextTransitionIndex;
     },
     initialTransition(...args) {
-      const [snapshot, effects] = withExecutionIdentity(executionIdentity, () =>
-        initialTransition(logic, ...args)
+      const [snapshot, effects] = withSystemInspector(inspect, () =>
+        withExecutionIdentity(executionIdentity, () =>
+          initialTransition(logic, ...args)
+        )
       );
       return [installSystemRuntime(snapshot), tagEffects(effects)];
     },
     transition(snapshot, event) {
-      const [nextSnapshot, effects] = withExecutionIdentity(
-        executionIdentity,
-        () => transition(logic, snapshot, event)
+      const [nextSnapshot, effects] = withSystemInspector(inspect, () =>
+        withExecutionIdentity(executionIdentity, () =>
+          transition(logic, snapshot, event)
+        )
       );
       return [installSystemRuntime(nextSnapshot), tagEffects(effects)];
     },
-    getActorRef(snapshot) {
-      return getSnapshotActorRef(snapshot as Snapshot<unknown>)?.actor;
+    getActorRef(snapshot, address) {
+      const root = getSnapshotActorRef(snapshot as Snapshot<unknown>)?.actor;
+      if (!root || address === undefined) {
+        return root;
+      }
+      return findByAddress(root, address);
     },
     async executeEffects(effects) {
       if (currentBatch) {
@@ -506,7 +607,7 @@ export function createDurable<TLogic extends AnyActorLogic>(
           }
         }
         await settle(batch);
-        return batch.rootEvents as DurableRootEvent<EventFromLogic<TLogic>>[];
+        pendingRootEvents.push(...batch.rootEvents);
       } catch (error) {
         // Drain before discarding so batch-initiated operations are not still
         // running when the retrying host re-executes the effects. The failed
@@ -523,10 +624,16 @@ export function createDurable<TLogic extends AnyActorLogic>(
       if (lastTransitionIndex === undefined) {
         throw new Error('Cannot wait for an event before the first transition');
       }
+      // Root-bound events produced while effects executed are handed out
+      // before durably waiting for an external event.
+      const queued = pendingRootEvents.shift();
+      if (queued) {
+        return queued.event as EventFromLogic<TLogic>;
+      }
       return adapter.waitForEvent({
         id: `event:${lastTransitionIndex}`,
         transitionIndex: lastTransitionIndex
-      });
+      }) as Promise<EventFromLogic<TLogic>>;
     },
     async run(...args) {
       if (
@@ -536,15 +643,12 @@ export function createDurable<TLogic extends AnyActorLogic>(
         throw new DurableExecutionResumeError();
       }
       let [snapshot, effects] = execution.initialTransition(...args);
-      const internalEvents = await execution.executeEffects(effects);
+      await execution.executeEffects(effects);
 
       while ((snapshot as Snapshot<OutputFrom<TLogic>>).status === 'active') {
-        // Root-bound events produced while effects executed are processed
-        // before durably waiting for an external event.
-        const event =
-          internalEvents.shift()?.event ?? (await execution.waitForEvent());
+        const event = await execution.waitForEvent();
         [snapshot, effects] = execution.transition(snapshot, event);
-        internalEvents.push(...(await execution.executeEffects(effects)));
+        await execution.executeEffects(effects);
       }
 
       const terminalSnapshot = snapshot as Snapshot<OutputFrom<TLogic>>;

--- a/packages/core/src/inspectionAmbient.ts
+++ b/packages/core/src/inspectionAmbient.ts
@@ -1,0 +1,45 @@
+import type { InspectionEvent } from './inspection.ts';
+
+/**
+ * The ambiently installed system inspector. Set for the duration of a durable
+ * execution's transitions (`createDurable(..., { inspect })`), it makes the
+ * pure-transition machinery observable: freshly constructed runtime systems
+ * attach it, and snapshot systems created while it is set forward inspection
+ * to their base system instead of stubbing it out.
+ */
+let ambientInspector: ((inspectionEvent: InspectionEvent) => void) | undefined;
+
+/** @internal */
+export function hasAmbientInspector(): boolean {
+  return ambientInspector !== undefined;
+}
+
+/** @internal */
+export function getAmbientInspector():
+  | ((inspectionEvent: InspectionEvent) => void)
+  | undefined {
+  return ambientInspector;
+}
+
+/**
+ * Runs `fn` with systems it creates wired to `inspect` from construction, so
+ * creation-time inspection events (the root actor's own registration, actors
+ * spawned during the first transition) are observed too.
+ *
+ * @internal
+ */
+export function withSystemInspector<T>(
+  inspect: ((inspectionEvent: InspectionEvent) => void) | undefined,
+  fn: () => T
+): T {
+  if (!inspect) {
+    return fn();
+  }
+  const previous = ambientInspector;
+  ambientInspector = inspect;
+  try {
+    return fn();
+  } finally {
+    ambientInspector = previous;
+  }
+}

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -58,6 +58,7 @@ import {
   Next_InvokeConfig,
   Next_StateNodeConfig,
   Next_TransitionConfigOrTarget,
+  OutputFromConfig,
   ValidateHistoryDefaults,
   ValidateStateTargets,
   WithDefault
@@ -619,6 +620,33 @@ type SetupOutput<TSchemas, TOutputSchema extends StandardSchemaV1> = [
 ] extends [never]
   ? InferOutput<TOutputSchema, unknown>
   : InferOutput<SetupSchema<TSchemas, 'output'>, unknown>;
+
+/**
+ * Whether an output schema was declared, either in `setup({ schemas })` or in
+ * the machine config's own `schemas.output`. A declared schema is always
+ * authoritative for the machine's output type.
+ */
+type HasOutputSchema<TSchemas, TOutputSchema extends StandardSchemaV1> = [
+  SetupSchema<TSchemas, 'output'>
+] extends [never]
+  ? StandardSchemaV1 extends TOutputSchema
+    ? false
+    : true
+  : true;
+
+/**
+ * The machine's output type. A declared output schema wins; otherwise the type
+ * is inferred from the config's `output` property (a mapper's return type, or
+ * the static value's type).
+ */
+type SetupOrConfigOutput<
+  TSchemas,
+  TOutputSchema extends StandardSchemaV1,
+  TConfig
+> =
+  HasOutputSchema<TSchemas, TOutputSchema> extends true
+    ? SetupOutput<TSchemas, TOutputSchema>
+    : OutputFromConfig<TConfig, SetupOutput<TSchemas, TOutputSchema>>;
 
 type SetupEmitted<
   TSchemas,
@@ -2087,7 +2115,7 @@ export interface SetupReturn<
     [SetupSchema<TSchemas, 'input'>] extends [never]
       ? TInput
       : SetupInput<TSchemas, TInputSchema>,
-    SetupOutput<TSchemas, TOutputSchema>,
+    SetupOrConfigOutput<TSchemas, TOutputSchema, TConfig>,
     SetupEmitted<TSchemas, TEmittedSchemaMap>,
     SetupMeta<TSchemas, TMetaSchema>,
     MergeStateSchema<

--- a/packages/core/src/snapshotActorRef.ts
+++ b/packages/core/src/snapshotActorRef.ts
@@ -1,3 +1,4 @@
+import { hasAmbientInspector } from './inspectionAmbient.ts';
 import type { AnyActor, Snapshot } from './types.ts';
 
 /** Snapshot-scoped actor identity and system view. @internal */
@@ -90,6 +91,7 @@ export function createSnapshotSystem(
   children: Record<string, AnyActor | undefined>,
   baseState?: SnapshotSystemState
 ): AnyActor['system'] {
+  const forwardInspection = hasAmbientInspector();
   const registeredActors = copyRegisteredActors(baseSystem, baseState);
   const keyedActors = new Map<PropertyKey, AnyActor | undefined>(
     baseState?.keyedActors ?? getKeyedActors(baseSystem)
@@ -130,10 +132,18 @@ export function createSnapshotSystem(
     },
     get: (registryKey: PropertyKey) => keyedActors.get(registryKey),
     getAll: () => Object.fromEntries(keyedActors),
-    // Pure transition resolution must not leak topology inspection events into
-    // a live runtime system.
-    _hasInspectionObservers: () => false,
-    _sendInspectionEvent: () => {}
+    // Pure transition resolution must not leak topology inspection events
+    // into a live runtime system — planning branches stay silent. The one
+    // exception is a durable execution's own transitions (marked by the
+    // ambient inspector at creation time): there the pure path IS the
+    // execution, so inspection forwards to the base system's observers.
+    _hasInspectionObservers: forwardInspection
+      ? () => baseSystem._hasInspectionObservers?.() ?? false
+      : () => false,
+    _sendInspectionEvent: forwardInspection
+      ? (event: Parameters<AnyActor['system']['_sendInspectionEvent']>[0]) =>
+          baseSystem._sendInspectionEvent(event)
+      : () => {}
   });
 
   for (const [registryKey, actor] of keyedActors) {

--- a/packages/core/src/system.ts
+++ b/packages/core/src/system.ts
@@ -14,6 +14,7 @@ import {
 } from './types.ts';
 import { XSTATE_TIMER } from './constants.ts';
 import { toObserver } from './utils.ts';
+import { getAmbientInspector } from './inspectionAmbient.ts';
 import { markSystemSnapshotDirty } from './snapshotActorRef.ts';
 import {
   assertEventCanBeSent,
@@ -122,6 +123,11 @@ export function withExecutionIdentity<T>(
     ambientExecutionIdentity = previous;
   }
 }
+
+export {
+  hasAmbientInspector,
+  withSystemInspector
+} from './inspectionAmbient.ts';
 
 /**
  * Derives the deterministic id prefix for a generated actor id from its actor
@@ -551,6 +557,10 @@ class RuntimeSystem<T extends ActorSystemInfo> implements ActorSystem<T> {
     this._clock = options.clock;
     this._logger = options.logger;
     this.createActorRef = options.createActorRef;
+    const ambientInspector = getAmbientInspector();
+    if (ambientInspector) {
+      this.inspect(ambientInspector);
+    }
     this._snapshot = {
       _scheduledTimers: restoredSnapshot?.scheduler ?? emptyScheduledTimers,
       // System-level counters are process-local backstops; per-actor

--- a/packages/core/src/transition.ts
+++ b/packages/core/src/transition.ts
@@ -1,4 +1,5 @@
 import { createInitEvent } from './eventUtils';
+import { hasAmbientInspector } from './system';
 import {
   attachSnapshotActorRef,
   createInertActorScope,
@@ -29,6 +30,8 @@ import {
   createSpawnEffect,
   finalizeTransitionResult
 } from './transitionActions.ts';
+
+import type { EventObject } from './types';
 
 type MachineMicrostep = [AnyMachineSnapshot, ExecutableActionObject[]];
 
@@ -87,6 +90,7 @@ export function transition<T extends AnyActorLogic>(
     nextSnapshot === snapshot
       ? nextSnapshot
       : attachSnapshotActorRef(actorScope, nextSnapshot);
+  inspectPureTransition(actorScope, returnedSnapshot, event);
   return [returnedSnapshot, effects as ExecutableActionObjectFromLogic<T>[]];
 }
 
@@ -113,10 +117,31 @@ export function initialTransition<T extends AnyActorLogic>(
 
   setInertActorScopeSnapshot(actorScope, nextSnapshot, false);
   const returnedSnapshot = attachSnapshotActorRef(actorScope, nextSnapshot);
+  inspectPureTransition(actorScope, returnedSnapshot, createInitEvent(input));
   return [
     returnedSnapshot,
     executableActions as ExecutableActionObjectFromLogic<T>[]
   ];
+}
+
+/**
+ * Emits the `@xstate.transition` inspection event for a snapshot produced by
+ * the pure transition path, where no live actor loop does it. Free unless an
+ * inspector is ambiently installed (a durable execution created with
+ * `inspect`): only then is the snapshot's actor ref materialized to emit.
+ */
+function inspectPureTransition(
+  actorScope: unknown,
+  snapshot: unknown,
+  event: EventObject
+): void {
+  if (!hasAmbientInspector()) {
+    return;
+  }
+  const self = (actorScope as { self?: AnyActor }).self;
+  if (self?.system._hasInspectionObservers?.()) {
+    self._inspectTransition(snapshot as never, event);
+  }
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1992,6 +1992,8 @@ export interface ActorRuntime<
   toJSON?: () => any;
   _parent?: any;
   system: any;
+  /** @internal Emits the transition inspection event for `snapshot`. */
+  _inspectTransition(snapshot: TSnapshot, event: EventObject): void;
   /** @internal */
   _processingStatus: ProcessingStatus;
   /** @internal */

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -52,6 +52,31 @@ export type InferOutput<T extends StandardSchemaV1, U> = Compute<
 >;
 
 /**
+ * Extracts the machine output type from the config's `output` property: the
+ * return type of an output mapper, or the type of a static output value.
+ * Falls back to `TFallback` when the config declares no `output`.
+ */
+export type OutputFromConfig<TConfig, TFallback> = TConfig extends {
+  output: infer TOutput;
+}
+  ? TOutput extends (...args: never[]) => infer TResult
+    ? TResult
+    : TOutput
+  : TFallback;
+
+/**
+ * The machine's output type when no output schema is declared in `setup()`: a
+ * declared `schemas.output` is authoritative, otherwise the output type is
+ * inferred from the config's `output` property.
+ */
+export type SchemaOrConfigOutput<
+  TOutputSchema extends StandardSchemaV1,
+  TConfig
+> = StandardSchemaV1 extends TOutputSchema
+  ? OutputFromConfig<TConfig, InferOutput<TOutputSchema, unknown>>
+  : InferOutput<TOutputSchema, unknown>;
+
+/**
  * Event payloads from schemas (e.g. Zod) are often inferred as optional in
  * output types. Wrapping in Required<> ensures properties defined in the schema
  * are required on the event. Type-only schemas created with the `types()`

--- a/packages/core/test/addressFirstIdentity.test.ts
+++ b/packages/core/test/addressFirstIdentity.test.ts
@@ -1498,8 +1498,9 @@ describe('tenth round: review findings', () => {
     });
     expect(durable.rootAddress).toBe('a%2Fb');
     const [, effects] = durable.initialTransition();
-    const rootEvents = await durable.executeEffects(effects);
-    expect(rootEvents.map((r: any) => r.event.type)).toEqual(['HELLO']);
+    await durable.executeEffects(effects);
+    const hello = await durable.waitForEvent();
+    expect(hello.type).toBe('HELLO');
   });
 });
 

--- a/packages/core/test/durable-address-first.test.ts
+++ b/packages/core/test/durable-address-first.test.ts
@@ -77,18 +77,16 @@ describe('durable execution with only adapter runtime operations', () => {
     ]);
 
     [snapshot, effects] = durable.transition(snapshot, { type: 'KICK' });
-    const rootEvents = await durable.executeEffects(effects);
+    await durable.executeEffects(effects);
     // The child's reply was produced with no per-actor wiring, captured by
-    // the execution instead of reaching the host's sendEvent, and returned
-    // with its source for the durable loop.
+    // the execution instead of reaching the host's sendEvent, and retained:
+    // `waitForEvent()` hands it out before deferring to the adapter.
     expect(operations).toContain('send:order->order/worker:0:PING');
     expect(operations).not.toContain('send:order/worker:0->order:WORKER.READY');
-    expect(rootEvents).toEqual([
-      { event: { type: 'WORKER.READY' }, source: expect.anything() }
-    ]);
-    expect(rootEvents[0]!.source?.address).toBe('order/worker:0');
+    const reply = await durable.waitForEvent();
+    expect(reply).toEqual({ type: 'WORKER.READY' });
 
-    [snapshot] = durable.transition(snapshot, rootEvents[0]!.event);
+    [snapshot] = durable.transition(snapshot, reply);
     expect(snapshot.status).toBe('done');
   });
 });
@@ -350,8 +348,10 @@ describe('review findings: fourth round', () => {
     // The child's WORKER-bound reply (none here) and any captured root events
     // from the failed batch are gone; a fresh batch starts clean.
     const [, kickEffects] = durable.transition(snapshot, { type: 'KICK' });
-    const rootEvents = await durable.executeEffects(kickEffects);
-    expect(rootEvents).toEqual([]);
+    await durable.executeEffects(kickEffects);
+    // Nothing was retained from the failed batch: `waitForEvent()` falls
+    // straight through to the adapter.
+    await expect(durable.waitForEvent()).rejects.toThrow('host-driven loop');
   });
 
   it('a per-effect runtime falls back to the system runtime for omitted operations', async () => {
@@ -429,7 +429,7 @@ describe('review findings: fifth round', () => {
     );
     // A retrying host re-executes the same effects; the previous batch's
     // failure must not be replayed.
-    await expect(durable.executeEffects(effects)).resolves.toEqual([]);
+    await expect(durable.executeEffects(effects)).resolves.toBeUndefined();
   });
 });
 
@@ -465,7 +465,7 @@ describe('review findings: sixth round', () => {
     });
 
     const [snapshot, effects] = durable.initialTransition();
-    expect(await durable.executeEffects(effects)).toEqual([]);
+    await durable.executeEffects(effects);
 
     // The loop is now parked. The host delivers an event to the live child,
     // whose reply is addressed to the root: it must reach the host runtime's
@@ -479,11 +479,13 @@ describe('review findings: sixth round', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(sent).toContain('order:WORKER.READY');
 
-    // A later, unrelated batch must not surface that host-owned delivery.
+    // A later, unrelated batch must not surface that host-owned delivery:
+    // nothing was retained, so `waitForEvent()` falls through to the adapter.
     const [, nextEffects] = durable.transition(snapshot, {
       type: 'WORKER.READY'
     });
-    expect(await durable.executeEffects(nextEffects)).toEqual([]);
+    await durable.executeEffects(nextEffects);
+    await expect(durable.waitForEvent()).rejects.toThrow('host-driven loop');
   });
 
   it('an operation that fails while the loop is parked does not fail the next batch', async () => {
@@ -542,7 +544,7 @@ describe('review findings: sixth round', () => {
     // The next batch succeeds on its own merits.
     parked = false;
     const [, kickEffects] = durable.transition(snapshot, { type: 'KICK' });
-    await expect(durable.executeEffects(kickEffects)).resolves.toBeDefined();
+    await expect(durable.executeEffects(kickEffects)).resolves.toBeUndefined();
   });
 });
 

--- a/packages/core/test/durable-conformance.ts
+++ b/packages/core/test/durable-conformance.ts
@@ -238,6 +238,11 @@ export function durableExecutionConformance({
         await execution.send({ type: 'SEND' });
 
         await expect(execution.result).resolves.toBe('communicated');
+        // Only the parent→child PING is a host operation. The child's PONG
+        // is addressed to the root: the execution captures and retains it,
+        // and the loop takes it through `waitForEvent()` — the host's own
+        // sendEvent never sees it (that the result resolved proves it was
+        // applied).
         expect(
           execution.operations.filter(({ type }) => type === 'event.send')
         ).toEqual([
@@ -245,11 +250,6 @@ export function durableExecutionConformance({
             sourceId: 'x:0',
             targetId: 'worker',
             eventType: 'PING'
-          }),
-          expect.objectContaining({
-            sourceId: 'worker',
-            targetId: 'x:0',
-            eventType: 'PONG'
           })
         ]);
       });

--- a/packages/core/test/durable-execution-identity.test.ts
+++ b/packages/core/test/durable-execution-identity.test.ts
@@ -19,6 +19,23 @@ const machine = setup({ actors: { fraudCheck } }).createMachine({
   }
 });
 
+/**
+ * Takes the root events a settled batch retained: `waitForEvent()` hands them
+ * out until it defers to the adapter, whose host-driven stub throws.
+ */
+async function takeRootEvents(execution: {
+  waitForEvent(): Promise<unknown>;
+}): Promise<any[]> {
+  const events: any[] = [];
+  for (;;) {
+    try {
+      events.push(await execution.waitForEvent());
+    } catch {
+      return events;
+    }
+  }
+}
+
 function createHost(steps: Map<string, unknown>, executionId?: string) {
   return createDurable(machine, {
     executionId,
@@ -46,16 +63,16 @@ describe('deterministic execution identity', () => {
     const steps = new Map<string, unknown>();
     const first = createHost(steps, 'exec-1');
     const [s1, e1] = first.initialTransition();
-    const events1 = await first.executeEffects(e1);
+    await first.executeEffects(e1);
+    const events1 = await takeRootEvents(first);
 
     const second = createHost(steps, 'exec-1');
     const [s2, e2] = second.initialTransition();
-    const events2 = await second.executeEffects(e2);
+    await second.executeEffects(e2);
+    const events2 = await takeRootEvents(second);
 
-    expect(events1.map(({ event }) => event)).toEqual(
-      events2.map(({ event }) => event)
-    );
-    const sessionId = (events1[0]!.event as { sessionId?: string }).sessionId;
+    expect(events1).toEqual(events2);
+    const sessionId = (events1[0] as { sessionId?: string }).sessionId;
     expect(sessionId).toMatch(/^exec-1:/);
     void s1;
     void s2;
@@ -68,8 +85,9 @@ describe('deterministic execution identity', () => {
     // root and a journaling host records the event verbatim.
     const first = createHost(steps, 'exec-1');
     const [snapshot1, effects1] = first.initialTransition();
-    const [journaled] = await first.executeEffects(effects1);
-    expect(journaled!.event.type).toMatch(/^xstate\.done\.actor/);
+    await first.executeEffects(effects1);
+    const [journaled] = await takeRootEvents(first);
+    expect(journaled.type).toMatch(/^xstate\.done\.actor/);
 
     // Crash. Replay from the beginning in a "fresh process": same journal,
     // same executionId. The replayed step returns its memoized result, and
@@ -78,7 +96,7 @@ describe('deterministic execution identity', () => {
     const second = createHost(steps, 'exec-1');
     const [snapshot2, effects2] = second.initialTransition();
     await second.executeEffects(effects2);
-    const [replayed] = second.transition(snapshot2 as never, journaled!.event);
+    const [replayed] = second.transition(snapshot2 as never, journaled);
     expect((replayed as { value?: unknown }).value).toBe('approved');
     void snapshot1;
   });
@@ -87,12 +105,13 @@ describe('deterministic execution identity', () => {
     const steps = new Map<string, unknown>();
     const first = createHost(steps);
     const [, effects1] = first.initialTransition();
-    const [journaled] = await first.executeEffects(effects1);
+    await first.executeEffects(effects1);
+    const [journaled] = await takeRootEvents(first);
 
     const second = createHost(steps);
     const [snapshot2, effects2] = second.initialTransition();
     await second.executeEffects(effects2);
-    const [replayed] = second.transition(snapshot2 as never, journaled!.event);
+    const [replayed] = second.transition(snapshot2 as never, journaled);
     // The recorded sessionId embeds run 1's random system id, so the
     // completion is dropped as stale — the documented reason to pin
     // executionId on journaling hosts.
@@ -155,8 +174,9 @@ describe('runLogic: the async actor as the durable unit', () => {
 
     const first = host('exec-1');
     const [, e1] = first.initialTransition({ total: 1500 });
-    const [done1] = await first.executeEffects(e1);
-    expect(done1!.event.type).toMatch(/^xstate\.done\.actor/);
+    await first.executeEffects(e1);
+    const [done1] = await takeRootEvents(first);
+    expect(done1.type).toMatch(/^xstate\.done\.actor/);
     expect(executions).toBe(1);
 
     // Crash → replay: the body does not re-run, and the journaled
@@ -165,7 +185,7 @@ describe('runLogic: the async actor as the durable unit', () => {
     const [s2, e2] = second.initialTransition({ total: 1500 });
     await second.executeEffects(e2);
     expect(executions).toBe(1);
-    const [replayed] = second.transition(s2 as never, done1!.event);
+    const [replayed] = second.transition(s2 as never, done1);
     expect((replayed as { value?: unknown }).value).toBe('approved');
   });
 
@@ -197,9 +217,10 @@ describe('runLogic: the async actor as the durable unit', () => {
     });
 
     const [snapshot, effects] = durable.initialTransition({ total: 1500 });
-    const [done] = await durable.executeEffects(effects);
+    await durable.executeEffects(effects);
+    const [done] = await takeRootEvents(durable);
     expect(shipped).toEqual([{ src: 'score', input: { total: 1500 } }]);
-    const [next] = durable.transition(snapshot as never, done!.event);
+    const [next] = durable.transition(snapshot as never, done);
     expect((next as { value?: unknown }).value).toBe('approved');
   });
 });

--- a/packages/core/test/durable-inspection.test.ts
+++ b/packages/core/test/durable-inspection.test.ts
@@ -1,0 +1,80 @@
+import { createAsyncLogic, setup } from '../src/index.ts';
+import { createDurable } from '../src/durable/index.ts';
+import type { InspectionEvent } from '../src/inspection.ts';
+
+const fraudCheck = createAsyncLogic({
+  id: 'fraudCheck',
+  run: async () => 0.2
+});
+
+const machine = setup({ actors: { fraudCheck } }).createMachine({
+  id: 'order',
+  initial: 'verifying',
+  states: {
+    verifying: {
+      invoke: { id: 'fraud', src: 'fraudCheck', onDone: { target: 'approved' } }
+    },
+    approved: {}
+  }
+});
+
+describe('durable execution inspection', () => {
+  it('the inspect option observes the whole run without any adapter wiring', async () => {
+    const inspected: InspectionEvent[] = [];
+    const durable = createDurable(
+      machine,
+      {
+        executeAction: () => {},
+        startActor: (actor) => {
+          actor.start();
+        },
+        waitForEvent: () => {
+          throw new Error('host-driven loop');
+        }
+      },
+      { inspect: (ev) => inspected.push(ev) }
+    );
+
+    const [snapshot, effects] = durable.initialTransition();
+    await durable.executeEffects(effects);
+    const done = await durable.waitForEvent();
+    const [next] = durable.transition(snapshot, done);
+    expect(next.status).toBe('active');
+    expect((next as { value?: unknown }).value).toBe('approved');
+
+    const types = new Set(inspected.map((ev) => ev.type));
+    // The two-event protocol covers the whole run: actor topology (root and
+    // the invoked child, observed from construction) plus every transition.
+    expect(types).toContain('@xstate.actor');
+    expect(types).toContain('@xstate.transition');
+    const actors = inspected
+      .filter((ev) => ev.type === '@xstate.actor')
+      .map((ev) => (ev.actorRef as { address?: string }).address);
+    expect(actors).toContain('order');
+    expect(actors).toContain('order/fraud');
+    // The completion transition is observed with its causing event.
+    expect(
+      inspected.some(
+        (ev) =>
+          ev.type === '@xstate.transition' &&
+          ev.event.type.startsWith('xstate.done.actor')
+      )
+    ).toBe(true);
+  });
+
+  it('inspection is host observability only: none without the option', async () => {
+    const durable = createDurable(machine, {
+      executeAction: () => {},
+      startActor: (actor) => {
+        actor.start();
+      },
+      waitForEvent: () => {
+        throw new Error('host-driven loop');
+      }
+    });
+    const [snapshot, effects] = durable.initialTransition();
+    await durable.executeEffects(effects);
+    const [next] = durable.transition(snapshot, await durable.waitForEvent());
+    expect((next as { value?: unknown }).value).toBe('approved');
+  });
+});

--- a/packages/core/test/durable-reference-host.test.ts
+++ b/packages/core/test/durable-reference-host.test.ts
@@ -148,31 +148,16 @@ class InMemoryDurableHost implements DurableConformanceHarness {
       }
     });
 
-    const rootId = () => durable.rootAddress;
-    const enqueueRootEvents = (
-      rootEvents: Awaited<ReturnType<typeof durable.executeEffects>>
-    ) => {
-      for (const { event, source } of rootEvents) {
-        operations.push({
-          type: 'event.send' as const,
-          sourceId: source?.id,
-          targetId: rootId(),
-          eventType: event.type
-        });
-        enqueue(event);
-      }
-    };
-
     const result = (async () => {
       let effects;
       [snapshot, effects] = durable.initialTransition(input as never);
       rootAddress = durable.getActorRef(snapshot)?.address;
-      enqueueRootEvents(await durable.executeEffects(effects));
+      await durable.executeEffects(effects);
 
       while ((snapshot as Snapshot<unknown>).status === 'active') {
         const event = await durable.waitForEvent();
         [snapshot, effects] = durable.transition(snapshot, event);
-        enqueueRootEvents(await durable.executeEffects(effects));
+        await durable.executeEffects(effects);
       }
 
       const terminal = snapshot as Snapshot<unknown>;

--- a/packages/core/test/machineOutput.types.test.ts
+++ b/packages/core/test/machineOutput.types.test.ts
@@ -1,0 +1,164 @@
+import { createActor, createMachine, setup, types } from '../src/index.ts';
+import type { OutputFrom } from '../src/index.ts';
+
+describe('machine output type inference', () => {
+  it('infers the output type from the config output mapper', () => {
+    const machine = setup({
+      schemas: {
+        context: types<{ shipped: string[] }>()
+      }
+    }).createMachine({
+      context: { shipped: ['a'] },
+      initial: 'done',
+      states: { done: { type: 'final' } },
+      output: ({ context }) => ({
+        status: 'shipped' as const,
+        skus: context.shipped
+      })
+    });
+
+    type Output = OutputFrom<typeof machine>;
+
+    ((_output: Output) => {
+      _output satisfies { status: 'shipped'; skus: string[] };
+    })({ status: 'shipped', skus: [] });
+
+    const actor = createActor(machine).start();
+    expect(actor.getSnapshot().output).toEqual({
+      status: 'shipped',
+      skus: ['a']
+    });
+  });
+
+  it('infers the output type from a static config output value', () => {
+    const machine = setup({}).createMachine({
+      initial: 'done',
+      states: { done: { type: 'final' } },
+      output: { done: true, code: 200 }
+    });
+
+    ((_output: OutputFrom<typeof machine>) => {
+      _output satisfies { done: boolean; code: number };
+    })({ done: true, code: 200 });
+  });
+
+  it('infers the output type from the config output mapper of a plain machine', () => {
+    const machine = createMachine({
+      initial: 'done',
+      states: { done: { type: 'final' } },
+      output: () => ({ ok: true })
+    });
+
+    ((_output: OutputFrom<typeof machine>) => {
+      _output satisfies { ok: boolean };
+    })({ ok: true });
+  });
+
+  it('keeps an inline schemas.output authoritative', () => {
+    const machine = setup({}).createMachine({
+      schemas: { output: types<{ total: number }>() },
+      initial: 'done',
+      states: { done: { type: 'final' } },
+      output: () => ({ total: 1 })
+    });
+
+    ((_output: OutputFrom<typeof machine>) => {
+      _output satisfies { total: number };
+      // @ts-expect-error the declared schema is authoritative
+      _output satisfies { status: string };
+    })({ total: 1 });
+  });
+
+  it('keeps a setup-level schemas.output authoritative', () => {
+    const machine = setup({
+      schemas: { output: types<{ ok: boolean }>() }
+    }).createMachine({
+      initial: 'done',
+      states: { done: { type: 'final' } },
+      output: () => ({ ok: true })
+    });
+
+    ((_output: OutputFrom<typeof machine>) => {
+      _output satisfies { ok: boolean };
+      // @ts-expect-error the declared schema is authoritative
+      _output satisfies { status: string };
+    })({ ok: true });
+  });
+
+  it('contextually types the output mapper arguments', () => {
+    setup({
+      schemas: {
+        context: types<{ shipped: string[] }>(),
+        events: {
+          FINISH: types<{}>()
+        }
+      }
+    }).createMachine({
+      context: { shipped: [] },
+      initial: 'done',
+      states: { done: { type: 'final' } },
+      output: ({ context, event }) => {
+        context.shipped satisfies string[];
+        // @ts-expect-error context is contextually typed
+        context.shipped satisfies number[];
+        event satisfies { type: string };
+        return { skus: context.shipped };
+      }
+    });
+  });
+
+  it('leaves the output type at its default when no output is declared', () => {
+    const machine = setup({}).createMachine({
+      initial: 'idle',
+      states: { idle: {} }
+    });
+
+    ((_output: OutputFrom<typeof machine>) => {
+      _output satisfies {} | null | undefined;
+    })({});
+  });
+
+  it('flows an inferred output into an invoking parent', () => {
+    const child = setup({}).createMachine({
+      initial: 'done',
+      states: { done: { type: 'final' } },
+      output: () => ({ status: 'shipped' as const })
+    });
+
+    setup({ actors: { child } }).createMachine({
+      initial: 'waiting',
+      states: {
+        waiting: {
+          invoke: {
+            src: 'child',
+            onDone: ({ event }) => {
+              event.output satisfies { status: 'shipped' };
+              // @ts-expect-error output is the inferred child output
+              event.output satisfies { status: 'cancelled' };
+              return { target: 'done' as const };
+            }
+          }
+        },
+        done: {}
+      }
+    });
+  });
+
+  it('does not regress state completion output typing', () => {
+    setup({
+      states: {
+        step: {
+          schemas: { output: types<{ count: number }>() }
+        }
+      }
+    }).createMachine({
+      initial: 'step',
+      states: {
+        step: {
+          type: 'final',
+          output: () => ({ count: 1 })
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #5663, from the host-example review (the "north star" pass). Four API improvements that shrink every durable host's drive loop and remove the remaining casts:

## Retained root events (the big one)

`executeEffects` now retains the root-addressed events it captures, and `execution.waitForEvent()` hands them out before deferring to the adapter. `executeEffects` resolves `void`. The canonical loop loses its hand-rolled queue:

```ts
let [state, effects] = execution.initialTransition(input);
await execution.executeEffects(effects);

while (state.status === 'active') {
  [state, effects] = execution.transition(state, await execution.waitForEvent());
  await execution.executeEffects(effects);
}
```

## Inspection for durable executions

`createDurable(logic, adapter, { inspect })` observes the `@xstate.actor` / `@xstate.transition` protocol across the whole live tree — **including transitions computed by the pure path**, which were previously invisible. Mechanics: freshly constructed runtime systems attach the ambient inspector at construction, and snapshot systems created under it forward inspection to their base system; ordinary planning branches keep the existing no-leak stub. Host observability (operation logs, tracing, test hooks) now lives outside the adapter.

## Address lookup

`execution.getActorRef(snapshot, address)` resolves a logical address against the live actor tree — for hosts whose durable mailbox stores addresses as strings (Restate's `findLiveActor` becomes a one-liner).

## Output inference

`OutputFrom` infers from the config's `output` function when no `schemas.output` is declared (schema stays authoritative when present). Was silently `{}`, forcing casts downstream.

## Generic-host typing

`DurableSnapshot` keeps the `status`/`output`/`error` discriminant visible for an unresolved `TLogic`, and adapter `waitForEvent` may return plain event objects — generic host libraries need no `as never`/`as Snapshot` casts.

## Test changes (all migrations to the new contract, none weakened)

- durable identity/address-first/reference-host tests read retained events via `waitForEvent()` instead of the old return value; leak checks now probe `waitForEvent` falling through to the adapter.
- The conformance "routes messages" test no longer asserts the child→root reply as a host `event.send` op — that delivery is execution-internal by design now (the resolved output proves it applied).
- The captured-event `source` assertions were dropped with the return value; source-level observability is `inspect`'s job.

Validation: 2316 core tests, typecheck 0, lint/format clean.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5669" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->