### PR TITLE
Fix machine snapshot shape after initialization errors

### DIFF
--- a/.changeset/calm-machines-match.md
+++ b/.changeset/calm-machines-match.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Machine snapshots now retain their machine-specific methods when initialization fails, so methods such as `snapshot.matches(...)` remain available on error snapshots.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -3,6 +3,7 @@ import { assign } from './actions.ts';
 import { $$ACTOR_TYPE, createActor } from './createActor.ts';
 import { createInitEvent } from './eventUtils.ts';
 import {
+  cloneMachineSnapshot,
   createMachineSnapshot,
   getPersistedSnapshot,
   MachineSnapshot
@@ -438,27 +439,43 @@ export class StateMachine<
   > {
     const initEvent = createInitEvent(input) as unknown as TEvent; // TODO: fix;
     const internalQueue: AnyEventObject[] = [];
-    const preInitialState = this._getPreInitialState(
-      actorScope,
-      initEvent,
-      internalQueue
-    );
-    const [nextState] = initialMicrostep(
-      this.root,
-      preInitialState,
-      actorScope,
-      initEvent,
-      internalQueue
-    );
+    let snapshot = createMachineSnapshot(
+      {
+        context:
+          typeof this.config.context !== 'function' && this.config.context
+            ? this.config.context
+            : ({} as TContext),
+        _nodes: [this.root],
+        children: {},
+        status: 'active'
+      },
+      this
+    ) as ReturnType<typeof this._getPreInitialState>;
 
-    const { snapshot: macroState } = macrostep(
-      nextState,
-      initEvent as AnyEventObject,
-      actorScope,
-      internalQueue
-    );
+    try {
+      snapshot = this._getPreInitialState(actorScope, initEvent, internalQueue);
+      const [nextState] = initialMicrostep(
+        this.root,
+        snapshot,
+        actorScope,
+        initEvent,
+        internalQueue
+      );
 
-    return macroState as SnapshotFrom<this>;
+      const { snapshot: macroState } = macrostep(
+        nextState,
+        initEvent as AnyEventObject,
+        actorScope,
+        internalQueue
+      );
+
+      return macroState as SnapshotFrom<this>;
+    } catch (error) {
+      return cloneMachineSnapshot(snapshot, {
+        status: 'error',
+        error
+      }) as SnapshotFrom<this>;
+    }
   }
 
   public start(

--- a/packages/core/test/input.test.ts
+++ b/packages/core/test/input.test.ts
@@ -61,6 +61,28 @@ describe('input', () => {
     expect(snapshot.status).toBe('error');
   });
 
+  it('should retain the machine snapshot interface when resolving input throws', () => {
+    const machine = createMachine({
+      types: {} as {
+        input: { greeting: string };
+        context: { message: string };
+      },
+      context: ({ input }) => ({
+        message: `Hello, ${input.greeting}`
+      }),
+      initial: 'saving',
+      states: {
+        saving: {}
+      }
+    });
+
+    // @ts-expect-error Missing input deliberately exercises initialization.
+    const snapshot = createActor(machine).getSnapshot();
+
+    expect(snapshot.status).toBe('error');
+    expect(snapshot.matches('saving')).toBe(true);
+  });
+
   it('should be a type error if input is not expected yet provided', () => {
     const machine = createMachine({
       context: { count: 42 }


### PR DESCRIPTION
## Summary

- preserve the machine snapshot shape when initialization fails
- keep `matches` and other machine snapshot helpers available on error snapshots
- add a regression test for input/context initialization failures

Fixes #5436

## Tests

- `pnpm test:core`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5678" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->