### PR TITLE
Document durable timers for event-journal hosts

### DIFF
--- a/.changeset/fiery-spiders-count.md
+++ b/.changeset/fiery-spiders-count.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Document durable timer semantics for event-journal hosts.

--- a/docs/durable-execution.md
+++ b/docs/durable-execution.md
@@ -162,6 +162,47 @@ string `src` key, and `JSON.stringify` on a reference produces that identity.
 To place several executions of the same machine on one transport, namespace
 the wire address with a host key outside the logical address.
 
+## Durable timers
+
+<!-- logical timer snapshot and durable adapter timer operations from packages/core/src/types.ts, packages/core/src/system.ts, and packages/core/src/durable/index.ts -->
+
+`scheduleTimer(source, id, delay)` is the complete host-neutral scheduling
+contract. `source.address` and `id` identify the logical timer; both are stable
+when the same event journal is replayed. Persist an absolute deadline derived
+from `delay` when accepting the operation, then let the host's scheduler wake a
+new process. The serializable firing input is `{ type: 'xstate.timer', id }`.
+Journal that input before applying it. For a root timer, pass it to
+`durable.transition(snapshot, event)` after recreating the execution and
+replaying earlier journal entries.
+
+```ts
+scheduleTimer: (source, id, delay) => {
+  const event = { type: 'xstate.timer', id };
+  if (!journal.hasTimerFiring(source.address, id)) {
+    host.schedule({
+      address: source.address,
+      id,
+      dueAt: host.now() + delay,
+      event
+    });
+  }
+}
+```
+
+`snapshot.timers` is the public, per-actor set of pending logical timers. Each
+entry contains its deterministic `id`, declared `delay`, delivery type, event
+and logical target. It intentionally has no host deadline or remaining-time
+field: persist that bookkeeping atomically with accepting `scheduleTimer`.
+For a child timer, retain `source.address`; after restoring the tree,
+`durable.getActorRef(snapshot, address)` resolves the current timer source.
+
+When a state exits before its timer fires, the transition removes the entry
+from `snapshot.timers` and emits `cancelTimer(source, id)`. Stopping an actor
+routes `cancelAllTimers(source)` through the same adapter. These operations are
+installed across the live actor tree, including restored children, so host-side
+alarms can use `(source.address, id)` consistently. A stale firing input whose
+timer is no longer pending is ignored.
+
 ## The effect contract
 
 `initialTransition()` and `transition()` remain pure. The helper tags their

