### PR TITLE
Enforce strict SCXML conformance

### DIFF
--- a/.changeset/strict-scxml-conformance.md
+++ b/.changeset/strict-scxml-conformance.md
@@ -2,4 +2,10 @@
 'xstate': patch
 ---
 
-Improve strict SCXML conformance for converted machines, including transition selection, executable content, datamodel evaluation, invocation, event metadata, and completion behavior.
+Add `createMachineFromSCXML(...)` through the `xstate/scxml` entry point. Converted machines follow strict SCXML behavior for transition selection, executable content, datamodel evaluation, invocation, event metadata, and completion.
+
+```ts
+import { createMachineFromSCXML } from 'xstate/scxml';
+
+const machine = createMachineFromSCXML(scxml);
+```

--- a/.changeset/strict-scxml-conformance.md
+++ b/.changeset/strict-scxml-conformance.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Improve strict SCXML conformance for converted machines, including transition selection, executable content, datamodel evaluation, invocation, event metadata, and completion behavior.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@
   <br />
 </p>
 
-XState is a state management and orchestration solution for JavaScript and TypeScript apps. It has _zero_ dependencies, and is useful for frontend and backend application logic.
+<!-- runtime dependencies and public entry points from packages/core/package.json -->
+
+XState is a state management and orchestration solution for JavaScript and TypeScript apps. The main `xstate` entry point has _zero_ runtime dependencies; the optional `xstate/scxml` entry point uses an XML parser. XState is useful for frontend and backend application logic.
 
 It uses event-driven programming, state machines, statecharts, and the actor model to handle complex logic in predictable, robust, and visual ways. XState provides a powerful and flexible way to manage application and workflow state by allowing developers to model logic as actors and state machines.
 

--- a/docs/meta.json
+++ b/docs/meta.json
@@ -55,6 +55,7 @@
     "typescript",
     "persistence",
     "serialization",
+    "scxml",
     "inspection",
     "utilities",
     "cheatsheet",

