### PR TITLE
Fix Changesets packing with pnpm 10

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Please read [our code of conduct](https://github.com/statelyai/xstate/blob/main/
 <!-- runtime and package manager versions matching .node-version and package.json#packageManager -->
 
 - Use Node 24.16.0.
-- Enable Corepack and run `pnpm install`. The repository pins pnpm 9.15.9.
+- Enable Corepack and run `pnpm install`. The repository pins pnpm 10.34.5.
 
 ## Making changes
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,15 @@
     "!(CLAUDE).{ts,tsx,mts,cts,js,jsx,mjs,cjs,json,jsonc,json5,md,mdx,css,scss,less,yml,yaml,html}": "oxfmt --write"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild",
+      "husky",
+      "lmdb",
+      "msgpackr-extract",
+      "svelte-preprocess",
+      "vue-demi"
+    ],
     "overrides": {
       "@types/node": "25.2.1",
       "stylus": "0.55.0",
@@ -100,5 +109,5 @@
       "@vue/test-utils@2.4.6": "patches/@vue__test-utils@2.4.6.patch"
     }
   },
-  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"
+  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
 
 patchedDependencies:
   '@vue/test-utils@2.4.6':
-    hash: drgml7uwcocw5qdowdzbfcfg3e
+    hash: c6febd94304e3a020e9bc9b25d5afa0394e9b011f6328d19dc10b24617742f43
     path: patches/@vue__test-utils@2.4.6.patch
 
 importers:
@@ -8984,7 +8984,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.27.6
       '@testing-library/dom': 9.3.4
-      '@vue/test-utils': 2.4.6(patch_hash=drgml7uwcocw5qdowdzbfcfg3e)
+      '@vue/test-utils': 2.4.6(patch_hash=c6febd94304e3a020e9bc9b25d5afa0394e9b011f6328d19dc10b24617742f43)
       vue: 3.5.27(typescript@7.0.2)
     optionalDependencies:
       '@vue/compiler-sfc': 3.5.29
@@ -9305,7 +9305,7 @@ snapshots:
   '@vue/shared@3.5.29':
     optional: true
 
-  '@vue/test-utils@2.4.6(patch_hash=drgml7uwcocw5qdowdzbfcfg3e)':
+  '@vue/test-utils@2.4.6(patch_hash=c6febd94304e3a020e9bc9b25d5afa0394e9b011f6328d19dc10b24617742f43)':
     dependencies:
       js-beautify: 1.15.4
       vue-component-type-helpers: 2.2.12

--- a/scripts/ensure-pnpm.js
+++ b/scripts/ensure-pnpm.js
@@ -1,3 +1,3 @@
-if (!/pnpm\/9/.test(process.env.npm_config_user_agent)) {
-  throw new Error('Please use `pnpm@^9` for installs.');
+if (!/pnpm\/10\./.test(process.env.npm_config_user_agent)) {
+  throw new Error('Please use `pnpm@^10` for installs.');
 }


### PR DESCRIPTION
Changesets v3 invokes pnpm pack with --out, which pnpm 9 does not support. Upgrade the repository pin and refresh the pnpm 10 patch hash so frozen installs continue to work.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5684" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->