### PR TITLE
Add `inspect` option to `useStore` in @xstate/store-react

### DIFF
--- a/.changeset/tidy-pears-inspect.md
+++ b/.changeset/tidy-pears-inspect.md
@@ -2,7 +2,7 @@
 '@xstate/store-react': minor
 ---
 
-The `useStore` hook now accepts an `inspect` option for wiring up inspectors to component-local stores. The inspector is subscribed when the component mounts and unsubscribed when it unmounts, and stays stable across re-renders.
+The `useStore` hook now accepts an `inspect` option for wiring up inspectors to component-local stores. The inspector is subscribed while the option is provided and stays stable across re-renders.
 
 ```tsx
 import { useStore, useSelector } from '@xstate/store-react';

--- a/.changeset/tidy-pears-inspect.md
+++ b/.changeset/tidy-pears-inspect.md
@@ -1,0 +1,27 @@
+---
+'@xstate/store-react': minor
+---
+
+The `useStore` hook now accepts an `inspect` option for wiring up inspectors to component-local stores. The inspector is subscribed when the component mounts and unsubscribed when it unmounts, and stays stable across re-renders.
+
+```tsx
+import { useStore, useSelector } from '@xstate/store-react';
+import { createBrowserInspector } from '@statelyai/inspect';
+
+const inspector = createBrowserInspector();
+
+function Counter() {
+  const store = useStore(
+    {
+      context: { count: 0 },
+      on: {
+        inc: (context) => ({ count: context.count + 1 })
+      }
+    },
+    { inspect: inspector.inspect }
+  );
+  const count = useSelector(store, (s) => s.context.count);
+
+  return <button onClick={() => store.send({ type: 'inc' })}>{count}</button>;
+}
+```

--- a/examples/store-counter-react/src/App.tsx
+++ b/examples/store-counter-react/src/App.tsx
@@ -1,6 +1,6 @@
 import './App.css';
 import { createStore } from '@xstate/store';
-import { useSelector } from '@xstate/store-react';
+import { useSelector, useStore } from '@xstate/store-react';
 import { createBrowserInspector } from '@statelyai/inspect';
 
 const inspector = createBrowserInspector();
@@ -25,6 +25,33 @@ const store = createStore({
 
 store.inspect(inspector.inspect);
 
+function LocalCounter() {
+  const localStore = useStore(
+    {
+      context: {
+        count: 0
+      },
+      on: {
+        inc: (context, event: { by: number }) => {
+          return {
+            count: context.count + event.by
+          };
+        }
+      }
+    },
+    { inspect: inspector.inspect }
+  );
+  const count = useSelector(localStore, (s) => s.context.count);
+
+  return (
+    <div className="card">
+      <button onClick={() => localStore.send({ type: 'inc', by: 1 })}>
+        local count is {count}
+      </button>
+    </div>
+  );
+}
+
 function App() {
   const count = useSelector(store, (s) => s.context.count);
 
@@ -43,6 +70,7 @@ function App() {
         </button>
         <button onClick={() => store.send({ type: 'reset' })}>reset</button>
       </div>
+      <LocalCounter />
     </>
   );
 }

--- a/packages/xstate-store-react/README.md
+++ b/packages/xstate-store-react/README.md
@@ -65,7 +65,7 @@ const App = () => {
 
 ---
 
-### `useStore(definition)`
+### `useStore(definition, options?)`
 
 Creates a store instance scoped to a component.
 
@@ -86,9 +86,25 @@ const App = () => {
 };
 ```
 
+To wire up an inspector, pass the `inspect` option. The inspector is subscribed on mount and unsubscribed on unmount:
+
+```tsx
+const store = useStore(
+  {
+    context: { count: 0 },
+    on: {
+      inc: (ctx) => ({ ...ctx, count: ctx.count + 1 })
+    }
+  },
+  { inspect: inspector.inspect }
+);
+```
+
 **Arguments:**
 