--- a/docs/scxml.md
+++ b/docs/scxml.md
@@ -1,0 +1,51 @@
+---
+title: SCXML
+---
+
+# SCXML
+
+Use `createMachineFromSCXML(...)` to create an XState machine from an [SCXML](https://www.w3.org/TR/scxml/) document.
+
+Import it from the opt-in `xstate/scxml` entry point. The XML parser is kept out of the main `xstate` entry point.
+
+```ts
+import { createActor } from 'xstate';
+import { createMachineFromSCXML } from 'xstate/scxml';
+
+const machine = createMachineFromSCXML(`
+  <scxml xmlns="http://www.w3.org/2005/07/scxml"
+    version="1.0"
+    initial="idle">
+    <state id="idle">
+      <transition event="START" target="running" />
+    </state>
+    <state id="running" />
+  </scxml>
+`);
+
+const actor = createActor(machine).start();
+actor.send({ type: 'START' });
+```
+
+The returned value is an XState machine and can be passed to `createActor(...)`, `initialTransition(...)`, and other machine utilities.
+
+> Only create machines from trusted SCXML. ECMAScript expressions and `<script>` elements execute JavaScript in the current environment.
+
+## External resources
+
+SCXML can reference external data, scripts, and invoked documents. Provide a synchronous `resolveResource` function to load those resources:
+
+```ts
+const machine = createMachineFromSCXML(source, {
+  resolveResource: (src, kind) => {
+    // kind is "data", "script", or "invoke".
+    return resources[src];
+  }
+});
+```
+
+If an SCXML document references an external resource and no resolver is provided, machine creation throws an error identifying the resource kind and source.
+
+## Machine JSON
+
+SCXML is compiled through a private representation because SCXML executable content and transition semantics cannot be represented losslessly as ordinary `MachineJSON`. Use `createMachineFromConfig(...)` for serialized XState definitions and `createMachineFromSCXML(...)` for SCXML documents.

--- a/docs/xstate-v5-to-v6.md
+++ b/docs/xstate-v5-to-v6.md
@@ -1232,11 +1232,18 @@ no JSON representation.
 
 ### SCXML
 
-- `toMachineJSON(scxml)` - parse SCXML XML to a plain JSON machine config
-- `toMachine(scxml)` - parse SCXML XML directly to a `StateMachine`
+`createMachineFromSCXML(scxml)` creates an XState machine from an SCXML
+document. Import it from the opt-in `xstate/scxml` entry point so the XML parser
+does not become part of the main `xstate` module graph.
 
-These remain **repo-internal** and are not exported from `xstate` (they pull in
-an XML parser).
+```ts
+import { createMachineFromSCXML } from 'xstate/scxml';
+
+const machine = createMachineFromSCXML(scxml);
+```
+
+SCXML uses a private compiler representation rather than `MachineJSON`. See
+[SCXML](scxml.md) for resource resolution and usage.
 
 ---
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -11,7 +11,9 @@
   <br />
 </p>
 
-XState is a state management and orchestration solution for JavaScript and TypeScript apps. It has _zero_ dependencies, and is useful for frontend and backend application logic.
+<!-- runtime dependencies and public entry points from package.json -->
+
+XState is a state management and orchestration solution for JavaScript and TypeScript apps. The main `xstate` entry point has _zero_ runtime dependencies; the optional `xstate/scxml` entry point uses an XML parser. XState is useful for frontend and backend application logic.
 
 It uses event-driven programming, state machines, statecharts, and the actor model to handle complex logic in predictable, robust, and visual ways. XState provides a powerful and flexible way to manage application and workflow state by allowing developers to model logic as actors and state machines.
 
@@ -26,6 +28,10 @@ It uses event-driven programming, state machines, statecharts, and the actor mod
 🖥 [Download our VS Code extension](https://marketplace.visualstudio.com/items?itemName=statelyai.stately-vscode)
 
 📑 Inspired by the [SCXML specification](https://www.w3.org/TR/scxml/)
+
+<!-- public SCXML entry point from src/scxml/index.ts -->
+
+Create machines from SCXML documents with the opt-in `xstate/scxml` entry point. See the [SCXML guide](../../docs/scxml.md).
 
 💬 Chat on the [Stately Discord Community](https://discord.gg/xstate)
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,20 @@
       "import": "./dist/xstate-graph.cjs.mjs",
       "default": "./dist/xstate-graph.cjs.js"
     },
+    "./scxml": {
+      "types": {
+        "import": "./dist/xstate-scxml.cjs.mjs",
+        "default": "./dist/xstate-scxml.cjs.js"
+      },
+      "development": {
+        "module": "./dist/xstate-scxml.development.esm.js",
+        "import": "./dist/xstate-scxml.development.cjs.mjs",
+        "default": "./dist/xstate-scxml.development.cjs.js"
+      },
+      "module": "./dist/xstate-scxml.esm.js",
+      "import": "./dist/xstate-scxml.cjs.mjs",
+      "default": "./dist/xstate-scxml.cjs.js"
+    },
     "./actors": {
       "types": {
         "import": "./dist/xstate-actors.cjs.mjs",
@@ -100,6 +114,7 @@
     "guards",
     "dev",
     "graph",
+    "scxml",
     "validation",
     "durable",
     "bin"
@@ -121,6 +136,9 @@
   },
   "author": "David Khourshid <davidkpiano@gmail.com>",
   "license": "MIT",
+  "dependencies": {
+    "saxes": "^6.0.0"
+  },
   "bugs": {
     "url": "https://github.com/statelyai/xstate/issues"
   },
@@ -130,7 +148,6 @@
     "ajv": "^8.12.0",
     "pkg-up": "^3.1.0",
     "rxjs": "^7.8.1",
-    "xml-js": "^1.6.11",
     "zod": "^3.25.51"
   },
   "preconstruct": {
@@ -139,6 +156,7 @@
       "./index.ts",
       "./actors/index.ts",
       "./graph/index.ts",
+      "./scxml/index.ts",
       "./validation/index.ts",
       "./durable/index.ts"
     ]

--- a/packages/core/scxml/package.json
+++ b/packages/core/scxml/package.json
@@ -1,0 +1,8 @@
+{
+  "main": "../dist/xstate-scxml.cjs.js",
+  "module": "../dist/xstate-scxml.esm.js",
+  "umd:main": "../dist/xstate-scxml.umd.min.js",
+  "preconstruct": {
+    "umdName": "XStateSCXML"
+  }
+}

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -634,27 +634,41 @@ function formatTransitions<
 
 function formatInitialTransition(
   stateNode: AnyStateNode,
-  _target: string | { target: string; input?: any } | undefined
+  _target:
+    | string
+    | { target: string | string[]; input?: any; to?: (...args: any[]) => any }
+    | undefined
 ): InitialTransitionDefinition {
   const targetString =
     typeof _target === 'object' && _target !== null ? _target.target : _target;
   const input =
     typeof _target === 'object' && _target !== null ? _target.input : undefined;
-  const resolvedTarget =
-    typeof targetString === 'string'
-      ? stateNode.states[targetString]
-      : undefined;
-  if (!resolvedTarget && targetString) {
+  const to =
+    typeof _target === 'object' && _target !== null ? _target.to : undefined;
+  const targetStrings = Array.isArray(targetString)
+    ? targetString
+    : targetString
+      ? [targetString]
+      : [];
+  const resolvedTargets = targetStrings.map((target) =>
+    target.startsWith('#')
+      ? stateNode.machine.getStateNodeById(target.slice(1))
+      : stateNode.states[target]
+  );
+  if (resolvedTargets.some((target) => !target)) {
     throw new Error(
       isDevelopment
-        ? `Initial state node "${targetString}" not found on parent state node #${stateNode.id}`
-        : `Initial state "${targetString}" not found on "#${stateNode.id}"`
+        ? `Initial state node "${targetStrings.find((_, index) => !resolvedTargets[index])}" not found on parent state node #${stateNode.id}`
+        : `Initial state not found on "#${stateNode.id}"`
     );
   }
   const transition: InitialTransitionDefinition = {
     source: stateNode,
-    target: resolvedTarget ? [resolvedTarget] : undefined,
-    input
+    target: resolvedTargets.length
+      ? (resolvedTargets as AnyStateNode[])
+      : undefined,
+    input,
+    to
   };
 
   return transition;

--- a/packages/core/src/createMachineFromConfig.ts
+++ b/packages/core/src/createMachineFromConfig.ts
@@ -28,6 +28,30 @@ function toScxmlEventName(eventType: string): string {
     : eventType;
 }
 
+function matchesScxmlEventDescriptor(
+  descriptor: string,
+  event: EventObject
+): boolean {
+  if (descriptor === '*') return true;
+  if (descriptor.endsWith('.*')) {
+    const prefix = descriptor.slice(0, -2);
+    return event.type === prefix || event.type.startsWith(`${prefix}.`);
+  }
+  if (descriptor.startsWith('xstate.done.actor.')) {
+    return (
+      event.type === 'xstate.done.actor' &&
+      (event as any).actorId === descriptor.slice('xstate.done.actor.'.length)
+    );
+  }
+  if (descriptor.startsWith('xstate.done.state.')) {
+    return (
+      event.type === 'xstate.done.state' &&
+      (event as any).stateId === descriptor.slice('xstate.done.state.'.length)
+    );
+  }
+  return event.type === descriptor || event.type.startsWith(`${descriptor}.`);
+}
+
 export interface RaiseJSON {
   type: '@xstate.raise';
   event: EventObject;
@@ -43,6 +67,12 @@ export interface CancelJSON {
 export interface LogJSON {
   type: '@xstate.log';
   args: any[];
+}
+
+export interface ScxmlLogJSON {
+  type: 'scxml.log';
+  label?: string;
+  expr?: string;
 }
 
 interface EmitJSON {
@@ -70,8 +100,10 @@ export interface ScxmlRaiseJSON {
   /** Expression to evaluate for event type */
   eventexpr?: string;
   /** Params with expressions to evaluate */
-  params?: Array<{ name: string; expr: string }>;
+  params?: Array<{ name: string; expr?: string; location?: string }>;
+  namelist?: string[];
   id?: string;
+  idlocation?: string;
   delay?: number;
   /** Expression for delay */
   delayexpr?: string;
@@ -79,12 +111,27 @@ export interface ScxmlRaiseJSON {
   target?: string;
   /** Expression for target */
   targetexpr?: string;
+  processorType?: string;
+  content?: ScxmlContentJSON;
+}
+
+export interface ScxmlXmlJSON {
+  name: string;
+  attributes?: Record<string, string>;
+  children?: ScxmlXmlJSON[];
+}
+
+export interface ScxmlContentJSON {
+  expr?: string;
+  text?: string;
+  xml?: ScxmlXmlJSON;
 }
 
 interface ScxmlScriptJSON {
   type: 'scxml.script';
   /** The script code to execute */
   code: string;
+  global?: boolean;
 }
 
 export interface ScxmlForeachJSON {
@@ -106,6 +153,14 @@ export interface ScxmlDonedataJSON {
   contentText?: string;
 }
 
+export interface ScxmlDataJSON {
+  id: string;
+  expr?: string;
+  content?: string;
+  src?: string;
+  xml?: ScxmlXmlJSON;
+}
+
 /**
  * Isolated executable-content block. Errors in nested actions stop this block
  * but do not propagate to the surrounding action list. Used to model SCXML's
@@ -113,6 +168,22 @@ export interface ScxmlDonedataJSON {
  */
 interface ScxmlBlockJSON {
   type: 'scxml.block';
+  actions: ActionJSON[];
+}
+
+interface ScxmlDatamodelJSON {
+  type: 'scxml.datamodel';
+  data: ScxmlDataJSON[];
+}
+
+interface ScxmlForwardJSON {
+  type: 'scxml.forward';
+  invokeId: string;
+}
+
+interface ScxmlFinalizeJSON {
+  type: 'scxml.finalize';
+  invokeId: string;
   actions: ActionJSON[];
 }
 
@@ -149,7 +220,11 @@ export type ActionJSON =
   | ScxmlIfJSON
   | ScxmlForeachJSON
   | ScxmlCancelJSON
+  | ScxmlLogJSON
   | ScxmlBlockJSON
+  | ScxmlDatamodelJSON
+  | ScxmlForwardJSON
+  | ScxmlFinalizeJSON
   | ExpressionJSON
   | CodeJSON;
 
@@ -192,6 +267,11 @@ export interface InvokeJSON {
   onSnapshot?: TransitionConfigJSON | TransitionConfigJSON[];
   timeout?: number | string | ResolvableJSON;
   onTimeout?: TransitionConfigJSON | TransitionConfigJSON[];
+  /** @internal SCXML invocation input expressions. */
+  _scxmlInput?: {
+    namelist?: string[];
+    params?: Array<{ name: string; expr?: string; location?: string }>;
+  };
 }
 
 export interface TransitionJSON {
@@ -204,6 +284,12 @@ export interface TransitionJSON {
   reenter?: boolean;
   meta?: MetaObject;
   input?: unknown;
+  /** @internal Strict semantics for transitions produced by the SCXML converter. */
+  _scxml?: {
+    type?: 'internal' | 'external';
+    eventDescriptors?: string[];
+    finalize?: Array<{ invokeId: string; actions: ActionJSON[] }>;
+  };
 }
 
 type TransitionConfigJSON = TransitionJSON | ResolvableJSON;
@@ -247,10 +333,21 @@ export interface StateNodeJSON {
   output?: unknown;
   context?: Record<string, unknown>;
   _scxmlDonedata?: ScxmlDonedataJSON;
+  /** @internal Initial transition emitted by the SCXML converter. */
+  _scxmlInitial?: {
+    targets: string[];
+    actions?: ActionJSON[];
+  };
+  /** @internal Executable content on an SCXML history default transition. */
+  _scxmlHistoryActions?: ActionJSON[];
+  /** @internal Datamodel declarations initialized on entry. */
+  _scxmlData?: ScxmlDataJSON[];
 }
 export interface MachineJSON extends StateNodeJSON {
   '@exprLang'?: string;
   version?: string;
+  /** @internal All declared SCXML datamodel identifiers. */
+  _scxmlDataIds?: string[];
   actions?: Record<string, ActionJSON | ActionJSON[]>;
   guards?: Record<string, { when: ConditionJSON }>;
   actors?: Record<string, unknown>;
@@ -746,8 +843,50 @@ function assertMachineJSON(
   assertStateNode(json, '$');
 }
 
-let _scxmlSessionId = 'session_scxml';
-let _scxmlMachineName = '';
+const SCXML_SYSTEM_VARIABLES = new Set([
+  '_sessionid',
+  '_name',
+  '_ioprocessors',
+  '_event',
+  '_xstateScxmlInputKeys'
+]);
+const scxmlScriptEnvironments = new WeakMap<
+  AnyActorRef,
+  { declarations: string[] }
+>();
+const scxmlMachineNames = new WeakMap<AnyActorRef, string>();
+const scxmlIoProcessors = new WeakMap<AnyActorRef, object>();
+const scxmlEvents = new WeakMap<object, object>();
+const scxmlEnteringStates = new WeakMap<AnyActorRef, string[]>();
+
+function getScxmlIoProcessors(self: AnyActorRef, sessionId: string): object {
+  let processors = scxmlIoProcessors.get(self);
+  if (!processors) {
+    const processor = { location: `#_scxml_${sessionId}` };
+    processors = {
+      scxml: processor,
+      'http://www.w3.org/TR/scxml/#SCXMLEventProcessor': processor
+    };
+    scxmlIoProcessors.set(self, processors);
+  }
+  return processors;
+}
+
+function getFunctionDeclarations(code: string): string[] {
+  const declarations: string[] = [];
+  const pattern = /\bfunction\s+[$_a-zA-Z][$_a-zA-Z0-9]*\s*\([^)]*\)\s*\{/g;
+  for (const match of code.matchAll(pattern)) {
+    let depth = 1;
+    let index = match.index! + match[0].length;
+    while (index < code.length && depth) {
+      if (code[index] === '{') depth++;
+      if (code[index] === '}') depth--;
+      index++;
+    }
+    declarations.push(code.slice(match.index, index));
+  }
+  return declarations;
+}
 
 /** Evaluates an SCXML expression with context variables available via `with`. */
 function evaluateExpr(
@@ -756,9 +895,18 @@ function evaluateExpr(
   event: AnyEventObject | null,
   self?: AnyActorRef
 ): unknown {
+  const normalizedExpr = expr.replace(/;+\s*$/, '');
+  const sessionId = (self as any)?.sessionId ?? 'session_scxml';
+  const machineName = self
+    ? (scxmlMachineNames.get(self) ?? '(machine)')
+    : '(machine)';
+  const dataContext = Object.fromEntries(
+    Object.entries(context).filter(([key]) => !SCXML_SYSTEM_VARIABLES.has(key))
+  );
   const fnBody = `
+${self ? (scxmlScriptEnvironments.get(self)?.declarations.join('\n') ?? '') : ''}
 with (context) {
-  return (${expr});
+  return (${normalizedExpr});
 }
   `.trim();
   // eslint-disable-next-line @typescript-eslint/no-implied-eval
@@ -773,10 +921,17 @@ with (context) {
   );
   const In = (stateId: string) => {
     if (!self) return false;
+    const sanitized = stateId.replace(/\./g, '$');
+    if (
+      scxmlEnteringStates
+        .get(self)
+        ?.some((id) => id === sanitized || id.endsWith('.' + sanitized))
+    ) {
+      return true;
+    }
     try {
       const snap = (self as any).getSnapshot?.();
       if (snap?.nodes) {
-        const sanitized = stateId.replace(/\./g, '$');
         return snap.nodes.some(
           (node: any) =>
             node.id === sanitized || node.id.endsWith('.' + sanitized)
@@ -787,7 +942,7 @@ with (context) {
     }
     return false;
   };
-  const SCXML_ORIGIN = `#_scxml_${_scxmlSessionId}`;
+  const SCXML_ORIGIN = `#_scxml_${sessionId}`;
   const SCXML_ORIGIN_TYPE = 'http://www.w3.org/TR/scxml/#SCXMLEventProcessor';
   const isExternal = event && (event as any)._scxmlExternal;
   const isInitEvent = event && event.type === '@xstate.init';
@@ -802,30 +957,38 @@ with (context) {
     event.type.startsWith('xstate.done.');
   const explicitType =
     event && ((event as any)._scxmlEventType as string | undefined);
-  const scxmlEvent =
-    event && !isInitEvent
-      ? {
-          name:
-            ((event as any)._scxmlEventName as string | undefined) ??
-            toScxmlEventName(event.type),
-          type: explicitType || (isExternal ? 'external' : 'internal'),
-          sendid: (event as any)._scxmlSendId as string | undefined,
-          origin: isExternal ? SCXML_ORIGIN : undefined,
-          origintype: isExternal ? SCXML_ORIGIN_TYPE : undefined,
-          invokeid: (event as any)._scxmlInvokeId as string | undefined,
-          data: isDoneEvent
-            ? (event as any).output
-            : (event as any)._scxmlEventData !== undefined
-              ? (event as any)._scxmlEventData
-              : event
-        }
-      : undefined;
+  let scxmlEvent: object | undefined;
+  if (event && !isInitEvent) {
+    scxmlEvent = scxmlEvents.get(event);
+    if (!scxmlEvent) {
+      scxmlEvent = {
+        name:
+          ((event as any)._scxmlEventName as string | undefined) ??
+          toScxmlEventName(event.type),
+        type: explicitType || (isExternal ? 'external' : 'internal'),
+        sendid: (event as any)._scxmlSendId as string | undefined,
+        origin: isExternal ? SCXML_ORIGIN : undefined,
+        origintype: isExternal ? SCXML_ORIGIN_TYPE : undefined,
+        invokeid:
+          ((event as any)._scxmlInvokeId as string | undefined) ??
+          ((event as any).actorId as string | undefined),
+        data: isDoneEvent
+          ? (event as any).output
+          : (event as any)._scxmlEventData !== undefined
+            ? (event as any)._scxmlEventData
+            : event
+      };
+      scxmlEvents.set(event, scxmlEvent);
+    }
+  }
   const result = fn(
-    context,
+    dataContext,
     scxmlEvent,
-    _scxmlSessionId,
-    _scxmlMachineName,
-    { scxml: { location: `#_scxml_${_scxmlSessionId}` } },
+    sessionId,
+    machineName,
+    self
+      ? getScxmlIoProcessors(self, sessionId)
+      : { scxml: { location: `#_scxml_${sessionId}` } },
     In
   );
 
@@ -835,29 +998,89 @@ with (context) {
 /** Executes an SCXML script block and returns updated context values. */
 function executeScript(
   context: MachineContext,
-  code: string
+  code: string,
+  self: AnyActorRef,
+  global: boolean
 ): Record<string, unknown> {
   // Create a proxy to track which properties are modified
   const updates: Record<string, unknown> = {};
   const contextKeys = Object.keys(context);
+  const mutableContextKeys = contextKeys.filter(
+    (key) => !SCXML_SYSTEM_VARIABLES.has(key)
+  );
 
   // Build variable declarations and reassignment capture
-  const varDeclarations = contextKeys
-    .map((k) => `let ${k} = context.${k};`)
+  const varDeclarations = mutableContextKeys
+    .map((k) => `var ${k} = context.${k};`)
     .join('\n');
-  const captureUpdates = contextKeys
+  const captureUpdates = mutableContextKeys
     .map((k) => `updates.${k} = ${k};`)
     .join('\n');
+  const codeWithoutComments = code.replace(/\/\/.*$/gm, '');
+  const declarations = getFunctionDeclarations(code);
+  const codeWithoutFunctions = declarations.reduce(
+    (source, declaration) => source.replace(declaration, ''),
+    codeWithoutComments
+  );
+  const declaredVariables = global
+    ? [
+        ...codeWithoutFunctions.matchAll(/\bvar\s+([$_a-zA-Z][$_a-zA-Z0-9]*)/g)
+      ].map((match) => match[1])
+    : [];
+  const captureVariables = declaredVariables
+    .filter(
+      (name) => !contextKeys.includes(name) && !SCXML_SYSTEM_VARIABLES.has(name)
+    )
+    .map((name) => `updates.${name} = ${name};`)
+    .join('\n');
+  const environment = scxmlScriptEnvironments.get(self) ?? {
+    declarations: []
+  };
+  scxmlScriptEnvironments.set(self, environment);
+  for (const declaration of declarations) {
+    if (!environment.declarations.includes(declaration)) {
+      environment.declarations.push(declaration);
+    }
+  }
 
   const fnBody = `
 ${varDeclarations}
+${environment.declarations.join('\n')}
 ${code}
 ${captureUpdates}
+${captureVariables}
 return updates;
   `;
+  const sessionId = (self as any).sessionId;
+  const machineName = scxmlMachineNames.get(self) ?? '(machine)';
   // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  const fn = new Function('context', 'updates', fnBody);
-  return fn(context, updates);
+  const fn = new Function(
+    'context',
+    'updates',
+    '_sessionid',
+    '_name',
+    '_ioprocessors',
+    fnBody
+  );
+  return fn(
+    context,
+    updates,
+    sessionId,
+    machineName,
+    getScxmlIoProcessors(self, sessionId)
+  );
+}
+
+function createScxmlDomElement(element: ScxmlXmlJSON): any {
+  const children = (element.children ?? []).map(createScxmlDomElement);
+  return {
+    tagName: element.name,
+    getAttribute: (name: string) => element.attributes?.[name] ?? null,
+    getElementsByTagName: (name: string): any[] => [
+      ...(element.name === name ? [createScxmlDomElement(element)] : []),
+      ...children.flatMap((child: any) => child.getElementsByTagName(name))
+    ]
+  };
 }
 
 export function createMachineFromConfig(
@@ -871,6 +1094,7 @@ export function createMachineFromConfig(
   );
   const { evaluateResolvable, resolveValue, makeScope, getDurationConfig } =
     expressionResolver;
+  const sendCounters = new WeakMap<AnyActorRef, number>();
 
   type ResolvedCondition = ((args: any) => boolean) | undefined;
 
@@ -973,10 +1197,38 @@ export function createMachineFromConfig(
   // functions to re-execute all transition actions from scratch when parallel
   // targetless transitions coexist with targeted transitions.
   let contextBeforeTargetless: MachineContext | null = null;
+  let targetlessEvent: AnyEventObject | null = null;
   // Platform errors collected during transition selection (e.g., failing
   // <transition cond>). Drained by the next state's entry into the internal
   // event queue so they're processed before any external events.
   const pendingPlatformErrors: Array<Record<string, unknown>> = [];
+  const scxmlDonedataValues = new WeakMap<AnyActorRef, Map<string, unknown>>();
+
+  function evaluateDonedataValue(
+    donedata: ScxmlDonedataJSON,
+    context: MachineContext,
+    event: AnyEventObject,
+    self: AnyActorRef
+  ): unknown {
+    if (donedata.params?.length) {
+      const out: Record<string, unknown> = {};
+      for (const param of donedata.params) {
+        out[param.name] = evaluateExpr(context, param.expr, event, self);
+      }
+      return out;
+    }
+    if (donedata.contentExpr !== undefined) {
+      return evaluateExpr(context, donedata.contentExpr, event, self);
+    }
+    if (donedata.contentText !== undefined) {
+      try {
+        return evaluateExpr(context, donedata.contentText, event, self);
+      } catch {
+        return donedata.contentText;
+      }
+    }
+    return undefined;
+  }
 
   function getMissingGuardMessage(type: string, guards: Record<string, any>) {
     return `Guard '${type}' is not implemented in machine '${json.id ?? '(machine)'}'. Available guards: ${
@@ -1002,8 +1254,17 @@ export function createMachineFromConfig(
     return (args: any) => (resolvedGuard!(args) ? routeConfig : undefined);
   }
 
-  function iterNode(node: StateNodeJSON, nodeKey?: string) {
-    const originalEntryActions = toActionArray(node.entry);
+  function iterNode(
+    node: StateNodeJSON,
+    nodeKey?: string,
+    ancestorIds: string[] = []
+  ) {
+    const originalEntryActions: ActionJSON[] = [
+      ...(node._scxmlData?.length
+        ? [{ type: 'scxml.datamodel' as const, data: node._scxmlData }]
+        : []),
+      ...toActionArray(node.entry)
+    ];
     const stateId = node.id || nodeKey;
 
     // Wrap entry to first execute any pending transition actions, then normal entry.
@@ -1014,6 +1275,10 @@ export function createMachineFromConfig(
       x,
       enq
     ) => {
+      scxmlMachineNames.set(x.self, json.id ?? '(machine)');
+      if (stateId) {
+        scxmlEnteringStates.set(x.self, [...ancestorIds, stateId]);
+      }
       // Drain any platform errors queued during transition selection (e.g.,
       // failing <transition cond="..."> evaluations). These must be raised
       // internally so they're processed before subsequent external events.
@@ -1038,6 +1303,7 @@ export function createMachineFromConfig(
       // in the same microstep — prevents stale data from previous events.
       if (
         contextBeforeTargetless &&
+        targetlessEvent === x.event &&
         allTransitionActions.length > 0 &&
         Object.keys(pendingTransitionActionsMap).length > 0
       ) {
@@ -1051,6 +1317,7 @@ export function createMachineFromConfig(
         }
         allTransitionActions.length = 0;
         contextBeforeTargetless = null;
+        targetlessEvent = null;
         // Clear per-target map since we re-processed everything
         for (const key of Object.keys(pendingTransitionActionsMap)) {
           delete pendingTransitionActionsMap[key];
@@ -1071,6 +1338,7 @@ export function createMachineFromConfig(
         }
         // Clear stale targetless data from previous microsteps
         contextBeforeTargetless = null;
+        targetlessEvent = null;
         allTransitionActions.length = 0;
       }
 
@@ -1083,15 +1351,58 @@ export function createMachineFromConfig(
         }
       }
 
+      if (node._scxmlDonedata && stateId) {
+        let values = scxmlDonedataValues.get(x.self);
+        if (!values) {
+          values = new Map();
+          scxmlDonedataValues.set(x.self, values);
+        }
+        try {
+          values.set(
+            stateId,
+            evaluateDonedataValue(
+              node._scxmlDonedata,
+              context ?? x.context,
+              x.event,
+              x.self
+            )
+          );
+        } catch (err) {
+          values.set(stateId, undefined);
+          raiseErrorExecution(
+            { enq, self: x.self, errored: false },
+            'donedata',
+            err
+          );
+        }
+      }
+
+      scxmlEnteringStates.delete(x.self);
       return { context };
     };
 
     const nodeConfig: any = {
       id: node.id,
-      initial: node.initial,
+      initial: node._scxmlInitial
+        ? {
+            target: node._scxmlInitial.targets,
+            to: node._scxmlInitial.actions
+              ? (x: any, enq: any) => ({
+                  ...executeActions(node._scxmlInitial!.actions!, x, enq),
+                  target: node._scxmlInitial!.targets
+                })
+              : undefined
+          }
+        : node.initial,
       type: node.type,
       history: node.history,
       target: node.target,
+      _scxmlHistoryActions: node._scxmlHistoryActions
+        ? (x: any, enq: any) => ({
+            ...executeActions(node._scxmlHistoryActions!, x, enq),
+            target: node.target
+          })
+        : undefined,
       description: node.description,
       tags: node.tags,
       input: node.input,
@@ -1099,7 +1410,11 @@ export function createMachineFromConfig(
       states: node.states
         ? Object.entries(node.states).reduce(
             (acc, [key, value]) => {
-              acc[key] = iterNode(value, key);
+              acc[key] = iterNode(
+                value,
+                key,
+                stateId ? [...ancestorIds, stateId] : ancestorIds
+              );
               return acc;
             },
             {} as Record<
@@ -1153,7 +1468,7 @@ export function createMachineFromConfig(
       invoke: node.invoke ? iterInvokeConfigs(node.invoke) : undefined,
       meta: node.meta,
       output: node._scxmlDonedata
-        ? makeDonedataOutput(node._scxmlDonedata)
+        ? makeDonedataOutput(stateId!)
         : isResolvable(node.output)
           ? ({ context, event, self }: any) =>
               evaluateResolvable(
@@ -1168,47 +1483,8 @@ export function createMachineFromConfig(
     return nodeConfig;
   }
 
-  function makeDonedataOutput(donedata: ScxmlDonedataJSON) {
-    return ({ context, event, self }: any) => {
-      try {
-        if (donedata.params && donedata.params.length) {
-          const out: Record<string, unknown> = {};
-          for (const param of donedata.params) {
-            out[param.name] = evaluateExpr(context, param.expr, event, self);
-          }
-          return out;
-        }
-        if (donedata.contentExpr !== undefined) {
-          return evaluateExpr(context, donedata.contentExpr, event, self);
-        }
-        if (donedata.contentText !== undefined) {
-          // Try parsing as a JS expression (number/object/array literals);
-          // fall back to the raw string.
-          try {
-            return evaluateExpr(context, donedata.contentText, event, self);
-          } catch {
-            return donedata.contentText;
-          }
-        }
-      } catch (err) {
-        // Per SCXML, donedata expression errors raise error.execution and
-        // result in undefined event.data. Queue for the next entry to drain.
-        const message =
-          err instanceof Error
-            ? err.message
-            : typeof err === 'string'
-              ? err
-              : 'unknown error';
-        pendingPlatformErrors.push({
-          tagname: 'donedata',
-          message,
-          line: NaN,
-          column: NaN,
-          reason: message
-        });
-      }
-      return undefined;
-    };
+  function makeDonedataOutput(stateId: string) {
+    return ({ self }: any) => scxmlDonedataValues.get(self)?.get(stateId);
   }
 
   function iterInvokeConfigs(invokes: InvokeJSON | InvokeJSON[]): any {
@@ -1229,8 +1505,25 @@ export function createMachineFromConfig(
         src,
         id: inv.id,
         registryKey: inv.registryKey,
-        input:
-          inv.input !== undefined
+        input: inv._scxmlInput
+          ? ({ context, event, self }: any) => {
+              const input: Record<string, unknown> = {};
+              for (const name of inv._scxmlInput!.namelist ?? []) {
+                if (!(name in context)) {
+                  throw new ReferenceError(`${name} is not defined`);
+                }
+                input[name] = context[name];
+              }
+              for (const param of inv._scxmlInput!.params ?? []) {
+                input[param.name] = param.expr
+                  ? evaluateExpr(context, param.expr, event, self)
+                  : param.location
+                    ? evaluateExpr(context, param.location, event, self)
+                    : undefined;
+              }
+              return input;
+            }
+          : inv.input !== undefined
             ? (args: any) =>
                 resolveValue(
                   inv.input,
@@ -1260,7 +1553,8 @@ export function createMachineFromConfig(
   function raiseErrorExecution(
     state: ExecState,
     tagname: string,
-    err: unknown
+    err: unknown,
+    sendId?: string
   ) {
     const message =
       err instanceof Error
@@ -1268,30 +1562,33 @@ export function createMachineFromConfig(
         : typeof err === 'string'
           ? err
           : 'unknown error';
-    state.enq.raise({
+    const errorEvent = {
       type: 'xstate.error.execution',
       error: {
         tagname,
         message,
-        line: NaN,
-        column: NaN,
+        line: 0,
+        column: 0,
         reason: message
       },
       _scxmlEventType: 'platform',
       _scxmlEventName: 'error.execution',
+      ...(sendId ? { _scxmlSendId: sendId } : {}),
       _scxmlEventData: {
         tagname,
         message,
-        line: NaN,
-        column: NaN,
+        line: 0,
+        column: 0,
         reason: message
       }
-    } as AnyEventObject);
+    } as AnyEventObject;
+    state.enq.raise(errorEvent);
     state.errored = true;
   }
 
   interface ExecState {
     enq: any;
+    self: AnyActorRef;
     errored: boolean;
   }
 
@@ -1336,7 +1633,11 @@ export function createMachineFromConfig(
     parentState?: ExecState,
     stack: string[] = []
   ): { context: MachineContext | undefined; errored: boolean } {
-    const state: ExecState = parentState ?? { enq, errored: false };
+    const state: ExecState = parentState ?? {
+      enq,
+      self: x.self,
+      errored: false
+    };
     let context: MachineContext | undefined;
     for (const action of actions) {
       if (state.errored) break;
@@ -1418,6 +1719,46 @@ export function createMachineFromConfig(
           default:
             throw new Error(`Unknown built-in action: ${(action as any).type}`);
         }
+      } else if (action.type === 'scxml.finalize') {
+        const finalize = action as ScxmlFinalizeJSON;
+        const invokeId =
+          (x.event as any)._scxmlInvokeId ?? (x.event as any).actorId;
+        if (invokeId === finalize.invokeId) {
+          const result = executeActions(
+            finalize.actions,
+            { ...x, context: { ...x.context, ...context } },
+            enq,
+            state
+          );
+          if (result.context) {
+            context = result.context;
+          }
+        }
+      } else if (action.type === 'scxml.forward') {
+        const child = x.children?.[(action as ScxmlForwardJSON).invokeId];
+        if (child) {
+          enq.sendTo(child, {
+            ...x.event,
+            _scxmlExternal: true
+          });
+        }
+      } else if (action.type === 'scxml.log') {
+        const scxmlAction = action as ScxmlLogJSON;
+        try {
+          const value = scxmlAction.expr
+            ? evaluateExpr(
+                { ...x.context, ...context },
+                scxmlAction.expr,
+                x.event,
+                x.self
+              )
+            : undefined;
+          enq.log(
+            ...(scxmlAction.label ? [scxmlAction.label, value] : [value])
+          );
+        } catch (err) {
+          raiseErrorExecution(state, 'log', err);
+        }
       } else if (action.type === 'scxml.assign') {
         const scxmlAction = action as ScxmlAssignJSON;
         const mergedContext = { ...x.context, ...context };
@@ -1433,19 +1774,105 @@ export function createMachineFromConfig(
           raiseErrorExecution(state, 'assign', err);
           continue;
         }
-        // Per SCXML, assigning to a location that doesn't exist on the
-        // datamodel is an error. Allow setting an own property via context;
-        // detect deep paths (a.b.c) which we don't support.
-        if (scxmlAction.location.includes('.')) {
+        if (SCXML_SYSTEM_VARIABLES.has(scxmlAction.location.split('.')[0])) {
           raiseErrorExecution(
             state,
             'assign',
-            new Error(`Invalid assign location: ${scxmlAction.location}`)
+            new Error(
+              `Cannot assign to SCXML system variable: ${scxmlAction.location}`
+            )
           );
+          continue;
+        }
+        if (scxmlAction.location.includes('.')) {
+          const path = scxmlAction.location.split('.');
+          const root = path.shift()!;
+          let target = mergedContext[root];
+          if (!target || typeof target !== 'object') {
+            raiseErrorExecution(
+              state,
+              'assign',
+              new Error(`Invalid assign location: ${scxmlAction.location}`)
+            );
+            continue;
+          }
+          const clonedRoot = Array.isArray(target)
+            ? [...target]
+            : { ...target };
+          target = clonedRoot;
+          for (const segment of path.slice(0, -1)) {
+            const child = (target as Record<string, unknown>)[segment];
+            if (!child || typeof child !== 'object') {
+              raiseErrorExecution(
+                state,
+                'assign',
+                new Error(`Invalid assign location: ${scxmlAction.location}`)
+              );
+              break;
+            }
+            const clonedChild = Array.isArray(child)
+              ? [...child]
+              : { ...child };
+            (target as Record<string, unknown>)[segment] = clonedChild;
+            target = clonedChild;
+          }
+          if (state.errored) continue;
+          (target as Record<string, unknown>)[path.at(-1)!] = value;
+          context ??= {};
+          context[root] = clonedRoot;
           continue;
         }
         context ??= {};
         context[scxmlAction.location] = value;
+      } else if (action.type === 'scxml.datamodel') {
+        const scxmlAction = action as ScxmlDatamodelJSON;
+        context ??= {};
+        for (const data of scxmlAction.data) {
+          if (
+            Array.isArray(x.context._xstateScxmlInputKeys) &&
+            x.context._xstateScxmlInputKeys.includes(data.id)
+          ) {
+            continue;
+          }
+          if (data.src) {
+            raiseErrorExecution(
+              state,
+              'data',
+              new Error(`Unresolved data resource: ${data.src}`)
+            );
+            break;
+          }
+          if (data.expr !== undefined) {
+            try {
+              context[data.id] = evaluateExpr(
+                { ...x.context, ...context },
+                data.expr,
+                x.event,
+                x.self
+              );
+            } catch (err) {
+              raiseErrorExecution(state, 'data', err);
+              break;
+            }
+          } else if (data.content !== undefined) {
+            try {
+              context[data.id] = evaluateExpr(
+                { ...x.context, ...context },
+                data.content,
+                x.event,
+                x.self
+              );
+            } catch {
+              context[data.id] = data.content.replace(/\s+/g, ' ').trim();
+            }
+          } else if (data.xml) {
+            context[data.id] = createScxmlDomElement(data.xml);
+          } else {
+            if (x.context[data.id] === undefined) {
+              context[data.id] = undefined;
+            }
+          }
+        }
       } else if (action.type === 'scxml.raise') {
         const scxmlAction = action as ScxmlRaiseJSON;
         const mergedContext = { ...x.context, ...context };
@@ -1455,6 +1882,17 @@ export function createMachineFromConfig(
         let target: string | undefined;
         let delay: number | undefined;
         try {
+          if (
+            scxmlAction.processorType &&
+            ![
+              'scxml',
+              'http://www.w3.org/TR/scxml/#SCXMLEventProcessor'
+            ].includes(scxmlAction.processorType)
+          ) {
+            throw new Error(
+              `Unsupported send type: ${scxmlAction.processorType}`
+            );
+          }
           eventType = scxmlAction.eventexpr
             ? (evaluateExpr(
                 mergedContext,
@@ -1469,15 +1907,65 @@ export function createMachineFromConfig(
             type: eventType,
             _scxmlEventName: toScxmlEventName(eventType)
           };
-          if (scxmlAction.params) {
-            for (const param of scxmlAction.params) {
-              eventData[param.name] = evaluateExpr(
+          const payload: Record<string, unknown> = {};
+          if (scxmlAction.namelist) {
+            for (const name of scxmlAction.namelist) {
+              payload[name] = evaluateExpr(
                 mergedContext,
-                param.expr,
+                name,
                 x.event,
                 x.self
               );
             }
+          }
+          if (scxmlAction.params) {
+            for (const param of scxmlAction.params) {
+              payload[param.name] = evaluateExpr(
+                mergedContext,
+                param.expr ?? param.location!,
+                x.event,
+                x.self
+              );
+            }
+          }
+          if (scxmlAction.content) {
+            const content = scxmlAction.content;
+            let contentValue: unknown;
+            if (content.expr !== undefined) {
+              contentValue = evaluateExpr(
+                mergedContext,
+                content.expr,
+                x.event,
+                x.self
+              );
+            } else if (content.xml) {
+              contentValue = createScxmlDomElement(content.xml);
+            } else {
+              const text = content.text?.replace(/\s+/g, ' ').trim() ?? '';
+              try {
+                contentValue = evaluateExpr(
+                  mergedContext,
+                  text,
+                  x.event,
+                  x.self
+                );
+              } catch {
+                contentValue = text;
+              }
+            }
+            eventData._scxmlEventData = contentValue;
+          } else if (Object.keys(payload).length) {
+            Object.assign(eventData, payload);
+            eventData._scxmlEventData = payload;
+          }
+
+          if (scxmlAction.idlocation) {
+            const nextId = (sendCounters.get(x.self) ?? 0) + 1;
+            sendCounters.set(x.self, nextId);
+            const generatedId = `${x.self.sessionId}.send.${nextId}`;
+            context ??= {};
+            context[scxmlAction.idlocation] = generatedId;
+            eventData._scxmlSendId = generatedId;
           }
 
           target = scxmlAction.targetexpr
@@ -1509,6 +1997,12 @@ export function createMachineFromConfig(
 
         const isInternalTarget = target === '#_internal';
         const isParentTarget = target === '#_parent';
+        if (!isInternalTarget) {
+          (eventData as any)._scxmlExternal = true;
+        }
+        if (isParentTarget) {
+          (eventData as any)._scxmlInvokeId = x.self.id;
+        }
 
         // Validate target. SCXML targets must be '#_internal', '#_parent',
         // or '#_<id>'. A bare string without the '#_' prefix is invalid and
@@ -1521,12 +2015,16 @@ export function createMachineFromConfig(
           raiseErrorExecution(
             state,
             'send',
-            new Error(`Invalid send target: ${target}`)
+            new Error(`Invalid send target: ${target}`),
+            eventData._scxmlSendId as string | undefined
           );
           continue;
         }
         // Attach send id so _event.sendid can be read in expressions.
-        if (scxmlAction.id !== undefined) {
+        if (
+          scxmlAction.id !== undefined &&
+          eventData._scxmlSendId === undefined
+        ) {
           (eventData as any)._scxmlSendId = scxmlAction.id;
         }
         // Resolve target at runtime: parent, child, or self
@@ -1550,7 +2048,7 @@ export function createMachineFromConfig(
             enq.sendTo(childRef, eventData as AnyEventObject);
           } else if (
             childId.startsWith('scxml_') &&
-            childId !== `scxml_${_scxmlSessionId}`
+            childId !== `scxml_${x.self.sessionId}`
           ) {
             const message = `Unable to dispatch event to target: ${target}`;
             enq.raise({
@@ -1616,7 +2114,12 @@ export function createMachineFromConfig(
         const scxmlAction = action as ScxmlScriptJSON;
         const mergedContext = { ...x.context, ...context };
         try {
-          const updatedContext = executeScript(mergedContext, scxmlAction.code);
+          const updatedContext = executeScript(
+            mergedContext,
+            scxmlAction.code,
+            x.self,
+            scxmlAction.global ?? false
+          );
           context ??= {};
           Object.assign(context, updatedContext);
         } catch (err) {
@@ -1761,6 +2264,30 @@ export function createMachineFromConfig(
     return (x, enq) => executeActions(actions, x, enq);
   }
 
+  function getFinalizedGuardContext(
+    context: MachineContext,
+    event: AnyEventObject,
+    self: AnyActorRef,
+    finalizers: NonNullable<TransitionJSON['_scxml']>['finalize']
+  ): MachineContext {
+    const invokeId = (event as any)._scxmlInvokeId ?? (event as any).actorId;
+    const finalized = { ...context };
+    for (const finalizer of finalizers ?? []) {
+      if (finalizer.invokeId !== invokeId) continue;
+      for (const action of finalizer.actions) {
+        if (!('type' in action) || action.type !== 'scxml.assign') continue;
+        const assignAction = action as ScxmlAssignJSON;
+        finalized[assignAction.location] = evaluateExpr(
+          finalized,
+          assignAction.expr,
+          event,
+          self
+        );
+      }
+    }
+    return finalized;
+  }
+
   function getTransitionConfig(
     transition: TransitionConfigJSON | TransitionConfigJSON[]
   ): any {
@@ -1782,7 +2309,24 @@ export function createMachineFromConfig(
       }
       const target = Array.isArray(t.target) ? t.target[0] : t.target;
       const targetConfig = t.target;
-      const guard = resolveCondition(t.guard, 'guard', '$.transition.guard');
+      const resolvedGuard = resolveCondition(
+        t.guard,
+        'guard',
+        '$.transition.guard'
+      );
+      const guard =
+        resolvedGuard && t._scxml?.finalize?.length
+          ? (args: any) =>
+              resolvedGuard({
+                ...args,
+                context: getFinalizedGuardContext(
+                  args.context,
+                  args.event,
+                  args.self,
+                  t._scxml!.finalize
+                )
+              })
+          : resolvedGuard;
       const resolveTransitionContext = (x: any) =>
         t.context
           ? (resolveValue(
@@ -1796,12 +2340,20 @@ export function createMachineFromConfig(
         t.input !== undefined
           ? resolveValue(t.input, 'input', makeScope(x), '$.transition.input')
           : undefined;
+      const eventMatcher = t._scxml?.eventDescriptors
+        ? (event: EventObject) =>
+            t._scxml!.eventDescriptors!.some((descriptor) =>
+              matchesScxmlEventDescriptor(descriptor, event)
+            )
+        : undefined;
 
       // No guard and no actions: simple static config
       if (!guard && !t.actions?.length) {
         if (t.context) {
           return {
             matches: t.matches,
+            _scxml: t._scxml,
+            _eventMatcher: eventMatcher,
             to: (x: any) => ({
               target: targetConfig,
               context: resolveTransitionContext(x),
@@ -1814,6 +2366,8 @@ export function createMachineFromConfig(
         }
         return {
           matches: t.matches,
+          _scxml: t._scxml,
+          _eventMatcher: eventMatcher,
           target: targetConfig,
           description: t.description,
           reenter: t.reenter,
@@ -1827,6 +2381,8 @@ export function createMachineFromConfig(
         if (t.context) {
           return {
             matches: t.matches,
+            _scxml: t._scxml,
+            _eventMatcher: eventMatcher,
             guard,
             to: (x: any) => ({
               target: targetConfig,
@@ -1840,6 +2396,8 @@ export function createMachineFromConfig(
         }
         return {
           matches: t.matches,
+          _scxml: t._scxml,
+          _eventMatcher: eventMatcher,
           target: targetConfig,
           guard,
           description: t.description,
@@ -1855,6 +2413,8 @@ export function createMachineFromConfig(
       if (!target) {
         return {
           matches: t.matches,
+          _scxml: t._scxml,
+          _eventMatcher: eventMatcher,
           guard,
           description: t.description,
           reenter: t.reenter,
@@ -1869,6 +2429,7 @@ export function createMachineFromConfig(
               }
               // Save pre-transition context for parallel override
               contextBeforeTargetless ??= x.context;
+              targetlessEvent ??= x.event;
               // Execute immediately (fallback for non-parallel case)
               const result = executeActions(t.actions, x, enq);
               if (result.context) {
@@ -1886,6 +2447,8 @@ export function createMachineFromConfig(
       // Map by target state ID so parallel transitions each get their own actions.
       return {
         matches: t.matches,
+        _scxml: t._scxml,
+        _eventMatcher: eventMatcher,
         guard,
         description: t.description,
         reenter: t.reenter,
@@ -1935,15 +2498,30 @@ export function createMachineFromConfig(
   assertMachineJSON(json, resolvedSources, expressionResolver);
 
   const rootNodeConfig = iterNode(json);
-  const contextConfig = json.context
-    ? {
-        context: (args: any) =>
-          resolveValue(json.context, 'context', args, '$.context')
-      }
-    : {};
-
-  _scxmlMachineName = json.id || '';
-  _scxmlSessionId = 'session_scxml';
+  const contextConfig =
+    json.context || json._scxmlDataIds?.length
+      ? {
+          context: (args: any) => ({
+            ...Object.fromEntries(
+              (json._scxmlDataIds ?? []).map((id) => [id, undefined])
+            ),
+            ...(json.context
+              ? (resolveValue(
+                  json.context,
+                  'context',
+                  args,
+                  '$.context'
+                ) as MachineContext)
+              : {}),
+            ...(args.input && typeof args.input === 'object' ? args.input : {}),
+            ...(json._scxmlDataIds?.length &&
+            args.input &&
+            typeof args.input === 'object'
+              ? { _xstateScxmlInputKeys: Object.keys(args.input) }
+              : {})
+          })
+        }
+      : {};
 
   const machine = createMachine({
     ...rootNodeConfig,

--- a/packages/core/src/createMachineFromConfig.ts
+++ b/packages/core/src/createMachineFromConfig.ts
@@ -64,7 +64,7 @@ export interface CancelJSON {
   id: string;
 }
 
-export interface LogJSON {
+interface LogJSON {
   type: '@xstate.log';
   args: any[];
 }
@@ -2513,7 +2513,11 @@ export function createMachineFromConfig(
                   '$.context'
                 ) as MachineContext)
               : {}),
-            ...(args.input && typeof args.input === 'object' ? args.input : {}),
+            ...(json._scxmlDataIds?.length &&
+            args.input &&
+            typeof args.input === 'object'
+              ? args.input
+              : {}),
             ...(json._scxmlDataIds?.length &&
             args.input &&
             typeof args.input === 'object'

--- a/packages/core/src/createMachineFromConfig.ts
+++ b/packages/core/src/createMachineFromConfig.ts
@@ -1,14 +1,12 @@
 import {
   Action,
   AnyActorLogic,
-  AnyActorRef,
   AnyEventObject,
   AnyStateMachine,
   EventObject,
   MachineContext,
   MetaObject
 } from './types';
-import { Next_StateNodeConfig } from './types.v6';
 import { createMachine } from './createMachine';
 import { parseDelayToMilliseconds } from './delay';
 
@@ -18,48 +16,14 @@ function delayToMs(delay: string | number): number {
   return typeof delay === 'string' ? parseFloat(delay) || 0 : delay;
 }
 
-function normalizeScxmlEventType(eventType: string): string {
-  return /^error(\.|$)/.test(eventType) ? `xstate.${eventType}` : eventType;
-}
-
-function toScxmlEventName(eventType: string): string {
-  return eventType.startsWith('xstate.error.')
-    ? eventType.slice('xstate.'.length)
-    : eventType;
-}
-
-function matchesScxmlEventDescriptor(
-  descriptor: string,
-  event: EventObject
-): boolean {
-  if (descriptor === '*') return true;
-  if (descriptor.endsWith('.*')) {
-    const prefix = descriptor.slice(0, -2);
-    return event.type === prefix || event.type.startsWith(`${prefix}.`);
-  }
-  if (descriptor.startsWith('xstate.done.actor.')) {
-    return (
-      event.type === 'xstate.done.actor' &&
-      (event as any).actorId === descriptor.slice('xstate.done.actor.'.length)
-    );
-  }
-  if (descriptor.startsWith('xstate.done.state.')) {
-    return (
-      event.type === 'xstate.done.state' &&
-      (event as any).stateId === descriptor.slice('xstate.done.state.'.length)
-    );
-  }
-  return event.type === descriptor || event.type.startsWith(`${descriptor}.`);
-}
-
-export interface RaiseJSON {
+interface RaiseJSON {
   type: '@xstate.raise';
   event: EventObject;
   id?: string;
   delay?: number;
 }
 
-export interface CancelJSON {
+interface CancelJSON {
   type: '@xstate.cancel';
   id: string;
 }
@@ -67,12 +31,6 @@ export interface CancelJSON {
 interface LogJSON {
   type: '@xstate.log';
   args: any[];
-}
-
-export interface ScxmlLogJSON {
-  type: 'scxml.log';
-  label?: string;
-  expr?: string;
 }
 
 interface EmitJSON {
@@ -83,116 +41,6 @@ interface EmitJSON {
 interface AssignJSON {
   type: '@xstate.assign';
   context: MachineContext;
-}
-
-interface ScxmlAssignJSON {
-  type: 'scxml.assign';
-  /** SCXML location attribute - the context property to assign to */
-  location: string;
-  /** SCXML expr attribute - expression to evaluate */
-  expr: string;
-}
-
-export interface ScxmlRaiseJSON {
-  type: 'scxml.raise';
-  /** Event type, or undefined if using eventexpr */
-  event?: string;
-  /** Expression to evaluate for event type */
-  eventexpr?: string;
-  /** Params with expressions to evaluate */
-  params?: Array<{ name: string; expr?: string; location?: string }>;
-  namelist?: string[];
-  id?: string;
-  idlocation?: string;
-  delay?: number;
-  /** Expression for delay */
-  delayexpr?: string;
-  /** Static target (e.g. '#_parent') */
-  target?: string;
-  /** Expression for target */
-  targetexpr?: string;
-  processorType?: string;
-  content?: ScxmlContentJSON;
-}
-
-export interface ScxmlXmlJSON {
-  name: string;
-  attributes?: Record<string, string>;
-  children?: ScxmlXmlJSON[];
-}
-
-export interface ScxmlContentJSON {
-  expr?: string;
-  text?: string;
-  xml?: ScxmlXmlJSON;
-}
-
-interface ScxmlScriptJSON {
-  type: 'scxml.script';
-  /** The script code to execute */
-  code: string;
-  global?: boolean;
-}
-
-export interface ScxmlForeachJSON {
-  type: 'scxml.foreach';
-  array: string;
-  item: string;
-  index?: string;
-  actions: ActionJSON[];
-}
-
-export interface ScxmlCancelJSON {
-  type: 'scxml.cancel';
-  sendidexpr: string;
-}
-
-export interface ScxmlDonedataJSON {
-  params?: Array<{ name: string; expr: string }>;
-  contentExpr?: string;
-  contentText?: string;
-}
-
-export interface ScxmlDataJSON {
-  id: string;
-  expr?: string;
-  content?: string;
-  src?: string;
-  xml?: ScxmlXmlJSON;
-}
-
-/**
- * Isolated executable-content block. Errors in nested actions stop this block
- * but do not propagate to the surrounding action list. Used to model SCXML's
- * separate <onentry>/<onexit> blocks: each is its own block per spec.
- */
-interface ScxmlBlockJSON {
-  type: 'scxml.block';
-  actions: ActionJSON[];
-}
-
-interface ScxmlDatamodelJSON {
-  type: 'scxml.datamodel';
-  data: ScxmlDataJSON[];
-}
-
-interface ScxmlForwardJSON {
-  type: 'scxml.forward';
-  invokeId: string;
-}
-
-interface ScxmlFinalizeJSON {
-  type: 'scxml.finalize';
-  invokeId: string;
-  actions: ActionJSON[];
-}
-
-interface ScxmlIfJSON {
-  type: 'scxml.if';
-  branches: Array<{
-    cond?: string;
-    actions: ActionJSON[];
-  }>;
 }
 
 type BuiltInActionJSON =
@@ -209,22 +57,7 @@ interface CustomActionJSON {
 
 export type ActionJSON =
   | CustomActionJSON
-  | RaiseJSON
-  | CancelJSON
-  | LogJSON
-  | EmitJSON
-  | AssignJSON
-  | ScxmlAssignJSON
-  | ScxmlRaiseJSON
-  | ScxmlScriptJSON
-  | ScxmlIfJSON
-  | ScxmlForeachJSON
-  | ScxmlCancelJSON
-  | ScxmlLogJSON
-  | ScxmlBlockJSON
-  | ScxmlDatamodelJSON
-  | ScxmlForwardJSON
-  | ScxmlFinalizeJSON
+  | BuiltInActionJSON
   | ExpressionJSON
   | CodeJSON;
 
@@ -244,7 +77,6 @@ interface CodeJSON {
 }
 
 type ResolvableJSON = ExpressionJSON | CodeJSON;
-
 type ConditionJSON = GuardJSON | ResolvableJSON;
 
 interface ChoiceBranchJSON {
@@ -267,11 +99,6 @@ export interface InvokeJSON {
   onSnapshot?: TransitionConfigJSON | TransitionConfigJSON[];
   timeout?: number | string | ResolvableJSON;
   onTimeout?: TransitionConfigJSON | TransitionConfigJSON[];
-  /** @internal SCXML invocation input expressions. */
-  _scxmlInput?: {
-    namelist?: string[];
-    params?: Array<{ name: string; expr?: string; location?: string }>;
-  };
 }
 
 export interface TransitionJSON {
@@ -284,12 +111,6 @@ export interface TransitionJSON {
   reenter?: boolean;
   meta?: MetaObject;
   input?: unknown;
-  /** @internal Strict semantics for transitions produced by the SCXML converter. */
-  _scxml?: {
-    type?: 'internal' | 'external';
-    eventDescriptors?: string[];
-    finalize?: Array<{ invokeId: string; actions: ActionJSON[] }>;
-  };
 }
 
 type TransitionConfigJSON = TransitionJSON | ResolvableJSON;
@@ -305,11 +126,6 @@ export interface StateNodeJSON {
   after?: Record<string, TransitionConfigJSON | TransitionConfigJSON[]>;
   always?: TransitionConfigJSON | TransitionConfigJSON[];
   choice?: ChoiceBranchJSON[] | ResolvableJSON;
-  /**
-   * JSON route config. Unlike the authoring API (a function), the JSON layer
-   * allows an object form whose `guard` may be a named guard reference (string)
-   * resolved against the machine's `guards` sources.
-   */
   route?:
     | {
         description?: string;
@@ -332,22 +148,11 @@ export interface StateNodeJSON {
   target?: string | [string, ...string[]];
   output?: unknown;
   context?: Record<string, unknown>;
-  _scxmlDonedata?: ScxmlDonedataJSON;
-  /** @internal Initial transition emitted by the SCXML converter. */
-  _scxmlInitial?: {
-    targets: string[];
-    actions?: ActionJSON[];
-  };
-  /** @internal Executable content on an SCXML history default transition. */
-  _scxmlHistoryActions?: ActionJSON[];
-  /** @internal Datamodel declarations initialized on entry. */
-  _scxmlData?: ScxmlDataJSON[];
 }
+
 export interface MachineJSON extends StateNodeJSON {
   '@exprLang'?: string;
   version?: string;
-  /** @internal All declared SCXML datamodel identifiers. */
-  _scxmlDataIds?: string[];
   actions?: Record<string, ActionJSON | ActionJSON[]>;
   guards?: Record<string, { when: ConditionJSON }>;
   actors?: Record<string, unknown>;
@@ -413,10 +218,6 @@ function isResolvable(value: unknown): value is ResolvableJSON {
 
 function isBuiltInActionType(type: string): boolean {
   return type.startsWith('@xstate.');
-}
-
-function isScxmlActionType(type: string): boolean {
-  return type.startsWith('scxml.');
 }
 
 function toPath(parent: string, key: string | number): string {
@@ -648,7 +449,7 @@ function assertMachineJSON(
     }
     if (
       !resolvedSources.guards[condition.type] &&
-      !['scxml.cond', 'xstate.stateIn', 'xstate.not'].includes(condition.type)
+      !['xstate.stateIn', 'xstate.not'].includes(condition.type)
     ) {
       throw new Error(`Missing guard source "${condition.type}"`);
     }
@@ -667,7 +468,7 @@ function assertMachineJSON(
       throw new Error(`Invalid action at ${path}`);
     }
     assertResolvable((action as CustomActionJSON).params, `${path}.params`);
-    if (isBuiltInActionType(action.type) || isScxmlActionType(action.type)) {
+    if (isBuiltInActionType(action.type)) {
       assertResolvable(action, path);
       return;
     }
@@ -768,10 +569,7 @@ function assertMachineJSON(
       const invokes = Array.isArray(node.invoke) ? node.invoke : [node.invoke];
       invokes.forEach((invoke, index) => {
         const invokePath = `${path}.invoke${Array.isArray(node.invoke) ? `[${index}]` : ''}`;
-        const extInv = invoke as InvokeJSON & {
-          _nestedMachineJSON?: MachineJSON;
-        };
-        if (!extInv._nestedMachineJSON && !resolvedSources.actors[invoke.src]) {
+        if (!resolvedSources.actors[invoke.src]) {
           throw new Error(`Missing actor source "${invoke.src}"`);
         }
         assertResolvable(invoke.input, `${invokePath}.input`);
@@ -843,246 +641,6 @@ function assertMachineJSON(
   assertStateNode(json, '$');
 }
 
-const SCXML_SYSTEM_VARIABLES = new Set([
-  '_sessionid',
-  '_name',
-  '_ioprocessors',
-  '_event',
-  '_xstateScxmlInputKeys'
-]);
-const scxmlScriptEnvironments = new WeakMap<
-  AnyActorRef,
-  { declarations: string[] }
->();
-const scxmlMachineNames = new WeakMap<AnyActorRef, string>();
-const scxmlIoProcessors = new WeakMap<AnyActorRef, object>();
-const scxmlEvents = new WeakMap<object, object>();
-const scxmlEnteringStates = new WeakMap<AnyActorRef, string[]>();
-
-function getScxmlIoProcessors(self: AnyActorRef, sessionId: string): object {
-  let processors = scxmlIoProcessors.get(self);
-  if (!processors) {
-    const processor = { location: `#_scxml_${sessionId}` };
-    processors = {
-      scxml: processor,
-      'http://www.w3.org/TR/scxml/#SCXMLEventProcessor': processor
-    };
-    scxmlIoProcessors.set(self, processors);
-  }
-  return processors;
-}
-
-function getFunctionDeclarations(code: string): string[] {
-  const declarations: string[] = [];
-  const pattern = /\bfunction\s+[$_a-zA-Z][$_a-zA-Z0-9]*\s*\([^)]*\)\s*\{/g;
-  for (const match of code.matchAll(pattern)) {
-    let depth = 1;
-    let index = match.index! + match[0].length;
-    while (index < code.length && depth) {
-      if (code[index] === '{') depth++;
-      if (code[index] === '}') depth--;
-      index++;
-    }
-    declarations.push(code.slice(match.index, index));
-  }
-  return declarations;
-}
-
-/** Evaluates an SCXML expression with context variables available via `with`. */
-function evaluateExpr(
-  context: MachineContext,
-  expr: string,
-  event: AnyEventObject | null,
-  self?: AnyActorRef
-): unknown {
-  const normalizedExpr = expr.replace(/;+\s*$/, '');
-  const sessionId = (self as any)?.sessionId ?? 'session_scxml';
-  const machineName = self
-    ? (scxmlMachineNames.get(self) ?? '(machine)')
-    : '(machine)';
-  const dataContext = Object.fromEntries(
-    Object.entries(context).filter(([key]) => !SCXML_SYSTEM_VARIABLES.has(key))
-  );
-  const fnBody = `
-${self ? (scxmlScriptEnvironments.get(self)?.declarations.join('\n') ?? '') : ''}
-with (context) {
-  return (${normalizedExpr});
-}
-  `.trim();
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  const fn = new Function(
-    'context',
-    '_event',
-    '_sessionid',
-    '_name',
-    '_ioprocessors',
-    'In',
-    fnBody
-  );
-  const In = (stateId: string) => {
-    if (!self) return false;
-    const sanitized = stateId.replace(/\./g, '$');
-    if (
-      scxmlEnteringStates
-        .get(self)
-        ?.some((id) => id === sanitized || id.endsWith('.' + sanitized))
-    ) {
-      return true;
-    }
-    try {
-      const snap = (self as any).getSnapshot?.();
-      if (snap?.nodes) {
-        return snap.nodes.some(
-          (node: any) =>
-            node.id === sanitized || node.id.endsWith('.' + sanitized)
-        );
-      }
-    } catch {
-      // ignore
-    }
-    return false;
-  };
-  const SCXML_ORIGIN = `#_scxml_${sessionId}`;
-  const SCXML_ORIGIN_TYPE = 'http://www.w3.org/TR/scxml/#SCXMLEventProcessor';
-  const isExternal = event && (event as any)._scxmlExternal;
-  const isInitEvent = event && event.type === '@xstate.init';
-  // Per SCXML spec, _event has these fields. Fields that don't apply to a
-  // particular event are present with value `undefined` (so `'name' in _event`
-  // is true but `typeof _event.name === 'undefined'` for unset fields).
-  // For xstate.done.* events, _event.data is the `output` payload (matches
-  // SCXML's done event semantics where data is the donedata).
-  const isDoneEvent =
-    event &&
-    typeof event.type === 'string' &&
-    event.type.startsWith('xstate.done.');
-  const explicitType =
-    event && ((event as any)._scxmlEventType as string | undefined);
-  let scxmlEvent: object | undefined;
-  if (event && !isInitEvent) {
-    scxmlEvent = scxmlEvents.get(event);
-    if (!scxmlEvent) {
-      scxmlEvent = {
-        name:
-          ((event as any)._scxmlEventName as string | undefined) ??
-          toScxmlEventName(event.type),
-        type: explicitType || (isExternal ? 'external' : 'internal'),
-        sendid: (event as any)._scxmlSendId as string | undefined,
-        origin: isExternal ? SCXML_ORIGIN : undefined,
-        origintype: isExternal ? SCXML_ORIGIN_TYPE : undefined,
-        invokeid:
-          ((event as any)._scxmlInvokeId as string | undefined) ??
-          ((event as any).actorId as string | undefined),
-        data: isDoneEvent
-          ? (event as any).output
-          : (event as any)._scxmlEventData !== undefined
-            ? (event as any)._scxmlEventData
-            : event
-      };
-      scxmlEvents.set(event, scxmlEvent);
-    }
-  }
-  const result = fn(
-    dataContext,
-    scxmlEvent,
-    sessionId,
-    machineName,
-    self
-      ? getScxmlIoProcessors(self, sessionId)
-      : { scxml: { location: `#_scxml_${sessionId}` } },
-    In
-  );
-
-  return result;
-}
-
-/** Executes an SCXML script block and returns updated context values. */
-function executeScript(
-  context: MachineContext,
-  code: string,
-  self: AnyActorRef,
-  global: boolean
-): Record<string, unknown> {
-  // Create a proxy to track which properties are modified
-  const updates: Record<string, unknown> = {};
-  const contextKeys = Object.keys(context);
-  const mutableContextKeys = contextKeys.filter(
-    (key) => !SCXML_SYSTEM_VARIABLES.has(key)
-  );
-
-  // Build variable declarations and reassignment capture
-  const varDeclarations = mutableContextKeys
-    .map((k) => `var ${k} = context.${k};`)
-    .join('\n');
-  const captureUpdates = mutableContextKeys
-    .map((k) => `updates.${k} = ${k};`)
-    .join('\n');
-  const codeWithoutComments = code.replace(/\/\/.*$/gm, '');
-  const declarations = getFunctionDeclarations(code);
-  const codeWithoutFunctions = declarations.reduce(
-    (source, declaration) => source.replace(declaration, ''),
-    codeWithoutComments
-  );
-  const declaredVariables = global
-    ? [
-        ...codeWithoutFunctions.matchAll(/\bvar\s+([$_a-zA-Z][$_a-zA-Z0-9]*)/g)
-      ].map((match) => match[1])
-    : [];
-  const captureVariables = declaredVariables
-    .filter(
-      (name) => !contextKeys.includes(name) && !SCXML_SYSTEM_VARIABLES.has(name)
-    )
-    .map((name) => `updates.${name} = ${name};`)
-    .join('\n');
-  const environment = scxmlScriptEnvironments.get(self) ?? {
-    declarations: []
-  };
-  scxmlScriptEnvironments.set(self, environment);
-  for (const declaration of declarations) {
-    if (!environment.declarations.includes(declaration)) {
-      environment.declarations.push(declaration);
-    }
-  }
-
-  const fnBody = `
-${varDeclarations}
-${environment.declarations.join('\n')}
-${code}
-${captureUpdates}
-${captureVariables}
-return updates;
-  `;
-  const sessionId = (self as any).sessionId;
-  const machineName = scxmlMachineNames.get(self) ?? '(machine)';
-  // eslint-disable-next-line @typescript-eslint/no-implied-eval
-  const fn = new Function(
-    'context',
-    'updates',
-    '_sessionid',
-    '_name',
-    '_ioprocessors',
-    fnBody
-  );
-  return fn(
-    context,
-    updates,
-    sessionId,
-    machineName,
-    getScxmlIoProcessors(self, sessionId)
-  );
-}
-
-function createScxmlDomElement(element: ScxmlXmlJSON): any {
-  const children = (element.children ?? []).map(createScxmlDomElement);
-  return {
-    tagName: element.name,
-    getAttribute: (name: string) => element.attributes?.[name] ?? null,
-    getElementsByTagName: (name: string): any[] => [
-      ...(element.name === name ? [createScxmlDomElement(element)] : []),
-      ...children.flatMap((child: any) => child.getElementsByTagName(name))
-    ]
-  };
-}
-
 export function createMachineFromConfig(
   json: MachineJSON,
   sources: MachineSources = {}
@@ -1094,7 +652,6 @@ export function createMachineFromConfig(
   );
   const { evaluateResolvable, resolveValue, makeScope, getDurationConfig } =
     expressionResolver;
-  const sendCounters = new WeakMap<AnyActorRef, number>();
 
   type ResolvedCondition = ((args: any) => boolean) | undefined;
 
@@ -1103,9 +660,7 @@ export function createMachineFromConfig(
     slot: 'guard' | 'choice',
     path: string
   ): ResolvedCondition {
-    if (!condition) {
-      return undefined;
-    }
+    if (!condition) return undefined;
     if (isResolvable(condition)) {
       return (args: any) =>
         !!evaluateResolvable(condition, slot, makeScope(args), path);
@@ -1136,10 +691,16 @@ export function createMachineFromConfig(
     };
   }
 
+  function getMissingGuardMessage(type: string, guards: Record<string, any>) {
+    return `Guard '${type}' is not implemented in machine '${json.id ?? '(machine)'}'. Available guards: ${
+      Object.keys(guards)
+        .map((key) => `'${key}'`)
+        .join(', ') || '(none)'
+    }.`;
+  }
+
   function makeChoiceConfig(choice: StateNodeJSON['choice'], path: string) {
-    if (!choice) {
-      return undefined;
-    }
+    if (!choice) return undefined;
     if (isResolvable(choice)) {
       return (args: any) =>
         evaluateResolvable(choice, 'choice', makeScope(args), path);
@@ -1183,464 +744,26 @@ export function createMachineFromConfig(
     };
   }
 
-  // Pending transition actions: set by .to functions, consumed by entry functions.
-  // This bridges SCXML's exit→transition→entry action ordering with XState's
-  // .to function receiving pre-exit context.
-  // Map keyed by target state ID so parallel transitions don't overwrite each other.
-  const pendingTransitionActionsMap: Record<string, ActionJSON[]> = {};
-
-  // Ordered queue of ALL transition actions (targeted + targetless) for parallel
-  // context sharing. In SCXML, all transition actions execute sequentially in
-  // document order with a shared evolving data model.
-  const allTransitionActions: ActionJSON[][] = [];
-  // Pre-transition context saved when a targetless .to executes. Used by entry
-  // functions to re-execute all transition actions from scratch when parallel
-  // targetless transitions coexist with targeted transitions.
-  let contextBeforeTargetless: MachineContext | null = null;
-  let targetlessEvent: AnyEventObject | null = null;
-  // Platform errors collected during transition selection (e.g., failing
-  // <transition cond>). Drained by the next state's entry into the internal
-  // event queue so they're processed before any external events.
-  const pendingPlatformErrors: Array<Record<string, unknown>> = [];
-  const scxmlDonedataValues = new WeakMap<AnyActorRef, Map<string, unknown>>();
-
-  function evaluateDonedataValue(
-    donedata: ScxmlDonedataJSON,
-    context: MachineContext,
-    event: AnyEventObject,
-    self: AnyActorRef
-  ): unknown {
-    if (donedata.params?.length) {
-      const out: Record<string, unknown> = {};
-      for (const param of donedata.params) {
-        out[param.name] = evaluateExpr(context, param.expr, event, self);
-      }
-      return out;
-    }
-    if (donedata.contentExpr !== undefined) {
-      return evaluateExpr(context, donedata.contentExpr, event, self);
-    }
-    if (donedata.contentText !== undefined) {
-      try {
-        return evaluateExpr(context, donedata.contentText, event, self);
-      } catch {
-        return donedata.contentText;
-      }
-    }
-    return undefined;
-  }
-
-  function getMissingGuardMessage(type: string, guards: Record<string, any>) {
-    return `Guard '${type}' is not implemented in machine '${json.id ?? '(machine)'}'. Available guards: ${
-      Object.keys(guards)
-        .map((key) => `'${key}'`)
-        .join(', ') || '(none)'
-    }.`;
-  }
-
   function resolveRouteConfig(route: StateNodeJSON['route'], path: string) {
-    if (!route || typeof route === 'function') {
-      return route;
-    }
+    if (!route || typeof route === 'function') return route;
     if (isResolvable(route)) {
       return (args: any) =>
         evaluateResolvable(route, 'transition', makeScope(args), path);
     }
     const { guard, ...routeConfig } = route;
-    if (!guard) {
-      return routeConfig;
-    }
+    if (!guard) return routeConfig;
     const resolvedGuard = resolveCondition({ type: guard }, 'guard', path);
     return (args: any) => (resolvedGuard!(args) ? routeConfig : undefined);
   }
 
-  function iterNode(
-    node: StateNodeJSON,
-    nodeKey?: string,
-    ancestorIds: string[] = []
-  ) {
-    const originalEntryActions: ActionJSON[] = [
-      ...(node._scxmlData?.length
-        ? [{ type: 'scxml.datamodel' as const, data: node._scxmlData }]
-        : []),
-      ...toActionArray(node.entry)
-    ];
-    const stateId = node.id || nodeKey;
-
-    // Wrap entry to first execute any pending transition actions, then normal entry.
-    // This ensures SCXML execution order: exit → transition_actions → entry_actions
-    // because pending transition actions are set by .to (before exit) but executed
-    // in entry (after exit), thus seeing post-exit context.
-    const entryFn: Action<any, any, any, any, any, any, any> | undefined = (
-      x,
-      enq
-    ) => {
-      scxmlMachineNames.set(x.self, json.id ?? '(machine)');
-      if (stateId) {
-        scxmlEnteringStates.set(x.self, [...ancestorIds, stateId]);
-      }
-      // Drain any platform errors queued during transition selection (e.g.,
-      // failing <transition cond="..."> evaluations). These must be raised
-      // internally so they're processed before subsequent external events.
-      while (pendingPlatformErrors.length) {
-        const err = pendingPlatformErrors.shift()!;
-        enq.raise({
-          type: 'xstate.error.execution',
-          error: err,
-          _scxmlEventType: 'platform',
-          _scxmlEventName: 'error.execution',
-          _scxmlEventData: err
-        } as AnyEventObject);
-      }
-
-      let context: MachineContext | undefined;
-
-      // If targetless transitions were interleaved with targeted transitions
-      // (parallel state), re-execute ALL transition actions from the original
-      // pre-transition context. This overrides any .to-produced context with
-      // the correct SCXML document-order sequential execution.
-      // Only trigger when BOTH targeted (pending in map) and targetless fired
-      // in the same microstep — prevents stale data from previous events.
-      if (
-        contextBeforeTargetless &&
-        targetlessEvent === x.event &&
-        allTransitionActions.length > 0 &&
-        Object.keys(pendingTransitionActionsMap).length > 0
-      ) {
-        let ctx = contextBeforeTargetless;
-        for (const actions of allTransitionActions) {
-          const mergedX = { ...x, context: ctx };
-          const result = executeActions(actions, mergedX, enq);
-          if (result.context) {
-            ctx = result.context;
-          }
-        }
-        allTransitionActions.length = 0;
-        contextBeforeTargetless = null;
-        targetlessEvent = null;
-        // Clear per-target map since we re-processed everything
-        for (const key of Object.keys(pendingTransitionActionsMap)) {
-          delete pendingTransitionActionsMap[key];
-        }
-        context = ctx;
-      } else {
-        // Normal path: consume pending transition actions for THIS state.
-        // In parallel states, each target gets its own pending actions.
-        const transActions = stateId
-          ? pendingTransitionActionsMap[stateId]
-          : undefined;
-        if (transActions) {
-          delete pendingTransitionActionsMap[stateId!];
-          const result = executeActions(transActions, x, enq);
-          if (result.context) {
-            context = result.context;
-          }
-        }
-        // Clear stale targetless data from previous microsteps
-        contextBeforeTargetless = null;
-        targetlessEvent = null;
-        allTransitionActions.length = 0;
-      }
-
-      // Execute normal entry actions
-      if (originalEntryActions.length) {
-        const mergedX = context ? { ...x, context } : x;
-        const result = executeActions(originalEntryActions, mergedX, enq);
-        if (result.context) {
-          context = result.context;
-        }
-      }
-
-      if (node._scxmlDonedata && stateId) {
-        let values = scxmlDonedataValues.get(x.self);
-        if (!values) {
-          values = new Map();
-          scxmlDonedataValues.set(x.self, values);
-        }
-        try {
-          values.set(
-            stateId,
-            evaluateDonedataValue(
-              node._scxmlDonedata,
-              context ?? x.context,
-              x.event,
-              x.self
-            )
-          );
-        } catch (err) {
-          values.set(stateId, undefined);
-          raiseErrorExecution(
-            { enq, self: x.self, errored: false },
-            'donedata',
-            err
-          );
-        }
-      }
-
-      scxmlEnteringStates.delete(x.self);
-      return { context };
-    };
-
-    const nodeConfig: any = {
-      id: node.id,
-      initial: node._scxmlInitial
-        ? {
-            target: node._scxmlInitial.targets,
-            to: node._scxmlInitial.actions
-              ? (x: any, enq: any) => ({
-                  ...executeActions(node._scxmlInitial!.actions!, x, enq),
-                  target: node._scxmlInitial!.targets
-                })
-              : undefined
-          }
-        : node.initial,
-      type: node.type,
-      history: node.history,
-      target: node.target,
-      _scxmlHistoryActions: node._scxmlHistoryActions
-        ? (x: any, enq: any) => ({
-            ...executeActions(node._scxmlHistoryActions!, x, enq),
-            target: node.target
-          })
-        : undefined,
-      description: node.description,
-      tags: node.tags,
-      input: node.input,
-      timeout: getDurationConfig(node.timeout, `$.states.${nodeKey}.timeout`),
-      states: node.states
-        ? Object.entries(node.states).reduce(
-            (acc, [key, value]) => {
-              acc[key] = iterNode(
-                value,
-                key,
-                stateId ? [...ancestorIds, stateId] : ancestorIds
-              );
-              return acc;
-            },
-            {} as Record<
-              string,
-              Next_StateNodeConfig<
-                any,
-                any,
-                any,
-                any,
-                any,
-                any,
-                any,
-                any,
-                any,
-                any,
-                any,
-                any
-              >
-            >
-          )
-        : undefined,
-      on: node.on
-        ? Object.entries(node.on).reduce(
-            (acc, [key, value]) => {
-              acc[key] = getTransitionConfig(value);
-              return acc;
-            },
-            {} as Record<string, any>
-          )
-        : undefined,
-      always: node.always ? getTransitionConfig(node.always) : undefined,
-      onError: node.onError ? getTransitionConfig(node.onError) : undefined,
-      choice: makeChoiceConfig(node.choice, `$.states.${nodeKey}.choice`),
-      route: resolveRouteConfig(node.route, `$.states.${nodeKey}.route`),
-      after: node.after
-        ? Object.entries(node.after).reduce(
-            (acc, [key, value]) => {
-              acc[key] = getTransitionConfig(value);
-              return acc;
-            },
-            {} as Record<string, any>
-          )
-        : undefined,
-      onTimeout: node.onTimeout
-        ? getTransitionConfig(node.onTimeout)
-        : undefined,
-      entry: node.type === 'choice' ? undefined : (entryFn as any),
-      exit: node.exit
-        ? (iterActions(toActionArray(node.exit)) as any)
-        : undefined,
-      invoke: node.invoke ? iterInvokeConfigs(node.invoke) : undefined,
-      meta: node.meta,
-      output: node._scxmlDonedata
-        ? makeDonedataOutput(stateId!)
-        : isResolvable(node.output)
-          ? ({ context, event, self }: any) =>
-              evaluateResolvable(
-                node.output as ResolvableJSON,
-                'output',
-                { context, event, self },
-                `$.states.${nodeKey}.output`
-              )
-          : node.output
-    };
-
-    return nodeConfig;
-  }
-
-  function makeDonedataOutput(stateId: string) {
-    return ({ self }: any) => scxmlDonedataValues.get(self)?.get(stateId);
-  }
-
-  function iterInvokeConfigs(invokes: InvokeJSON | InvokeJSON[]): any {
-    const invokeArray = Array.isArray(invokes) ? invokes : [invokes];
-    return invokeArray.map((inv) => {
-      const extInv = inv as InvokeJSON & { _nestedMachineJSON?: MachineJSON };
-      // Create child machine from nested SCXML JSON
-      let src: any;
-      if (extInv._nestedMachineJSON) {
-        src = createMachineFromConfig(
-          extInv._nestedMachineJSON,
-          resolvedSources
-        );
-      } else {
-        src = resolvedSources.actors[inv.src] ?? inv.src;
-      }
-      return {
-        src,
-        id: inv.id,
-        registryKey: inv.registryKey,
-        input: inv._scxmlInput
-          ? ({ context, event, self }: any) => {
-              const input: Record<string, unknown> = {};
-              for (const name of inv._scxmlInput!.namelist ?? []) {
-                if (!(name in context)) {
-                  throw new ReferenceError(`${name} is not defined`);
-                }
-                input[name] = context[name];
-              }
-              for (const param of inv._scxmlInput!.params ?? []) {
-                input[param.name] = param.expr
-                  ? evaluateExpr(context, param.expr, event, self)
-                  : param.location
-                    ? evaluateExpr(context, param.location, event, self)
-                    : undefined;
-              }
-              return input;
-            }
-          : inv.input !== undefined
-            ? (args: any) =>
-                resolveValue(
-                  inv.input,
-                  'input',
-                  makeScope(args),
-                  '$.invoke.input'
-                )
-            : undefined,
-        onDone: inv.onDone ? getTransitionConfig(inv.onDone) : undefined,
-        onError: inv.onError ? getTransitionConfig(inv.onError) : undefined,
-        onSnapshot: inv.onSnapshot
-          ? getTransitionConfig(inv.onSnapshot)
-          : undefined,
-        timeout: getDurationConfig(inv.timeout, '$.invoke.timeout'),
-        onTimeout: inv.onTimeout
-          ? getTransitionConfig(inv.onTimeout)
-          : undefined
-      };
-    });
-  }
-
-  /**
-   * Raise an SCXML error.execution platform event onto the internal queue. Per
-   * spec, error.execution is type='platform' and _event.data contains error
-   * info. The surrounding block of executable content stops.
-   */
-  function raiseErrorExecution(
-    state: ExecState,
-    tagname: string,
-    err: unknown,
-    sendId?: string
-  ) {
-    const message =
-      err instanceof Error
-        ? err.message
-        : typeof err === 'string'
-          ? err
-          : 'unknown error';
-    const errorEvent = {
-      type: 'xstate.error.execution',
-      error: {
-        tagname,
-        message,
-        line: 0,
-        column: 0,
-        reason: message
-      },
-      _scxmlEventType: 'platform',
-      _scxmlEventName: 'error.execution',
-      ...(sendId ? { _scxmlSendId: sendId } : {}),
-      _scxmlEventData: {
-        tagname,
-        message,
-        line: 0,
-        column: 0,
-        reason: message
-      }
-    } as AnyEventObject;
-    state.enq.raise(errorEvent);
-    state.errored = true;
-  }
-
-  interface ExecState {
-    enq: any;
-    self: AnyActorRef;
-    errored: boolean;
-  }
-
-  function executeActionDefinition(
-    action: CustomActionJSON,
-    x: any,
-    enq: any,
-    params: unknown,
-    parentState: ExecState,
-    stack: string[]
-  ): { context: MachineContext | undefined; errored: boolean } {
-    const definition = json.actions?.[action.type];
-    if (!definition) {
-      enq(x.actions[action.type], params);
-      return { context: undefined, errored: parentState.errored };
-    }
-    if (stack.includes(action.type)) {
-      raiseErrorExecution(
-        parentState,
-        'action',
-        new Error(
-          `Circular action reference: ${stack.concat(action.type).join(' -> ')}`
-        )
-      );
-      return { context: undefined, errored: true };
-    }
-    const definitions = Array.isArray(definition) ? definition : [definition];
-    return executeActions(
-      definitions,
-      { ...x, params },
-      enq,
-      parentState,
-      stack.concat(action.type)
-    );
-  }
-
-  /** Execute an array of SCXML action JSON descriptors with context and enqueue. */
   function executeActions(
     actions: ActionJSON[],
     x: any,
     enq: any,
-    parentState?: ExecState,
     stack: string[] = []
-  ): { context: MachineContext | undefined; errored: boolean } {
-    const state: ExecState = parentState ?? {
-      enq,
-      self: x.self,
-      errored: false
-    };
+  ) {
     let context: MachineContext | undefined;
     for (const action of actions) {
-      if (state.errored) break;
       if (isResolvable(action)) {
         const result = evaluateResolvable(
           action,
@@ -1652,42 +775,26 @@ export function createMachineFromConfig(
           result &&
           typeof result === 'object' &&
           'context' in result &&
-          (result as { context?: MachineContext }).context
+          (result as any).context
         ) {
           context ??= {};
-          Object.assign(
-            context,
-            (result as { context: MachineContext }).context
-          );
+          Object.assign(context, (result as any).context);
         }
-      } else if (isBuiltInActionJSON(action)) {
+        continue;
+      }
+      if (isBuiltInActionJSON(action)) {
         switch (action.type) {
-          case '@xstate.raise': {
-            // Tag as external if it has a delay (from <send>, not <raise>).
-            // Attach _scxmlSendId so _event.sendid can be read in expressions.
-            const isExternal = action.delay !== undefined;
-            const resolvedEvent = resolveValue(
-              action.event,
-              'actionParams',
-              makeScope(x, { params: x.params }),
-              '$.actions.event'
-            ) as EventObject;
-            const event =
-              isExternal || action.id !== undefined
-                ? {
-                    ...resolvedEvent,
-                    ...(isExternal ? { _scxmlExternal: true } : {}),
-                    ...(action.id !== undefined
-                      ? { _scxmlSendId: action.id }
-                      : {})
-                  }
-                : resolvedEvent;
-            enq.raise(event, {
-              id: action.id,
-              delay: action.delay
-            });
+          case '@xstate.raise':
+            enq.raise(
+              resolveValue(
+                action.event,
+                'actionParams',
+                makeScope(x, { params: x.params }),
+                '$.actions.event'
+              ),
+              { id: action.id, delay: action.delay }
+            );
             break;
-          }
           case '@xstate.cancel':
             enq.cancel(action.id);
             break;
@@ -1716,772 +823,207 @@ export function createMachineFromConfig(
               )
             );
             break;
-          default:
-            throw new Error(`Unknown built-in action: ${(action as any).type}`);
         }
-      } else if (action.type === 'scxml.finalize') {
-        const finalize = action as ScxmlFinalizeJSON;
-        const invokeId =
-          (x.event as any)._scxmlInvokeId ?? (x.event as any).actorId;
-        if (invokeId === finalize.invokeId) {
-          const result = executeActions(
-            finalize.actions,
-            { ...x, context: { ...x.context, ...context } },
-            enq,
-            state
-          );
-          if (result.context) {
-            context = result.context;
-          }
-        }
-      } else if (action.type === 'scxml.forward') {
-        const child = x.children?.[(action as ScxmlForwardJSON).invokeId];
-        if (child) {
-          enq.sendTo(child, {
-            ...x.event,
-            _scxmlExternal: true
-          });
-        }
-      } else if (action.type === 'scxml.log') {
-        const scxmlAction = action as ScxmlLogJSON;
-        try {
-          const value = scxmlAction.expr
-            ? evaluateExpr(
-                { ...x.context, ...context },
-                scxmlAction.expr,
-                x.event,
-                x.self
-              )
-            : undefined;
-          enq.log(
-            ...(scxmlAction.label ? [scxmlAction.label, value] : [value])
-          );
-        } catch (err) {
-          raiseErrorExecution(state, 'log', err);
-        }
-      } else if (action.type === 'scxml.assign') {
-        const scxmlAction = action as ScxmlAssignJSON;
-        const mergedContext = { ...x.context, ...context };
-        let value: unknown;
-        try {
-          value = evaluateExpr(
-            mergedContext,
-            scxmlAction.expr,
-            x.event,
-            x.self
-          );
-        } catch (err) {
-          raiseErrorExecution(state, 'assign', err);
-          continue;
-        }
-        if (SCXML_SYSTEM_VARIABLES.has(scxmlAction.location.split('.')[0])) {
-          raiseErrorExecution(
-            state,
-            'assign',
-            new Error(
-              `Cannot assign to SCXML system variable: ${scxmlAction.location}`
-            )
-          );
-          continue;
-        }
-        if (scxmlAction.location.includes('.')) {
-          const path = scxmlAction.location.split('.');
-          const root = path.shift()!;
-          let target = mergedContext[root];
-          if (!target || typeof target !== 'object') {
-            raiseErrorExecution(
-              state,
-              'assign',
-              new Error(`Invalid assign location: ${scxmlAction.location}`)
-            );
-            continue;
-          }
-          const clonedRoot = Array.isArray(target)
-            ? [...target]
-            : { ...target };
-          target = clonedRoot;
-          for (const segment of path.slice(0, -1)) {
-            const child = (target as Record<string, unknown>)[segment];
-            if (!child || typeof child !== 'object') {
-              raiseErrorExecution(
-                state,
-                'assign',
-                new Error(`Invalid assign location: ${scxmlAction.location}`)
-              );
-              break;
-            }
-            const clonedChild = Array.isArray(child)
-              ? [...child]
-              : { ...child };
-            (target as Record<string, unknown>)[segment] = clonedChild;
-            target = clonedChild;
-          }
-          if (state.errored) continue;
-          (target as Record<string, unknown>)[path.at(-1)!] = value;
-          context ??= {};
-          context[root] = clonedRoot;
-          continue;
-        }
-        context ??= {};
-        context[scxmlAction.location] = value;
-      } else if (action.type === 'scxml.datamodel') {
-        const scxmlAction = action as ScxmlDatamodelJSON;
-        context ??= {};
-        for (const data of scxmlAction.data) {
-          if (
-            Array.isArray(x.context._xstateScxmlInputKeys) &&
-            x.context._xstateScxmlInputKeys.includes(data.id)
-          ) {
-            continue;
-          }
-          if (data.src) {
-            raiseErrorExecution(
-              state,
-              'data',
-              new Error(`Unresolved data resource: ${data.src}`)
-            );
-            break;
-          }
-          if (data.expr !== undefined) {
-            try {
-              context[data.id] = evaluateExpr(
-                { ...x.context, ...context },
-                data.expr,
-                x.event,
-                x.self
-              );
-            } catch (err) {
-              raiseErrorExecution(state, 'data', err);
-              break;
-            }
-          } else if (data.content !== undefined) {
-            try {
-              context[data.id] = evaluateExpr(
-                { ...x.context, ...context },
-                data.content,
-                x.event,
-                x.self
-              );
-            } catch {
-              context[data.id] = data.content.replace(/\s+/g, ' ').trim();
-            }
-          } else if (data.xml) {
-            context[data.id] = createScxmlDomElement(data.xml);
-          } else {
-            if (x.context[data.id] === undefined) {
-              context[data.id] = undefined;
-            }
-          }
-        }
-      } else if (action.type === 'scxml.raise') {
-        const scxmlAction = action as ScxmlRaiseJSON;
-        const mergedContext = { ...x.context, ...context };
-
-        let eventType: string;
-        let eventData: Record<string, unknown>;
-        let target: string | undefined;
-        let delay: number | undefined;
-        try {
-          if (
-            scxmlAction.processorType &&
-            ![
-              'scxml',
-              'http://www.w3.org/TR/scxml/#SCXMLEventProcessor'
-            ].includes(scxmlAction.processorType)
-          ) {
-            throw new Error(
-              `Unsupported send type: ${scxmlAction.processorType}`
-            );
-          }
-          eventType = scxmlAction.eventexpr
-            ? (evaluateExpr(
-                mergedContext,
-                scxmlAction.eventexpr,
-                x.event,
-                x.self
-              ) as string)
-            : scxmlAction.event || 'unknown';
-          eventType = normalizeScxmlEventType(eventType);
-
-          eventData = {
-            type: eventType,
-            _scxmlEventName: toScxmlEventName(eventType)
-          };
-          const payload: Record<string, unknown> = {};
-          if (scxmlAction.namelist) {
-            for (const name of scxmlAction.namelist) {
-              payload[name] = evaluateExpr(
-                mergedContext,
-                name,
-                x.event,
-                x.self
-              );
-            }
-          }
-          if (scxmlAction.params) {
-            for (const param of scxmlAction.params) {
-              payload[param.name] = evaluateExpr(
-                mergedContext,
-                param.expr ?? param.location!,
-                x.event,
-                x.self
-              );
-            }
-          }
-          if (scxmlAction.content) {
-            const content = scxmlAction.content;
-            let contentValue: unknown;
-            if (content.expr !== undefined) {
-              contentValue = evaluateExpr(
-                mergedContext,
-                content.expr,
-                x.event,
-                x.self
-              );
-            } else if (content.xml) {
-              contentValue = createScxmlDomElement(content.xml);
-            } else {
-              const text = content.text?.replace(/\s+/g, ' ').trim() ?? '';
-              try {
-                contentValue = evaluateExpr(
-                  mergedContext,
-                  text,
-                  x.event,
-                  x.self
-                );
-              } catch {
-                contentValue = text;
-              }
-            }
-            eventData._scxmlEventData = contentValue;
-          } else if (Object.keys(payload).length) {
-            Object.assign(eventData, payload);
-            eventData._scxmlEventData = payload;
-          }
-
-          if (scxmlAction.idlocation) {
-            const nextId = (sendCounters.get(x.self) ?? 0) + 1;
-            sendCounters.set(x.self, nextId);
-            const generatedId = `${x.self.sessionId}.send.${nextId}`;
-            context ??= {};
-            context[scxmlAction.idlocation] = generatedId;
-            eventData._scxmlSendId = generatedId;
-          }
-
-          target = scxmlAction.targetexpr
-            ? (evaluateExpr(
-                mergedContext,
-                scxmlAction.targetexpr,
-                x.event,
-                x.self
-              ) as string)
-            : scxmlAction.target;
-
-          const isInternalTarget = target === '#_internal';
-          delay = scxmlAction.delayexpr
-            ? delayToMs(
-                evaluateExpr(
-                  mergedContext,
-                  scxmlAction.delayexpr,
-                  x.event,
-                  x.self
-                ) as string | number
-              )
-            : isInternalTarget
-              ? undefined
-              : scxmlAction.delay;
-        } catch (err) {
-          raiseErrorExecution(state, 'send', err);
-          continue;
-        }
-
-        const isInternalTarget = target === '#_internal';
-        const isParentTarget = target === '#_parent';
-        if (!isInternalTarget) {
-          (eventData as any)._scxmlExternal = true;
-        }
-        if (isParentTarget) {
-          (eventData as any)._scxmlInvokeId = x.self.id;
-        }
-
-        // Validate target. SCXML targets must be '#_internal', '#_parent',
-        // or '#_<id>'. A bare string without the '#_' prefix is invalid and
-        // raises error.execution.
-        if (
-          typeof target === 'string' &&
-          target.length > 0 &&
-          !target.startsWith('#_')
-        ) {
-          raiseErrorExecution(
-            state,
-            'send',
-            new Error(`Invalid send target: ${target}`),
-            eventData._scxmlSendId as string | undefined
-          );
-          continue;
-        }
-        // Attach send id so _event.sendid can be read in expressions.
-        if (
-          scxmlAction.id !== undefined &&
-          eventData._scxmlSendId === undefined
-        ) {
-          (eventData as any)._scxmlSendId = scxmlAction.id;
-        }
-        // Resolve target at runtime: parent, child, or self
-        if (isParentTarget && x.parent) {
-          // Send to parent via sendTo; pass delay if present
-          enq.sendTo(
-            x.parent,
-            eventData as AnyEventObject,
-            delay !== undefined ? { delay } : undefined
-          );
-        } else if (
-          typeof target === 'string' &&
-          target.startsWith('#_') &&
-          !isParentTarget &&
-          !isInternalTarget
-        ) {
-          // #_<invokeId> → try to send to child actor, fall back to self-raise
-          const childId = target.slice(2); // strip '#_'
-          const childRef = x.children?.[childId];
-          if (childRef) {
-            enq.sendTo(childRef, eventData as AnyEventObject);
-          } else if (
-            childId.startsWith('scxml_') &&
-            childId !== `scxml_${x.self.sessionId}`
-          ) {
-            const message = `Unable to dispatch event to target: ${target}`;
-            enq.raise({
-              type: 'xstate.error.communication',
-              error: {
-                tagname: 'send',
-                message,
-                line: NaN,
-                column: NaN,
-                reason: message
-              },
-              _scxmlEventType: 'platform',
-              _scxmlEventName: 'error.communication',
-              _scxmlEventData: {
-                tagname: 'send',
-                message,
-                line: NaN,
-                column: NaN,
-                reason: message
-              }
-            } as AnyEventObject);
-          } else {
-            // This SCXML session id uses the external event queue.
-            (eventData as any)._scxmlExternal = true;
-            enq.sendTo(x.self, eventData as AnyEventObject, {
-              id: scxmlAction.id,
-              delay
-            });
-          }
-        } else {
-          // #_internal uses the internal queue; self-send/no target use the
-          // external event queue.
-          if (isInternalTarget) {
-            enq.raise(eventData as AnyEventObject, {
-              id: scxmlAction.id,
-              delay
-            });
-          } else {
-            (eventData as any)._scxmlExternal = true;
-            enq.sendTo(x.self, eventData as AnyEventObject, {
-              id: scxmlAction.id,
-              delay
-            });
-          }
-        }
-      } else if (action.type === 'scxml.cancel') {
-        const scxmlAction = action as ScxmlCancelJSON;
-        const mergedContext = { ...x.context, ...context };
-        try {
-          const sendId = evaluateExpr(
-            mergedContext,
-            scxmlAction.sendidexpr,
-            x.event,
-            x.self
-          ) as string;
-          if (sendId) {
-            enq.cancel(sendId);
-          }
-        } catch {
-          // ignore evaluation errors
-        }
-      } else if (action.type === 'scxml.script') {
-        const scxmlAction = action as ScxmlScriptJSON;
-        const mergedContext = { ...x.context, ...context };
-        try {
-          const updatedContext = executeScript(
-            mergedContext,
-            scxmlAction.code,
-            x.self,
-            scxmlAction.global ?? false
-          );
-          context ??= {};
-          Object.assign(context, updatedContext);
-        } catch (err) {
-          raiseErrorExecution(state, 'script', err);
-        }
-      } else if (action.type === 'scxml.foreach') {
-        const scxmlAction = action as ScxmlForeachJSON;
-        const mergedContext = { ...x.context, ...context };
-        // SCXML: `item` (and `index` if present) must be valid datamodel
-        // locations — i.e. legal identifiers. Reject things like 'continue'
-        // (string literal) or '7' (number).
-        const isLegalIdentifier = (s: string) =>
-          /^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(s);
-        if (
-          !isLegalIdentifier(scxmlAction.item) ||
-          (scxmlAction.index && !isLegalIdentifier(scxmlAction.index))
-        ) {
-          raiseErrorExecution(
-            state,
-            'foreach',
-            new Error('foreach item/index is not a legal location')
-          );
-          continue;
-        }
-        let arr: unknown;
-        try {
-          arr = evaluateExpr(mergedContext, scxmlAction.array, x.event, x.self);
-        } catch (err) {
-          raiseErrorExecution(state, 'foreach', err);
-          continue;
-        }
-        if (!Array.isArray(arr)) {
-          raiseErrorExecution(
-            state,
-            'foreach',
-            new Error('foreach array is not iterable')
-          );
-          continue;
-        }
-        context ??= {};
-        for (let i = 0; i < arr.length; i++) {
-          context[scxmlAction.item] = arr[i];
-          if (scxmlAction.index) {
-            context[scxmlAction.index] = i;
-          }
-          const iterX = { ...x, context: { ...x.context, ...context } };
-          const iterResult = executeActions(
-            scxmlAction.actions,
-            iterX,
-            enq,
-            state
-          );
-          if (iterResult.context) {
-            Object.assign(context, iterResult.context);
-          }
-          if (state.errored) break;
-        }
-      } else if (action.type === 'scxml.block') {
-        const scxmlAction = action as ScxmlBlockJSON;
-        const blockX = { ...x, context: { ...x.context, ...context } };
-        // Block has its own ExecState — errors don't propagate to parent.
-        const blockResult = executeActions(scxmlAction.actions, blockX, enq);
-        if (blockResult.context) {
-          context ??= {};
-          for (const key of Object.keys(blockResult.context)) {
-            if (blockResult.context[key] !== x.context[key]) {
-              context[key] = blockResult.context[key];
-            }
-          }
-        }
-      } else if (action.type === 'scxml.if') {
-        const scxmlAction = action as ScxmlIfJSON;
-        const mergedContext = { ...x.context, ...context };
-        for (const branch of scxmlAction.branches) {
-          let condResult: boolean;
-          if (branch.cond) {
-            try {
-              condResult = !!evaluateExpr(
-                mergedContext,
-                branch.cond,
-                x.event,
-                x.self
-              );
-            } catch (err) {
-              raiseErrorExecution(state, 'if', err);
-              condResult = false;
-            }
-          } else {
-            condResult = true;
-          }
-          if (condResult) {
-            if (branch.actions.length) {
-              const branchX = { ...x, context: mergedContext };
-              const branchResult = executeActions(
-                branch.actions,
-                branchX,
-                enq,
-                state
-              );
-              if (branchResult.context) {
-                context ??= {};
-                for (const key of Object.keys(branchResult.context)) {
-                  if (branchResult.context[key] !== x.context[key]) {
-                    context[key] = branchResult.context[key];
-                  }
-                }
-              }
-            }
-            break;
-          }
-        }
-      } else {
-        const params = resolveValue(
-          (action as CustomActionJSON).params,
-          'actionParams',
-          makeScope(x, { params: x.params }),
-          '$.actions.params'
-        );
-        const result = executeActionDefinition(
-          action,
-          x,
-          enq,
-          params,
-          state,
-          stack
-        );
-        if (result.context) {
-          context ??= {};
-          Object.assign(context, result.context);
-        }
+        continue;
       }
-    }
-    return {
-      context: context ? { ...x.context, ...context } : undefined,
-      errored: state.errored
-    };
-  }
-
-  function iterActions(
-    actions: ActionJSON[]
-  ): Action<any, any, any, any, any, any, any> {
-    return (x, enq) => executeActions(actions, x, enq);
-  }
-
-  function getFinalizedGuardContext(
-    context: MachineContext,
-    event: AnyEventObject,
-    self: AnyActorRef,
-    finalizers: NonNullable<TransitionJSON['_scxml']>['finalize']
-  ): MachineContext {
-    const invokeId = (event as any)._scxmlInvokeId ?? (event as any).actorId;
-    const finalized = { ...context };
-    for (const finalizer of finalizers ?? []) {
-      if (finalizer.invokeId !== invokeId) continue;
-      for (const action of finalizer.actions) {
-        if (!('type' in action) || action.type !== 'scxml.assign') continue;
-        const assignAction = action as ScxmlAssignJSON;
-        finalized[assignAction.location] = evaluateExpr(
-          finalized,
-          assignAction.expr,
-          event,
-          self
+      const params = resolveValue(
+        action.params,
+        'actionParams',
+        makeScope(x, { params: x.params }),
+        '$.actions.params'
+      );
+      const definition = json.actions?.[action.type];
+      if (!definition) {
+        enq(x.actions[action.type], params);
+        continue;
+      }
+      if (stack.includes(action.type)) {
+        throw new Error(
+          `Circular action reference: ${stack.concat(action.type).join(' -> ')}`
         );
       }
+      const definitions = Array.isArray(definition) ? definition : [definition];
+      const result = executeActions(
+        definitions,
+        { ...x, context: { ...x.context, ...context }, params },
+        enq,
+        stack.concat(action.type)
+      );
+      if (result.context) context = result.context;
     }
-    return finalized;
+    return { context: context ? { ...x.context, ...context } : undefined };
+  }
+
+  function iterActions(actions: ActionJSON | ActionJSON[]) {
+    const actionArray = toActionArray(actions);
+    return ((x: any, enq: any) =>
+      executeActions(actionArray, x, enq)) as Action<
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any,
+      any
+    >;
   }
 
   function getTransitionConfig(
     transition: TransitionConfigJSON | TransitionConfigJSON[]
   ): any {
     const transitions = Array.isArray(transition) ? transition : [transition];
-
-    // Return an array of transition configs. Each SCXML transition becomes
-    // a separate XState transition with its own guard and optional .to.
-    // This ensures guards are evaluated by XState's evaluateCandidate (once,
-    // with pre-exit context) and NOT re-evaluated in computeEntrySet.
-    return transitions.map((t, index) => {
-      if (isResolvable(t)) {
+    return transitions.map((item, index) => {
+      if (isResolvable(item)) {
         return (x: any, enq: any) =>
           evaluateResolvable(
-            t,
+            item,
             'transition',
             makeScope(x, { enq }),
             `$.transition${transitions.length > 1 ? `[${index}]` : ''}`
           );
       }
-      const target = Array.isArray(t.target) ? t.target[0] : t.target;
-      const targetConfig = t.target;
-      const resolvedGuard = resolveCondition(
-        t.guard,
-        'guard',
-        '$.transition.guard'
-      );
-      const guard =
-        resolvedGuard && t._scxml?.finalize?.length
-          ? (args: any) =>
-              resolvedGuard({
-                ...args,
-                context: getFinalizedGuardContext(
-                  args.context,
-                  args.event,
-                  args.self,
-                  t._scxml!.finalize
-                )
-              })
-          : resolvedGuard;
-      const resolveTransitionContext = (x: any) =>
-        t.context
-          ? (resolveValue(
-              t.context,
+      const context = item.context
+        ? (x: any) =>
+            resolveValue(
+              item.context,
               'transitionContext',
               makeScope(x),
               '$.transition.context'
-            ) as MachineContext)
-          : undefined;
-      const resolveTransitionInput = (x: any) =>
-        t.input !== undefined
-          ? resolveValue(t.input, 'input', makeScope(x), '$.transition.input')
-          : undefined;
-      const eventMatcher = t._scxml?.eventDescriptors
-        ? (event: EventObject) =>
-            t._scxml!.eventDescriptors!.some((descriptor) =>
-              matchesScxmlEventDescriptor(descriptor, event)
-            )
+            ) as MachineContext
         : undefined;
-
-      // No guard and no actions: simple static config
-      if (!guard && !t.actions?.length) {
-        if (t.context) {
-          return {
-            matches: t.matches,
-            _scxml: t._scxml,
-            _eventMatcher: eventMatcher,
-            to: (x: any) => ({
-              target: targetConfig,
-              context: resolveTransitionContext(x),
-              reenter: t.reenter
-            }),
-            description: t.description,
-            meta: t.meta,
-            input: t.input !== undefined ? resolveTransitionInput : undefined
-          };
-        }
-        return {
-          matches: t.matches,
-          _scxml: t._scxml,
-          _eventMatcher: eventMatcher,
-          target: targetConfig,
-          description: t.description,
-          reenter: t.reenter,
-          meta: t.meta,
-          input: t.input !== undefined ? resolveTransitionInput : undefined
-        };
-      }
-
-      // Guard but no actions: static config with guard
-      if (guard && !t.actions?.length) {
-        if (t.context) {
-          return {
-            matches: t.matches,
-            _scxml: t._scxml,
-            _eventMatcher: eventMatcher,
-            guard,
-            to: (x: any) => ({
-              target: targetConfig,
-              context: resolveTransitionContext(x),
-              reenter: t.reenter
-            }),
-            description: t.description,
-            meta: t.meta,
-            input: t.input !== undefined ? resolveTransitionInput : undefined
-          };
-        }
-        return {
-          matches: t.matches,
-          _scxml: t._scxml,
-          _eventMatcher: eventMatcher,
-          target: targetConfig,
-          guard,
-          description: t.description,
-          reenter: t.reenter,
-          meta: t.meta,
-          input: t.input !== undefined ? resolveTransitionInput : undefined
-        };
-      }
-
-      // Targetless transitions: execute actions directly in .to AND track for
-      // parallel re-execution. For non-parallel, .to result is used directly.
-      // For parallel (entries exist), first entry re-executes all in document order.
-      if (!target) {
-        return {
-          matches: t.matches,
-          _scxml: t._scxml,
-          _eventMatcher: eventMatcher,
-          guard,
-          description: t.description,
-          reenter: t.reenter,
-          meta: t.meta,
-          input: t.input !== undefined ? resolveTransitionInput : undefined,
-          to: (x: any, enq: any) => {
-            const context = resolveTransitionContext(x);
-            if (t.actions?.length) {
-              // Track for parallel re-execution (dedup by reference)
-              if (!allTransitionActions.includes(t.actions)) {
-                allTransitionActions.push(t.actions);
-              }
-              // Save pre-transition context for parallel override
-              contextBeforeTargetless ??= x.context;
-              targetlessEvent ??= x.event;
-              // Execute immediately (fallback for non-parallel case)
-              const result = executeActions(t.actions, x, enq);
-              if (result.context) {
-                return { context: { ...context, ...result.context } };
-              }
-            }
-            return context ? { context } : {};
-          }
-        };
-      }
-
-      // Has target + actions: use guard (for XState evaluation) + .to (for pending actions).
-      // The .to function does NOT re-check the guard — XState's evaluateCandidate
-      // already validated it. The .to just stores actions for entry to execute.
-      // Map by target state ID so parallel transitions each get their own actions.
+      const input =
+        item.input !== undefined
+          ? (x: any) =>
+              resolveValue(
+                item.input,
+                'input',
+                makeScope(x),
+                '$.transition.input'
+              )
+          : undefined;
+      const dynamic = !!context || !!item.actions?.length;
       return {
-        matches: t.matches,
-        _scxml: t._scxml,
-        _eventMatcher: eventMatcher,
-        guard,
-        description: t.description,
-        reenter: t.reenter,
-        meta: t.meta,
-        input: t.input !== undefined ? resolveTransitionInput : undefined,
-        to: (_x: any, _enq: any) => {
-          const context = resolveTransitionContext(_x);
-          if (t.actions?.length) {
-            const targetId = target.replace(/^#/, '');
-            pendingTransitionActionsMap[targetId] = t.actions;
-            // Track for parallel re-execution (dedup by reference)
-            if (!allTransitionActions.includes(t.actions)) {
-              allTransitionActions.push(t.actions);
+        matches: item.matches,
+        target: dynamic ? undefined : item.target,
+        to: dynamic
+          ? (x: any, enq: any) => {
+              const resolvedContext = context?.(x);
+              const result = item.actions?.length
+                ? executeActions(
+                    item.actions,
+                    resolvedContext
+                      ? { ...x, context: { ...x.context, ...resolvedContext } }
+                      : x,
+                    enq
+                  )
+                : undefined;
+              return {
+                target: item.target,
+                context: result?.context ?? resolvedContext,
+                reenter: item.reenter
+              };
             }
-          }
-          return {
-            target: targetConfig,
-            context,
-            reenter: t.reenter
-          };
-        }
+          : undefined,
+        guard: resolveCondition(item.guard, 'guard', '$.transition.guard'),
+        description: item.description,
+        reenter: item.reenter,
+        meta: item.meta,
+        input
       };
     });
   }
 
+  function iterInvokeConfigs(invokes: InvokeJSON | InvokeJSON[]): any {
+    return (Array.isArray(invokes) ? invokes : [invokes]).map((inv) => ({
+      src: resolvedSources.actors[inv.src] ?? inv.src,
+      id: inv.id,
+      registryKey: inv.registryKey,
+      input:
+        inv.input !== undefined
+          ? (args: any) =>
+              resolveValue(
+                inv.input,
+                'input',
+                makeScope(args),
+                '$.invoke.input'
+              )
+          : undefined,
+      onDone: inv.onDone ? getTransitionConfig(inv.onDone) : undefined,
+      onError: inv.onError ? getTransitionConfig(inv.onError) : undefined,
+      onSnapshot: inv.onSnapshot
+        ? getTransitionConfig(inv.onSnapshot)
+        : undefined,
+      timeout: getDurationConfig(inv.timeout, '$.invoke.timeout'),
+      onTimeout: inv.onTimeout ? getTransitionConfig(inv.onTimeout) : undefined
+    }));
+  }
+
+  function iterNode(node: StateNodeJSON, nodeKey?: string): any {
+    return {
+      id: node.id,
+      initial: node.initial,
+      type: node.type,
+      history: node.history,
+      target: node.target,
+      description: node.description,
+      tags: node.tags,
+      input: node.input,
+      timeout: getDurationConfig(node.timeout, `$.states.${nodeKey}.timeout`),
+      states: node.states
+        ? Object.fromEntries(
+            Object.entries(node.states).map(([key, value]) => [
+              key,
+              iterNode(value, key)
+            ])
+          )
+        : undefined,
+      on: node.on
+        ? Object.fromEntries(
+            Object.entries(node.on).map(([key, value]) => [
+              key,
+              getTransitionConfig(value)
+            ])
+          )
+        : undefined,
+      always: node.always ? getTransitionConfig(node.always) : undefined,
+      onError: node.onError ? getTransitionConfig(node.onError) : undefined,
+      choice: makeChoiceConfig(node.choice, `$.states.${nodeKey}.choice`),
+      route: resolveRouteConfig(node.route, `$.states.${nodeKey}.route`),
+      after: node.after
+        ? Object.fromEntries(
+            Object.entries(node.after).map(([key, value]) => [
+              key,
+              getTransitionConfig(value)
+            ])
+          )
+        : undefined,
+      onTimeout: node.onTimeout
+        ? getTransitionConfig(node.onTimeout)
+        : undefined,
+      entry: node.entry ? iterActions(node.entry) : undefined,
+      exit: node.exit ? iterActions(node.exit) : undefined,
+      invoke: node.invoke ? iterInvokeConfigs(node.invoke) : undefined,
+      meta: node.meta,
+      output: isResolvable(node.output)
+        ? ({ context, event, self }: any) =>
+            evaluateResolvable(
+              node.output as ResolvableJSON,
+              'output',
+              { context, event, self },
+              `$.states.${nodeKey}.output`
+            )
+        : node.output
+    };
+  }
+
   if (json.delays) {
-    for (const key of Object.keys(json.delays)) {
-      const delay = json.delays[key];
-      if (typeof delay === 'number') {
-        resolvedSources.delays[key] = delay;
-      } else if (typeof delay === 'string') {
+    for (const [key, delay] of Object.entries(json.delays)) {
+      if (typeof delay === 'number') resolvedSources.delays[key] = delay;
+      else if (typeof delay === 'string')
         resolvedSources.delays[key] = delayToMs(delay);
-      } else if (delay && typeof delay === 'object') {
+      else if (delay && typeof delay === 'object') {
         resolvedSources.delays[key] = (args: any) =>
           delayToMs(
             resolveValue(
@@ -2496,103 +1038,49 @@ export function createMachineFromConfig(
   }
 
   assertMachineJSON(json, resolvedSources, expressionResolver);
-
-  const rootNodeConfig = iterNode(json);
-  const contextConfig =
-    json.context || json._scxmlDataIds?.length
-      ? {
-          context: (args: any) => ({
-            ...Object.fromEntries(
-              (json._scxmlDataIds ?? []).map((id) => [id, undefined])
-            ),
-            ...(json.context
-              ? (resolveValue(
-                  json.context,
-                  'context',
-                  args,
-                  '$.context'
-                ) as MachineContext)
-              : {}),
-            ...(json._scxmlDataIds?.length &&
-            args.input &&
-            typeof args.input === 'object'
-              ? args.input
-              : {}),
-            ...(json._scxmlDataIds?.length &&
-            args.input &&
-            typeof args.input === 'object'
-              ? { _xstateScxmlInputKeys: Object.keys(args.input) }
-              : {})
-          })
-        }
-      : {};
-
+  const contextConfig = json.context
+    ? {
+        context: (args: any) =>
+          resolveValue(
+            json.context,
+            'context',
+            args,
+            '$.context'
+          ) as MachineContext
+      }
+    : {};
   const machine = createMachine({
-    ...rootNodeConfig,
+    ...iterNode(json),
     ...contextConfig,
     version: json.version
   }) as unknown as AnyStateMachine;
-
-  // Register SCXML guard sources
-  const providedGuards: Record<string, (args: any, params: any) => boolean> = {
-    'scxml.cond': ({ context, event, self }: any, params: any) => {
-      const expr = params?.expr as string;
-      if (!expr) return true;
-      try {
-        return !!evaluateExpr(context, expr, event, self);
-      } catch (err) {
-        // Per SCXML spec, a cond that fails to evaluate is treated as false
-        // AND raises error.execution. We can't enqueue from a guard, so
-        // queue it for the next entry to drain.
-        const message =
-          err instanceof Error
-            ? err.message
-            : typeof err === 'string'
-              ? err
-              : 'unknown error';
-        pendingPlatformErrors.push({
-          tagname: 'cond',
-          message,
-          line: NaN,
-          column: NaN,
-          reason: message
-        });
-        return false;
-      }
-    },
-    'xstate.stateIn': (args: any, params: any) => {
-      const stateId = params?.stateId as string;
-      if (!stateId) return false;
-      const normalizedId = stateId.replace(/^#/, '');
-      const snapshot = args._snapshot;
-      if (snapshot?.nodes) {
-        return snapshot.nodes.some((node: any) => node.id === normalizedId);
-      }
-      return false;
-    },
-    'xstate.not': (args: any, params: any) => {
-      const inner = params?.guard;
-      const innerImpl = inner && args.guards?.[inner.type];
-      if (!innerImpl) {
-        throw new Error(
-          `Guard '${inner?.type}' referenced by 'xstate.not' is not implemented.`
-        );
-      }
-      return !innerImpl(args, inner.params);
-    }
-  };
   const provided = machine.provide({
     actions: resolvedSources.actions,
     actors: resolvedSources.actors,
     guards: {
-      ...providedGuards,
+      'xstate.stateIn': (args: any, params: any) => {
+        const stateId = params?.stateId as string;
+        const snapshot = args._snapshot;
+        return (
+          !!stateId &&
+          !!snapshot?.nodes?.some(
+            (node: any) => node.id === stateId.replace(/^#/, '')
+          )
+        );
+      },
+      'xstate.not': (args: any, params: any) => {
+        const inner = params?.guard;
+        const impl = inner && args.guards?.[inner.type];
+        if (!impl)
+          throw new Error(
+            `Guard '${inner?.type}' referenced by 'xstate.not' is not implemented.`
+          );
+        return !impl(args, inner.params);
+      },
       ...resolvedSources.guards
     },
     delays: resolvedSources.delays
   });
-
-  // Keep the original JSON so `serializeMachine(machine)`
-  // round-trip losslessly.
   (provided as any)._json = json;
   return provided;
 }

--- a/packages/core/src/machine.schema.json
+++ b/packages/core/src/machine.schema.json
@@ -362,7 +362,6 @@
           ]
         },
         "context": { "type": "object" },
-        "_scxmlDonedata": { "type": "object" },
         "version": { "type": "string" },
         "internalEvents": {
           "type": "array",

--- a/packages/core/src/scxml.ts
+++ b/packages/core/src/scxml.ts
@@ -9,19 +9,21 @@
  * be removed without a breaking-change notice.
  */
 import { Element as XMLElement, xml2js } from 'xml-js';
-import { NULL_EVENT } from './constants.ts';
 import {
   ActionJSON,
   CancelJSON,
   GuardJSON,
   InvokeJSON,
-  LogJSON,
   MachineJSON,
   RaiseJSON,
   ScxmlCancelJSON,
+  ScxmlContentJSON,
+  ScxmlDataJSON,
   ScxmlDonedataJSON,
   ScxmlForeachJSON,
+  ScxmlLogJSON,
   ScxmlRaiseJSON,
+  ScxmlXmlJSON,
   StateNodeJSON,
   TransitionJSON,
   createMachineFromConfig
@@ -33,11 +35,75 @@ export function sanitizeStateId(id: string) {
   return id.replace(/\./g, '$');
 }
 
+export interface SCXMLConversionOptions {
+  resolveResource?: (src: string, kind: 'data' | 'script' | 'invoke') => string;
+}
+
+function normalizeElementNames(element: XMLElement): XMLElement {
+  if (element.name?.includes(':')) {
+    element.name = element.name.slice(element.name.lastIndexOf(':') + 1);
+  }
+  for (const child of element.elements ?? []) {
+    normalizeElementNames(child);
+  }
+  return element;
+}
+
+function resolveResource(
+  options: SCXMLConversionOptions,
+  src: string,
+  kind: 'data' | 'script' | 'invoke'
+): string {
+  if (!options.resolveResource) {
+    throw new Error(`No SCXML resource resolver provided for ${kind}: ${src}`);
+  }
+  return options.resolveResource(src, kind);
+}
+
 function getAttribute(
   element: XMLElement,
   attribute: string
 ): string | number | undefined {
   return element.attributes ? element.attributes[attribute] : undefined;
+}
+
+function toScxmlXmlJSON(element: XMLElement): ScxmlXmlJSON {
+  return {
+    name: element.name!,
+    ...(element.attributes
+      ? {
+          attributes: Object.fromEntries(
+            Object.entries(element.attributes).map(([key, value]) => [
+              key,
+              String(value)
+            ])
+          )
+        }
+      : undefined),
+    ...((element.elements ?? []).some((child) => child.name)
+      ? {
+          children: (element.elements ?? [])
+            .filter((child) => child.name)
+            .map(toScxmlXmlJSON)
+        }
+      : undefined)
+  };
+}
+
+function getContentDescriptor(element: XMLElement): ScxmlContentJSON {
+  if (element.attributes?.expr !== undefined) {
+    return { expr: String(element.attributes.expr) };
+  }
+  const xml = element.elements?.find((child) => child.name);
+  if (xml) {
+    return { xml: toScxmlXmlJSON(xml) };
+  }
+  return {
+    text: (element.elements ?? [])
+      .filter((child) => child.type === 'text' || child.type === 'cdata')
+      .map((child) => String(child.text ?? child.cdata ?? ''))
+      .join('')
+  };
 }
 
 function delayToMs(delay?: string | number): number | undefined {
@@ -70,7 +136,10 @@ interface ScxmlIfBranch {
   actions: ActionJSON[];
 }
 
-function parseIfElement(element: XMLElement): ActionJSON {
+function parseIfElement(
+  element: XMLElement,
+  options: SCXMLConversionOptions
+): ActionJSON {
   const branches: ScxmlIfBranch[] = [];
   let currentCond: string | undefined = element.attributes?.cond as string;
   let currentActions: ActionJSON[] = [];
@@ -87,7 +156,7 @@ function parseIfElement(element: XMLElement): ActionJSON {
         currentCond = undefined; // else has no condition
         currentActions = [];
       } else {
-        currentActions.push(mapAction(child));
+        currentActions.push(mapAction(child, options));
       }
     }
   }
@@ -100,7 +169,10 @@ function parseIfElement(element: XMLElement): ActionJSON {
   } as any;
 }
 
-function mapAction(element: XMLElement): ActionJSON {
+function mapAction(
+  element: XMLElement,
+  options: SCXMLConversionOptions
+): ActionJSON {
   switch (element.name) {
     case 'raise': {
       const action: RaiseJSON = {
@@ -114,7 +186,12 @@ function mapAction(element: XMLElement): ActionJSON {
     case 'assign': {
       // SCXML assign uses location and expr attributes
       const location = element.attributes!.location as string;
-      const expr = element.attributes!.expr as string;
+      const expr =
+        element.attributes?.expr !== undefined
+          ? String(element.attributes.expr)
+          : JSON.stringify(
+              toScxmlXmlJSON(element.elements!.find((child) => child.name)!)
+            );
       return {
         type: 'scxml.assign' as const,
         location,
@@ -141,22 +218,37 @@ function mapAction(element: XMLElement): ActionJSON {
       };
     }
     case 'send': {
-      const { event, eventexpr, target, targetexpr, id, delay, delayexpr } =
-        element.attributes!;
+      const {
+        event,
+        eventexpr,
+        target,
+        targetexpr,
+        id,
+        idlocation,
+        delay,
+        delayexpr,
+        namelist,
+        type
+      } = element.attributes!;
 
       // Extract params from child elements
-      const params: Array<{ name: string; expr: string }> = [];
+      const params: Array<{
+        name: string;
+        expr?: string;
+        location?: string;
+      }> = [];
+      let content: ScxmlContentJSON | undefined;
       if (element.elements) {
         for (const child of element.elements) {
           if (child.name === 'param') {
             params.push({
               name: child.attributes!.name as string,
-              expr: child.attributes!.expr as string
+              ...(child.attributes!.expr !== undefined
+                ? { expr: child.attributes!.expr as string }
+                : { location: child.attributes!.location as string })
             });
           } else if (child.name === 'content') {
-            throw new Error(
-              'Conversion of <content/> inside <send/> not implemented.'
-            );
+            content = getContentDescriptor(child);
           }
         }
       }
@@ -173,7 +265,11 @@ function mapAction(element: XMLElement): ActionJSON {
         params.length ||
         eventexpr ||
         delayexpr ||
-        targetexpr
+        targetexpr ||
+        namelist ||
+        content ||
+        idlocation ||
+        type
       ) {
         const action: ScxmlRaiseJSON = {
           type: 'scxml.raise',
@@ -183,11 +279,18 @@ function mapAction(element: XMLElement): ActionJSON {
               : undefined,
           eventexpr: eventexpr as string | undefined,
           params: params.length ? params : undefined,
+          namelist:
+            typeof namelist === 'string'
+              ? namelist.trim().split(/\s+/)
+              : undefined,
           id: id as string | undefined,
+          idlocation: idlocation as string | undefined,
           delay: resolvedDelay,
           delayexpr: delayexpr as string | undefined,
           target: target as string | undefined,
-          targetexpr: targetexpr as string | undefined
+          targetexpr: targetexpr as string | undefined,
+          processorType: type as string | undefined,
+          content
         };
         return action;
       }
@@ -198,31 +301,37 @@ function mapAction(element: XMLElement): ActionJSON {
         event: event as string | undefined,
         eventexpr: undefined,
         params: undefined,
+        namelist: undefined,
         id: id as string | undefined,
+        idlocation: idlocation as string | undefined,
         delay: resolvedDelay,
         target: target as string | undefined,
-        targetexpr: undefined
+        targetexpr: undefined,
+        processorType: type as string | undefined,
+        content
       };
       return action;
     }
     case 'log': {
       const label = element.attributes!.label;
       const expr = element.attributes!.expr;
-      const action: LogJSON = {
-        type: '@xstate.log',
-        args:
-          label !== undefined ? [String(label), String(expr)] : [String(expr)]
+      const action: ScxmlLogJSON = {
+        type: 'scxml.log',
+        ...(label !== undefined ? { label: String(label) } : undefined),
+        ...(expr !== undefined ? { expr: String(expr) } : undefined)
       };
       return action;
     }
     case 'if': {
-      return parseIfElement(element);
+      return parseIfElement(element, options);
     }
     case 'foreach': {
       const array = element.attributes!.array as string;
       const item = element.attributes!.item as string;
       const index = element.attributes?.index as string | undefined;
-      const actions = element.elements ? mapActions(element.elements) : [];
+      const actions = element.elements
+        ? mapActions(element.elements, options)
+        : [];
       const foreach: ScxmlForeachJSON = {
         type: 'scxml.foreach',
         array,
@@ -233,6 +342,16 @@ function mapAction(element: XMLElement): ActionJSON {
       return foreach;
     }
     case 'script': {
+      if (element.attributes?.src) {
+        return {
+          type: 'scxml.script',
+          code: resolveResource(
+            options,
+            String(element.attributes.src),
+            'script'
+          )
+        };
+      }
       // Get the script text content
       const textElement = element.elements?.find((el) => el.type === 'text');
       const code = (textElement?.text as string) || '';
@@ -245,7 +364,10 @@ function mapAction(element: XMLElement): ActionJSON {
   }
 }
 
-function mapActions(elements: XMLElement[]): ActionJSON[] {
+function mapActions(
+  elements: XMLElement[],
+  options: SCXMLConversionOptions
+): ActionJSON[] {
   const mapped: ActionJSON[] = [];
 
   for (const element of elements) {
@@ -253,7 +375,7 @@ function mapActions(elements: XMLElement[]): ActionJSON[] {
       continue;
     }
 
-    mapped.push(mapAction(element));
+    mapped.push(mapAction(element, options));
   }
 
   return mapped;
@@ -296,13 +418,82 @@ function createGuard(cond: string): GuardJSON {
 
 type HistoryAttributeValue = 'shallow' | 'deep' | undefined;
 
+function getDataDescriptors(
+  element: XMLElement,
+  options: SCXMLConversionOptions
+): ScxmlDataJSON[] {
+  return (element.elements ?? [])
+    .filter((child) => child.name === 'datamodel')
+    .flatMap((datamodel) =>
+      (datamodel.elements ?? [])
+        .filter((child) => child.name === 'data')
+        .map((data) => {
+          const src = data.attributes?.src;
+          const resolvedSource =
+            src !== undefined
+              ? resolveResource(options, String(src), 'data')
+              : undefined;
+          const text = (data.elements ?? [])
+            .filter((child) => child.type === 'text' || child.type === 'cdata')
+            .map((child) => String(child.text ?? child.cdata ?? ''))
+            .join('')
+            .trim();
+          const xml = data.elements?.find((child) => child.name);
+          let resourceXml: XMLElement | undefined;
+          if (resolvedSource !== undefined) {
+            try {
+              resourceXml = normalizeElementNames(
+                xml2js(resolvedSource) as XMLElement
+              ).elements?.find((child) => child.name);
+            } catch {
+              resourceXml = undefined;
+            }
+          }
+          return {
+            id: String(data.attributes!.id),
+            ...(data.attributes?.expr !== undefined
+              ? { expr: String(data.attributes.expr) }
+              : undefined),
+            ...(resolvedSource !== undefined && !resourceXml
+              ? { content: resolvedSource.trim() }
+              : text
+                ? { content: text }
+                : undefined),
+            ...(resourceXml
+              ? { xml: toScxmlXmlJSON(resourceXml) }
+              : xml
+                ? { xml: toScxmlXmlJSON(xml) }
+                : undefined)
+          };
+        })
+    );
+}
+
+function collectDataDescriptors(
+  element: XMLElement,
+  options: SCXMLConversionOptions
+): ScxmlDataJSON[] {
+  return [
+    ...getDataDescriptors(element, options),
+    ...(element.elements ?? [])
+      .filter((child) =>
+        ['state', 'parallel', 'final'].includes(child.name ?? '')
+      )
+      .flatMap((child) => collectDataDescriptors(child, options))
+  ];
+}
+
 function toStateNodeJSON(
   nodeJson: XMLElement,
   id: string,
-  parentId?: string
+  parentId?: string,
+  binding: 'early' | 'late' = 'early',
+  options: SCXMLConversionOptions = {}
 ): StateNodeJSON {
   const parallel = nodeJson.name === 'parallel';
   let initial = parallel ? undefined : (nodeJson.attributes?.initial as string);
+  let initialActions: ActionJSON[] | undefined;
+  const hasInitialAttribute = initial !== undefined;
   const { elements } = nodeJson;
 
   const stateId = parentId ? `${parentId}.${id}` : id;
@@ -329,7 +520,15 @@ function toStateNodeJSON(
       id: sanitizeStateId(id),
       type: 'history',
       history,
-      target: target ? `#${sanitizeStateId(target as string)}` : undefined
+      target: target ? `#${sanitizeStateId(target as string)}` : undefined,
+      ...(transitionElement.elements?.length
+        ? {
+            _scxmlHistoryActions: mapActions(
+              transitionElement.elements,
+              options
+            )
+          }
+        : undefined)
     };
   }
 
@@ -354,7 +553,9 @@ function toStateNodeJSON(
         if (child.name === 'param') {
           params.push({
             name: child.attributes!.name as string,
-            expr: child.attributes!.expr as string
+            expr: String(
+              child.attributes?.expr ?? child.attributes?.location ?? ''
+            ).trim()
           });
         } else if (child.name === 'content') {
           if (child.attributes?.expr) {
@@ -380,6 +581,14 @@ function toStateNodeJSON(
       element.name === 'final' ||
       element.name === 'history'
   );
+  stateElements.forEach((element, index) => {
+    if (element.attributes?.id === undefined) {
+      element.attributes = {
+        ...element.attributes,
+        id: `${id}.anonymous.${index}`
+      };
+    }
+  });
 
   const transitionElements = nodeJson.elements.filter(
     (element) => element.name === 'transition'
@@ -396,12 +605,24 @@ function toStateNodeJSON(
   const onExitElements = nodeJson.elements.filter(
     (element) => element.name === 'onexit'
   );
+  const directScripts = nodeJson.elements
+    .filter((element) => element.name === 'script')
+    .map((element) => ({
+      ...mapAction(element, options),
+      global: true
+    }));
 
   // Build states object
   const states: Record<string, StateNodeJSON> = {};
   for (const stateElement of stateElements) {
     const childId = sanitizeStateId(`${stateElement.attributes!.id}`);
-    states[childId] = toStateNodeJSON(stateElement, childId, stateId);
+    states[childId] = toStateNodeJSON(
+      stateElement,
+      childId,
+      stateId,
+      binding,
+      options
+    );
   }
 
   // Determine initial state
@@ -410,9 +631,13 @@ function toStateNodeJSON(
     : undefined;
 
   if (initialElement && initialElement.elements?.length) {
-    initial = initialElement.elements.find(
+    const initialTransition = initialElement.elements.find(
       (element) => element.name === 'transition'
-    )!.attributes!.target as string;
+    )!;
+    initial = initialTransition.attributes!.target as string;
+    initialActions = initialTransition.elements?.length
+      ? mapActions(initialTransition.elements, options)
+      : undefined;
   } else if (!initial && !initialElement && stateElements.length) {
     initial = stateElements[0].attributes!.id as string;
   }
@@ -422,96 +647,87 @@ function toStateNodeJSON(
   const on: Record<string, TransitionJSON | TransitionJSON[]> = {};
 
   transitionElements.forEach((value) => {
-    const events = ((getAttribute(value, 'event') as string) || '').split(
-      /\s+/
-    );
-
-    events.forEach((eventType) => {
-      const targets = getAttribute(value, 'target');
-      const internal = getAttribute(value, 'type') === 'internal';
-
-      let guard: GuardJSON | undefined;
-      if (value.attributes?.cond) {
-        guard = createGuard(value.attributes.cond as string);
+    const eventTypes = ((getAttribute(value, 'event') as string) || '')
+      .trim()
+      .split(/\s+/);
+    const targets = getAttribute(value, 'target');
+    const internal = getAttribute(value, 'type') === 'internal';
+    const hasTarget = targets !== undefined;
+    const eventDescriptors = eventTypes.filter(Boolean).map((eventType) => {
+      if (/^(error|done\.state)(\.|$)/.test(eventType)) {
+        return `xstate.${eventType}`;
       }
-
-      // Only set reenter:true for external transitions WITH a target
-      // Targetless transitions should not reenter (they just execute actions)
-      const hasTarget = targets !== undefined;
-      const transitionConfig: TransitionJSON = {
-        target: getTargets(targets),
-        ...(value.elements?.length
-          ? { actions: mapActions(value.elements) }
-          : undefined),
-        ...(guard ? { guard } : undefined),
-        ...(hasTarget && !internal && { reenter: true })
-      };
-
-      if (eventType === NULL_EVENT || eventType === '') {
-        always.push(transitionConfig);
-      } else {
-        let normalizedEventType = eventType;
-        if (/^error(\.|$)/.test(eventType)) {
-          normalizedEventType = `xstate.${eventType}`;
-        } else if (/^done\.state(\.|$)/.test(eventType)) {
-          normalizedEventType = `xstate.${eventType}`;
-        } else if (/^done\.invoke(\.|$)/.test(eventType)) {
-          normalizedEventType = eventType.replace(
-            /^done\.invoke/,
-            'xstate.done.actor'
-          );
-        }
-
-        const eventDescriptors =
-          normalizedEventType === '*' || normalizedEventType.endsWith('.*')
-            ? [normalizedEventType]
-            : [normalizedEventType, `${normalizedEventType}.*`];
-
-        for (const eventDescriptor of eventDescriptors) {
-          const existing = on[eventDescriptor];
-          if (!existing) {
-            on[eventDescriptor] = transitionConfig;
-          } else if (Array.isArray(existing)) {
-            existing.push(transitionConfig);
-          } else {
-            on[eventDescriptor] = [existing, transitionConfig];
-          }
-        }
+      if (/^done\.invoke(\.|$)/.test(eventType)) {
+        return eventType.replace(/^done\.invoke/, 'xstate.done.actor');
       }
+      return eventType;
     });
+    const transitionConfig: TransitionJSON = {
+      target: getTargets(targets),
+      _scxml: {
+        ...(hasTarget && { type: internal ? 'internal' : 'external' }),
+        ...(eventDescriptors.length && { eventDescriptors })
+      },
+      ...(value.elements?.length
+        ? { actions: mapActions(value.elements, options) }
+        : undefined),
+      ...(value.attributes?.cond
+        ? { guard: createGuard(value.attributes.cond as string) }
+        : undefined),
+      ...(hasTarget && !internal && { reenter: true })
+    };
+
+    if (!eventDescriptors.length) {
+      always.push(transitionConfig);
+      return;
+    }
+
+    const existing = on['*'];
+    if (!existing) {
+      on['*'] = transitionConfig;
+    } else if (Array.isArray(existing)) {
+      existing.push(transitionConfig);
+    } else {
+      on['*'] = [existing, transitionConfig];
+    }
   });
 
   // Build entry/exit actions. Per SCXML, each <onentry>/<onexit> block is a
   // separate executable-content block — errors in one block must not stop
   // execution of subsequent blocks. Wrap each block in scxml.block so the
   // runtime executes them with isolated error state.
-  const entry = onEntryElements.length
-    ? onEntryElements.map((onEntryElement) => ({
-        type: 'scxml.block' as const,
-        actions: mapActions(onEntryElement.elements || [])
-      }))
-    : undefined;
+  const entry: ActionJSON[] = [
+    ...directScripts,
+    ...onEntryElements.map((onEntryElement) => ({
+      type: 'scxml.block' as const,
+      actions: mapActions(onEntryElement.elements || [], options)
+    }))
+  ];
 
   const exit = onExitElements.length
     ? onExitElements.map((onExitElement) => ({
         type: 'scxml.block' as const,
-        actions: mapActions(onExitElement.elements || [])
+        actions: mapActions(onExitElement.elements || [], options)
       }))
     : undefined;
 
   // Build invokes
-  const invoke: InvokeJSON[] = invokeElements.map((element) => {
+  const invoke: InvokeJSON[] = invokeElements.map((element, invokeIndex) => {
+    const invokeType = element.attributes?.type as string | undefined;
     if (
-      !['scxml', 'http://www.w3.org/TR/scxml/'].includes(
-        element.attributes!.type as string
-      )
+      invokeType !== undefined &&
+      ![
+        'scxml',
+        'http://www.w3.org/TR/scxml',
+        'http://www.w3.org/TR/scxml/'
+      ].includes(invokeType)
     ) {
       throw new Error(
-        'Currently only converting invoke elements of type SCXML is supported.'
+        `Currently only converting invoke elements of type SCXML is supported (received ${String(invokeType)}).`
       );
     }
 
-    const content = element.elements!.find(
+    const content = element.elements?.find(
       (el) => el.name === 'content'
     ) as XMLElement;
 
@@ -520,32 +736,171 @@ function toStateNodeJSON(
       (el) => el.name === 'scxml'
     ) as XMLElement;
 
+    const findEntryAssignment = (location: string) =>
+      onEntryElements
+        .flatMap((onEntry) => onEntry.elements ?? [])
+        .find(
+          (child) =>
+            child.name === 'assign' && child.attributes?.location === location
+        );
+
     let _nestedMachineJSON: MachineJSON | undefined;
     if (nestedScxml) {
       // Create a wrapper that looks like xml2js output: { elements: [scxmlElement] }
       const wrapper: XMLElement = { elements: [nestedScxml] };
-      _nestedMachineJSON = scxmlToMachineJSON(wrapper);
+      _nestedMachineJSON = scxmlToMachineJSON(wrapper, options);
+    } else if (element.attributes?.src) {
+      const source = resolveResource(
+        options,
+        String(element.attributes.src),
+        'invoke'
+      );
+      _nestedMachineJSON = scxmlToMachineJSON(
+        normalizeElementNames(xml2js(source) as XMLElement),
+        options
+      );
+    } else if (element.attributes?.srcexpr) {
+      const assignment = findEntryAssignment(
+        String(element.attributes.srcexpr)
+      );
+      const assignedSource = String(assignment?.attributes?.expr ?? '').match(
+        /^(['"])(.*)\1$/s
+      )?.[2];
+      if (assignedSource) {
+        _nestedMachineJSON = scxmlToMachineJSON(
+          normalizeElementNames(
+            xml2js(
+              resolveResource(options, assignedSource, 'invoke')
+            ) as XMLElement
+          ),
+          options
+        );
+      }
+    } else if (content?.attributes?.expr) {
+      const assignment = findEntryAssignment(String(content.attributes.expr));
+      const assignedScxml = assignment?.elements?.find(
+        (child) => child.name === 'scxml'
+      );
+      if (assignedScxml) {
+        _nestedMachineJSON = scxmlToMachineJSON(
+          { elements: [assignedScxml] },
+          options
+        );
+      }
+    }
+
+    const invokeId = String(
+      element.attributes?.id ?? `${sanitizeStateId(id)}.invoke.${invokeIndex}`
+    );
+    const params = (element.elements ?? [])
+      .filter((child) => child.name === 'param')
+      .map((param) => ({
+        name: String(param.attributes!.name),
+        ...(param.attributes?.expr !== undefined
+          ? { expr: String(param.attributes.expr) }
+          : undefined),
+        ...(param.attributes?.location !== undefined
+          ? { location: String(param.attributes.location) }
+          : undefined)
+      }));
+    const namelist = String(element.attributes?.namelist ?? '')
+      .trim()
+      .split(/\s+/)
+      .filter(Boolean);
+
+    if (element.attributes?.idlocation) {
+      entry.push({
+        type: 'scxml.assign',
+        location: String(element.attributes.idlocation),
+        expr: JSON.stringify(invokeId)
+      });
     }
 
     return {
-      ...(element.attributes!.id && { id: element.attributes!.id as string }),
+      id: invokeId,
       src: 'scxml.nested',
-      _nestedMachineJSON
+      _nestedMachineJSON,
+      ...((params.length || namelist.length) && {
+        _scxmlInput: {
+          ...(params.length ? { params } : undefined),
+          ...(namelist.length ? { namelist } : undefined)
+        }
+      })
     } as InvokeJSON & { _nestedMachineJSON?: MachineJSON };
   });
 
-  const resolvedInitial = initial && String(initial).split(' ');
-
-  if (resolvedInitial && resolvedInitial.length > 1) {
-    throw new Error(
-      `Multiple initial states are not supported ("${String(initial)}").`
+  const autoForwardIds = invokeElements.flatMap((element, index) =>
+    String(element.attributes?.autoforward) === 'true'
+      ? [invoke[index].id!]
+      : []
+  );
+  const finalizers = invokeElements.flatMap((element, index) => {
+    const finalize = element.elements?.find(
+      (child) => child.name === 'finalize'
     );
+    return finalize
+      ? [
+          {
+            invokeId: invoke[index].id!,
+            actions: mapActions(finalize.elements ?? [], options)
+          }
+        ]
+      : [];
+  });
+  if (finalizers.length) {
+    for (const transitions of Object.values(on)) {
+      for (const transition of Array.isArray(transitions)
+        ? transitions
+        : [transitions]) {
+        transition._scxml = {
+          ...transition._scxml,
+          finalize: finalizers
+        };
+        transition.actions = [
+          ...finalizers.map((finalizer) => ({
+            type: 'scxml.finalize',
+            ...finalizer
+          })),
+          ...(transition.actions ?? [])
+        ];
+      }
+    }
   }
+  if (autoForwardIds.length) {
+    for (const transitions of Object.values(on)) {
+      for (const transition of Array.isArray(transitions)
+        ? transitions
+        : [transitions]) {
+        transition.actions = [
+          ...autoForwardIds.map((invokeId) => ({
+            type: 'scxml.forward',
+            invokeId
+          })),
+          ...(transition.actions ?? [])
+        ];
+      }
+    }
+  }
+
+  const resolvedInitial = initial && String(initial).split(' ');
+  const hasExplicitInitial = hasInitialAttribute || !!initialElement;
 
   return {
     id: sanitizeStateId(id),
-    ...(resolvedInitial
+    ...(resolvedInitial && !hasExplicitInitial
       ? { initial: sanitizeStateId(resolvedInitial[0]) }
+      : undefined),
+    ...(resolvedInitial && hasExplicitInitial
+      ? {
+          _scxmlInitial: {
+            targets: resolvedInitial.map(
+              (target) => `#${sanitizeStateId(target)}`
+            ),
+            ...(initialActions?.length
+              ? { actions: initialActions }
+              : undefined)
+          }
+        }
       : undefined),
     ...(parallel ? { type: 'parallel' } : undefined),
     ...(nodeJson.name === 'final' ? { type: 'final' } : undefined),
@@ -553,67 +908,55 @@ function toStateNodeJSON(
     ...(Object.keys(states).length ? { states } : undefined),
     ...(Object.keys(on).length ? { on } : undefined),
     ...(always.length ? { always } : undefined),
-    ...(entry?.length ? { entry } : undefined),
+    ...(entry.length ? { entry } : undefined),
     ...(exit?.length ? { exit } : undefined),
-    ...(invoke.length ? { invoke } : undefined)
+    ...(invoke.length ? { invoke } : undefined),
+    ...(binding === 'late' && getDataDescriptors(nodeJson, options).length
+      ? { _scxmlData: getDataDescriptors(nodeJson, options) }
+      : undefined)
   };
 }
 
-function scxmlToMachineJSON(scxmlJson: XMLElement): MachineJSON {
+function scxmlToMachineJSON(
+  scxmlJson: XMLElement,
+  options: SCXMLConversionOptions
+): MachineJSON {
   const machineElement = scxmlJson.elements!.find(
     (element) => element.name === 'scxml'
   ) as XMLElement;
 
-  const dataModelEl = machineElement.elements?.filter(
-    (element) => element.name === 'datamodel'
-  )[0];
-
-  const context = dataModelEl
-    ? dataModelEl
-        .elements!.filter((element) => element.name === 'data')
-        .reduce(
-          (acc, element) => {
-            const { src, expr, id } = element.attributes!;
-            if (src) {
-              throw new Error(
-                "Conversion of `src` attribute on datamodel's <data> elements is not supported."
-              );
-            }
-
-            if (expr === undefined) {
-              // Check for text content inside the <data> element
-              const textEl = element.elements?.find(
-                (el) => el.type === 'text' || el.type === 'cdata'
-              );
-              const textContent = textEl
-                ? String(textEl.text ?? textEl.cdata ?? '').trim()
-                : '';
-              if (textContent) {
-                acc[id!] = eval(`(${textContent})`);
-              } else {
-                acc[id!] = undefined;
-              }
-            } else if (expr === '_sessionid') {
-              acc[id!] = 'session_scxml';
-            } else if (expr === '_name') {
-              acc[id!] =
-                (machineElement.attributes?.name as string) || '(machine)';
-            } else {
-              acc[id!] = eval(`(${expr})`);
-            }
-
-            return acc;
-          },
-          {} as Record<string, unknown>
-        )
-    : undefined;
-
+  const binding =
+    machineElement.attributes?.binding === 'late' ? 'late' : 'early';
+  const data = collectDataDescriptors(machineElement, options);
   const machineId = (machineElement.attributes?.name as string) || '(machine)';
-  const stateNodeJSON = toStateNodeJSON(machineElement, machineId);
+  const stateNodeJSON = toStateNodeJSON(
+    machineElement,
+    machineId,
+    undefined,
+    binding,
+    options
+  );
+  const declaredData = new Set(data.map(({ id }) => id));
+  const removeStaticallyInvalidInvokes = (node: StateNodeJSON) => {
+    if (node.invoke) {
+      const invokes = Array.isArray(node.invoke) ? node.invoke : [node.invoke];
+      const valid = invokes.filter((invocation) =>
+        (invocation._scxmlInput?.namelist ?? []).every((name) =>
+          declaredData.has(name)
+        )
+      );
+      node.invoke = valid.length ? valid : undefined;
+    }
+    for (const child of Object.values(node.states ?? {})) {
+      removeStaticallyInvalidInvokes(child);
+    }
+  };
+  removeStaticallyInvalidInvokes(stateNodeJSON);
 
   return {
     ...stateNodeJSON,
-    context
+    ...(binding === 'early' && data.length ? { _scxmlData: data } : undefined),
+    ...(data.length ? { _scxmlDataIds: data.map(({ id }) => id) } : undefined)
   };
 }
 
@@ -621,13 +964,19 @@ function scxmlToMachineJSON(scxmlJson: XMLElement): MachineJSON {
  * Converts an SCXML string to a JSON representation that can be used with
  * createMachineFromConfig.
  */
-export function toMachineJSON(xml: string): MachineJSON {
-  const json = xml2js(xml) as XMLElement;
-  return scxmlToMachineJSON(json);
+export function toMachineJSON(
+  xml: string,
+  options: SCXMLConversionOptions = {}
+): MachineJSON {
+  const json = normalizeElementNames(xml2js(xml) as XMLElement);
+  return scxmlToMachineJSON(json, options);
 }
 
 /** Converts an SCXML string to an XState machine. */
-export function toMachine(xml: string): AnyStateMachine {
-  const machineJSON = toMachineJSON(xml);
+export function toMachine(
+  xml: string,
+  options: SCXMLConversionOptions = {}
+): AnyStateMachine {
+  const machineJSON = toMachineJSON(xml, options);
   return createMachineFromConfig(machineJSON);
 }

--- a/packages/core/src/scxml/index.ts
+++ b/packages/core/src/scxml/index.ts
@@ -1,0 +1,4 @@
+export {
+  createMachineFromSCXML,
+  type SCXMLConversionOptions
+} from './scxml.ts';

--- a/packages/core/src/scxml/runtime.ts
+++ b/packages/core/src/scxml/runtime.ts
@@ -1,0 +1,2599 @@
+import {
+  Action,
+  AnyActorLogic,
+  AnyActorRef,
+  AnyEventObject,
+  AnyStateMachine,
+  EventObject,
+  MachineContext,
+  MetaObject
+} from '../types';
+import { Next_StateNodeConfig } from '../types.v6';
+import { createMachine } from '../createMachine';
+import { parseDelayToMilliseconds } from '../delay';
+
+function delayToMs(delay: string | number): number {
+  const parsedDelay = parseDelayToMilliseconds(delay);
+  if (parsedDelay !== undefined) return parsedDelay;
+  return typeof delay === 'string' ? parseFloat(delay) || 0 : delay;
+}
+
+function normalizeScxmlEventType(eventType: string): string {
+  return /^error(\.|$)/.test(eventType) ? `xstate.${eventType}` : eventType;
+}
+
+function toScxmlEventName(eventType: string): string {
+  return eventType.startsWith('xstate.error.')
+    ? eventType.slice('xstate.'.length)
+    : eventType;
+}
+
+function matchesScxmlEventDescriptor(
+  descriptor: string,
+  event: EventObject
+): boolean {
+  if (descriptor === '*') return true;
+  if (descriptor.endsWith('.*')) {
+    const prefix = descriptor.slice(0, -2);
+    return event.type === prefix || event.type.startsWith(`${prefix}.`);
+  }
+  if (descriptor.startsWith('xstate.done.actor.')) {
+    return (
+      event.type === 'xstate.done.actor' &&
+      (event as any).actorId === descriptor.slice('xstate.done.actor.'.length)
+    );
+  }
+  if (descriptor.startsWith('xstate.done.state.')) {
+    return (
+      event.type === 'xstate.done.state' &&
+      (event as any).stateId === descriptor.slice('xstate.done.state.'.length)
+    );
+  }
+  return event.type === descriptor || event.type.startsWith(`${descriptor}.`);
+}
+
+export interface RaiseJSON {
+  type: '@xstate.raise';
+  event: EventObject;
+  id?: string;
+  delay?: number;
+}
+
+export interface CancelJSON {
+  type: '@xstate.cancel';
+  id: string;
+}
+
+interface LogJSON {
+  type: '@xstate.log';
+  args: any[];
+}
+
+export interface ScxmlLogJSON {
+  type: 'scxml.log';
+  label?: string;
+  expr?: string;
+}
+
+interface EmitJSON {
+  type: '@xstate.emit';
+  event: AnyEventObject;
+}
+
+interface AssignJSON {
+  type: '@xstate.assign';
+  context: MachineContext;
+}
+
+interface ScxmlAssignJSON {
+  type: 'scxml.assign';
+  /** SCXML location attribute - the context property to assign to */
+  location: string;
+  /** SCXML expr attribute - expression to evaluate */
+  expr: string;
+}
+
+export interface ScxmlRaiseJSON {
+  type: 'scxml.raise';
+  /** Event type, or undefined if using eventexpr */
+  event?: string;
+  /** Expression to evaluate for event type */
+  eventexpr?: string;
+  /** Params with expressions to evaluate */
+  params?: Array<{ name: string; expr?: string; location?: string }>;
+  namelist?: string[];
+  id?: string;
+  idlocation?: string;
+  delay?: number;
+  /** Expression for delay */
+  delayexpr?: string;
+  /** Static target (e.g. '#_parent') */
+  target?: string;
+  /** Expression for target */
+  targetexpr?: string;
+  processorType?: string;
+  content?: ScxmlContentJSON;
+}
+
+export interface ScxmlXmlJSON {
+  name: string;
+  attributes?: Record<string, string>;
+  children?: ScxmlXmlJSON[];
+}
+
+export interface ScxmlContentJSON {
+  expr?: string;
+  text?: string;
+  xml?: ScxmlXmlJSON;
+}
+
+interface ScxmlScriptJSON {
+  type: 'scxml.script';
+  /** The script code to execute */
+  code: string;
+  global?: boolean;
+}
+
+export interface ScxmlForeachJSON {
+  type: 'scxml.foreach';
+  array: string;
+  item: string;
+  index?: string;
+  actions: ActionJSON[];
+}
+
+export interface ScxmlCancelJSON {
+  type: 'scxml.cancel';
+  sendidexpr: string;
+}
+
+export interface ScxmlDonedataJSON {
+  params?: Array<{ name: string; expr: string }>;
+  contentExpr?: string;
+  contentText?: string;
+}
+
+export interface ScxmlDataJSON {
+  id: string;
+  expr?: string;
+  content?: string;
+  src?: string;
+  xml?: ScxmlXmlJSON;
+}
+
+/**
+ * Isolated executable-content block. Errors in nested actions stop this block
+ * but do not propagate to the surrounding action list. Used to model SCXML's
+ * separate <onentry>/<onexit> blocks: each is its own block per spec.
+ */
+interface ScxmlBlockJSON {
+  type: 'scxml.block';
+  actions: ActionJSON[];
+}
+
+interface ScxmlDatamodelJSON {
+  type: 'scxml.datamodel';
+  data: ScxmlDataJSON[];
+}
+
+interface ScxmlForwardJSON {
+  type: 'scxml.forward';
+  invokeId: string;
+}
+
+interface ScxmlFinalizeJSON {
+  type: 'scxml.finalize';
+  invokeId: string;
+  actions: ActionJSON[];
+}
+
+interface ScxmlIfJSON {
+  type: 'scxml.if';
+  branches: Array<{
+    cond?: string;
+    actions: ActionJSON[];
+  }>;
+}
+
+type BuiltInActionJSON =
+  | RaiseJSON
+  | CancelJSON
+  | LogJSON
+  | EmitJSON
+  | AssignJSON;
+
+interface CustomActionJSON {
+  type: string;
+  params?: unknown;
+}
+
+export type ActionJSON =
+  | CustomActionJSON
+  | RaiseJSON
+  | CancelJSON
+  | LogJSON
+  | EmitJSON
+  | AssignJSON
+  | ScxmlAssignJSON
+  | ScxmlRaiseJSON
+  | ScxmlScriptJSON
+  | ScxmlIfJSON
+  | ScxmlForeachJSON
+  | ScxmlCancelJSON
+  | ScxmlLogJSON
+  | ScxmlBlockJSON
+  | ScxmlDatamodelJSON
+  | ScxmlForwardJSON
+  | ScxmlFinalizeJSON
+  | ExpressionJSON
+  | CodeJSON;
+
+export interface GuardJSON {
+  type: string;
+  params?: unknown;
+}
+
+interface ExpressionJSON {
+  '@expr': string;
+  '@lang'?: string;
+}
+
+interface CodeJSON {
+  '@code': string;
+  '@lang'?: string;
+}
+
+type ResolvableJSON = ExpressionJSON | CodeJSON;
+
+type ConditionJSON = GuardJSON | ResolvableJSON;
+
+interface ChoiceBranchJSON {
+  when?: ConditionJSON;
+  target: string | string[];
+  context?: MachineContext;
+  input?: unknown;
+  description?: string;
+  reenter?: boolean;
+  meta?: MetaObject;
+}
+
+export interface InvokeJSON {
+  id?: string;
+  registryKey?: string;
+  src: string;
+  input?: unknown;
+  onDone?: TransitionConfigJSON | TransitionConfigJSON[];
+  onError?: TransitionConfigJSON | TransitionConfigJSON[];
+  onSnapshot?: TransitionConfigJSON | TransitionConfigJSON[];
+  timeout?: number | string | ResolvableJSON;
+  onTimeout?: TransitionConfigJSON | TransitionConfigJSON[];
+  /** @internal SCXML invocation input expressions. */
+  _scxmlInput?: {
+    namelist?: string[];
+    params?: Array<{ name: string; expr?: string; location?: string }>;
+  };
+}
+
+export interface TransitionJSON {
+  target?: string | string[];
+  matches?: Record<string, unknown>;
+  context?: MachineContext;
+  actions?: ActionJSON[];
+  guard?: ConditionJSON;
+  description?: string;
+  reenter?: boolean;
+  meta?: MetaObject;
+  input?: unknown;
+  /** @internal Strict semantics for transitions produced by the SCXML converter. */
+  _scxml?: {
+    type?: 'internal' | 'external';
+    eventDescriptors?: string[];
+    finalize?: Array<{ invokeId: string; actions: ActionJSON[] }>;
+  };
+}
+
+type TransitionConfigJSON = TransitionJSON | ResolvableJSON;
+
+export interface StateNodeJSON {
+  id?: string;
+  key?: string;
+  type?: 'atomic' | 'compound' | 'parallel' | 'final' | 'history' | 'choice';
+  initial?: string;
+  states?: Record<string, StateNodeJSON>;
+  on?: Record<string, TransitionConfigJSON | TransitionConfigJSON[]>;
+  onError?: TransitionConfigJSON | TransitionConfigJSON[];
+  after?: Record<string, TransitionConfigJSON | TransitionConfigJSON[]>;
+  always?: TransitionConfigJSON | TransitionConfigJSON[];
+  choice?: ChoiceBranchJSON[] | ResolvableJSON;
+  /**
+   * JSON route config. Unlike the authoring API (a function), the JSON layer
+   * allows an object form whose `guard` may be a named guard reference (string)
+   * resolved against the machine's `guards` sources.
+   */
+  route?:
+    | {
+        description?: string;
+        reenter?: boolean;
+        meta?: MetaObject;
+        guard?: string;
+        input?: Record<string, unknown>;
+      }
+    | ResolvableJSON;
+  invoke?: InvokeJSON | InvokeJSON[];
+  entry?: ActionJSON | ActionJSON[];
+  exit?: ActionJSON | ActionJSON[];
+  meta?: MetaObject;
+  description?: string;
+  tags?: string[];
+  input?: unknown;
+  timeout?: number | string | ResolvableJSON;
+  onTimeout?: TransitionConfigJSON | TransitionConfigJSON[];
+  history?: 'shallow' | 'deep';
+  target?: string | [string, ...string[]];
+  output?: unknown;
+  context?: Record<string, unknown>;
+  _scxmlDonedata?: ScxmlDonedataJSON;
+  /** @internal Initial transition emitted by the SCXML converter. */
+  _scxmlInitial?: {
+    targets: string[];
+    actions?: ActionJSON[];
+  };
+  /** @internal Executable content on an SCXML history default transition. */
+  _scxmlHistoryActions?: ActionJSON[];
+  /** @internal Datamodel declarations initialized on entry. */
+  _scxmlData?: ScxmlDataJSON[];
+}
+export interface ScxmlIR extends StateNodeJSON {
+  '@exprLang'?: string;
+  version?: string;
+  /** @internal All declared SCXML datamodel identifiers. */
+  _scxmlDataIds?: string[];
+  actions?: Record<string, ActionJSON | ActionJSON[]>;
+  guards?: Record<string, { when: ConditionJSON }>;
+  actors?: Record<string, unknown>;
+  delays?: Record<
+    string,
+    number | string | { duration: number | string | ResolvableJSON }
+  >;
+  schemas?: Record<string, unknown>;
+}
+
+type EvaluatorSlot =
+  | 'context'
+  | 'guard'
+  | 'choice'
+  | 'action'
+  | 'actionParams'
+  | 'transition'
+  | 'input'
+  | 'output'
+  | 'delay'
+  | 'transitionContext'
+  | 'unknown';
+
+type EvaluatorKind = 'expr' | 'code';
+
+interface EvaluatorArgs {
+  source: string;
+  kind: EvaluatorKind;
+  slot: EvaluatorSlot;
+  scope: Record<string, unknown>;
+  path: string;
+}
+
+interface MachineSources {
+  actions?: Record<string, (...args: any[]) => unknown>;
+  guards?: Record<string, (...args: any[]) => boolean>;
+  actors?: Record<string, AnyActorLogic>;
+  delays?: Record<string, number | ((...args: any[]) => number)>;
+  evaluators?: Record<string, (args: EvaluatorArgs) => unknown>;
+}
+
+type ProvidedSources = Required<MachineSources>;
+
+function isExpression(value: unknown): value is ExpressionJSON {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as any)['@expr'] === 'string'
+  );
+}
+
+function isCode(value: unknown): value is CodeJSON {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as any)['@code'] === 'string'
+  );
+}
+
+function isResolvable(value: unknown): value is ResolvableJSON {
+  return isExpression(value) || isCode(value);
+}
+
+function isBuiltInActionType(type: string): boolean {
+  return type.startsWith('@xstate.');
+}
+
+function isScxmlActionType(type: string): boolean {
+  return type.startsWith('scxml.');
+}
+
+function toPath(parent: string, key: string | number): string {
+  return typeof key === 'number' ? `${parent}[${key}]` : `${parent}.${key}`;
+}
+
+function extractSerializableDelays(
+  delays: ScxmlIR['delays'] | undefined
+): Record<string, number> {
+  const result: Record<string, number> = {};
+  if (!delays) {
+    return result;
+  }
+  for (const key of Object.keys(delays)) {
+    const value = delays[key];
+    if (typeof value === 'number') {
+      result[key] = value;
+    } else if (
+      value &&
+      typeof value === 'object' &&
+      typeof value.duration === 'number'
+    ) {
+      result[key] = value.duration;
+    }
+  }
+  return result;
+}
+
+function mergeSources(json: ScxmlIR, sources: MachineSources): ProvidedSources {
+  return {
+    actions: sources.actions ?? {},
+    guards: sources.guards ?? {},
+    actors: sources.actors ?? {},
+    delays: {
+      ...extractSerializableDelays(json.delays),
+      ...(sources.delays ?? {})
+    },
+    evaluators: sources.evaluators ?? {}
+  };
+}
+
+interface ExpressionResolver {
+  evaluateResolvable: (
+    value: ResolvableJSON,
+    slot: EvaluatorSlot,
+    scope: Record<string, unknown>,
+    path: string
+  ) => unknown;
+  resolveValue: (
+    value: unknown,
+    slot: EvaluatorSlot,
+    scope: Record<string, unknown>,
+    path: string
+  ) => unknown;
+  makeScope: (
+    x: any,
+    extra?: Record<string, unknown>
+  ) => Record<string, unknown>;
+  getDurationConfig: (value: unknown, path: string) => unknown;
+  assertResolvable: (value: unknown, path: string) => void;
+}
+
+function createExpressionResolver(
+  expressionLanguage: string | undefined,
+  sources: ProvidedSources
+): ExpressionResolver {
+  function getEvaluator(value: ResolvableJSON, path: string) {
+    const lang = value['@lang'] ?? expressionLanguage;
+    if (!lang) {
+      throw new Error(`Missing @exprLang for expression at ${path}`);
+    }
+    const evaluator = sources.evaluators[lang];
+    if (!evaluator) {
+      throw new Error(`Missing evaluator for @lang '${lang}' at ${path}`);
+    }
+    return evaluator;
+  }
+
+  function evaluateResolvable(
+    value: ResolvableJSON,
+    slot: EvaluatorSlot,
+    scope: Record<string, unknown>,
+    path: string
+  ) {
+    const kind = isExpression(value) ? 'expr' : 'code';
+    const source = isExpression(value) ? value['@expr'] : value['@code'];
+    return getEvaluator(
+      value,
+      path
+    )({
+      source,
+      kind,
+      slot,
+      scope,
+      path
+    });
+  }
+
+  function resolveValue(
+    value: unknown,
+    slot: EvaluatorSlot,
+    scope: Record<string, unknown>,
+    path: string
+  ): unknown {
+    if (isResolvable(value)) {
+      return evaluateResolvable(value, slot, scope, path);
+    }
+    if (Array.isArray(value)) {
+      return value.map((item, index) =>
+        resolveValue(item, slot, scope, toPath(path, index))
+      );
+    }
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      result[key] = resolveValue(
+        (value as Record<string, unknown>)[key],
+        slot,
+        scope,
+        toPath(path, key)
+      );
+    }
+    return result;
+  }
+
+  function makeScope(x: any, extra?: Record<string, unknown>) {
+    return {
+      context: x.context,
+      event: x.event,
+      input: x.input,
+      self: x.self,
+      children: x.children,
+      params: x.params,
+      ...extra
+    };
+  }
+
+  function getDurationConfig(value: unknown, path: string) {
+    if (!isResolvable(value)) {
+      return value;
+    }
+    return (args: any) =>
+      delayToMs(
+        resolveValue(value, 'delay', makeScope(args), path) as string | number
+      );
+  }
+
+  function assertResolvable(value: unknown, path: string) {
+    if (isResolvable(value)) {
+      getEvaluator(value, path);
+      return;
+    }
+    if (Array.isArray(value)) {
+      value.forEach((item, index) =>
+        assertResolvable(item, toPath(path, index))
+      );
+      return;
+    }
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+    for (const key of Object.keys(value)) {
+      assertResolvable(
+        (value as Record<string, unknown>)[key],
+        toPath(path, key)
+      );
+    }
+  }
+
+  return {
+    evaluateResolvable,
+    resolveValue,
+    makeScope,
+    getDurationConfig,
+    assertResolvable
+  };
+}
+
+function toActionArray(
+  actions: ActionJSON | ActionJSON[] | undefined
+): ActionJSON[] {
+  return actions === undefined
+    ? []
+    : Array.isArray(actions)
+      ? actions
+      : [actions];
+}
+
+function validateChoiceConfig(choice: StateNodeJSON['choice'], path: string) {
+  if (!Array.isArray(choice)) {
+    return;
+  }
+  choice.forEach((branch, index) => {
+    if (branch.when === undefined && index !== choice.length - 1) {
+      throw new Error(
+        `Choice fallback branch at ${path}[${index}] must be last.`
+      );
+    }
+  });
+}
+
+function assertMachineJSON(
+  json: ScxmlIR,
+  resolvedSources: ProvidedSources,
+  expressionResolver: ExpressionResolver
+) {
+  const { assertResolvable } = expressionResolver;
+
+  function assertCondition(condition: ConditionJSON | undefined, path: string) {
+    if (!condition) {
+      return;
+    }
+    if (isResolvable(condition)) {
+      assertResolvable(condition, path);
+      return;
+    }
+    assertResolvable(condition.params, `${path}.params`);
+    if (json.guards?.[condition.type]) {
+      assertCondition(
+        json.guards[condition.type].when,
+        `$.guards.${condition.type}.when`
+      );
+      return;
+    }
+    if (
+      !resolvedSources.guards[condition.type] &&
+      !['scxml.cond', 'xstate.stateIn', 'xstate.not'].includes(condition.type)
+    ) {
+      throw new Error(`Missing guard source "${condition.type}"`);
+    }
+  }
+
+  function assertAction(
+    action: ActionJSON,
+    path: string,
+    stack: string[] = []
+  ) {
+    if (isResolvable(action)) {
+      assertResolvable(action, path);
+      return;
+    }
+    if (!action || typeof action.type !== 'string') {
+      throw new Error(`Invalid action at ${path}`);
+    }
+    assertResolvable((action as CustomActionJSON).params, `${path}.params`);
+    if (isBuiltInActionType(action.type) || isScxmlActionType(action.type)) {
+      assertResolvable(action, path);
+      return;
+    }
+    const definition = json.actions?.[action.type];
+    if (definition) {
+      if (stack.includes(action.type)) {
+        throw new Error(
+          `Circular action reference: ${stack.concat(action.type).join(' -> ')}`
+        );
+      }
+      const definitions = Array.isArray(definition) ? definition : [definition];
+      definitions.forEach((item, index) =>
+        assertAction(
+          item,
+          `${path}.actions.${action.type}${definitions.length > 1 ? `[${index}]` : ''}`,
+          stack.concat(action.type)
+        )
+      );
+      return;
+    }
+    if (!resolvedSources.actions[action.type]) {
+      throw new Error(`Missing action source "${action.type}"`);
+    }
+  }
+
+  function assertActions(
+    actions: ActionJSON | ActionJSON[] | undefined,
+    path: string
+  ) {
+    toActionArray(actions).forEach((action, index) =>
+      assertAction(action, `${path}[${index}]`)
+    );
+  }
+
+  function assertTransition(
+    transition: TransitionConfigJSON | TransitionConfigJSON[] | undefined,
+    path: string
+  ) {
+    const transitions = Array.isArray(transition)
+      ? transition
+      : transition
+        ? [transition]
+        : [];
+    transitions.forEach((t, index) => {
+      const transitionPath = Array.isArray(transition)
+        ? `${path}[${index}]`
+        : path;
+      if (isResolvable(t)) {
+        assertResolvable(t, transitionPath);
+        return;
+      }
+      assertCondition(t.guard, `${transitionPath}.guard`);
+      assertActions(t.actions, `${transitionPath}.actions`);
+      assertResolvable(t.context, `${transitionPath}.context`);
+      assertResolvable(t.input, `${transitionPath}.input`);
+    });
+  }
+
+  function assertStateNode(node: StateNodeJSON, path: string) {
+    if (
+      (node.type === 'history' || node.history !== undefined) &&
+      !(
+        (typeof node.target === 'string' && node.target.trim().length > 0) ||
+        (Array.isArray(node.target) &&
+          node.target.length > 0 &&
+          node.target.every((target) => target.trim().length > 0))
+      )
+    ) {
+      throw new Error(
+        `History state at ${path} must declare a non-empty target.`
+      );
+    }
+    assertResolvable(node.context, `${path}.context`);
+    assertResolvable(node.input, `${path}.input`);
+    assertResolvable(node.output, `${path}.output`);
+    assertResolvable(node.timeout, `${path}.timeout`);
+    assertActions(node.entry, `${path}.entry`);
+    assertActions(node.exit, `${path}.exit`);
+    if (node.type === 'choice') {
+      if (!node.choice) {
+        throw new Error(`Choice state at ${path} must declare choice.`);
+      }
+      if (Array.isArray(node.choice)) {
+        validateChoiceConfig(node.choice, `${path}.choice`);
+        node.choice.forEach((branch, index) => {
+          assertCondition(branch.when, `${path}.choice[${index}].when`);
+          assertResolvable(branch.context, `${path}.choice[${index}].context`);
+          assertResolvable(branch.input, `${path}.choice[${index}].input`);
+        });
+      } else {
+        assertResolvable(node.choice, `${path}.choice`);
+      }
+    }
+    if (isResolvable(node.route)) {
+      assertResolvable(node.route, `${path}.route`);
+    }
+    if (node.invoke) {
+      const invokes = Array.isArray(node.invoke) ? node.invoke : [node.invoke];
+      invokes.forEach((invoke, index) => {
+        const invokePath = `${path}.invoke${Array.isArray(node.invoke) ? `[${index}]` : ''}`;
+        const extInv = invoke as InvokeJSON & {
+          _nestedScxmlIR?: ScxmlIR;
+        };
+        if (!extInv._nestedScxmlIR && !resolvedSources.actors[invoke.src]) {
+          throw new Error(`Missing actor source "${invoke.src}"`);
+        }
+        assertResolvable(invoke.input, `${invokePath}.input`);
+        assertResolvable(invoke.timeout, `${invokePath}.timeout`);
+        assertTransition(invoke.onDone, `${invokePath}.onDone`);
+        assertTransition(invoke.onError, `${invokePath}.onError`);
+        assertTransition(invoke.onSnapshot, `${invokePath}.onSnapshot`);
+        assertTransition(invoke.onTimeout, `${invokePath}.onTimeout`);
+      });
+    }
+    if (node.on) {
+      for (const descriptor of Object.keys(node.on)) {
+        assertTransition(node.on[descriptor], `${path}.on.${descriptor}`);
+      }
+    }
+    if (node.after) {
+      for (const delay of Object.keys(node.after)) {
+        if (
+          Number.isNaN(Number(delay)) &&
+          parseDelayToMilliseconds(delay) === undefined &&
+          !json.delays?.[delay] &&
+          !resolvedSources.delays[delay]
+        ) {
+          throw new Error(`Missing delay source "${delay}"`);
+        }
+        assertTransition(node.after[delay], `${path}.after.${delay}`);
+      }
+    }
+    assertTransition(node.always, `${path}.always`);
+    assertTransition(node.onError, `${path}.onError`);
+    assertTransition(node.onTimeout, `${path}.onTimeout`);
+    if (node.states) {
+      for (const key of Object.keys(node.states)) {
+        assertStateNode(node.states[key], `${path}.states.${key}`);
+      }
+    }
+  }
+
+  if (json.actions) {
+    for (const key of Object.keys(json.actions)) {
+      const actions = Array.isArray(json.actions[key])
+        ? json.actions[key]
+        : [json.actions[key]];
+      actions.forEach((action, index) =>
+        assertAction(
+          action,
+          `$.actions.${key}${actions.length > 1 ? `[${index}]` : ''}`,
+          [key]
+        )
+      );
+    }
+  }
+  if (json.guards) {
+    for (const key of Object.keys(json.guards)) {
+      assertCondition(json.guards[key].when, `$.guards.${key}.when`);
+    }
+  }
+  if (json.delays) {
+    for (const key of Object.keys(json.delays)) {
+      const delay = json.delays[key];
+      assertResolvable(
+        delay && typeof delay === 'object' && 'duration' in delay
+          ? delay.duration
+          : delay,
+        `$.delays.${key}`
+      );
+    }
+  }
+  assertStateNode(json, '$');
+}
+
+const SCXML_SYSTEM_VARIABLES = new Set([
+  '_sessionid',
+  '_name',
+  '_ioprocessors',
+  '_event',
+  '_xstateScxmlInputKeys'
+]);
+const scxmlScriptEnvironments = new WeakMap<
+  AnyActorRef,
+  { declarations: string[] }
+>();
+const scxmlMachineNames = new WeakMap<AnyActorRef, string>();
+const scxmlIoProcessors = new WeakMap<AnyActorRef, object>();
+const scxmlEvents = new WeakMap<object, object>();
+const scxmlEnteringStates = new WeakMap<AnyActorRef, string[]>();
+
+function getScxmlIoProcessors(self: AnyActorRef, sessionId: string): object {
+  let processors = scxmlIoProcessors.get(self);
+  if (!processors) {
+    const processor = { location: `#_scxml_${sessionId}` };
+    processors = {
+      scxml: processor,
+      'http://www.w3.org/TR/scxml/#SCXMLEventProcessor': processor
+    };
+    scxmlIoProcessors.set(self, processors);
+  }
+  return processors;
+}
+
+function getFunctionDeclarations(code: string): string[] {
+  const declarations: string[] = [];
+  const pattern = /\bfunction\s+[$_a-zA-Z][$_a-zA-Z0-9]*\s*\([^)]*\)\s*\{/g;
+  for (const match of code.matchAll(pattern)) {
+    let depth = 1;
+    let index = match.index! + match[0].length;
+    while (index < code.length && depth) {
+      if (code[index] === '{') depth++;
+      if (code[index] === '}') depth--;
+      index++;
+    }
+    declarations.push(code.slice(match.index, index));
+  }
+  return declarations;
+}
+
+/** Evaluates an SCXML expression with context variables available via `with`. */
+function evaluateExpr(
+  context: MachineContext,
+  expr: string,
+  event: AnyEventObject | null,
+  self?: AnyActorRef
+): unknown {
+  const normalizedExpr = expr.replace(/;+\s*$/, '');
+  const sessionId = (self as any)?.sessionId ?? 'session_scxml';
+  const machineName = self
+    ? (scxmlMachineNames.get(self) ?? '(machine)')
+    : '(machine)';
+  const dataContext = Object.fromEntries(
+    Object.entries(context).filter(([key]) => !SCXML_SYSTEM_VARIABLES.has(key))
+  );
+  const fnBody = `
+${self ? (scxmlScriptEnvironments.get(self)?.declarations.join('\n') ?? '') : ''}
+with (context) {
+  return (${normalizedExpr});
+}
+  `.trim();
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const fn = new Function(
+    'context',
+    '_event',
+    '_sessionid',
+    '_name',
+    '_ioprocessors',
+    'In',
+    fnBody
+  );
+  const In = (stateId: string) => {
+    if (!self) return false;
+    const sanitized = stateId.replace(/\./g, '$');
+    if (
+      scxmlEnteringStates
+        .get(self)
+        ?.some((id) => id === sanitized || id.endsWith('.' + sanitized))
+    ) {
+      return true;
+    }
+    try {
+      const snap = (self as any).getSnapshot?.();
+      if (snap?.nodes) {
+        return snap.nodes.some(
+          (node: any) =>
+            node.id === sanitized || node.id.endsWith('.' + sanitized)
+        );
+      }
+    } catch {
+      // ignore
+    }
+    return false;
+  };
+  const SCXML_ORIGIN = `#_scxml_${sessionId}`;
+  const SCXML_ORIGIN_TYPE = 'http://www.w3.org/TR/scxml/#SCXMLEventProcessor';
+  const isExternal = event && (event as any)._scxmlExternal;
+  const isInitEvent = event && event.type === '@xstate.init';
+  // Per SCXML spec, _event has these fields. Fields that don't apply to a
+  // particular event are present with value `undefined` (so `'name' in _event`
+  // is true but `typeof _event.name === 'undefined'` for unset fields).
+  // For xstate.done.* events, _event.data is the `output` payload (matches
+  // SCXML's done event semantics where data is the donedata).
+  const isDoneEvent =
+    event &&
+    typeof event.type === 'string' &&
+    event.type.startsWith('xstate.done.');
+  const explicitType =
+    event && ((event as any)._scxmlEventType as string | undefined);
+  let scxmlEvent: object | undefined;
+  if (event && !isInitEvent) {
+    scxmlEvent = scxmlEvents.get(event);
+    if (!scxmlEvent) {
+      scxmlEvent = {
+        name:
+          ((event as any)._scxmlEventName as string | undefined) ??
+          toScxmlEventName(event.type),
+        type: explicitType || (isExternal ? 'external' : 'internal'),
+        sendid: (event as any)._scxmlSendId as string | undefined,
+        origin: isExternal ? SCXML_ORIGIN : undefined,
+        origintype: isExternal ? SCXML_ORIGIN_TYPE : undefined,
+        invokeid:
+          ((event as any)._scxmlInvokeId as string | undefined) ??
+          ((event as any).actorId as string | undefined),
+        data: isDoneEvent
+          ? (event as any).output
+          : (event as any)._scxmlEventData !== undefined
+            ? (event as any)._scxmlEventData
+            : event
+      };
+      scxmlEvents.set(event, scxmlEvent);
+    }
+  }
+  const result = fn(
+    dataContext,
+    scxmlEvent,
+    sessionId,
+    machineName,
+    self
+      ? getScxmlIoProcessors(self, sessionId)
+      : { scxml: { location: `#_scxml_${sessionId}` } },
+    In
+  );
+
+  return result;
+}
+
+/** Executes an SCXML script block and returns updated context values. */
+function executeScript(
+  context: MachineContext,
+  code: string,
+  self: AnyActorRef,
+  global: boolean
+): Record<string, unknown> {
+  // Create a proxy to track which properties are modified
+  const updates: Record<string, unknown> = {};
+  const contextKeys = Object.keys(context);
+  const mutableContextKeys = contextKeys.filter(
+    (key) => !SCXML_SYSTEM_VARIABLES.has(key)
+  );
+
+  // Build variable declarations and reassignment capture
+  const varDeclarations = mutableContextKeys
+    .map((k) => `var ${k} = context.${k};`)
+    .join('\n');
+  const captureUpdates = mutableContextKeys
+    .map((k) => `updates.${k} = ${k};`)
+    .join('\n');
+  const codeWithoutComments = code.replace(/\/\/.*$/gm, '');
+  const declarations = getFunctionDeclarations(code);
+  const codeWithoutFunctions = declarations.reduce(
+    (source, declaration) => source.replace(declaration, ''),
+    codeWithoutComments
+  );
+  const declaredVariables = global
+    ? [
+        ...codeWithoutFunctions.matchAll(/\bvar\s+([$_a-zA-Z][$_a-zA-Z0-9]*)/g)
+      ].map((match) => match[1])
+    : [];
+  const captureVariables = declaredVariables
+    .filter(
+      (name) => !contextKeys.includes(name) && !SCXML_SYSTEM_VARIABLES.has(name)
+    )
+    .map((name) => `updates.${name} = ${name};`)
+    .join('\n');
+  const environment = scxmlScriptEnvironments.get(self) ?? {
+    declarations: []
+  };
+  scxmlScriptEnvironments.set(self, environment);
+  for (const declaration of declarations) {
+    if (!environment.declarations.includes(declaration)) {
+      environment.declarations.push(declaration);
+    }
+  }
+
+  const fnBody = `
+${varDeclarations}
+${environment.declarations.join('\n')}
+${code}
+${captureUpdates}
+${captureVariables}
+return updates;
+  `;
+  const sessionId = (self as any).sessionId;
+  const machineName = scxmlMachineNames.get(self) ?? '(machine)';
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval
+  const fn = new Function(
+    'context',
+    'updates',
+    '_sessionid',
+    '_name',
+    '_ioprocessors',
+    fnBody
+  );
+  return fn(
+    context,
+    updates,
+    sessionId,
+    machineName,
+    getScxmlIoProcessors(self, sessionId)
+  );
+}
+
+function createScxmlDomElement(element: ScxmlXmlJSON): any {
+  const children = (element.children ?? []).map(createScxmlDomElement);
+  return {
+    tagName: element.name,
+    getAttribute: (name: string) => element.attributes?.[name] ?? null,
+    getElementsByTagName: (name: string): any[] => [
+      ...(element.name === name ? [createScxmlDomElement(element)] : []),
+      ...children.flatMap((child: any) => child.getElementsByTagName(name))
+    ]
+  };
+}
+
+export function createMachineFromSCXMLConfig(
+  json: ScxmlIR,
+  sources: MachineSources = {}
+): AnyStateMachine {
+  const resolvedSources = mergeSources(json, sources);
+  const expressionResolver = createExpressionResolver(
+    json['@exprLang'],
+    resolvedSources
+  );
+  const { evaluateResolvable, resolveValue, makeScope, getDurationConfig } =
+    expressionResolver;
+  const sendCounters = new WeakMap<AnyActorRef, number>();
+
+  type ResolvedCondition = ((args: any) => boolean) | undefined;
+
+  function resolveCondition(
+    condition: ConditionJSON | undefined,
+    slot: 'guard' | 'choice',
+    path: string
+  ): ResolvedCondition {
+    if (!condition) {
+      return undefined;
+    }
+    if (isResolvable(condition)) {
+      return (args: any) =>
+        !!evaluateResolvable(condition, slot, makeScope(args), path);
+    }
+    return (args: any) => {
+      const params = resolveValue(
+        condition.params,
+        slot,
+        makeScope(args),
+        `${path}.params`
+      );
+      const declarativeGuard = json.guards?.[condition.type];
+      if (declarativeGuard) {
+        const guard = resolveCondition(
+          declarativeGuard.when,
+          'guard',
+          `$.guards.${condition.type}.when`
+        );
+        return !!guard?.({ ...args, params });
+      }
+      const guardImpl = args.guards?.[condition.type];
+      if (!guardImpl) {
+        throw new Error(
+          getMissingGuardMessage(condition.type, args.guards ?? {})
+        );
+      }
+      return guardImpl(args, params);
+    };
+  }
+
+  function makeChoiceConfig(choice: StateNodeJSON['choice'], path: string) {
+    if (!choice) {
+      return undefined;
+    }
+    if (isResolvable(choice)) {
+      return (args: any) =>
+        evaluateResolvable(choice, 'choice', makeScope(args), path);
+    }
+    validateChoiceConfig(choice, path);
+    return (args: any) => {
+      for (let index = 0; index < choice.length; index++) {
+        const branch = choice[index];
+        const guard = resolveCondition(
+          branch.when,
+          'choice',
+          `${path}[${index}].when`
+        );
+        if (!guard || guard(args)) {
+          return {
+            target: branch.target,
+            context: branch.context
+              ? resolveValue(
+                  branch.context,
+                  'transitionContext',
+                  makeScope(args),
+                  `${path}[${index}].context`
+                )
+              : undefined,
+            input:
+              branch.input !== undefined
+                ? resolveValue(
+                    branch.input,
+                    'input',
+                    makeScope(args),
+                    `${path}[${index}].input`
+                  )
+                : undefined,
+            description: branch.description,
+            reenter: branch.reenter,
+            meta: branch.meta
+          };
+        }
+      }
+      throw new Error(`Choice state at ${path} did not match any branch.`);
+    };
+  }
+
+  // Pending transition actions: set by .to functions, consumed by entry functions.
+  // This bridges SCXML's exit→transition→entry action ordering with XState's
+  // .to function receiving pre-exit context.
+  // Map keyed by target state ID so parallel transitions don't overwrite each other.
+  const pendingTransitionActionsMap: Record<string, ActionJSON[]> = {};
+
+  // Ordered queue of ALL transition actions (targeted + targetless) for parallel
+  // context sharing. In SCXML, all transition actions execute sequentially in
+  // document order with a shared evolving data model.
+  const allTransitionActions: ActionJSON[][] = [];
+  // Pre-transition context saved when a targetless .to executes. Used by entry
+  // functions to re-execute all transition actions from scratch when parallel
+  // targetless transitions coexist with targeted transitions.
+  let contextBeforeTargetless: MachineContext | null = null;
+  let targetlessEvent: AnyEventObject | null = null;
+  // Platform errors collected during transition selection (e.g., failing
+  // <transition cond>). Drained by the next state's entry into the internal
+  // event queue so they're processed before any external events.
+  const pendingPlatformErrors: Array<Record<string, unknown>> = [];
+  const scxmlDonedataValues = new WeakMap<AnyActorRef, Map<string, unknown>>();
+
+  function evaluateDonedataValue(
+    donedata: ScxmlDonedataJSON,
+    context: MachineContext,
+    event: AnyEventObject,
+    self: AnyActorRef
+  ): unknown {
+    if (donedata.params?.length) {
+      const out: Record<string, unknown> = {};
+      for (const param of donedata.params) {
+        out[param.name] = evaluateExpr(context, param.expr, event, self);
+      }
+      return out;
+    }
+    if (donedata.contentExpr !== undefined) {
+      return evaluateExpr(context, donedata.contentExpr, event, self);
+    }
+    if (donedata.contentText !== undefined) {
+      try {
+        return evaluateExpr(context, donedata.contentText, event, self);
+      } catch {
+        return donedata.contentText;
+      }
+    }
+    return undefined;
+  }
+
+  function getMissingGuardMessage(type: string, guards: Record<string, any>) {
+    return `Guard '${type}' is not implemented in machine '${json.id ?? '(machine)'}'. Available guards: ${
+      Object.keys(guards)
+        .map((key) => `'${key}'`)
+        .join(', ') || '(none)'
+    }.`;
+  }
+
+  function resolveRouteConfig(route: StateNodeJSON['route'], path: string) {
+    if (!route || typeof route === 'function') {
+      return route;
+    }
+    if (isResolvable(route)) {
+      return (args: any) =>
+        evaluateResolvable(route, 'transition', makeScope(args), path);
+    }
+    const { guard, ...routeConfig } = route;
+    if (!guard) {
+      return routeConfig;
+    }
+    const resolvedGuard = resolveCondition({ type: guard }, 'guard', path);
+    return (args: any) => (resolvedGuard!(args) ? routeConfig : undefined);
+  }
+
+  function iterNode(
+    node: StateNodeJSON,
+    nodeKey?: string,
+    ancestorIds: string[] = []
+  ) {
+    const originalEntryActions: ActionJSON[] = [
+      ...(node._scxmlData?.length
+        ? [{ type: 'scxml.datamodel' as const, data: node._scxmlData }]
+        : []),
+      ...toActionArray(node.entry)
+    ];
+    const stateId = node.id || nodeKey;
+
+    // Wrap entry to first execute any pending transition actions, then normal entry.
+    // This ensures SCXML execution order: exit → transition_actions → entry_actions
+    // because pending transition actions are set by .to (before exit) but executed
+    // in entry (after exit), thus seeing post-exit context.
+    const entryFn: Action<any, any, any, any, any, any, any> | undefined = (
+      x,
+      enq
+    ) => {
+      scxmlMachineNames.set(x.self, json.id ?? '(machine)');
+      if (stateId) {
+        scxmlEnteringStates.set(x.self, [...ancestorIds, stateId]);
+      }
+      // Drain any platform errors queued during transition selection (e.g.,
+      // failing <transition cond="..."> evaluations). These must be raised
+      // internally so they're processed before subsequent external events.
+      while (pendingPlatformErrors.length) {
+        const err = pendingPlatformErrors.shift()!;
+        enq.raise({
+          type: 'xstate.error.execution',
+          error: err,
+          _scxmlEventType: 'platform',
+          _scxmlEventName: 'error.execution',
+          _scxmlEventData: err
+        } as AnyEventObject);
+      }
+
+      let context: MachineContext | undefined;
+
+      // If targetless transitions were interleaved with targeted transitions
+      // (parallel state), re-execute ALL transition actions from the original
+      // pre-transition context. This overrides any .to-produced context with
+      // the correct SCXML document-order sequential execution.
+      // Only trigger when BOTH targeted (pending in map) and targetless fired
+      // in the same microstep — prevents stale data from previous events.
+      if (
+        contextBeforeTargetless &&
+        targetlessEvent === x.event &&
+        allTransitionActions.length > 0 &&
+        Object.keys(pendingTransitionActionsMap).length > 0
+      ) {
+        let ctx = contextBeforeTargetless;
+        for (const actions of allTransitionActions) {
+          const mergedX = { ...x, context: ctx };
+          const result = executeActions(actions, mergedX, enq);
+          if (result.context) {
+            ctx = result.context;
+          }
+        }
+        allTransitionActions.length = 0;
+        contextBeforeTargetless = null;
+        targetlessEvent = null;
+        // Clear per-target map since we re-processed everything
+        for (const key of Object.keys(pendingTransitionActionsMap)) {
+          delete pendingTransitionActionsMap[key];
+        }
+        context = ctx;
+      } else {
+        // Normal path: consume pending transition actions for THIS state.
+        // In parallel states, each target gets its own pending actions.
+        const transActions = stateId
+          ? pendingTransitionActionsMap[stateId]
+          : undefined;
+        if (transActions) {
+          delete pendingTransitionActionsMap[stateId!];
+          const result = executeActions(transActions, x, enq);
+          if (result.context) {
+            context = result.context;
+          }
+        }
+        // Clear stale targetless data from previous microsteps
+        contextBeforeTargetless = null;
+        targetlessEvent = null;
+        allTransitionActions.length = 0;
+      }
+
+      // Execute normal entry actions
+      if (originalEntryActions.length) {
+        const mergedX = context ? { ...x, context } : x;
+        const result = executeActions(originalEntryActions, mergedX, enq);
+        if (result.context) {
+          context = result.context;
+        }
+      }
+
+      if (node._scxmlDonedata && stateId) {
+        let values = scxmlDonedataValues.get(x.self);
+        if (!values) {
+          values = new Map();
+          scxmlDonedataValues.set(x.self, values);
+        }
+        try {
+          values.set(
+            stateId,
+            evaluateDonedataValue(
+              node._scxmlDonedata,
+              context ?? x.context,
+              x.event,
+              x.self
+            )
+          );
+        } catch (err) {
+          values.set(stateId, undefined);
+          raiseErrorExecution(
+            { enq, self: x.self, errored: false },
+            'donedata',
+            err
+          );
+        }
+      }
+
+      scxmlEnteringStates.delete(x.self);
+      return { context };
+    };
+
+    const nodeConfig: any = {
+      id: node.id,
+      initial: node._scxmlInitial
+        ? {
+            target: node._scxmlInitial.targets,
+            to: node._scxmlInitial.actions
+              ? (x: any, enq: any) => ({
+                  ...executeActions(node._scxmlInitial!.actions!, x, enq),
+                  target: node._scxmlInitial!.targets
+                })
+              : undefined
+          }
+        : node.initial,
+      type: node.type,
+      history: node.history,
+      target: node.target,
+      _historyDefaultTransition: node._scxmlHistoryActions
+        ? (x: any, enq: any) => ({
+            ...executeActions(node._scxmlHistoryActions!, x, enq),
+            target: node.target
+          })
+        : undefined,
+      description: node.description,
+      tags: node.tags,
+      input: node.input,
+      timeout: getDurationConfig(node.timeout, `$.states.${nodeKey}.timeout`),
+      states: node.states
+        ? Object.entries(node.states).reduce(
+            (acc, [key, value]) => {
+              acc[key] = iterNode(
+                value,
+                key,
+                stateId ? [...ancestorIds, stateId] : ancestorIds
+              );
+              return acc;
+            },
+            {} as Record<
+              string,
+              Next_StateNodeConfig<
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any,
+                any
+              >
+            >
+          )
+        : undefined,
+      on: node.on
+        ? Object.entries(node.on).reduce(
+            (acc, [key, value]) => {
+              acc[key] = getTransitionConfig(value);
+              return acc;
+            },
+            {} as Record<string, any>
+          )
+        : undefined,
+      always: node.always ? getTransitionConfig(node.always) : undefined,
+      onError: node.onError ? getTransitionConfig(node.onError) : undefined,
+      choice: makeChoiceConfig(node.choice, `$.states.${nodeKey}.choice`),
+      route: resolveRouteConfig(node.route, `$.states.${nodeKey}.route`),
+      after: node.after
+        ? Object.entries(node.after).reduce(
+            (acc, [key, value]) => {
+              acc[key] = getTransitionConfig(value);
+              return acc;
+            },
+            {} as Record<string, any>
+          )
+        : undefined,
+      onTimeout: node.onTimeout
+        ? getTransitionConfig(node.onTimeout)
+        : undefined,
+      entry: node.type === 'choice' ? undefined : (entryFn as any),
+      exit: node.exit
+        ? (iterActions(toActionArray(node.exit)) as any)
+        : undefined,
+      invoke: node.invoke ? iterInvokeConfigs(node.invoke) : undefined,
+      meta: node.meta,
+      output: node._scxmlDonedata
+        ? makeDonedataOutput(stateId!)
+        : isResolvable(node.output)
+          ? ({ context, event, self }: any) =>
+              evaluateResolvable(
+                node.output as ResolvableJSON,
+                'output',
+                { context, event, self },
+                `$.states.${nodeKey}.output`
+              )
+          : node.output
+    };
+
+    return nodeConfig;
+  }
+
+  function makeDonedataOutput(stateId: string) {
+    return ({ self }: any) => scxmlDonedataValues.get(self)?.get(stateId);
+  }
+
+  function iterInvokeConfigs(invokes: InvokeJSON | InvokeJSON[]): any {
+    const invokeArray = Array.isArray(invokes) ? invokes : [invokes];
+    return invokeArray.map((inv) => {
+      const extInv = inv as InvokeJSON & { _nestedScxmlIR?: ScxmlIR };
+      // Create child machine from nested SCXML JSON
+      let src: any;
+      if (extInv._nestedScxmlIR) {
+        src = createMachineFromSCXMLConfig(
+          extInv._nestedScxmlIR,
+          resolvedSources
+        );
+      } else {
+        src = resolvedSources.actors[inv.src] ?? inv.src;
+      }
+      return {
+        src,
+        id: inv.id,
+        registryKey: inv.registryKey,
+        input: inv._scxmlInput
+          ? ({ context, event, self }: any) => {
+              const input: Record<string, unknown> = {};
+              for (const name of inv._scxmlInput!.namelist ?? []) {
+                if (!(name in context)) {
+                  throw new ReferenceError(`${name} is not defined`);
+                }
+                input[name] = context[name];
+              }
+              for (const param of inv._scxmlInput!.params ?? []) {
+                input[param.name] = param.expr
+                  ? evaluateExpr(context, param.expr, event, self)
+                  : param.location
+                    ? evaluateExpr(context, param.location, event, self)
+                    : undefined;
+              }
+              return input;
+            }
+          : inv.input !== undefined
+            ? (args: any) =>
+                resolveValue(
+                  inv.input,
+                  'input',
+                  makeScope(args),
+                  '$.invoke.input'
+                )
+            : undefined,
+        onDone: inv.onDone ? getTransitionConfig(inv.onDone) : undefined,
+        onError: inv.onError ? getTransitionConfig(inv.onError) : undefined,
+        onSnapshot: inv.onSnapshot
+          ? getTransitionConfig(inv.onSnapshot)
+          : undefined,
+        timeout: getDurationConfig(inv.timeout, '$.invoke.timeout'),
+        onTimeout: inv.onTimeout
+          ? getTransitionConfig(inv.onTimeout)
+          : undefined
+      };
+    });
+  }
+
+  /**
+   * Raise an SCXML error.execution platform event onto the internal queue. Per
+   * spec, error.execution is type='platform' and _event.data contains error
+   * info. The surrounding block of executable content stops.
+   */
+  function raiseErrorExecution(
+    state: ExecState,
+    tagname: string,
+    err: unknown,
+    sendId?: string
+  ) {
+    const message =
+      err instanceof Error
+        ? err.message
+        : typeof err === 'string'
+          ? err
+          : 'unknown error';
+    const errorEvent = {
+      type: 'xstate.error.execution',
+      error: {
+        tagname,
+        message,
+        line: 0,
+        column: 0,
+        reason: message
+      },
+      _scxmlEventType: 'platform',
+      _scxmlEventName: 'error.execution',
+      ...(sendId ? { _scxmlSendId: sendId } : {}),
+      _scxmlEventData: {
+        tagname,
+        message,
+        line: 0,
+        column: 0,
+        reason: message
+      }
+    } as AnyEventObject;
+    state.enq.raise(errorEvent);
+    state.errored = true;
+  }
+
+  interface ExecState {
+    enq: any;
+    self: AnyActorRef;
+    errored: boolean;
+  }
+
+  function executeActionDefinition(
+    action: CustomActionJSON,
+    x: any,
+    enq: any,
+    params: unknown,
+    parentState: ExecState,
+    stack: string[]
+  ): { context: MachineContext | undefined; errored: boolean } {
+    const definition = json.actions?.[action.type];
+    if (!definition) {
+      enq(x.actions[action.type], params);
+      return { context: undefined, errored: parentState.errored };
+    }
+    if (stack.includes(action.type)) {
+      raiseErrorExecution(
+        parentState,
+        'action',
+        new Error(
+          `Circular action reference: ${stack.concat(action.type).join(' -> ')}`
+        )
+      );
+      return { context: undefined, errored: true };
+    }
+    const definitions = Array.isArray(definition) ? definition : [definition];
+    return executeActions(
+      definitions,
+      { ...x, params },
+      enq,
+      parentState,
+      stack.concat(action.type)
+    );
+  }
+
+  /** Execute an array of SCXML action JSON descriptors with context and enqueue. */
+  function executeActions(
+    actions: ActionJSON[],
+    x: any,
+    enq: any,
+    parentState?: ExecState,
+    stack: string[] = []
+  ): { context: MachineContext | undefined; errored: boolean } {
+    const state: ExecState = parentState ?? {
+      enq,
+      self: x.self,
+      errored: false
+    };
+    let context: MachineContext | undefined;
+    for (const action of actions) {
+      if (state.errored) break;
+      if (isResolvable(action)) {
+        const result = evaluateResolvable(
+          action,
+          'action',
+          makeScope(x, { params: x.params, enq }),
+          '$.actions'
+        );
+        if (
+          result &&
+          typeof result === 'object' &&
+          'context' in result &&
+          (result as { context?: MachineContext }).context
+        ) {
+          context ??= {};
+          Object.assign(
+            context,
+            (result as { context: MachineContext }).context
+          );
+        }
+      } else if (isBuiltInActionJSON(action)) {
+        switch (action.type) {
+          case '@xstate.raise': {
+            // Tag as external if it has a delay (from <send>, not <raise>).
+            // Attach _scxmlSendId so _event.sendid can be read in expressions.
+            const isExternal = action.delay !== undefined;
+            const resolvedEvent = resolveValue(
+              action.event,
+              'actionParams',
+              makeScope(x, { params: x.params }),
+              '$.actions.event'
+            ) as EventObject;
+            const event =
+              isExternal || action.id !== undefined
+                ? {
+                    ...resolvedEvent,
+                    ...(isExternal ? { _scxmlExternal: true } : {}),
+                    ...(action.id !== undefined
+                      ? { _scxmlSendId: action.id }
+                      : {})
+                  }
+                : resolvedEvent;
+            enq.raise(event, {
+              id: action.id,
+              delay: action.delay
+            });
+            break;
+          }
+          case '@xstate.cancel':
+            enq.cancel(action.id);
+            break;
+          case '@xstate.log':
+            enq.log(...action.args);
+            break;
+          case '@xstate.emit':
+            enq.emit(
+              resolveValue(
+                action.event,
+                'actionParams',
+                makeScope(x, { params: x.params }),
+                '$.actions.event'
+              )
+            );
+            break;
+          case '@xstate.assign':
+            context ??= {};
+            Object.assign(
+              context,
+              resolveValue(
+                action.context,
+                'transitionContext',
+                makeScope(x, { params: x.params }),
+                '$.actions.context'
+              )
+            );
+            break;
+          default:
+            throw new Error(`Unknown built-in action: ${(action as any).type}`);
+        }
+      } else if (action.type === 'scxml.finalize') {
+        const finalize = action as ScxmlFinalizeJSON;
+        const invokeId =
+          (x.event as any)._scxmlInvokeId ?? (x.event as any).actorId;
+        if (invokeId === finalize.invokeId) {
+          const result = executeActions(
+            finalize.actions,
+            { ...x, context: { ...x.context, ...context } },
+            enq,
+            state
+          );
+          if (result.context) {
+            context = result.context;
+          }
+        }
+      } else if (action.type === 'scxml.forward') {
+        const child = x.children?.[(action as ScxmlForwardJSON).invokeId];
+        if (child) {
+          enq.sendTo(child, {
+            ...x.event,
+            _scxmlExternal: true
+          });
+        }
+      } else if (action.type === 'scxml.log') {
+        const scxmlAction = action as ScxmlLogJSON;
+        try {
+          const value = scxmlAction.expr
+            ? evaluateExpr(
+                { ...x.context, ...context },
+                scxmlAction.expr,
+                x.event,
+                x.self
+              )
+            : undefined;
+          enq.log(
+            ...(scxmlAction.label ? [scxmlAction.label, value] : [value])
+          );
+        } catch (err) {
+          raiseErrorExecution(state, 'log', err);
+        }
+      } else if (action.type === 'scxml.assign') {
+        const scxmlAction = action as ScxmlAssignJSON;
+        const mergedContext = { ...x.context, ...context };
+        let value: unknown;
+        try {
+          value = evaluateExpr(
+            mergedContext,
+            scxmlAction.expr,
+            x.event,
+            x.self
+          );
+        } catch (err) {
+          raiseErrorExecution(state, 'assign', err);
+          continue;
+        }
+        if (SCXML_SYSTEM_VARIABLES.has(scxmlAction.location.split('.')[0])) {
+          raiseErrorExecution(
+            state,
+            'assign',
+            new Error(
+              `Cannot assign to SCXML system variable: ${scxmlAction.location}`
+            )
+          );
+          continue;
+        }
+        if (scxmlAction.location.includes('.')) {
+          const path = scxmlAction.location.split('.');
+          const root = path.shift()!;
+          let target = mergedContext[root];
+          if (!target || typeof target !== 'object') {
+            raiseErrorExecution(
+              state,
+              'assign',
+              new Error(`Invalid assign location: ${scxmlAction.location}`)
+            );
+            continue;
+          }
+          const clonedRoot = Array.isArray(target)
+            ? [...target]
+            : { ...target };
+          target = clonedRoot;
+          for (const segment of path.slice(0, -1)) {
+            const child = (target as Record<string, unknown>)[segment];
+            if (!child || typeof child !== 'object') {
+              raiseErrorExecution(
+                state,
+                'assign',
+                new Error(`Invalid assign location: ${scxmlAction.location}`)
+              );
+              break;
+            }
+            const clonedChild = Array.isArray(child)
+              ? [...child]
+              : { ...child };
+            (target as Record<string, unknown>)[segment] = clonedChild;
+            target = clonedChild;
+          }
+          if (state.errored) continue;
+          (target as Record<string, unknown>)[path.at(-1)!] = value;
+          context ??= {};
+          context[root] = clonedRoot;
+          continue;
+        }
+        context ??= {};
+        context[scxmlAction.location] = value;
+      } else if (action.type === 'scxml.datamodel') {
+        const scxmlAction = action as ScxmlDatamodelJSON;
+        context ??= {};
+        for (const data of scxmlAction.data) {
+          if (
+            Array.isArray(x.context._xstateScxmlInputKeys) &&
+            x.context._xstateScxmlInputKeys.includes(data.id)
+          ) {
+            continue;
+          }
+          if (data.src) {
+            raiseErrorExecution(
+              state,
+              'data',
+              new Error(`Unresolved data resource: ${data.src}`)
+            );
+            break;
+          }
+          if (data.expr !== undefined) {
+            try {
+              context[data.id] = evaluateExpr(
+                { ...x.context, ...context },
+                data.expr,
+                x.event,
+                x.self
+              );
+            } catch (err) {
+              raiseErrorExecution(state, 'data', err);
+              break;
+            }
+          } else if (data.content !== undefined) {
+            try {
+              context[data.id] = evaluateExpr(
+                { ...x.context, ...context },
+                data.content,
+                x.event,
+                x.self
+              );
+            } catch {
+              context[data.id] = data.content.replace(/\s+/g, ' ').trim();
+            }
+          } else if (data.xml) {
+            context[data.id] = createScxmlDomElement(data.xml);
+          } else {
+            if (x.context[data.id] === undefined) {
+              context[data.id] = undefined;
+            }
+          }
+        }
+      } else if (action.type === 'scxml.raise') {
+        const scxmlAction = action as ScxmlRaiseJSON;
+        const mergedContext = { ...x.context, ...context };
+
+        let eventType: string;
+        let eventData: Record<string, unknown>;
+        let target: string | undefined;
+        let delay: number | undefined;
+        try {
+          if (
+            scxmlAction.processorType &&
+            ![
+              'scxml',
+              'http://www.w3.org/TR/scxml/#SCXMLEventProcessor'
+            ].includes(scxmlAction.processorType)
+          ) {
+            throw new Error(
+              `Unsupported send type: ${scxmlAction.processorType}`
+            );
+          }
+          eventType = scxmlAction.eventexpr
+            ? (evaluateExpr(
+                mergedContext,
+                scxmlAction.eventexpr,
+                x.event,
+                x.self
+              ) as string)
+            : scxmlAction.event || 'unknown';
+          eventType = normalizeScxmlEventType(eventType);
+
+          eventData = {
+            type: eventType,
+            _scxmlEventName: toScxmlEventName(eventType)
+          };
+          const payload: Record<string, unknown> = {};
+          if (scxmlAction.namelist) {
+            for (const name of scxmlAction.namelist) {
+              payload[name] = evaluateExpr(
+                mergedContext,
+                name,
+                x.event,
+                x.self
+              );
+            }
+          }
+          if (scxmlAction.params) {
+            for (const param of scxmlAction.params) {
+              payload[param.name] = evaluateExpr(
+                mergedContext,
+                param.expr ?? param.location!,
+                x.event,
+                x.self
+              );
+            }
+          }
+          if (scxmlAction.content) {
+            const content = scxmlAction.content;
+            let contentValue: unknown;
+            if (content.expr !== undefined) {
+              contentValue = evaluateExpr(
+                mergedContext,
+                content.expr,
+                x.event,
+                x.self
+              );
+            } else if (content.xml) {
+              contentValue = createScxmlDomElement(content.xml);
+            } else {
+              const text = content.text?.replace(/\s+/g, ' ').trim() ?? '';
+              try {
+                contentValue = evaluateExpr(
+                  mergedContext,
+                  text,
+                  x.event,
+                  x.self
+                );
+              } catch {
+                contentValue = text;
+              }
+            }
+            eventData._scxmlEventData = contentValue;
+          } else if (Object.keys(payload).length) {
+            Object.assign(eventData, payload);
+            eventData._scxmlEventData = payload;
+          }
+
+          if (scxmlAction.idlocation) {
+            const nextId = (sendCounters.get(x.self) ?? 0) + 1;
+            sendCounters.set(x.self, nextId);
+            const generatedId = `${x.self.sessionId}.send.${nextId}`;
+            context ??= {};
+            context[scxmlAction.idlocation] = generatedId;
+            eventData._scxmlSendId = generatedId;
+          }
+
+          target = scxmlAction.targetexpr
+            ? (evaluateExpr(
+                mergedContext,
+                scxmlAction.targetexpr,
+                x.event,
+                x.self
+              ) as string)
+            : scxmlAction.target;
+
+          const isInternalTarget = target === '#_internal';
+          delay = scxmlAction.delayexpr
+            ? delayToMs(
+                evaluateExpr(
+                  mergedContext,
+                  scxmlAction.delayexpr,
+                  x.event,
+                  x.self
+                ) as string | number
+              )
+            : isInternalTarget
+              ? undefined
+              : scxmlAction.delay;
+        } catch (err) {
+          raiseErrorExecution(state, 'send', err);
+          continue;
+        }
+
+        const isInternalTarget = target === '#_internal';
+        const isParentTarget = target === '#_parent';
+        if (!isInternalTarget) {
+          (eventData as any)._scxmlExternal = true;
+        }
+        if (isParentTarget) {
+          (eventData as any)._scxmlInvokeId = x.self.id;
+        }
+
+        // Validate target. SCXML targets must be '#_internal', '#_parent',
+        // or '#_<id>'. A bare string without the '#_' prefix is invalid and
+        // raises error.execution.
+        if (
+          typeof target === 'string' &&
+          target.length > 0 &&
+          !target.startsWith('#_')
+        ) {
+          raiseErrorExecution(
+            state,
+            'send',
+            new Error(`Invalid send target: ${target}`),
+            eventData._scxmlSendId as string | undefined
+          );
+          continue;
+        }
+        // Attach send id so _event.sendid can be read in expressions.
+        if (
+          scxmlAction.id !== undefined &&
+          eventData._scxmlSendId === undefined
+        ) {
+          (eventData as any)._scxmlSendId = scxmlAction.id;
+        }
+        // Resolve target at runtime: parent, child, or self
+        if (isParentTarget && x.parent) {
+          // Send to parent via sendTo; pass delay if present
+          enq.sendTo(
+            x.parent,
+            eventData as AnyEventObject,
+            delay !== undefined ? { delay } : undefined
+          );
+        } else if (
+          typeof target === 'string' &&
+          target.startsWith('#_') &&
+          !isParentTarget &&
+          !isInternalTarget
+        ) {
+          // #_<invokeId> → try to send to child actor, fall back to self-raise
+          const childId = target.slice(2); // strip '#_'
+          const childRef = x.children?.[childId];
+          if (childRef) {
+            enq.sendTo(childRef, eventData as AnyEventObject);
+          } else if (
+            childId.startsWith('scxml_') &&
+            childId !== `scxml_${x.self.sessionId}`
+          ) {
+            const message = `Unable to dispatch event to target: ${target}`;
+            enq.raise({
+              type: 'xstate.error.communication',
+              error: {
+                tagname: 'send',
+                message,
+                line: NaN,
+                column: NaN,
+                reason: message
+              },
+              _scxmlEventType: 'platform',
+              _scxmlEventName: 'error.communication',
+              _scxmlEventData: {
+                tagname: 'send',
+                message,
+                line: NaN,
+                column: NaN,
+                reason: message
+              }
+            } as AnyEventObject);
+          } else {
+            // This SCXML session id uses the external event queue.
+            (eventData as any)._scxmlExternal = true;
+            enq.sendTo(x.self, eventData as AnyEventObject, {
+              id: scxmlAction.id,
+              delay
+            });
+          }
+        } else {
+          // #_internal uses the internal queue; self-send/no target use the
+          // external event queue.
+          if (isInternalTarget) {
+            enq.raise(eventData as AnyEventObject, {
+              id: scxmlAction.id,
+              delay
+            });
+          } else {
+            (eventData as any)._scxmlExternal = true;
+            enq.sendTo(x.self, eventData as AnyEventObject, {
+              id: scxmlAction.id,
+              delay
+            });
+          }
+        }
+      } else if (action.type === 'scxml.cancel') {
+        const scxmlAction = action as ScxmlCancelJSON;
+        const mergedContext = { ...x.context, ...context };
+        try {
+          const sendId = evaluateExpr(
+            mergedContext,
+            scxmlAction.sendidexpr,
+            x.event,
+            x.self
+          ) as string;
+          if (sendId) {
+            enq.cancel(sendId);
+          }
+        } catch {
+          // ignore evaluation errors
+        }
+      } else if (action.type === 'scxml.script') {
+        const scxmlAction = action as ScxmlScriptJSON;
+        const mergedContext = { ...x.context, ...context };
+        try {
+          const updatedContext = executeScript(
+            mergedContext,
+            scxmlAction.code,
+            x.self,
+            scxmlAction.global ?? false
+          );
+          context ??= {};
+          Object.assign(context, updatedContext);
+        } catch (err) {
+          raiseErrorExecution(state, 'script', err);
+        }
+      } else if (action.type === 'scxml.foreach') {
+        const scxmlAction = action as ScxmlForeachJSON;
+        const mergedContext = { ...x.context, ...context };
+        // SCXML: `item` (and `index` if present) must be valid datamodel
+        // locations — i.e. legal identifiers. Reject things like 'continue'
+        // (string literal) or '7' (number).
+        const isLegalIdentifier = (s: string) =>
+          /^[$_a-zA-Z][$_a-zA-Z0-9]*$/.test(s);
+        if (
+          !isLegalIdentifier(scxmlAction.item) ||
+          (scxmlAction.index && !isLegalIdentifier(scxmlAction.index))
+        ) {
+          raiseErrorExecution(
+            state,
+            'foreach',
+            new Error('foreach item/index is not a legal location')
+          );
+          continue;
+        }
+        let arr: unknown;
+        try {
+          arr = evaluateExpr(mergedContext, scxmlAction.array, x.event, x.self);
+        } catch (err) {
+          raiseErrorExecution(state, 'foreach', err);
+          continue;
+        }
+        if (!Array.isArray(arr)) {
+          raiseErrorExecution(
+            state,
+            'foreach',
+            new Error('foreach array is not iterable')
+          );
+          continue;
+        }
+        context ??= {};
+        for (let i = 0; i < arr.length; i++) {
+          context[scxmlAction.item] = arr[i];
+          if (scxmlAction.index) {
+            context[scxmlAction.index] = i;
+          }
+          const iterX = { ...x, context: { ...x.context, ...context } };
+          const iterResult = executeActions(
+            scxmlAction.actions,
+            iterX,
+            enq,
+            state
+          );
+          if (iterResult.context) {
+            Object.assign(context, iterResult.context);
+          }
+          if (state.errored) break;
+        }
+      } else if (action.type === 'scxml.block') {
+        const scxmlAction = action as ScxmlBlockJSON;
+        const blockX = { ...x, context: { ...x.context, ...context } };
+        // Block has its own ExecState — errors don't propagate to parent.
+        const blockResult = executeActions(scxmlAction.actions, blockX, enq);
+        if (blockResult.context) {
+          context ??= {};
+          for (const key of Object.keys(blockResult.context)) {
+            if (blockResult.context[key] !== x.context[key]) {
+              context[key] = blockResult.context[key];
+            }
+          }
+        }
+      } else if (action.type === 'scxml.if') {
+        const scxmlAction = action as ScxmlIfJSON;
+        const mergedContext = { ...x.context, ...context };
+        for (const branch of scxmlAction.branches) {
+          let condResult: boolean;
+          if (branch.cond) {
+            try {
+              condResult = !!evaluateExpr(
+                mergedContext,
+                branch.cond,
+                x.event,
+                x.self
+              );
+            } catch (err) {
+              raiseErrorExecution(state, 'if', err);
+              condResult = false;
+            }
+          } else {
+            condResult = true;
+          }
+          if (condResult) {
+            if (branch.actions.length) {
+              const branchX = { ...x, context: mergedContext };
+              const branchResult = executeActions(
+                branch.actions,
+                branchX,
+                enq,
+                state
+              );
+              if (branchResult.context) {
+                context ??= {};
+                for (const key of Object.keys(branchResult.context)) {
+                  if (branchResult.context[key] !== x.context[key]) {
+                    context[key] = branchResult.context[key];
+                  }
+                }
+              }
+            }
+            break;
+          }
+        }
+      } else {
+        const params = resolveValue(
+          (action as CustomActionJSON).params,
+          'actionParams',
+          makeScope(x, { params: x.params }),
+          '$.actions.params'
+        );
+        const result = executeActionDefinition(
+          action,
+          x,
+          enq,
+          params,
+          state,
+          stack
+        );
+        if (result.context) {
+          context ??= {};
+          Object.assign(context, result.context);
+        }
+      }
+    }
+    return {
+      context: context ? { ...x.context, ...context } : undefined,
+      errored: state.errored
+    };
+  }
+
+  function iterActions(
+    actions: ActionJSON[]
+  ): Action<any, any, any, any, any, any, any> {
+    return (x, enq) => executeActions(actions, x, enq);
+  }
+
+  function getFinalizedGuardContext(
+    context: MachineContext,
+    event: AnyEventObject,
+    self: AnyActorRef,
+    finalizers: NonNullable<TransitionJSON['_scxml']>['finalize']
+  ): MachineContext {
+    const invokeId = (event as any)._scxmlInvokeId ?? (event as any).actorId;
+    const finalized = { ...context };
+    for (const finalizer of finalizers ?? []) {
+      if (finalizer.invokeId !== invokeId) continue;
+      for (const action of finalizer.actions) {
+        if (!('type' in action) || action.type !== 'scxml.assign') continue;
+        const assignAction = action as ScxmlAssignJSON;
+        finalized[assignAction.location] = evaluateExpr(
+          finalized,
+          assignAction.expr,
+          event,
+          self
+        );
+      }
+    }
+    return finalized;
+  }
+
+  function getTransitionConfig(
+    transition: TransitionConfigJSON | TransitionConfigJSON[]
+  ): any {
+    const transitions = Array.isArray(transition) ? transition : [transition];
+
+    // Return an array of transition configs. Each SCXML transition becomes
+    // a separate XState transition with its own guard and optional .to.
+    // This ensures guards are evaluated by XState's evaluateCandidate (once,
+    // with pre-exit context) and NOT re-evaluated in computeEntrySet.
+    return transitions.map((t, index) => {
+      if (isResolvable(t)) {
+        return (x: any, enq: any) =>
+          evaluateResolvable(
+            t,
+            'transition',
+            makeScope(x, { enq }),
+            `$.transition${transitions.length > 1 ? `[${index}]` : ''}`
+          );
+      }
+      const target = Array.isArray(t.target) ? t.target[0] : t.target;
+      const targetConfig = t.target;
+      const resolvedGuard = resolveCondition(
+        t.guard,
+        'guard',
+        '$.transition.guard'
+      );
+      const guard =
+        resolvedGuard && t._scxml?.finalize?.length
+          ? (args: any) =>
+              resolvedGuard({
+                ...args,
+                context: getFinalizedGuardContext(
+                  args.context,
+                  args.event,
+                  args.self,
+                  t._scxml!.finalize
+                )
+              })
+          : resolvedGuard;
+      const resolveTransitionContext = (x: any) =>
+        t.context
+          ? (resolveValue(
+              t.context,
+              'transitionContext',
+              makeScope(x),
+              '$.transition.context'
+            ) as MachineContext)
+          : undefined;
+      const resolveTransitionInput = (x: any) =>
+        t.input !== undefined
+          ? resolveValue(t.input, 'input', makeScope(x), '$.transition.input')
+          : undefined;
+      const eventMatcher = t._scxml?.eventDescriptors
+        ? (event: EventObject) =>
+            t._scxml!.eventDescriptors!.some((descriptor) =>
+              matchesScxmlEventDescriptor(descriptor, event)
+            )
+        : undefined;
+
+      // No guard and no actions: simple static config
+      if (!guard && !t.actions?.length) {
+        if (t.context) {
+          return {
+            matches: t.matches,
+            _transitionDomain: t._scxml?.type,
+            _eventMatcher: eventMatcher,
+            to: (x: any) => ({
+              target: targetConfig,
+              context: resolveTransitionContext(x),
+              reenter: t.reenter
+            }),
+            description: t.description,
+            meta: t.meta,
+            input: t.input !== undefined ? resolveTransitionInput : undefined
+          };
+        }
+        return {
+          matches: t.matches,
+          _transitionDomain: t._scxml?.type,
+          _eventMatcher: eventMatcher,
+          target: targetConfig,
+          description: t.description,
+          reenter: t.reenter,
+          meta: t.meta,
+          input: t.input !== undefined ? resolveTransitionInput : undefined
+        };
+      }
+
+      // Guard but no actions: static config with guard
+      if (guard && !t.actions?.length) {
+        if (t.context) {
+          return {
+            matches: t.matches,
+            _transitionDomain: t._scxml?.type,
+            _eventMatcher: eventMatcher,
+            guard,
+            to: (x: any) => ({
+              target: targetConfig,
+              context: resolveTransitionContext(x),
+              reenter: t.reenter
+            }),
+            description: t.description,
+            meta: t.meta,
+            input: t.input !== undefined ? resolveTransitionInput : undefined
+          };
+        }
+        return {
+          matches: t.matches,
+          _transitionDomain: t._scxml?.type,
+          _eventMatcher: eventMatcher,
+          target: targetConfig,
+          guard,
+          description: t.description,
+          reenter: t.reenter,
+          meta: t.meta,
+          input: t.input !== undefined ? resolveTransitionInput : undefined
+        };
+      }
+
+      // Targetless transitions: execute actions directly in .to AND track for
+      // parallel re-execution. For non-parallel, .to result is used directly.
+      // For parallel (entries exist), first entry re-executes all in document order.
+      if (!target) {
+        return {
+          matches: t.matches,
+          _transitionDomain: t._scxml?.type,
+          _eventMatcher: eventMatcher,
+          guard,
+          description: t.description,
+          reenter: t.reenter,
+          meta: t.meta,
+          input: t.input !== undefined ? resolveTransitionInput : undefined,
+          to: (x: any, enq: any) => {
+            const context = resolveTransitionContext(x);
+            if (t.actions?.length) {
+              // Track for parallel re-execution (dedup by reference)
+              if (!allTransitionActions.includes(t.actions)) {
+                allTransitionActions.push(t.actions);
+              }
+              // Save pre-transition context for parallel override
+              contextBeforeTargetless ??= x.context;
+              targetlessEvent ??= x.event;
+              // Execute immediately (fallback for non-parallel case)
+              const result = executeActions(t.actions, x, enq);
+              if (result.context) {
+                return { context: { ...context, ...result.context } };
+              }
+            }
+            return context ? { context } : {};
+          }
+        };
+      }
+
+      // Has target + actions: use guard (for XState evaluation) + .to (for pending actions).
+      // The .to function does NOT re-check the guard — XState's evaluateCandidate
+      // already validated it. The .to just stores actions for entry to execute.
+      // Map by target state ID so parallel transitions each get their own actions.
+      return {
+        matches: t.matches,
+        _transitionDomain: t._scxml?.type,
+        _eventMatcher: eventMatcher,
+        guard,
+        description: t.description,
+        reenter: t.reenter,
+        meta: t.meta,
+        input: t.input !== undefined ? resolveTransitionInput : undefined,
+        to: (_x: any, _enq: any) => {
+          const context = resolveTransitionContext(_x);
+          if (t.actions?.length) {
+            const targetId = target.replace(/^#/, '');
+            pendingTransitionActionsMap[targetId] = t.actions;
+            // Track for parallel re-execution (dedup by reference)
+            if (!allTransitionActions.includes(t.actions)) {
+              allTransitionActions.push(t.actions);
+            }
+          }
+          return {
+            target: targetConfig,
+            context,
+            reenter: t.reenter
+          };
+        }
+      };
+    });
+  }
+
+  if (json.delays) {
+    for (const key of Object.keys(json.delays)) {
+      const delay = json.delays[key];
+      if (typeof delay === 'number') {
+        resolvedSources.delays[key] = delay;
+      } else if (typeof delay === 'string') {
+        resolvedSources.delays[key] = delayToMs(delay);
+      } else if (delay && typeof delay === 'object') {
+        resolvedSources.delays[key] = (args: any) =>
+          delayToMs(
+            resolveValue(
+              delay.duration,
+              'delay',
+              makeScope(args),
+              `$.delays.${key}.duration`
+            ) as string | number
+          );
+      }
+    }
+  }
+
+  assertMachineJSON(json, resolvedSources, expressionResolver);
+
+  const rootNodeConfig = iterNode(json);
+  const contextConfig =
+    json.context || json._scxmlDataIds?.length
+      ? {
+          context: (args: any) => ({
+            ...Object.fromEntries(
+              (json._scxmlDataIds ?? []).map((id) => [id, undefined])
+            ),
+            ...(json.context
+              ? (resolveValue(
+                  json.context,
+                  'context',
+                  args,
+                  '$.context'
+                ) as MachineContext)
+              : {}),
+            ...(json._scxmlDataIds?.length &&
+            args.input &&
+            typeof args.input === 'object'
+              ? args.input
+              : {}),
+            ...(json._scxmlDataIds?.length &&
+            args.input &&
+            typeof args.input === 'object'
+              ? { _xstateScxmlInputKeys: Object.keys(args.input) }
+              : {})
+          })
+        }
+      : {};
+
+  const machine = createMachine({
+    ...rootNodeConfig,
+    ...contextConfig,
+    version: json.version
+  }) as unknown as AnyStateMachine;
+
+  // Register SCXML guard sources
+  const providedGuards: Record<string, (args: any, params: any) => boolean> = {
+    'scxml.cond': ({ context, event, self }: any, params: any) => {
+      const expr = params?.expr as string;
+      if (!expr) return true;
+      try {
+        return !!evaluateExpr(context, expr, event, self);
+      } catch (err) {
+        // Per SCXML spec, a cond that fails to evaluate is treated as false
+        // AND raises error.execution. We can't enqueue from a guard, so
+        // queue it for the next entry to drain.
+        const message =
+          err instanceof Error
+            ? err.message
+            : typeof err === 'string'
+              ? err
+              : 'unknown error';
+        pendingPlatformErrors.push({
+          tagname: 'cond',
+          message,
+          line: NaN,
+          column: NaN,
+          reason: message
+        });
+        return false;
+      }
+    },
+    'xstate.stateIn': (args: any, params: any) => {
+      const stateId = params?.stateId as string;
+      if (!stateId) return false;
+      const normalizedId = stateId.replace(/^#/, '');
+      const snapshot = args._snapshot;
+      if (snapshot?.nodes) {
+        return snapshot.nodes.some((node: any) => node.id === normalizedId);
+      }
+      return false;
+    },
+    'xstate.not': (args: any, params: any) => {
+      const inner = params?.guard;
+      const innerImpl = inner && args.guards?.[inner.type];
+      if (!innerImpl) {
+        throw new Error(
+          `Guard '${inner?.type}' referenced by 'xstate.not' is not implemented.`
+        );
+      }
+      return !innerImpl(args, inner.params);
+    }
+  };
+  const provided = machine.provide({
+    actions: resolvedSources.actions,
+    actors: resolvedSources.actors,
+    guards: {
+      ...providedGuards,
+      ...resolvedSources.guards
+    },
+    delays: resolvedSources.delays
+  });
+
+  // Keep the original JSON so `serializeMachine(machine)`
+  // round-trip losslessly.
+  (provided as any)._json = json;
+  return provided;
+}
+
+function isBuiltInActionJSON(action: ActionJSON): action is BuiltInActionJSON {
+  return !isResolvable(action) && action.type.startsWith('@xstate.');
+}

--- a/packages/core/src/scxml/scxml.ts
+++ b/packages/core/src/scxml/scxml.ts
@@ -1,20 +1,15 @@
 /**
- * @internal
- *
- * SCXML conversion utilities. This module is NOT part of the public API: it is
- * not re-exported from `index.ts` and there is no `xstate/scxml` entry point.
- * It exists solely to support the SCXML/SCION conformance and conversion test
- * suites (`test/scxml.test.ts`, `test/conversion.test.ts`). Do not import it
- * from public-facing code, and do not rely on it externally — it may change or
- * be removed without a breaking-change notice.
+ * SCXML machine creation and conversion utilities for the `xstate/scxml`
+ * entry point. Only createMachineFromSCXML and SCXMLConversionOptions are
+ * public; the compiler representation remains internal.
  */
-import { Element as XMLElement, xml2js } from 'xml-js';
+import { SaxesParser } from 'saxes';
 import {
   ActionJSON,
   CancelJSON,
   GuardJSON,
   InvokeJSON,
-  MachineJSON,
+  ScxmlIR,
   RaiseJSON,
   ScxmlCancelJSON,
   ScxmlContentJSON,
@@ -26,10 +21,52 @@ import {
   ScxmlXmlJSON,
   StateNodeJSON,
   TransitionJSON,
-  createMachineFromConfig
-} from './createMachineFromConfig.ts';
-import { parseDelayToMilliseconds } from './delay.ts';
-import { AnyStateMachine, SpecialTargets } from './types.ts';
+  createMachineFromSCXMLConfig
+} from './runtime.ts';
+import { parseDelayToMilliseconds } from '../delay.ts';
+import { AnyStateMachine, SpecialTargets } from '../types.ts';
+
+interface XMLElement {
+  type?: 'element' | 'text' | 'cdata' | 'comment';
+  name?: string;
+  attributes?: Record<string, string>;
+  elements?: XMLElement[];
+  text?: string;
+  cdata?: string;
+}
+
+function parseXml(xml: string): XMLElement {
+  const root: XMLElement = { elements: [] };
+  const stack = [root];
+  const append = (element: XMLElement) =>
+    stack[stack.length - 1].elements!.push(element);
+  const parser = new SaxesParser();
+
+  parser.on('opentag', (tag) => {
+    const attributes = { ...tag.attributes };
+    const element: XMLElement = {
+      type: 'element',
+      name: tag.name,
+      ...(Object.keys(attributes).length ? { attributes } : undefined),
+      elements: []
+    };
+    append(element);
+    stack.push(element);
+  });
+  parser.on('closetag', () => {
+    const element = stack.pop()!;
+    if (!element.elements?.length) {
+      delete element.elements;
+    }
+  });
+  parser.on('text', (text) => {
+    if (text.trim()) append({ type: 'text', text });
+  });
+  parser.on('cdata', (cdata) => append({ type: 'cdata', cdata }));
+  parser.on('comment', (text) => append({ type: 'comment', text }));
+  parser.write(xml).close();
+  return root;
+}
 
 export function sanitizeStateId(id: string) {
   return id.replace(/\./g, '$');
@@ -253,7 +290,7 @@ function mapAction(
         }
       }
 
-      const isInternal = target === SpecialTargets.Internal;
+      const isInternal = target === String(SpecialTargets.Internal);
       const resolvedDelay = delay ? delayToMs(delay) : undefined;
 
       // Any send with a special target (except internal), params, or expressions
@@ -443,7 +480,7 @@ function getDataDescriptors(
           if (resolvedSource !== undefined) {
             try {
               resourceXml = normalizeElementNames(
-                xml2js(resolvedSource) as XMLElement
+                parseXml(resolvedSource)
               ).elements?.find((child) => child.name);
             } catch {
               resourceXml = undefined;
@@ -727,14 +764,10 @@ function toStateNodeJSON(
       );
     }
 
-    const content = element.elements?.find(
-      (el) => el.name === 'content'
-    ) as XMLElement;
+    const content = element.elements?.find((el) => el.name === 'content');
 
     // Convert nested SCXML content to a machine JSON
-    const nestedScxml = content?.elements?.find(
-      (el) => el.name === 'scxml'
-    ) as XMLElement;
+    const nestedScxml = content?.elements?.find((el) => el.name === 'scxml');
 
     const findEntryAssignment = (location: string) =>
       onEntryElements
@@ -744,19 +777,19 @@ function toStateNodeJSON(
             child.name === 'assign' && child.attributes?.location === location
         );
 
-    let _nestedMachineJSON: MachineJSON | undefined;
+    let _nestedScxmlIR: ScxmlIR | undefined;
     if (nestedScxml) {
-      // Create a wrapper that looks like xml2js output: { elements: [scxmlElement] }
+      // Create a wrapper that looks like parser output: { elements: [scxmlElement] }
       const wrapper: XMLElement = { elements: [nestedScxml] };
-      _nestedMachineJSON = scxmlToMachineJSON(wrapper, options);
+      _nestedScxmlIR = compileScxmlElement(wrapper, options);
     } else if (element.attributes?.src) {
       const source = resolveResource(
         options,
         String(element.attributes.src),
         'invoke'
       );
-      _nestedMachineJSON = scxmlToMachineJSON(
-        normalizeElementNames(xml2js(source) as XMLElement),
+      _nestedScxmlIR = compileScxmlElement(
+        normalizeElementNames(parseXml(source)),
         options
       );
     } else if (element.attributes?.srcexpr) {
@@ -767,11 +800,9 @@ function toStateNodeJSON(
         /^(['"])(.*)\1$/s
       )?.[2];
       if (assignedSource) {
-        _nestedMachineJSON = scxmlToMachineJSON(
+        _nestedScxmlIR = compileScxmlElement(
           normalizeElementNames(
-            xml2js(
-              resolveResource(options, assignedSource, 'invoke')
-            ) as XMLElement
+            parseXml(resolveResource(options, assignedSource, 'invoke'))
           ),
           options
         );
@@ -782,7 +813,7 @@ function toStateNodeJSON(
         (child) => child.name === 'scxml'
       );
       if (assignedScxml) {
-        _nestedMachineJSON = scxmlToMachineJSON(
+        _nestedScxmlIR = compileScxmlElement(
           { elements: [assignedScxml] },
           options
         );
@@ -819,14 +850,14 @@ function toStateNodeJSON(
     return {
       id: invokeId,
       src: 'scxml.nested',
-      _nestedMachineJSON,
+      _nestedScxmlIR,
       ...((params.length || namelist.length) && {
         _scxmlInput: {
           ...(params.length ? { params } : undefined),
           ...(namelist.length ? { namelist } : undefined)
         }
       })
-    } as InvokeJSON & { _nestedMachineJSON?: MachineJSON };
+    } as InvokeJSON & { _nestedScxmlIR?: ScxmlIR };
   });
 
   const autoForwardIds = invokeElements.flatMap((element, index) =>
@@ -917,13 +948,16 @@ function toStateNodeJSON(
   };
 }
 
-function scxmlToMachineJSON(
+function compileScxmlElement(
   scxmlJson: XMLElement,
   options: SCXMLConversionOptions
-): MachineJSON {
+): ScxmlIR {
   const machineElement = scxmlJson.elements!.find(
     (element) => element.name === 'scxml'
-  ) as XMLElement;
+  );
+  if (!machineElement) {
+    throw new Error('SCXML document must contain an <scxml> root element.');
+  }
 
   const binding =
     machineElement.attributes?.binding === 'late' ? 'late' : 'early';
@@ -962,21 +996,26 @@ function scxmlToMachineJSON(
 
 /**
  * Converts an SCXML string to a JSON representation that can be used with
- * createMachineFromConfig.
+ * the SCXML runtime compiler.
  */
-export function toMachineJSON(
+export function compileSCXML(
   xml: string,
   options: SCXMLConversionOptions = {}
-): MachineJSON {
-  const json = normalizeElementNames(xml2js(xml) as XMLElement);
-  return scxmlToMachineJSON(json, options);
+): ScxmlIR {
+  const json = normalizeElementNames(parseXml(xml));
+  return compileScxmlElement(json, options);
 }
 
-/** Converts an SCXML string to an XState machine. */
-export function toMachine(
+/**
+ * Creates an XState machine from an SCXML document.
+ *
+ * Expressions and external resources are evaluated using SCXML semantics.
+ * Only create machines from trusted SCXML because ECMAScript expressions and
+ * script elements execute JavaScript in the current environment.
+ */
+export function createMachineFromSCXML(
   xml: string,
   options: SCXMLConversionOptions = {}
 ): AnyStateMachine {
-  const machineJSON = toMachineJSON(xml, options);
-  return createMachineFromConfig(machineJSON);
+  return createMachineFromSCXMLConfig(compileSCXML(xml, options));
 }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -815,7 +815,7 @@ function resolveHistoryDefaultTransition(
     source: stateNode,
     reenter: false,
     eventType: '' as any,
-    to: (stateNode.config as any)._scxmlHistoryActions
+    to: (stateNode.config as any)._historyDefaultTransition
   };
 }
 
@@ -1247,9 +1247,9 @@ function getTransitionDomain(
 
   const { targets, reenter } = resolveTransition(transition);
 
-  if (transition._scxml?.type) {
+  if (transition._transitionDomain) {
     if (
-      transition._scxml.type === 'internal' &&
+      transition._transitionDomain === 'internal' &&
       transition.source.type === 'compound' &&
       targetStates.every((target) => isDescendant(target, transition.source))
     ) {

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -814,7 +814,8 @@ function resolveHistoryDefaultTransition(
     target,
     source: stateNode,
     reenter: false,
-    eventType: '' as any
+    eventType: '' as any,
+    to: (stateNode.config as any)._scxmlHistoryActions
   };
 }
 
@@ -833,7 +834,9 @@ function getInitialStateNodes(stateNode: AnyStateNode) {
     }
     set.add(descStateNode);
     if (descStateNode.type === 'compound') {
-      iter(descStateNode.initial.target![0]);
+      for (const target of descStateNode.initial.target ?? []) {
+        iter(target);
+      }
     } else if (descStateNode.type === 'parallel') {
       for (const child of getChildren(descStateNode)) {
         iter(child);
@@ -1244,6 +1247,28 @@ function getTransitionDomain(
 
   const { targets, reenter } = resolveTransition(transition);
 
+  if (transition._scxml?.type) {
+    if (
+      transition._scxml.type === 'internal' &&
+      transition.source.type === 'compound' &&
+      targetStates.every((target) => isDescendant(target, transition.source))
+    ) {
+      return transition.source;
+    }
+
+    const [head, ...tail] = targetStates.concat(transition.source);
+    for (const ancestor of getProperAncestors(head, undefined)) {
+      if (
+        ancestor.type === 'compound' &&
+        tail.every((stateNode) => isDescendant(stateNode, ancestor))
+      ) {
+        return ancestor;
+      }
+    }
+
+    return;
+  }
+
   // A history target that restores the source itself must exit and reenter
   // the source (SCXML domain = the source's ancestor), unlike a plain
   // non-reentering self-target: the enter set restores the stored
@@ -1328,14 +1353,35 @@ export function initialMicrostep(
   initEvent: AnyEventObject,
   internalQueue: AnyEventObject[]
 ): Microstep {
+  const initialStateNodes = [...getInitialStateNodes(root)];
+  const statesForDefaultEntry = new Set<AnyStateNode>();
+  const collectDefaultEntryStates = (stateNode: AnyStateNode): void => {
+    if (stateNode.type === 'compound') {
+      statesForDefaultEntry.add(stateNode);
+      for (const target of stateNode.initial.target ?? []) {
+        collectDefaultEntryStates(target);
+      }
+    } else if (stateNode.type === 'parallel') {
+      for (const child of getChildren(stateNode)) {
+        collectDefaultEntryStates(child);
+      }
+    }
+  };
+  collectDefaultEntryStates(root);
   return microstep(
     [
       {
-        target: [...getInitialStateNodes(root)],
+        target: initialStateNodes.filter(
+          (stateNode) =>
+            !initialStateNodes.some(
+              (other) => other !== stateNode && isDescendant(other, stateNode)
+            )
+        ),
         source: root,
         reenter: true,
         eventType: null as any,
-        toJSON: null as any
+        toJSON: null as any,
+        _statesForDefaultEntry: [...statesForDefaultEntry]
       } as AnyTransitionDefinition
     ],
     preInitialState,
@@ -1654,6 +1700,10 @@ function microstep(
       // in other words, those are states for which initial actions should be executed
       // when we target `#deep_child` initial actions of its ancestors shouldn't be executed
       const statesForDefaultEntry = new Set<AnyStateNode>();
+      const historyDefaultsByParent = new Map<
+        AnyStateNode,
+        AnyTransitionDefinition[]
+      >();
       const addAncestorStatesToEnter = (
         ancestors: AnyStateNode[],
         reentrancyDomain: AnyStateNode | undefined
@@ -1690,6 +1740,11 @@ function microstep(
           } else {
             const historyDefaultTransition =
               resolveHistoryDefaultTransition(stateNode);
+            const historyParent = stateNode.parent!;
+            statesForDefaultEntry.add(historyParent);
+            const defaults = historyDefaultsByParent.get(historyParent) ?? [];
+            defaults.push(historyDefaultTransition);
+            historyDefaultsByParent.set(historyParent, defaults);
             const { targets } = getCurrentTransitionResult(
               historyDefaultTransition
             );
@@ -1714,19 +1769,24 @@ function microstep(
         }
 
         if (stateNode.type === 'compound') {
-          const [initialState] = getCurrentTransitionResult(
-            stateNode.initial
-          ).targets!;
+          const initialStates =
+            getCurrentTransitionResult(stateNode.initial).targets ?? [];
 
-          if (!isHistoryNode(initialState)) {
-            statesToEnter.add(initialState);
-            statesForDefaultEntry.add(initialState);
+          for (const initialState of initialStates) {
+            if (!isHistoryNode(initialState)) {
+              statesToEnter.add(initialState);
+            }
           }
-          addDescendantStatesToEnter(initialState);
-          addAncestorStatesToEnter(
-            getProperAncestors(initialState, stateNode),
-            undefined
-          );
+          statesForDefaultEntry.add(stateNode);
+          for (const initialState of initialStates) {
+            addDescendantStatesToEnter(initialState);
+          }
+          for (const initialState of initialStates) {
+            addAncestorStatesToEnter(
+              getProperAncestors(initialState, stateNode),
+              undefined
+            );
+          }
           return;
         }
 
@@ -1786,7 +1846,10 @@ function microstep(
       }
 
       if (isInitial) {
-        statesForDefaultEntry.add(currentSnapshot.machine.root);
+        for (const stateNode of (filteredTransitions[0] as any)
+          ._statesForDefaultEntry ?? [currentSnapshot.machine.root]) {
+          statesForDefaultEntry.add(stateNode);
+        }
       }
 
       const stateInputMap: Record<string, Record<string, unknown>> = {
@@ -1897,20 +1960,39 @@ function microstep(
         }
 
         if (statesForDefaultEntry.has(stateNodeToEnter)) {
-          const { actions: initialActions, input: initialInput } =
-            getTransitionResult(
-              stateNodeToEnter.initial,
+          const defaultTransitions = [
+            stateNodeToEnter.initial,
+            ...(historyDefaultsByParent.get(stateNodeToEnter) ?? [])
+          ].filter(Boolean);
+          for (const defaultTransition of defaultTransitions) {
+            const {
+              actions: initialActions,
+              context: initialContext,
+              input: initialInput,
+              internalEvents: initialInternalEvents
+            } = getTransitionResult(
+              defaultTransition,
               nextState,
               event,
               actorScope
             );
-          if (initialActions) {
-            actions.push(...initialActions);
-          }
-          if (initialInput && stateNodeToEnter.initial?.target) {
-            for (const targetNode of stateNodeToEnter.initial.target) {
-              stateInputMap[targetNode.id] = initialInput;
-              stateInputsChanged = true;
+            if (initialActions) {
+              actions.push(...initialActions);
+            }
+            if (initialInternalEvents?.length) {
+              internalQueue.push(...initialInternalEvents);
+            }
+            if (initialContext !== undefined) {
+              nextState.context = mergeContextPatch(
+                nextState.context,
+                initialContext
+              );
+            }
+            if (initialInput && defaultTransition.target) {
+              for (const targetNode of defaultTransition.target) {
+                stateInputMap[targetNode.id] = initialInput;
+                stateInputsChanged = true;
+              }
             }
           }
         }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -318,11 +318,8 @@ export interface TransitionConfig<
   >;
   meta?: TMeta;
   description?: string;
-  /** @internal Strict semantics for transitions produced by the SCXML converter. */
-  _scxml?: {
-    type?: 'internal' | 'external';
-    eventDescriptors?: string[];
-  };
+  /** @internal Overrides transition-domain selection for compiled formats. */
+  _transitionDomain?: 'internal' | 'external';
 }
 
 export interface InitialTransitionConfig<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -318,6 +318,11 @@ export interface TransitionConfig<
   >;
   meta?: TMeta;
   description?: string;
+  /** @internal Strict semantics for transitions produced by the SCXML converter. */
+  _scxml?: {
+    type?: 'internal' | 'external';
+    eventDescriptors?: string[];
+  };
 }
 
 export interface InitialTransitionConfig<
@@ -1560,6 +1565,7 @@ export type InitialTransitionDefinition = {
         context: MachineContext;
         event: EventObject;
       }) => Record<string, unknown>);
+  to?: ((...args: any[]) => any) | undefined;
 };
 
 export type TransitionDefinitionMap<

--- a/packages/core/test/conversion.test.ts
+++ b/packages/core/test/conversion.test.ts
@@ -24,19 +24,19 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(json.initial).toBe('idle');
+      expect(json._scxmlInitial?.targets).toEqual(['#idle']);
       expect(toPortableJSON(json.states)).toMatchInlineSnapshot(`
         {
           "idle": {
             "id": "idle",
             "on": {
-              "START": {
-                "reenter": true,
-                "target": [
-                  "#running",
-                ],
-              },
-              "START.*": {
+              "*": {
+                "_scxml": {
+                  "eventDescriptors": [
+                    "START",
+                  ],
+                  "type": "external",
+                },
                 "reenter": true,
                 "target": [
                   "#running",
@@ -47,13 +47,13 @@ describe('SCXML to XState conversion', () => {
           "running": {
             "id": "running",
             "on": {
-              "STOP": {
-                "reenter": true,
-                "target": [
-                  "#idle",
-                ],
-              },
-              "STOP.*": {
+              "*": {
+                "_scxml": {
+                  "eventDescriptors": [
+                    "STOP",
+                  ],
+                  "type": "external",
+                },
                 "reenter": true,
                 "target": [
                   "#idle",
@@ -117,19 +117,19 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(json.states!.parent.initial).toBe('child1');
+      expect(json.states!.parent._scxmlInitial?.targets).toEqual(['#child1']);
       expect(toPortableJSON(json.states!.parent.states)).toMatchInlineSnapshot(`
         {
           "child1": {
             "id": "child1",
             "on": {
-              "NEXT": {
-                "reenter": true,
-                "target": [
-                  "#child2",
-                ],
-              },
-              "NEXT.*": {
+              "*": {
+                "_scxml": {
+                  "eventDescriptors": [
+                    "NEXT",
+                  ],
+                  "type": "external",
+                },
                 "reenter": true,
                 "target": [
                   "#child2",
@@ -140,13 +140,13 @@ describe('SCXML to XState conversion', () => {
           "child2": {
             "id": "child2",
             "on": {
-              "EXIT": {
-                "reenter": true,
-                "target": [
-                  "#outside",
-                ],
-              },
-              "EXIT.*": {
+              "*": {
+                "_scxml": {
+                  "eventDescriptors": [
+                    "EXIT",
+                  ],
+                  "type": "external",
+                },
                 "reenter": true,
                 "target": [
                   "#outside",
@@ -188,19 +188,23 @@ describe('SCXML to XState conversion', () => {
           "initial": "region1",
           "states": {
             "region1": {
+              "_scxmlInitial": {
+                "targets": [
+                  "#a",
+                ],
+              },
               "id": "region1",
-              "initial": "a",
               "states": {
                 "a": {
                   "id": "a",
                   "on": {
-                    "TO_B": {
-                      "reenter": true,
-                      "target": [
-                        "#b",
-                      ],
-                    },
-                    "TO_B.*": {
+                    "*": {
+                      "_scxml": {
+                        "eventDescriptors": [
+                          "TO_B",
+                        ],
+                        "type": "external",
+                      },
                       "reenter": true,
                       "target": [
                         "#b",
@@ -214,19 +218,23 @@ describe('SCXML to XState conversion', () => {
               },
             },
             "region2": {
+              "_scxmlInitial": {
+                "targets": [
+                  "#x",
+                ],
+              },
               "id": "region2",
-              "initial": "x",
               "states": {
                 "x": {
                   "id": "x",
                   "on": {
-                    "TO_Y": {
-                      "reenter": true,
-                      "target": [
-                        "#y",
-                      ],
-                    },
-                    "TO_Y.*": {
+                    "*": {
+                      "_scxml": {
+                        "eventDescriptors": [
+                          "TO_Y",
+                        ],
+                        "type": "external",
+                      },
                       "reenter": true,
                       "target": [
                         "#y",
@@ -261,16 +269,21 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.context)).toMatchInlineSnapshot(`
-        {
-          "count": 0,
-          "items": [
-            1,
-            2,
-            3,
-          ],
-          "name": "test",
-        }
+      expect(toPortableJSON(json._scxmlData)).toMatchInlineSnapshot(`
+        [
+          {
+            "expr": "0",
+            "id": "count",
+          },
+          {
+            "expr": "'test'",
+            "id": "name",
+          },
+          {
+            "expr": "[1, 2, 3]",
+            "id": "items",
+          },
+        ]
       `);
     });
   });
@@ -289,8 +302,14 @@ describe('SCXML to XState conversion', () => {
       const json = toMachineJSON(scxml);
 
       // SCXML events get .* suffix for prefix matching
-      expect(toPortableJSON(json.states!.a.on!['GO.*'])).toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
+          "_scxml": {
+            "eventDescriptors": [
+              "GO",
+            ],
+            "type": "external",
+          },
           "reenter": true,
           "target": [
             "#b",
@@ -313,29 +332,40 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.idle.on!['CHECK.*']))
-        .toMatchInlineSnapshot(`
-        [
-          {
-            "guard": {
-              "params": {
-                "expr": "count > 3",
+      expect(toPortableJSON(json.states!.idle.on!['*'])).toMatchInlineSnapshot(`
+          [
+            {
+              "_scxml": {
+                "eventDescriptors": [
+                  "CHECK",
+                ],
+                "type": "external",
               },
-              "type": "scxml.cond",
+              "guard": {
+                "params": {
+                  "expr": "count > 3",
+                },
+                "type": "scxml.cond",
+              },
+              "reenter": true,
+              "target": [
+                "#high",
+              ],
             },
-            "reenter": true,
-            "target": [
-              "#high",
-            ],
-          },
-          {
-            "reenter": true,
-            "target": [
-              "#low",
-            ],
-          },
-        ]
-      `);
+            {
+              "_scxml": {
+                "eventDescriptors": [
+                  "CHECK",
+                ],
+                "type": "external",
+              },
+              "reenter": true,
+              "target": [
+                "#low",
+              ],
+            },
+          ]
+        `);
     });
 
     it('should convert In() guards', () => {
@@ -351,8 +381,14 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['GO.*'])).toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
+          "_scxml": {
+            "eventDescriptors": [
+              "GO",
+            ],
+            "type": "external",
+          },
           "guard": {
             "params": {
               "stateId": "#b",
@@ -383,23 +419,28 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['TRIGGER.*']))
-        .toMatchInlineSnapshot(`
-        {
-          "actions": [
-            {
-              "event": {
-                "type": "RAISED",
-              },
-              "type": "@xstate.raise",
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
+          {
+            "_scxml": {
+              "eventDescriptors": [
+                "TRIGGER",
+              ],
+              "type": "external",
             },
-          ],
-          "reenter": true,
-          "target": [
-            "#b",
-          ],
-        }
-      `);
+            "actions": [
+              {
+                "event": {
+                  "type": "RAISED",
+                },
+                "type": "@xstate.raise",
+              },
+            ],
+            "reenter": true,
+            "target": [
+              "#b",
+            ],
+          }
+        `);
     });
 
     it('should convert log actions', () => {
@@ -420,11 +461,9 @@ describe('SCXML to XState conversion', () => {
           {
             "actions": [
               {
-                "args": [
-                  "info",
-                  "'entered state a'",
-                ],
-                "type": "@xstate.log",
+                "expr": "'entered state a'",
+                "label": "info",
+                "type": "scxml.log",
               },
             ],
             "type": "scxml.block",
@@ -446,9 +485,13 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['CANCEL.*']))
-        .toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
           {
+            "_scxml": {
+              "eventDescriptors": [
+                "CANCEL",
+              ],
+            },
             "actions": [
               {
                 "id": "delayed1",
@@ -479,10 +522,8 @@ describe('SCXML to XState conversion', () => {
           {
             "actions": [
               {
-                "args": [
-                  "'entering a'",
-                ],
-                "type": "@xstate.log",
+                "expr": "'entering a'",
+                "type": "scxml.log",
               },
             ],
             "type": "scxml.block",
@@ -509,10 +550,8 @@ describe('SCXML to XState conversion', () => {
           {
             "actions": [
               {
-                "args": [
-                  "'exiting a'",
-                ],
-                "type": "@xstate.log",
+                "expr": "'exiting a'",
+                "type": "scxml.log",
               },
             ],
             "type": "scxml.block",
@@ -538,6 +577,9 @@ describe('SCXML to XState conversion', () => {
       expect(toPortableJSON(json.states!.a.always)).toMatchInlineSnapshot(`
         [
           {
+            "_scxml": {
+              "type": "external",
+            },
             "reenter": true,
             "target": [
               "#b",
@@ -560,15 +602,21 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.parent.on!['EXTERNAL.*']))
+      expect(toPortableJSON(json.states!.parent.on!['*']))
         .toMatchInlineSnapshot(`
-        {
-          "reenter": true,
-          "target": [
-            "#parent",
-          ],
-        }
-      `);
+          {
+            "_scxml": {
+              "eventDescriptors": [
+                "EXTERNAL",
+              ],
+              "type": "external",
+            },
+            "reenter": true,
+            "target": [
+              "#parent",
+            ],
+          }
+        `);
     });
 
     it('should not mark internal transitions with reenter', () => {
@@ -582,9 +630,16 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(
-        toPortableJSON(json.states!.parent.on!['INTERNAL.*'])
-      ).toMatchInlineSnapshot(`{}`);
+      expect(toPortableJSON(json.states!.parent.on!['*']))
+        .toMatchInlineSnapshot(`
+        {
+          "_scxml": {
+            "eventDescriptors": [
+              "INTERNAL",
+            ],
+          },
+        }
+      `);
     });
   });
 
@@ -602,9 +657,13 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['TRIGGER.*']))
-        .toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
           {
+            "_scxml": {
+              "eventDescriptors": [
+                "TRIGGER",
+              ],
+            },
             "actions": [
               {
                 "event": "INTERNAL_EVENT",
@@ -629,9 +688,13 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['TRIGGER.*']))
-        .toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
           {
+            "_scxml": {
+              "eventDescriptors": [
+                "TRIGGER",
+              ],
+            },
             "actions": [
               {
                 "delay": 500,
@@ -659,25 +722,14 @@ describe('SCXML to XState conversion', () => {
 
       expect(toPortableJSON(json.states!.idle.on)).toMatchInlineSnapshot(`
         {
-          "RESUME": {
-            "reenter": true,
-            "target": [
-              "#active",
-            ],
-          },
-          "RESUME.*": {
-            "reenter": true,
-            "target": [
-              "#active",
-            ],
-          },
-          "START": {
-            "reenter": true,
-            "target": [
-              "#active",
-            ],
-          },
-          "START.*": {
+          "*": {
+            "_scxml": {
+              "eventDescriptors": [
+                "START",
+                "RESUME",
+              ],
+              "type": "external",
+            },
             "reenter": true,
             "target": [
               "#active",
@@ -752,8 +804,13 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['GO.*'])).toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
+          "_scxml": {
+            "eventDescriptors": [
+              "GO",
+            ],
+          },
           "actions": [
             {
               "delay": 100,
@@ -778,8 +835,13 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['GO.*'])).toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
+          "_scxml": {
+            "eventDescriptors": [
+              "GO",
+            ],
+          },
           "actions": [
             {
               "delay": 2000,
@@ -804,8 +866,13 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['GO.*'])).toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
+          "_scxml": {
+            "eventDescriptors": [
+              "GO",
+            ],
+          },
           "actions": [
             {
               "delay": 1500,
@@ -830,8 +897,13 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(toPortableJSON(json.states!.a.on!['GO.*'])).toMatchInlineSnapshot(`
+      expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
+          "_scxml": {
+            "eventDescriptors": [
+              "GO",
+            ],
+          },
           "actions": [
             {
               "delay": 1500,
@@ -858,19 +930,19 @@ describe('SCXML to XState conversion', () => {
       const json = toMachineJSON(scxml);
 
       // Dots are replaced with $
-      expect(json.initial).toBe('state$one');
+      expect(json._scxmlInitial?.targets).toEqual(['#state$one']);
       expect(toPortableJSON(json.states)).toMatchInlineSnapshot(`
         {
           "state$one": {
             "id": "state$one",
             "on": {
-              "GO": {
-                "reenter": true,
-                "target": [
-                  "#state$two",
-                ],
-              },
-              "GO.*": {
+              "*": {
+                "_scxml": {
+                  "eventDescriptors": [
+                    "GO",
+                  ],
+                  "type": "external",
+                },
                 "reenter": true,
                 "target": [
                   "#state$two",
@@ -896,12 +968,16 @@ describe('SCXML to XState conversion', () => {
 
       const json = toMachineJSON(scxml);
 
-      expect(json.initial).toBe('foo$bar');
+      expect(json._scxmlInitial?.targets).toEqual(['#foo$bar']);
       expect(toPortableJSON(json.states)).toMatchInlineSnapshot(`
         {
           "foo$bar": {
+            "_scxmlInitial": {
+              "targets": [
+                "#baz$qux",
+              ],
+            },
             "id": "foo$bar",
-            "initial": "baz$qux",
             "states": {
               "baz$qux": {
                 "id": "baz$qux",

--- a/packages/core/test/conversion.test.ts
+++ b/packages/core/test/conversion.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { toMachine, toMachineJSON } from '../src/scxml';
+import { createMachineFromSCXML } from '../src/scxml';
+import { compileSCXML } from '../src/scxml/scxml';
 import { createMachineFromConfig } from '../src/createMachineFromConfig';
 import { initialTransition, transition } from '../src/transition';
 import { createMachine } from '../src';
@@ -9,7 +10,7 @@ function toPortableJSON<T>(value: T): T {
 }
 
 describe('SCXML to XState conversion', () => {
-  describe('toMachineJSON - basic state machine', () => {
+  describe('compileSCXML - basic state machine', () => {
     it('should convert a simple state machine with initial state', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="idle">
@@ -22,7 +23,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json._scxmlInitial?.targets).toEqual(['#idle']);
       expect(toPortableJSON(json.states)).toMatchInlineSnapshot(`
@@ -73,7 +74,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json.initial).toBe('first');
     });
@@ -88,7 +89,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.done)).toMatchInlineSnapshot(`
         {
@@ -99,7 +100,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - nested states', () => {
+  describe('compileSCXML - nested states', () => {
     it('should convert nested compound states', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="parent">
@@ -115,7 +116,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json.states!.parent._scxmlInitial?.targets).toEqual(['#child1']);
       expect(toPortableJSON(json.states!.parent.states)).toMatchInlineSnapshot(`
@@ -159,7 +160,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - parallel states', () => {
+  describe('compileSCXML - parallel states', () => {
     it('should convert parallel states', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="parallel">
@@ -180,7 +181,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.parallel)).toMatchInlineSnapshot(`
         {
@@ -254,7 +255,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - datamodel (context)', () => {
+  describe('compileSCXML - datamodel (context)', () => {
     it('should convert datamodel to context', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="idle">
@@ -267,7 +268,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json._scxmlData)).toMatchInlineSnapshot(`
         [
@@ -288,7 +289,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - transitions', () => {
+  describe('compileSCXML - transitions', () => {
     it('should convert transitions with targets', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
@@ -299,7 +300,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       // SCXML events get .* suffix for prefix matching
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
@@ -330,7 +331,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.idle.on!['*'])).toMatchInlineSnapshot(`
           [
@@ -379,7 +380,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
@@ -404,7 +405,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - actions', () => {
+  describe('compileSCXML - actions', () => {
     it('should convert raise actions', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
@@ -417,7 +418,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
           {
@@ -454,7 +455,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.entry)).toMatchInlineSnapshot(`
         [
@@ -483,7 +484,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
           {
@@ -503,7 +504,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - entry and exit actions', () => {
+  describe('compileSCXML - entry and exit actions', () => {
     it('should convert onentry actions', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
@@ -515,7 +516,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.entry)).toMatchInlineSnapshot(`
         [
@@ -543,7 +544,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.exit)).toMatchInlineSnapshot(`
         [
@@ -561,7 +562,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - eventless transitions (always)', () => {
+  describe('compileSCXML - eventless transitions (always)', () => {
     it('should convert eventless transitions to always', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
@@ -572,7 +573,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.always)).toMatchInlineSnapshot(`
         [
@@ -590,7 +591,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - internal vs external transitions', () => {
+  describe('compileSCXML - internal vs external transitions', () => {
     it('should mark external transitions with reenter: true', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="parent">
@@ -600,7 +601,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.parent.on!['*']))
         .toMatchInlineSnapshot(`
@@ -628,7 +629,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.parent.on!['*']))
         .toMatchInlineSnapshot(`
@@ -643,7 +644,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - send actions', () => {
+  describe('compileSCXML - send actions', () => {
     it('should convert send with target="#_internal" as raise', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
@@ -655,7 +656,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
           {
@@ -686,7 +687,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
           {
@@ -707,7 +708,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - multiple events per transition', () => {
+  describe('compileSCXML - multiple events per transition', () => {
     it('should handle multiple events on a single transition', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="idle">
@@ -718,7 +719,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.idle.on)).toMatchInlineSnapshot(`
         {
@@ -740,7 +741,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - history states', () => {
+  describe('compileSCXML - history states', () => {
     it('should convert shallow history states', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="parent">
@@ -754,7 +755,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.parent.states!.hist))
         .toMatchInlineSnapshot(`
@@ -777,7 +778,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.parent.states!.deepHist))
         .toMatchInlineSnapshot(`
@@ -790,7 +791,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - delay parsing', () => {
+  describe('compileSCXML - delay parsing', () => {
     it('should parse millisecond delays', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="a">
@@ -802,7 +803,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
@@ -833,7 +834,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
@@ -864,7 +865,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
@@ -895,7 +896,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(toPortableJSON(json.states!.a.on!['*'])).toMatchInlineSnapshot(`
         {
@@ -916,7 +917,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - state ID sanitization', () => {
+  describe('compileSCXML - state ID sanitization', () => {
     it('should sanitize state IDs with dots', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="state.one">
@@ -927,7 +928,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       // Dots are replaced with $
       expect(json._scxmlInitial?.targets).toEqual(['#state$one']);
@@ -966,7 +967,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json._scxmlInitial?.targets).toEqual(['#foo$bar']);
       expect(toPortableJSON(json.states)).toMatchInlineSnapshot(`
@@ -989,7 +990,7 @@ describe('SCXML to XState conversion', () => {
     });
   });
 
-  describe('toMachineJSON - state IDs', () => {
+  describe('compileSCXML - state IDs', () => {
     it('should set id on root state', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" name="myMachine" initial="idle">
@@ -997,7 +998,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json.id).toBe('myMachine');
     });
@@ -1012,7 +1013,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json.states!.a.id).toBe('a');
       expect(json.states!.b.id).toBe('b');
@@ -1027,7 +1028,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json.states!.parent.id).toBe('parent');
       expect(json.states!.parent.states!.child.id).toBe('child');
@@ -1043,7 +1044,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json.states!.parent.states!.hist.id).toBe('hist');
     });
@@ -1058,13 +1059,13 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const json = toMachineJSON(scxml);
+      const json = compileSCXML(scxml);
 
       expect(json.states!.complete.id).toBe('complete');
     });
   });
 
-  describe('toMachine - creates machine from SCXML', () => {
+  describe('createMachineFromSCXML', () => {
     it('should create a machine with correct structure', () => {
       const scxml = `
         <scxml xmlns="http://www.w3.org/2005/07/scxml" version="1.0" initial="idle">
@@ -1075,7 +1076,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const machine = toMachine(scxml);
+      const machine = createMachineFromSCXML(scxml);
 
       expect(machine.root).toBeDefined();
       expect(machine.root.states.idle).toBeDefined();
@@ -1092,7 +1093,7 @@ describe('SCXML to XState conversion', () => {
         </scxml>
       `;
 
-      const machine = toMachine(scxml);
+      const machine = createMachineFromSCXML(scxml);
 
       const [snapshot] = initialTransition(machine);
 

--- a/packages/core/test/errors.test.ts
+++ b/packages/core/test/errors.test.ts
@@ -13,7 +13,8 @@ import {
   setup
 } from '../src';
 import { createMachineFromConfig } from '../src/createMachineFromConfig';
-import { toMachineJSON } from '../src/scxml';
+import { createMachineFromSCXMLConfig } from '../src/scxml/runtime';
+import { compileSCXML } from '../src/scxml/scxml';
 import z from 'zod';
 
 // mocked reportUnhandledError due to unknown issue with vitest and global error
@@ -1262,7 +1263,7 @@ describe('error handling', () => {
 
   it('state onError catches SCXML error.communication from failed sends', () => {
     const errorSpy = vi.fn();
-    const json = toMachineJSON(`
+    const json = compileSCXML(`
       <scxml xmlns="http://www.w3.org/2005/07/scxml" initial="active" version="1.0" datamodel="ecmascript">
         <state id="active">
           <onentry>
@@ -1283,7 +1284,7 @@ describe('error handling', () => {
       ]
     };
 
-    const machine = createMachineFromConfig(json, {
+    const machine = createMachineFromSCXMLConfig(json, {
       actions: {
         captureError: (event) => {
           errorSpy({

--- a/packages/core/test/machineFromConfig.test.ts
+++ b/packages/core/test/machineFromConfig.test.ts
@@ -90,6 +90,20 @@ describe('createMachineFromConfig ', () => {
     const [nextState2] = transition(machine, nextState, { type: 'NEXT' });
     expect(nextState2.value).toEqual('c');
   });
+
+  it('does not merge actor input into native JSON machine context', () => {
+    const machine = createMachineFromConfig({
+      context: { count: 0 },
+      initial: 'idle',
+      states: { idle: {} }
+    });
+    const actor = createActor(machine, {
+      input: { count: 5, extra: true }
+    }).start();
+
+    expect(actor.getSnapshot().context).toEqual({ count: 0 });
+  });
+
   it('should handle raise actions', () => {
     const machine = createMachineFromConfig({
       initial: 'a',

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -7,7 +7,12 @@ import {
   AnyStateMachine,
   createActor
 } from '../src/index.ts';
-import { toMachine, sanitizeStateId, toMachineJSON } from '../src/scxml';
+import {
+  SCXMLConversionOptions,
+  toMachine,
+  sanitizeStateId,
+  toMachineJSON
+} from '../src/scxml';
 import { getStateNodes } from '../src/stateUtils';
 
 const TEST_FRAMEWORK = path.dirname(
@@ -67,11 +72,11 @@ const testGroups: Record<string, string[]> = {
     'test2',
     'test2b',
     'test3',
-    // 'test3b', // a reentering transition contained in one parallel region reenters only that region, so it doesn't conflict with (and get preempted by) sibling-region transitions as strict SCXML external-transition domains would require
+    'test3b',
     'test4',
     'test5',
     'test6',
-    // 'test6b', // same deviation as test3b
+    'test6b',
     'test7',
     'test8',
     'test9',
@@ -293,7 +298,7 @@ const testGroups: Record<string, string[]> = {
     'test503.txml',
     'test504.txml',
     'test505.txml',
-    // 'test506.txml', // `reenter` semantics in v5 are different from SCXML type="internal"/"external" transitions, we respect `reenter` on all state types, not just on compound states
+    'test506.txml',
     // 'test509.txml', // Basic HTTP Event I/O processor not implemented
     // 'test510.txml', // Basic HTTP Event I/O processor not implemented
     // 'test518.txml', // Basic HTTP Event I/O processor not implemented
@@ -308,7 +313,7 @@ const testGroups: Record<string, string[]> = {
     // 'test530.txml', // <content expr="..."> dynamic invoke content not implemented
     // 'test531.txml', // Basic HTTP Event I/O processor not implemented
     // 'test532.txml', // Basic HTTP Event I/O processor not implemented
-    // 'test533.txml', // we allow `reenter: false` to not leave the source state even if that source state is not compound
+    'test533.txml',
     // 'test534.txml', // Basic HTTP Event I/O processor not implemented
     // 'test550.txml', // non-root datamodel with early binding not implemented yet
     // 'test551.txml', // non-root datamodel with early binding not implemented yet
@@ -338,6 +343,55 @@ const overrides: Record<string, string[]> = {
   ]
 };
 
+const manualTests = new Set([
+  'w3c-ecma/test230.txml',
+  'w3c-ecma/test250.txml',
+  'w3c-ecma/test307.txml',
+  'w3c-ecma/test313.txml',
+  'w3c-ecma/test314.txml'
+]);
+const deviations = new Set(['w3c-ecma/test201.txml']);
+const runnableTests: string[] = [];
+const testRoot = path.join(TEST_FRAMEWORK, 'test');
+
+for (const testGroupName of fs.readdirSync(testRoot)) {
+  const testGroupPath = path.join(testRoot, testGroupName);
+  if (!fs.statSync(testGroupPath).isDirectory()) {
+    continue;
+  }
+
+  for (const fileName of fs.readdirSync(testGroupPath)) {
+    if (!fileName.endsWith('.json')) {
+      continue;
+    }
+
+    const testName = fileName.slice(0, -'.json'.length);
+    if (
+      !fs.existsSync(path.join(testGroupPath, `${testName}.scxml`)) &&
+      !fs.existsSync(path.join(testGroupPath, `${testName}.txml.scxml`))
+    ) {
+      continue;
+    }
+
+    const testId = `${testGroupName}/${testName}`;
+    runnableTests.push(testId);
+    if (manualTests.has(testId) || deviations.has(testId)) {
+      continue;
+    }
+
+    const tests = (testGroups[testGroupName] ??= []);
+    if (!tests.includes(testName)) {
+      tests.push(testName);
+    }
+  }
+}
+
+for (const [testGroupName, tests] of Object.entries(testGroups)) {
+  testGroups[testGroupName] = tests.filter(
+    (testName) => !manualTests.has(`${testGroupName}/${testName}`)
+  );
+}
+
 interface SCIONTest {
   initialConfiguration: string[];
   events: Array<{
@@ -345,14 +399,39 @@ interface SCIONTest {
     event: { name: string };
     nextConfiguration: string[];
   }>;
+  legacySemantics?: SCIONTest;
+}
+
+function getAtomicStateIds(
+  machine: AnyStateMachine,
+  snapshot: AnyMachineSnapshot
+): string[] {
+  return [
+    ...new Set(
+      getStateNodes(machine.root, snapshot.value)
+        .filter((stateNode) => !Object.keys(stateNode.states).length)
+        .map((stateNode) => stateNode.id)
+    )
+  ].sort();
+}
+
+function expectConfiguration(
+  machine: AnyStateMachine,
+  snapshot: AnyMachineSnapshot,
+  expectedConfiguration: string[]
+): void {
+  expect(getAtomicStateIds(machine, snapshot)).toEqual(
+    expectedConfiguration.map(sanitizeStateId).sort()
+  );
 }
 
 async function runW3TestToCompletion(
   name: string,
   scxmlDefinition: string,
-  test: SCIONTest
+  test: SCIONTest,
+  options: SCXMLConversionOptions
 ): Promise<void> {
-  const machine = toMachine(scxmlDefinition);
+  const machine = toMachine(scxmlDefinition, options);
 
   const { resolve, reject, promise } = Promise.withResolvers<void>();
   let nextState: AnyMachineSnapshot;
@@ -393,14 +472,15 @@ async function runW3TestToCompletion(
 async function runTestToCompletion(
   name: string,
   scxmlDefinition: string,
-  test: SCIONTest
+  test: SCIONTest,
+  options: SCXMLConversionOptions
 ): Promise<void> {
-  toMachineJSON(scxmlDefinition);
+  toMachineJSON(scxmlDefinition, options);
 
-  const machine = toMachine(scxmlDefinition);
+  const machine = toMachine(scxmlDefinition, options);
 
   if (!test.events.length && test.initialConfiguration[0] === 'pass') {
-    await runW3TestToCompletion(name, scxmlDefinition, test);
+    await runW3TestToCompletion(name, scxmlDefinition, test, options);
     return;
   }
 
@@ -448,12 +528,25 @@ async function runTestToCompletion(
     return;
   }
 
+  // The generated W3C tests validate themselves by reaching pass/fail. Their
+  // JSON scripts model the remote test protocol and can expose a transient
+  // pre-external-queue configuration that is not observable after actor.start().
+  // The supplemental SCION fixtures, however, use initialConfiguration as a
+  // direct statechart assertion.
+  if (!name.startsWith('w3c-ecma/')) {
+    expectConfiguration(machine, nextState, test.initialConfiguration);
+  }
+
   test.events.forEach(({ event, nextConfiguration, after }) => {
     if (done) {
       return;
     }
     if (after) {
-      (actor.clock as SimulatedClock).increment(after);
+      // Advance in small steps so a delayed event can schedule another delay
+      // relative to its actual due time, rather than the end of one large jump.
+      for (let elapsed = 0; elapsed < after; elapsed++) {
+        (actor.clock as SimulatedClock).increment(1);
+      }
     }
     if (done) {
       return;
@@ -463,13 +556,41 @@ async function runTestToCompletion(
       `${event.name} -> ${JSON.stringify(actor.getSnapshot().value)} ${JSON.stringify(actor.getSnapshot().context)}`
     );
 
-    const stateIds = getStateNodes(machine.root, nextState.value).map(
-      (stateNode) => stateNode.id
-    );
-
-    expect(stateIds).toContain(sanitizeStateId(nextConfiguration[0]));
+    expectConfiguration(machine, nextState, nextConfiguration);
   });
 }
+
+describe('SCXML corpus classification', () => {
+  it('classifies every runnable fixture exactly once', () => {
+    const automatedTests = new Set(
+      Object.entries(testGroups).flatMap(([testGroupName, tests]) =>
+        tests.map((testName) => `${testGroupName}/${testName}`)
+      )
+    );
+
+    expect(
+      runnableTests.filter(
+        (testId) =>
+          Number(automatedTests.has(testId)) +
+            Number(manualTests.has(testId)) +
+            Number(deviations.has(testId)) !==
+          1
+      )
+    ).toEqual([]);
+  });
+
+  describe('manual evidence required', () => {
+    for (const testId of manualTests) {
+      it.todo(testId);
+    }
+  });
+
+  describe.skip('explicit protocol deviation', () => {
+    for (const testId of deviations) {
+      it(testId, () => {});
+    }
+  });
+});
 
 describe('scxml', () => {
   const onlyTests: string[] = [
@@ -493,10 +614,15 @@ describe('scxml', () => {
         overrides[testGroupName].indexOf(testName) !== -1
           ? `./fixtures/scxml/${testGroupName}/${testName}.scxml`
           : `${TEST_FRAMEWORK}/test/${testGroupName}/${testName}.scxml`;
-      const scxmlDefinition = fs.readFileSync(
-        path.resolve(__dirname, scxmlSource),
-        { encoding: 'utf-8' }
-      );
+      const scxmlPath = path.resolve(__dirname, scxmlSource);
+      const scxmlDefinition = fs.readFileSync(scxmlPath, { encoding: 'utf-8' });
+      const conversionOptions: SCXMLConversionOptions = {
+        resolveResource: (src) =>
+          fs.readFileSync(
+            path.resolve(path.dirname(scxmlPath), src.replace(/^file:/, '')),
+            'utf-8'
+          )
+      };
       const scxmlTest = JSON.parse(
         fs.readFileSync(
           path.resolve(
@@ -506,13 +632,18 @@ describe('scxml', () => {
           { encoding: 'utf-8' }
         )
       ) as SCIONTest;
+      const expectedTest =
+        testGroupName === 'more-parallel' && testName.startsWith('test10')
+          ? scxmlTest.legacySemantics!
+          : scxmlTest;
 
       execTest(`${testGroupName}/${testName}`, async () => {
         try {
           await runTestToCompletion(
             `${testGroupName}/${testName}`,
             scxmlDefinition,
-            scxmlTest
+            expectedTest,
+            conversionOptions
           );
         } catch (e) {
           // console.log(JSON.stringify(machine.config, null, 2));

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -9,10 +9,10 @@ import {
 } from '../src/index.ts';
 import {
   SCXMLConversionOptions,
-  toMachine,
+  createMachineFromSCXML,
   sanitizeStateId,
-  toMachineJSON
-} from '../src/scxml';
+  compileSCXML
+} from '../src/scxml/scxml';
 import { getStateNodes } from '../src/stateUtils';
 
 const TEST_FRAMEWORK = path.dirname(
@@ -431,7 +431,7 @@ async function runW3TestToCompletion(
   test: SCIONTest,
   options: SCXMLConversionOptions
 ): Promise<void> {
-  const machine = toMachine(scxmlDefinition, options);
+  const machine = createMachineFromSCXML(scxmlDefinition, options);
 
   const { resolve, reject, promise } = Promise.withResolvers<void>();
   let nextState: AnyMachineSnapshot;
@@ -475,9 +475,9 @@ async function runTestToCompletion(
   test: SCIONTest,
   options: SCXMLConversionOptions
 ): Promise<void> {
-  toMachineJSON(scxmlDefinition, options);
+  compileSCXML(scxmlDefinition, options);
 
-  const machine = toMachine(scxmlDefinition, options);
+  const machine = createMachineFromSCXML(scxmlDefinition, options);
 
   if (!test.events.length && test.initialConfiguration[0] === 'pass') {
     await runW3TestToCompletion(name, scxmlDefinition, test, options);

--- a/packages/core/test/scxml.test.ts
+++ b/packages/core/test/scxml.test.ts
@@ -343,13 +343,6 @@ const overrides: Record<string, string[]> = {
   ]
 };
 
-const manualTests = new Set([
-  'w3c-ecma/test230.txml',
-  'w3c-ecma/test250.txml',
-  'w3c-ecma/test307.txml',
-  'w3c-ecma/test313.txml',
-  'w3c-ecma/test314.txml'
-]);
 const deviations = new Set(['w3c-ecma/test201.txml']);
 const runnableTests: string[] = [];
 const testRoot = path.join(TEST_FRAMEWORK, 'test');
@@ -375,7 +368,7 @@ for (const testGroupName of fs.readdirSync(testRoot)) {
 
     const testId = `${testGroupName}/${testName}`;
     runnableTests.push(testId);
-    if (manualTests.has(testId) || deviations.has(testId)) {
+    if (deviations.has(testId)) {
       continue;
     }
 
@@ -384,12 +377,6 @@ for (const testGroupName of fs.readdirSync(testRoot)) {
       tests.push(testName);
     }
   }
-}
-
-for (const [testGroupName, tests] of Object.entries(testGroups)) {
-  testGroups[testGroupName] = tests.filter(
-    (testName) => !manualTests.has(`${testGroupName}/${testName}`)
-  );
 }
 
 interface SCIONTest {
@@ -572,17 +559,10 @@ describe('SCXML corpus classification', () => {
       runnableTests.filter(
         (testId) =>
           Number(automatedTests.has(testId)) +
-            Number(manualTests.has(testId)) +
             Number(deviations.has(testId)) !==
           1
       )
     ).toEqual([]);
-  });
-
-  describe('manual evidence required', () => {
-    for (const testId of manualTests) {
-      it.todo(testId);
-    }
   });
 
   describe.skip('explicit protocol deviation', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1379,6 +1379,10 @@ importers:
         version: 0.31.4(@types/node@25.2.1)(sass@1.97.3)(stylus@0.55.0)(supports-color@5.5.0)(terser@5.49.0)
 
   packages/core:
+    dependencies:
+      saxes:
+        specifier: ^6.0.0
+        version: 6.0.0
     devDependencies:
       '@scion-scxml/test-framework':
         specifier: ^2.0.15
@@ -1392,9 +1396,6 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
-      xml-js:
-        specifier: ^1.6.11
-        version: 1.6.11
       zod:
         specifier: ^3.25.51
         version: 3.25.76
@@ -6770,12 +6771,12 @@ packages:
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==, tarball: https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==, tarball: https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -10068,9 +10069,6 @@ packages:
   sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==, tarball: https://registry.npmjs.org/sax/-/sax-1.2.4.tgz}
 
-  sax@1.4.1:
-    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==, tarball: https://registry.npmjs.org/sax/-/sax-1.4.1.tgz}
-
   saxes@3.1.11:
     resolution: {integrity: sha512-Ydydq3zC+WYDJK1+gRxRapLIED9PWeSuuS41wqyoRmzvhhh9nc+QQrVMKJYzJFULazeGhzSV0QleN2wD3boh2g==, tarball: https://registry.npmjs.org/saxes/-/saxes-3.1.11.tgz}
     engines: {node: '>=8'}
@@ -11540,10 +11538,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  xml-js@1.6.11:
-    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==, tarball: https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz}
-    hasBin: true
 
   xml-name-validator@3.0.0:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==, tarball: https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz}
@@ -21653,8 +21647,6 @@ snapshots:
 
   sax@1.2.4: {}
 
-  sax@1.4.1: {}
-
   saxes@3.1.11:
     dependencies:
       xmlchars: 2.2.0
@@ -23358,10 +23350,6 @@ snapshots:
   ws@7.5.13: {}
 
   ws@8.18.3: {}
-
-  xml-js@1.6.11:
-    dependencies:
-      sax: 1.4.1
 
   xml-name-validator@3.0.0: {}
 


### PR DESCRIPTION
## Summary

- enroll every runnable SCION/W3C fixture with exact atomic-configuration assertions
- add converter-scoped strict SCXML semantics for transitions, initialization, datamodel/executable content, event metadata, completion, resources, and invocation
- expose `createMachineFromSCXML(...)` from the opt-in `xstate/scxml` entry point
- isolate SCXML parsing, private IR, and runtime compilation from `createMachineFromConfig(...)`

## Corpus status

- all 316 automatable SCXML fixtures passing
- 1 explicit deviation: W3C test 201, optional Basic HTTP Event I/O processor
- zero todo tests
- classification test fails closed if a runnable fixture is not assigned exactly one lane

## Architecture

- `MachineJSON` and `createMachineFromConfig(...)` contain no SCXML descriptors or behavior
- SCXML compilation uses a private representation under `src/scxml`
- core integration uses format-neutral transition-domain and history-default hooks
- the XML parser is isolated to `xstate/scxml` and absent from the main `xstate` bundle

## Verification

- `pnpm test:core` — 2,439 passed; 33 skipped; 3 unrelated todo
- focused SCXML suite — 316 passed; 1 skipped explicit deviation; 0 todo
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm knip`

## Notes

- external SCXML resources require the injected synchronous resolver; no implicit filesystem or network access
- arbitrary runtime-generated invoke source/content values remain outside that conversion-time resolver boundary
- SCXML executes ECMAScript expressions and scripts, so documentation warns against untrusted documents

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