--- a/packages/core/test/durable-event-journal-timers.test.ts
+++ b/packages/core/test/durable-event-journal-timers.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createMachine, setup, type AnyActor } from '../src/index.ts';
+import { createDurable } from '../src/durable/index.ts';
+
+interface JournalEntry {
+  address: string;
+  event: { type: string; id?: string };
+}
+
+interface PendingTimer {
+  address: string;
+  id: string;
+  delay: number;
+  event: { type: 'xstate.timer'; id: string };
+}
+
+const timerKey = (address: string, id: string) => `${address}:${id}`;
+
+function createEventJournalHost(
+  machine: ReturnType<typeof createMachine>,
+  journal: JournalEntry[]
+) {
+  const pending = new Map<string, PendingTimer>();
+  const armTimer = vi.fn<(timer: PendingTimer) => void>((timer) => {
+    pending.set(timerKey(timer.address, timer.id), timer);
+  });
+  const cancelTimer = vi.fn<(source: AnyActor, id: string) => void>(
+    (source, id) => pending.delete(timerKey(source.address, id))
+  );
+  const cancelAllTimers = vi.fn<(source: AnyActor) => void>((source) => {
+    for (const [key, timer] of pending) {
+      if (timer.address === source.address) {
+        pending.delete(key);
+      }
+    }
+  });
+
+  const durable = createDurable(machine, {
+    executionId: 'event-journal-test',
+    executeAction: () => {},
+    scheduleTimer: (source, id, delay) => {
+      const event = { type: 'xstate.timer' as const, id };
+      const alreadyFired = journal.some(
+        (entry) =>
+          entry.address === source.address &&
+          entry.event.type === event.type &&
+          entry.event.id === id
+      );
+      if (!alreadyFired) {
+        armTimer({ address: source.address, id, delay, event });
+      }
+    },
+    cancelTimer,
+    cancelAllTimers,
+    waitForEvent: () => {
+      throw new Error('The event-journal host drives transitions directly');
+    }
+  });
+
+  const replay = async () => {
+    let [snapshot, effects] = durable.initialTransition();
+    await durable.executeEffects(effects);
+    for (const entry of journal) {
+      expect(entry.address).toBe(durable.rootAddress);
+      [snapshot, effects] = durable.transition(snapshot, entry.event as never);
+      await durable.executeEffects(effects);
+    }
+    return snapshot;
+  };
+
+  return {
+    durable,
+    pending,
+    armTimer,
+    cancelTimer,
+    cancelAllTimers,
+    replay
+  };
+}
+
+describe('durable event-journal timers', () => {
+  const timerMachine = createMachine({
+    id: 'reminder',
+    initial: 'waiting',
+    states: {
+      waiting: {
+        after: { 5000: { target: 'done' } },
+        on: { EXIT: { target: 'cancelled' } }
+      },
+      done: { type: 'final' },
+      cancelled: { type: 'final' }
+    }
+  });
+
+  it('fires a recorded timer after tearing down and replaying a fresh execution', async () => {
+    const journal: JournalEntry[] = [];
+    const firstProcess = createEventJournalHost(timerMachine, journal);
+    const waiting = await firstProcess.replay();
+    const [pendingTimer] = firstProcess.pending.values();
+
+    expect(waiting.value).toBe('waiting');
+    expect(pendingTimer).toEqual({
+      address: 'reminder',
+      id: expect.any(String),
+      delay: 5000,
+      event: { type: 'xstate.timer', id: expect.any(String) }
+    });
+    expect(pendingTimer.event.id).toBe(pendingTimer.id);
+
+    // The scheduler wakes a new process. Journal-first means recording the
+    // firing before replaying it through a freshly-created execution.
+    journal.push({
+      address: pendingTimer.address,
+      event: pendingTimer.event
+    });
+    const secondProcess = createEventJournalHost(timerMachine, journal);
+    const done = await secondProcess.replay();
+
+    expect(done.value).toBe('done');
+    expect(done.status).toBe('done');
+    expect(secondProcess.pending.size).toBe(0);
+  });
+
+  it('does not re-arm a timer whose firing is already journaled', async () => {
+    const firstProcess = createEventJournalHost(timerMachine, []);
+    await firstProcess.replay();
+    const [timer] = firstProcess.pending.values();
+    const journal: JournalEntry[] = [
+      { address: timer.address, event: timer.event }
+    ];
+
+    const replayProcess = createEventJournalHost(timerMachine, journal);
+    await replayProcess.replay();
+
+    expect(replayProcess.armTimer).not.toHaveBeenCalled();
+    expect(replayProcess.pending.size).toBe(0);
+  });
+
+  it('cancels a pending timer when a journaled event exits its state', async () => {
+    const journal: JournalEntry[] = [
+      { address: 'reminder', event: { type: 'EXIT' } }
+    ];
+    const process = createEventJournalHost(timerMachine, journal);
+    const cancelled = await process.replay();
+
+    expect(cancelled.value).toBe('cancelled');
+    expect(process.cancelTimer).toHaveBeenCalledWith(
+      expect.objectContaining({ address: 'reminder' }),
+      expect.any(String)
+    );
+    expect(process.pending.size).toBe(0);
+  });
+
+  it('routes child-owned timer cleanup through the adapter', async () => {
+    const child = createMachine({
+      id: 'childLogic',
+      initial: 'waiting',
+      states: {
+        waiting: { after: { 5000: { target: 'done' } } },
+        done: { type: 'final' }
+      }
+    });
+    const parent = setup({ actors: { child } }).createMachine({
+      id: 'parent',
+      initial: 'running',
+      states: {
+        running: {
+          invoke: { id: 'child', src: 'child' },
+          on: { EXIT: { target: 'done' } }
+        },
+        done: { type: 'final' }
+      }
+    });
+    const process = createEventJournalHost(parent, [
+      { address: 'parent', event: { type: 'EXIT' } }
+    ]);
+
+    await process.replay();
+
+    expect(process.cancelAllTimers).toHaveBeenCalledWith(
+      expect.objectContaining({ address: 'parent/child' })
+    );
+    expect(process.pending.size).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- document the stable durable timer identity and journalable firing event
- explain per-actor pending timer introspection and host-owned deadlines
- add an event-journal reference adapter covering process teardown, replay suppression, cancellation, and child timer cleanup

## Validation

- `pnpm test:core` — 2,335 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm exec changeset status --since origin/next`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5675" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->