### PR TITLE
Fix snapshot restore and durable root routing

### DIFF
--- a/.changeset/restored-durable-routing.md
+++ b/.changeset/restored-durable-routing.md
@@ -1,0 +1,21 @@
+---
+'xstate': patch
+---
+
+Restoring an externally migrated live snapshot now treats its `machine` property as a runtime association rather than persisted version metadata. Persisted snapshots continue validating their nested `{ id, version }` identity and legacy top-level `version` together.
+
+`getNextTransitions(snapshot)` returns an empty array for completed or errored snapshots.
+
+Setup-created machines whose input schema accepts `undefined` no longer require a meaningless `input` property when other actor options are provided, including after `machine.provide(...)`.
+
+Durable adapters can implement `enqueueRootEvent` when the host owns only the execution root's mailbox, without overriding delivery for co-located actors:
+
+```ts
+const durable = createDurable(machine, {
+  enqueueRootEvent: (_source, event) => host.enqueue(event),
+  executeAction,
+  waitForEvent
+});
+```
+
+Implement `sendEvent` only when the host owns routing for every target; use `deliverEvent` for co-located delivery. Durable replay guidance now explicitly covers inline entry and exit callbacks.

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -21,8 +21,7 @@ loop hooks: `executeAction` runs a custom action as a host step, and
 import { createDurable } from 'xstate/durable';
 
 const durable = createDurable(machine, {
-  sendEvent: (source, target, event) =>
-    host.send(source?.address, target.address, event),
+  enqueueRootEvent: (_source, event) => host.enqueue(event),
   scheduleTimer: (source, id, delay) =>
     host.schedule({ address: source.address, timerId: id, delay }),
   cancelTimer: (source, id) =>
@@ -40,6 +39,13 @@ const output = await durable.run(input);
 
 Runtime operations you omit keep their local behavior — spawned machine
 children run in this process, for example.
+
+`enqueueRootEvent` is the narrow hook most co-located hosts need: it receives
+events sent to the execution root while the loop is parked. Implement
+`sendEvent` only when the host owns routing for every target. That override
+replaces local delivery completely; call `deliverEvent(source, target, event)`
+for co-located targets instead of `target.send(event)`, which re-enters the
+runtime.
 
 The primary durable unit for async work is the actor itself: a developer
 writes a normal promise (`fromPromise`, `createAsyncLogic`) and invokes it;
@@ -208,9 +214,10 @@ Events addressed to the root actor do not reach `sendEvent` during
 `executeEffects`: the execution captures and retains them, and
 `waitForEvent()` hands them out — in capture order — before deferring to the
 adapter. While the loop is parked in the adapter's wait, a root-addressed
-event reaches `sendEvent` like any other target and belongs in the host's
-mailbox; if the adapter implements no `sendEvent`, producing one there throws,
-since delivering it locally to the inert root would silently lose it.
+event reaches `enqueueRootEvent`, or `sendEvent` when the adapter implements
+the broader routing override, and belongs in the host's mailbox. Producing one
+without either hook throws, since delivering it locally to the inert root
+would silently lose it.
 
 ### Journaling rules
 
@@ -240,15 +247,30 @@ host.
 ## Determinism constraints
 
 Replay only reconstructs the same effects when every transition is a pure
-function of the snapshot and event. Code that runs during a transition — 
-guards, transition functions, `context` assigners, `input` factories — must
-not read the clock, generate random values, or reach external state:
+function of the snapshot and event. Inline `entry` and `exit` callbacks run
+during transition calculation too, so a direct side effect there runs again
+whenever a durable host folds the event history. Guards, transition functions,
+`context` assigners, `input` factories, and inline entry/exit callbacks must
+not read the clock, generate random values, mutate external state, or perform
+I/O:
 `Date.now()`, `Math.random()`, and `crypto.randomUUID()` all produce a
 different effect sequence on replay, and nothing detects the divergence.
 Perform such work inside journaled operations (the host's `executeAction`,
 where the recorded result replays), or derive values deterministically from
 what the snapshot already carries — addresses and effect IDs are stable
 across replays and make good seeds and idempotency keys.
+
+```ts
+// Wrong: runs during every replay fold.
+entry: () => {
+  analytics.track('entered');
+}
+
+// Right: describes an effect for the durable host to execute or replay.
+entry: ({ context }, enq) => {
+  enq(notifyApprover, context.orderId);
+}
+```
 
 ## Checkpoints and placement
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -10,6 +10,10 @@ const persisted = actor.getPersistedSnapshot();
 localStorage.setItem('checkout', JSON.stringify(persisted));
 ```
 
+Do not persist or migrate `actor.getSnapshot()`. A live snapshot carries
+runtime-only state, including its producing machine; `getPersistedSnapshot()`
+removes those associations and writes the machine's serializable identity.
+
 Restore the actor with the `snapshot` option.
 
 ```ts

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -1323,7 +1323,17 @@ export class StateMachine<
     const usesInertScope = !actorScope;
     const resolvedActorScope = (actorScope ??
       createInertActorScope(this)) as NonNullable<typeof actorScope>;
-    const persistedMachine = (snapshot as any).machine;
+    const snapshotMachine = (snapshot as any).machine;
+    // A live machine snapshot carries its producing machine so helpers such as
+    // `matches()` can resolve state nodes. That runtime association is not the
+    // persisted `{ id, version }` identity written by getPersistedSnapshot().
+    const persistedMachine =
+      snapshotMachine &&
+      typeof snapshotMachine === 'object' &&
+      typeof snapshotMachine.transition === 'function' &&
+      'root' in snapshotMachine
+        ? undefined
+        : snapshotMachine;
     const legacyPersistedVersion: string | undefined = (snapshot as any)
       .version;
     const persistedVersion: string | undefined =

--- a/packages/core/src/durable/index.ts
+++ b/packages/core/src/durable/index.ts
@@ -75,12 +75,22 @@ export interface DurableEffect<TEffect> extends DurableEffectMetadata {
  * during `executeEffects`: the execution captures and retains them, and the
  * execution's `waitForEvent()` hands them out before deferring to this
  * adapter. While the loop is parked, a root-addressed event reaches
- * `sendEvent` like any other target, so the host enqueues it in its own
- * mailbox.
+ * `enqueueRootEvent`, or the broader `sendEvent` override when implemented,
+ * so the host can place it in its own mailbox.
  */
 export interface DurableExecutionAdapter<
   TLogic extends AnyActorLogic
 > extends Partial<ActorSystemRuntime> {
+  /**
+   * Enqueues an event addressed to this execution's root while the durable
+   * loop is parked in `waitForEvent()`. Use this when the host only owns the
+   * root mailbox; implementing `sendEvent` instead takes ownership of delivery
+   * for every target and must use `deliverEvent` for co-located actors.
+   */
+  enqueueRootEvent?(
+    source: AnyActor | undefined,
+    event: AnyEventObject
+  ): void | PromiseLike<void>;
   /**
    * Executes a custom action as a durable host step or activity. The host
    * should identify the action by `type` and memoize or deduplicate it using
@@ -312,7 +322,8 @@ export function createDurable<TLogic extends AnyActorLogic>(
         impl.bind(adapter);
     }
   }
-  const hasSystemRuntime = Object.keys(systemRuntime).length > 0;
+  const hasSystemRuntime =
+    Object.keys(systemRuntime).length > 0 || !!adapter.enqueueRootEvent;
 
   // One batch per `executeEffects` call. The wrapped runtime stays installed
   // on the actor system for the whole execution, so it also sees operations
@@ -427,12 +438,20 @@ export function createDurable<TLogic extends AnyActorLogic>(
       if (
         !currentBatch &&
         target.address === rootAddress &&
+        !runtime.sendEvent &&
+        adapter.enqueueRootEvent
+      ) {
+        return dispatch(() => adapter.enqueueRootEvent!(source, event));
+      }
+      if (
+        !currentBatch &&
+        target.address === rootAddress &&
         !runtime.sendEvent
       ) {
         // The root actor is inert; delivering locally would enqueue into a
         // mailbox that never runs, silently losing the event.
         throw new Error(
-          `A root-addressed event ("${event.type}") was produced while the durable loop was parked, but the adapter has no sendEvent to receive it. Implement sendEvent and enqueue root-addressed events in the host's mailbox.`
+          `A root-addressed event ("${event.type}") was produced while the durable loop was parked, but the adapter has no enqueueRootEvent or sendEvent to receive it. Implement enqueueRootEvent to place root-addressed events in the host's mailbox.`
         );
       }
       if (currentBatch && target.address === rootAddress) {

--- a/packages/core/src/transition.ts
+++ b/packages/core/src/transition.ts
@@ -239,6 +239,9 @@ export function getInitialMicrosteps<T extends AnyStateMachine>(
 export function getNextTransitions(
   state: AnyMachineSnapshot
 ): AnyTransitionDefinition[] {
+  if (state.status !== 'active') {
+    return [];
+  }
   const potentialTransitions: AnyTransitionDefinition[] = [];
   const atomicStates = state.nodes.filter(isAtomicStateNode);
   const visited = new Set();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -153,29 +153,32 @@ export type ActionArgs<
 };
 
 export type InputFrom<T> =
-  T extends StateMachine<
-    infer _TContext,
+  // Resolve the actor-logic contract first. Setup-created machines intersect
+  // StateMachine with literal identity metadata; inferring StateMachine's
+  // generic parameters through that intersection widens optional input.
+  T extends ActorLogic<
+    infer _TSnapshot,
     infer _TEvent,
-    infer _TChildren,
-    infer _TStateValue,
-    infer _TTag,
     infer TInput,
-    infer _TOutput,
-    infer _TEmitted,
-    infer _TMeta,
-    infer _TStateSchema,
-    infer _TActionMap,
-    infer _TActorMap,
-    infer _TGuardMap,
-    infer _TDelayMap
+    infer _TSystem,
+    infer _TEmitted
   >
     ? TInput
-    : T extends ActorLogic<
-          infer _TSnapshot,
+    : T extends StateMachine<
+          infer _TContext,
           infer _TEvent,
+          infer _TChildren,
+          infer _TStateValue,
+          infer _TTag,
           infer TInput,
-          infer _TSystem,
-          infer _TEmitted
+          infer _TOutput,
+          infer _TEmitted,
+          infer _TMeta,
+          infer _TStateSchema,
+          infer _TActionMap,
+          infer _TActorMap,
+          infer _TGuardMap,
+          infer _TDelayMap
         >
       ? TInput
       : never;

--- a/packages/core/test/durable-address-first.test.ts
+++ b/packages/core/test/durable-address-first.test.ts
@@ -622,7 +622,7 @@ describe('review findings: eighth round', () => {
     await first;
   });
 
-  it('a parked root-addressed event without a host sendEvent fails loudly', async () => {
+  it('a parked root-addressed event without a host mailbox hook fails loudly', async () => {
     let send: ((event: { type: string }) => void) | undefined;
     const emitter = createCallbackLogic(({ sendBack }) => {
       send = sendBack;
@@ -639,7 +639,7 @@ describe('review findings: eighth round', () => {
     const durable = createDurable(machine, {
       executeAction: () => {},
       // A runtime operation makes the adapter the system runtime, but there
-      // is no sendEvent to receive root-addressed events.
+      // is no root mailbox hook to receive root-addressed events.
       cancelTimer: () => {},
       waitForEvent: () => {
         throw new Error('host-driven loop');
@@ -651,7 +651,7 @@ describe('review findings: eighth round', () => {
     // The loop is parked: delivering locally would enqueue into the inert
     // root's mailbox and silently lose the event.
     expect(() => send!({ type: 'LATE' })).toThrow(
-      /parked.*no sendEvent|no sendEvent to receive it/
+      /parked.*no enqueueRootEvent or sendEvent/
     );
   });
 });

--- a/packages/core/test/durable-execution.test.ts
+++ b/packages/core/test/durable-execution.test.ts
@@ -274,6 +274,39 @@ describe('durable execution', () => {
     expect(runtime.sendEvent).toHaveBeenCalledWith(undefined, target, event);
   });
 
+  it('routes parked root events through the dedicated mailbox hook', async () => {
+    const enqueueRootEvent = vi.fn();
+    let providedRuntime: unknown;
+    const logic = createLogic({
+      context: undefined,
+      run: ({ event }, enq) => {
+        if (event.type === '@xstate.init') {
+          enq.effect((effectRuntime) => {
+            providedRuntime = effectRuntime;
+          });
+        }
+      }
+    });
+    const durable = createDurable(logic, {
+      executeAction: async (effect, _metadata, effectRuntime) => {
+        await effect.exec(effectRuntime);
+      },
+      enqueueRootEvent,
+      waitForEvent: () => ({ type: 'unused' })
+    });
+    const [, effects] = durable.initialTransition(undefined);
+    await durable.executeEffects(effects);
+
+    const source = { id: 'child' } as never;
+    const target = { address: durable.rootAddress } as never;
+    const event = { type: 'CHILD_EVENT' };
+    await (
+      providedRuntime as { sendEvent(...args: unknown[]): PromiseLike<void> }
+    ).sendEvent(source, target, event);
+
+    expect(enqueueRootEvent).toHaveBeenCalledWith(source, event);
+  });
+
   it('runs to completion and assigns stable IDs to event waits', async () => {
     const waits: Array<{ id: string; transitionIndex: number }> = [];
     const machine = createMachine({

--- a/packages/core/test/transition.test.ts
+++ b/packages/core/test/transition.test.ts
@@ -2833,6 +2833,38 @@ describe('transition function', () => {
 });
 
 describe('getNextTransitions', () => {
+  it('should return no transitions for an error snapshot', () => {
+    const machineV1 = createMachine({
+      version: '1',
+      initial: 'a',
+      states: { a: {} }
+    });
+    const machineV2 = createMachine({
+      version: '2',
+      initial: 'a',
+      states: { a: {} }
+    });
+    const persisted = createActor(machineV1).start().getPersistedSnapshot();
+    const errorSnapshot = createActor(machineV2, {
+      snapshot: persisted
+    }).getSnapshot();
+
+    expect(errorSnapshot.status).toBe('error');
+    expect(getNextTransitions(errorSnapshot)).toEqual([]);
+  });
+
+  it('should return no transitions for a completed snapshot', () => {
+    const machine = createMachine({
+      initial: 'done',
+      on: { RESET: { target: '.done' } },
+      states: { done: { type: 'final' } }
+    });
+    const doneSnapshot = createActor(machine).getSnapshot();
+
+    expect(doneSnapshot.status).toBe('done');
+    expect(getNextTransitions(doneSnapshot)).toEqual([]);
+  });
+
   it('should return all transitions from current state', () => {
     const machine = createMachine({
       initial: 'a',

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -5081,6 +5081,21 @@ describe('input', () => {
     createActor(machine);
   });
 
+  it('should not require input when a setup input schema accepts undefined', () => {
+    const machine = setup({
+      schemas: {
+        input: types<{} | null | undefined>()
+      }
+    }).createMachine({
+      context: {},
+      initial: 'active',
+      states: { active: {} }
+    });
+
+    createActor(machine, { inspect: () => {} });
+    createActor(machine.provide({}), { inspect: () => {} });
+  });
+
   it('should create actors from provided no-event setup machines', () => {
     const child = createMachine({});
     const machine = setup({

--- a/packages/core/test/versioning.test.ts
+++ b/packages/core/test/versioning.test.ts
@@ -43,6 +43,30 @@ describe('persisted snapshot versioning', () => {
     expect(restored.getSnapshot().value).toBe('b');
   });
 
+  it('does not treat a live snapshot machine reference as persisted identity', () => {
+    const machineV1 = createMachine({
+      id: 'checkout',
+      version: '1',
+      initial: 'a',
+      states: { a: { on: { NEXT: { target: 'b' } } }, b: {} }
+    });
+    const machineV2 = createMachine({
+      id: 'checkout',
+      version: '2',
+      initial: 'a',
+      states: { a: { on: { NEXT: { target: 'b' } } }, b: {} }
+    });
+    const actor = createActor(machineV1).start();
+    actor.send({ type: 'NEXT' });
+    const migrated = { ...actor.getSnapshot(), version: '2' };
+
+    const restored = createActor(machineV2, { snapshot: migrated }).start();
+
+    expect(restored.getSnapshot().status).toBe('active');
+    expect(restored.getSnapshot().value).toBe('b');
+    expect(restored.getSnapshot().machine).toBe(machineV2);
+  });
+
   it('restores from nested machine identity without the legacy top-level version', () => {
     const machine = createMachine({
       id: 'checkout',


### PR DESCRIPTION
## Summary

- distinguish live snapshot machine references from persisted machine identity during restore
- return no potential transitions for completed/error snapshots and preserve optional setup input through identity intersections
- add `enqueueRootEvent` for root-only durable mailboxes; document full `sendEvent`/`deliverEvent` ownership and replay-safe entry/exit effects

## Validation

- `pnpm test:core` (2,331 passed)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm changeset status --since=origin/next`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5673" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->