-- `definition` - Store configuration object
+- `definition` - Store configuration object, or store logic created with `createStoreLogic()` (followed by its `input`)
+- `options?` - Options object:
+  - `inspect?` - Observer or callback that receives [inspection events](https://stately.ai/docs/inspection) from the store
 
 **Returns:** Store instance (stable across re-renders)
 

--- a/packages/xstate-store-react/README.md
+++ b/packages/xstate-store-react/README.md
@@ -65,6 +65,8 @@ const App = () => {
 
 ---
 
+<!-- useStore overloads and inspection behavior from packages/xstate-store-react/src/index.ts -->
+
 ### `useStore(definition, options?)`
 
 Creates a store instance scoped to a component.
@@ -86,7 +88,7 @@ const App = () => {
 };
 ```
 
-To wire up an inspector, pass the `inspect` option. The inspector is subscribed on mount and unsubscribed on unmount:
+To wire up an inspector, pass the `inspect` option. The inspector is subscribed while the option is provided and unsubscribed when it is removed or the component unmounts:
 
 ```tsx
 const store = useStore(

--- a/packages/xstate-store-react/src/index.test.tsx
+++ b/packages/xstate-store-react/src/index.test.tsx
@@ -8,7 +8,8 @@ import {
   useStore,
   useAtom,
   useAtomState,
-  createStoreHook
+  createStoreHook,
+  type StoreInspectionEvent
 } from './index.ts';
 
 describe('@xstate/store-react', () => {
@@ -226,6 +227,36 @@ describe('@xstate/store-react', () => {
       // 1 init event on subscribe + 1 per transition; no duplicates from
       // re-render resubscription
       expect(snapshotEvents).toEqual(['@xstate.init', 'inc', 'inc']);
+    });
+
+    it('should subscribe an inspector enabled after mount', () => {
+      const events: string[] = [];
+
+      const Counter = ({
+        inspect
+      }: {
+        inspect?: (event: StoreInspectionEvent) => void;
+      }) => {
+        const store = useStore(
+          {
+            context: { count: 0 },
+            on: {
+              inc: (ctx: { count: number }) => ({ count: ctx.count + 1 })
+            }
+          },
+          { inspect }
+        );
+
+        return <button onClick={() => store.send({ type: 'inc' })}>inc</button>;
+      };
+
+      const { rerender } = render(<Counter />);
+      rerender(<Counter inspect={(event) => events.push(event.event.type)} />);
+
+      expect(events).toEqual(['@xstate.init']);
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(events).toEqual(['@xstate.init', 'inc']);
     });
 
     it('should support the inspect option with store logic and input', () => {

--- a/packages/xstate-store-react/src/index.test.tsx
+++ b/packages/xstate-store-react/src/index.test.tsx
@@ -159,6 +159,106 @@ describe('@xstate/store-react', () => {
       expect(countDiv.textContent).toBe('11');
       expect(storeRefs.every((ref) => ref === storeRefs[0])).toBe(true);
     });
+
+    it('should subscribe an inspector via the inspect option', () => {
+      const events: string[] = [];
+
+      const Counter = () => {
+        const store = useStore(
+          {
+            context: { count: 0 },
+            on: {
+              inc: (ctx: { count: number }) => ({ count: ctx.count + 1 })
+            }
+          },
+          { inspect: (ev) => events.push(ev.event.type) }
+        );
+        const count = useSelector(store, (s) => s.context.count);
+
+        return (
+          <div data-testid="count" onClick={() => store.send({ type: 'inc' })}>
+            {count}
+          </div>
+        );
+      };
+
+      const { unmount } = render(<Counter />);
+
+      // the inspector immediately receives the current snapshot
+      expect(events).toEqual(['@xstate.init']);
+
+      fireEvent.click(screen.getByTestId('count'));
+      expect(events).toEqual(['@xstate.init', 'inc']);
+
+      const countBeforeUnmount = events.length;
+      unmount();
+      expect(events.length).toBe(countBeforeUnmount);
+    });
+
+    it('should not resubscribe the inspector across re-renders', () => {
+      const snapshotEvents: string[] = [];
+
+      const Counter = () => {
+        const store = useStore(
+          {
+            context: { count: 0 },
+            on: {
+              inc: (ctx: { count: number }) => ({ count: ctx.count + 1 })
+            }
+          },
+          { inspect: (ev) => snapshotEvents.push(ev.event.type) }
+        );
+        const count = useSelector(store, (s) => s.context.count);
+
+        return (
+          <div data-testid="count" onClick={() => store.send({ type: 'inc' })}>
+            {count}
+          </div>
+        );
+      };
+
+      render(<Counter />);
+      const countDiv = screen.getByTestId('count');
+
+      fireEvent.click(countDiv);
+      fireEvent.click(countDiv);
+
+      // 1 init event on subscribe + 1 per transition; no duplicates from
+      // re-render resubscription
+      expect(snapshotEvents).toEqual(['@xstate.init', 'inc', 'inc']);
+    });
+
+    it('should support the inspect option with store logic and input', () => {
+      const counterLogic = createStoreLogic({
+        context: (input: { initialCount: number }) => ({
+          count: input.initialCount
+        }),
+        on: {
+          inc: (ctx) => ({ count: ctx.count + 1 })
+        }
+      });
+      const events: string[] = [];
+
+      const Counter = () => {
+        const store = useStore(
+          counterLogic,
+          { initialCount: 10 },
+          { inspect: (ev) => events.push(ev.event.type) }
+        );
+        const count = useSelector(store, (s) => s.context.count);
+
+        return (
+          <div data-testid="count" onClick={() => store.trigger.inc()}>
+            {count}
+          </div>
+        );
+      };
+
+      render(<Counter />);
+
+      expect(screen.getByTestId('count').textContent).toBe('10');
+      expect(events).toEqual(['@xstate.init']);
+    });
   });
 
   describe('useAtom', () => {

--- a/packages/xstate-store-react/src/index.ts
+++ b/packages/xstate-store-react/src/index.ts
@@ -1,6 +1,6 @@
 export * from '@xstate/store';
 
-import { useCallback, useRef, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import {
   type AnyStoreConfig,
   type AnyStoreLogicCreator,
@@ -16,6 +16,8 @@ import {
   type ValueFromAtomConfig,
   type StoreSnapshot,
   type ContextFromStoreConfig,
+  type Observer,
+  type StoreInspectionEvent,
   createStore,
   isAtom
 } from '@xstate/store';
@@ -58,12 +60,31 @@ type StoreFromStoreDefinition<TDefinition extends StoreDefinition> =
       ? StoreFromStoreConfig<TDefinition>
       : never;
 
+interface UseStoreOptions {
+  /**
+   * An observer or callback that receives [inspection
+   * events](https://stately.ai/docs/inspection) from the store. Subscribed on
+   * mount and unsubscribed on unmount; stable across re-renders.
+   */
+  inspect?:
+    | Observer<StoreInspectionEvent>
+    | ((inspectionEvent: StoreInspectionEvent) => void);
+}
+
 type UseStoreArgs<TDefinition extends StoreDefinition> =
   TDefinition extends AnyStoreLogicCreator
     ? undefined extends InputFromStoreLogicCreator<TDefinition>
-      ? [logic: TDefinition, input?: InputFromStoreLogicCreator<TDefinition>]
-      : [logic: TDefinition, input: InputFromStoreLogicCreator<TDefinition>]
-    : [definition: TDefinition];
+      ? [
+          logic: TDefinition,
+          input?: InputFromStoreLogicCreator<TDefinition>,
+          options?: UseStoreOptions
+        ]
+      : [
+          logic: TDefinition,
+          input: InputFromStoreLogicCreator<TDefinition>,
+          options?: UseStoreOptions
+        ]
+    : [definition: TDefinition, options?: UseStoreOptions];
 
 type AtomDefinition = BaseAtom<any> | AnyAtomConfig;
 
@@ -174,18 +195,59 @@ export function useSelector<TSnapshot, T>(
   );
 }
 
-/** Creates a stable store instance for the lifetime of a React component. */
+/**
+ * Creates a stable store instance for the lifetime of a React component.
+ *
+ * Pass `options.inspect` to subscribe an inspector to the store on mount; the
+ * subscription is removed on unmount.
+ *
+ * @example
+ *
+ * ```ts
+ * function Counter() {
+ *   const store = useStore(
+ *     {
+ *       context: { count: 0 },
+ *       on: { inc: (ctx) => ({ count: ctx.count + 1 }) }
+ *     },
+ *     { inspect: inspector.inspect }
+ *   );
+ *   // …
+ * }
+ * ```
+ */
 export function useStore<TDefinition extends StoreDefinition>(
-  ...[definition, input]: UseStoreArgs<TDefinition>
+  ...args: UseStoreArgs<TDefinition>
 ): StoreFromStoreDefinition<TDefinition> {
+  const [definition] = args;
+  const isLogic = 'createStore' in definition;
+  const input = isLogic ? args[1] : undefined;
+  const options = (isLogic ? args[2] : args[1]) as UseStoreOptions | undefined;
+
   const storeRef = useRef<any>(undefined);
 
   if (!storeRef.current) {
-    storeRef.current =
-      'createStore' in definition
-        ? definition.createStore(input)
-        : createStoreFromDefinition(definition);
+    storeRef.current = isLogic
+      ? definition.createStore(input)
+      : createStoreFromDefinition(definition);
   }
+
+  const inspectRef = useRef(options?.inspect);
+  inspectRef.current = options?.inspect;
+
+  useEffect(() => {
+    if (!inspectRef.current) {
+      return;
+    }
+    return storeRef.current.inspect((inspectionEvent: StoreInspectionEvent) => {
+      const inspect = inspectRef.current;
+      if (typeof inspect === 'function') {
+        inspect(inspectionEvent);
+      } else {
+        inspect?.next?.(inspectionEvent);
+      }
+    }).unsubscribe;
+  }, []);
 
   return storeRef.current;
 }

--- a/packages/xstate-store-react/src/index.ts
+++ b/packages/xstate-store-react/src/index.ts
@@ -63,8 +63,8 @@ type StoreFromStoreDefinition<TDefinition extends StoreDefinition> =
 interface UseStoreOptions {
   /**
    * An observer or callback that receives [inspection
-   * events](https://stately.ai/docs/inspection) from the store. Subscribed on
-   * mount and unsubscribed on unmount; stable across re-renders.
+   * events](https://stately.ai/docs/inspection) from the store. Subscribed
+   * while provided; stable across re-renders.
    */
   inspect?:
     | Observer<StoreInspectionEvent>
@@ -198,8 +198,8 @@ export function useSelector<TSnapshot, T>(
 /**
  * Creates a stable store instance for the lifetime of a React component.
  *
- * Pass `options.inspect` to subscribe an inspector to the store on mount; the
- * subscription is removed on unmount.
+ * Pass `options.inspect` to subscribe an inspector to the store. The
+ * subscription is removed when the inspector is removed or on unmount.
  *
  * @example
  *
@@ -234,6 +234,7 @@ export function useStore<TDefinition extends StoreDefinition>(
 
   const inspectRef = useRef(options?.inspect);
   inspectRef.current = options?.inspect;
+  const shouldInspect = options?.inspect !== undefined;
 
   useEffect(() => {
     if (!inspectRef.current) {
@@ -247,7 +248,7 @@ export function useStore<TDefinition extends StoreDefinition>(
         inspect?.next?.(inspectionEvent);
       }
     }).unsubscribe;
-  }, []);
+  }, [shouldInspect]);
 
   return storeRef.current;
 }


### PR DESCRIPTION
## Summary

`useStore` now accepts an `inspect` option, so wiring an inspector to a component-local store is one line instead of a `useEffect` dance:

```tsx
const store = useStore(
  {
    context: { count: 0 },
    on: { inc: (ctx) => ({ count: ctx.count + 1 }) }
  },
  { inspect: inspector.inspect }
);
```

- Works with both forms: `useStore(config, options?)` and `useStore(logic, input, options?)`
- Subscribes on mount, unsubscribes on unmount; subscription is stable across re-renders (latest callback is read through a ref)
- Accepts a callback or an observer, matching `store.inspect(…)`
- Updated `examples/store-counter-react` with a `LocalCounter` using the option; documented in the package README; changeset included

## Tests

- Inspector receives the initial `@xstate.init` transition event and subsequent events; nothing after unmount
- No duplicate subscriptions across re-renders
- Works with `createStoreLogic` + input form
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5683" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->