### PR TITLE
feat(core): strengthen setup state input contracts

### DIFF
--- a/.changeset/setup-state-contracts.md
+++ b/.changeset/setup-state-contracts.md
@@ -1,0 +1,8 @@
+---
+'xstate': minor
+---
+
+Improve `setup(...)` state contracts with typed structural metadata, recursive
+state input requirements for composite and parallel entry, history-default
+validation, strongly typed relative targets, and shared input requirements for
+literal target sets.

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -408,13 +408,30 @@ actor.send({ type: 'xstate.route', to: '#review' });
 
 // state input: schema in setup(...), value on the transition
 const s = setup({
-  states: { loading: { schemas: { input: z.object({ id: z.string() }) } } }
+  states: {
+    loading: { schemas: { input: z.object({ id: z.string() }) } },
+    active: {
+      type: 'parallel',
+      states: { playback: {}, volume: {} }
+    }
+  }
 });
 s.createMachine({
   initial: { target: 'loading', input: { id: 'a1' } },
-  states: { loading: { entry: ({ input }) => input.id } }
+  states: {
+    loading: { entry: ({ input }) => input.id },
+    active: {
+      states: {
+        playback: { initial: 'playing', states: { playing: {} } },
+        volume: { initial: 'audible', states: { audible: {} } }
+      }
+    }
+  }
 });
 ```
+
+State contracts without structural metadata remain permissive, so existing
+`setup(...)` machines do not need to add `type` or `initial` declarations.
 
 See [final](final-states.md), [history](history-states.md), [parallel](parallel-states.md), [choice](choice-states.md), [route](route-states.md) and [state input](state-input.md).
 

--- a/docs/history-states.md
+++ b/docs/history-states.md
@@ -110,6 +110,37 @@ Use history states when a user leaves a multi-step form and returns to the step 
 
 `target` on a history state is `string | string[]` and is checked against the machine's state paths, so an unknown default target is a type error as well as a runtime error. `snapshot.historyValue` is `Record<string, StateNode[]>` on a live snapshot and `Record<string, { id: string }[]>` once persisted.
 
+History defaults can be declared in `setup(...)` when the state topology is
+known there. The machine config can then omit `type` and `target`; the setup
+contract supplies them to the state node and the same target validation still
+applies:
+
+```ts
+const playerSetup = setup({
+  states: {
+    player: {
+      type: 'compound',
+      initial: 'stopped',
+      states: {
+        stopped: {},
+        hist: { type: 'history', target: 'stopped' }
+      }
+    }
+  }
+});
+
+playerSetup.createMachine({
+  initial: 'player',
+  states: { player: { states: { stopped: {}, hist: {} } } }
+});
+```
+
+History defaults have no `input` field. A setup history target therefore cannot
+be a state with required input. Target a compound or parallel state instead;
+its normal initial transitions must provide input for any newly entered child
+states. When history has a remembered configuration, the existing state inputs
+are restored with that configuration.
+
 ## History states cheatsheet
 
 ```ts

--- a/docs/parallel-states.md
+++ b/docs/parallel-states.md
@@ -102,6 +102,11 @@ Relative paths work the same way: `target: ['playback.stopped', 'volume.audible'
 
 The target set must be a legal configuration: the targets must be in different regions of a common parallel ancestor. Two targets in the same region throw at machine creation, not at send time.
 
+With typed setup state schemas, one `input` value is shared by every target in
+the set and must contain the fields required by each target. Inputs for
+descendants entered through a composite or parallel state's normal `initial`
+transitions remain declared on those initial transitions.
+
 ## Cross-region conditions
 
 Use `checkStateIn(...)` inside a [transition function](guards.md) to read another region.
@@ -128,6 +133,35 @@ Common uses: a media player with independent playback, volume and subtitle regio
 ## TypeScript
 
 Region keys are inferred from `states`, so `snapshot.value` and `matches` are typed against the real region structure and a misspelled region is a type error. `onDone` on a parallel state receives a done event whose `output` is an object keyed by region. With `setup({ states })`, declare the aggregate explicitly with the parallel state's `schemas.output` when the region contract needs to be available before the machine config is written.
+
+You can declare the parallel shape in `setup(...)` and fill in behavior in
+`createMachine(...)`:
+
+```ts
+const playerSetup = setup({
+  states: {
+    active: {
+      type: 'parallel',
+      states: { playback: {}, volume: {} }
+    }
+  }
+});
+
+playerSetup.createMachine({
+  initial: 'active',
+  states: {
+    active: {
+      states: {
+        playback: { initial: 'playing', states: { playing: {} } },
+        volume: { initial: 'audible', states: { audible: {} } }
+      }
+    }
+  }
+});
+```
+
+The setup contract supplies `type: 'parallel'`, so `active` cannot define an
+`initial` state and its state value is typed as an object of regions.
 
 ## Parallel states cheatsheet
 

--- a/docs/route-states.md
+++ b/docs/route-states.md
@@ -82,6 +82,10 @@ Route events are strongly typed. The `to` field only accepts `#id` strings for s
 
 Inside a route function, `context`, `event` and `guards` are inferred from the machine's schemas. When a machine is built from JSON with `createMachineFromConfig`, a route may reference a guard by name; an unimplemented name errors the actor at route time with `Guard 'isReady' is not implemented in machine 'flow'`.
 
+For a setup-defined route, declare `id` and `route: true` in the state
+contract. The machine config may omit both fields, and the route event remains
+typed against the declared `#id`.
+
 ## Route states cheatsheet
 
 ```ts

--- a/docs/setup-and-provide.md
+++ b/docs/setup-and-provide.md
@@ -41,6 +41,10 @@ When a structural contract declares child states, `createMachine(...)` still
 provides those child configs; setup supplies their contracts and defaults, not
 their runtime behavior.
 
+When setup is extended, repeated state names merge recursively. Extension
+fields and schemas win conflicts, while descendants declared only by the base
+or extension are preserved.
+
 Input requirements follow entry semantics. A transition that targets a
 composite state supplies that state's input, while the composite state's
 `initial` supplies input for its newly entered child. A parallel state follows

--- a/docs/setup-and-provide.md
+++ b/docs/setup-and-provide.md
@@ -29,6 +29,31 @@ const orderMachine = orderSetup.createMachine({
 
 `setup(...)` also accepts `states`, where each state declares its own schemas. That is what types the `initial: { target, input }` form and transitions carrying [state input](state-input.md).
 
+State contracts can also declare structural metadata: `type`, `initial`,
+`history`, `target`, and `id` (plus `route: true` for a routable state).
+`createMachine(...)` may omit those defaults, and the resulting state value and
+state-node metadata retain their types. Declaring a state `type` also checks
+its compatible machine shape: compound states need an `initial`, parallel
+states do not accept one, history states need a non-empty `target`, and final
+or choice states cannot define child-state behavior. Setups that only declare
+`schemas` remain permissive for compatibility with existing machine configs.
+When a structural contract declares child states, `createMachine(...)` still
+provides those child configs; setup supplies their contracts and defaults, not
+their runtime behavior.
+
+Input requirements follow entry semantics. A transition that targets a
+composite state supplies that state's input, while the composite state's
+`initial` supplies input for its newly entered child. A parallel state follows
+the same rule independently for each region, so every region with an
+input-bearing initial child needs an object-form `initial` transition. The
+path overload of `createStateConfig(...)` resolves relative targets such as
+`.child` and `.foo.grandchild` against the setup tree and types their input.
+
+History defaults do not have an input field. Therefore a setup history state
+cannot default directly to a state with required input; target a composite or
+parallel state whose normal initial transitions construct the required child
+inputs instead.
+
 State schemas can also declare `schemas.output` for the value emitted when that
 state completes. Final-state `output` functions and the parent state's `onDone`
 event use that local type. For a parallel state, declare the aggregate object on

--- a/docs/state-input.md
+++ b/docs/state-input.md
@@ -36,7 +36,7 @@ const uploadMachine = uploadSetup.createMachine({
 });
 ```
 
-State input is available to the target state's `entry`, `exit`, `on`, `after`, `timeout`, `onTimeout` and `output` functions. It persists across self-transitions and is replaced the next time the state is entered.
+State input is available to the target state's `entry`, `exit`, `on`, `after`, `timeout`, `onTimeout` and `output` functions. An invoked actor's `invoke.input` function also receives the state input, so it can adapt the state data to the actor's input contract. It persists across self-transitions and is replaced the next time the state is entered.
 
 ## Computing input
 
@@ -68,6 +68,21 @@ uploadSetup.createMachine({
 
 Nested states work the same way: a parent's `initial` passes input to its child.
 
+## Multiple targets
+
+XState applies one transition `input` to every target in a target array. When
+setup declares input schemas for those targets, the input must satisfy all of
+them:
+
+```ts
+target: ['active.left.ready', 'active.right.ready'],
+input: { leftId: 1, rightId: true }
+```
+
+Each target's descendants still receive their own input from their normal
+`initial` transitions. Widened target arrays remain compatible with existing
+configurations.
+
 ## Reading input from a snapshot
 
 `snapshot.getInputs()` returns the current inputs keyed by state node ID.
@@ -87,7 +102,7 @@ Use state input for data that belongs to one state rather than to the whole mach
 
 ## TypeScript
 
-Input is typed by the state's `schemas.input`. Transitions targeting the state require a matching `input`, and `({ input })` is typed inside that state's functions. Modular state configs created with `setup(...).createStateConfig(...)` are typed the same way. See [setup and provide](setup-and-provide.md).
+Input is typed by the state's `schemas.input`. Transitions targeting the state require a matching `input`, and `({ input })` is typed inside that state's functions, including `invoke.input`. Modular state configs created with `setup(...).createStateConfig(...)` are typed the same way. See [setup and provide](setup-and-provide.md).
 
 ## State input cheatsheet
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -3,7 +3,7 @@ title: TypeScript
 description: Define schemas and derive XState types.
 ---
 
-Define schemas with `setup(...)`. XState infers context, events, input and output from them.
+Define schemas with `setup(...)`. XState infers context, events, input and output from them. State contracts can additionally declare state-node structure and defaults, including `type`, `initial`, `history`, `target` and `id`.
 
 Enable TypeScript's `strict` mode. Keep schemas next to actor logic so runtime validation and inferred types describe the same contract.
 
@@ -28,6 +28,11 @@ const machine = setup({
   states: { active: {} }
 });
 ```
+
+Structural state contracts are checked only when declared. For example,
+`type: 'parallel'` forbids `initial`, while `type: 'compound'` requires one;
+the machine config may provide those defaults through `setup(...)`. Existing
+setups that declare only schemas keep their permissive machine-config typing.
 
 Public schema event keys create typed methods on `actor.trigger`; internal
 schema keys do not appear in the public trigger namespace.

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -30,9 +30,10 @@ const machine = setup({
 ```
 
 Structural state contracts are checked only when declared. For example,
-`type: 'parallel'` forbids `initial`, while `type: 'compound'` requires one;
-the machine config may provide those defaults through `setup(...)`. Existing
-setups that declare only schemas keep their permissive machine-config typing.
+`type: 'parallel'` forbids `initial`, while `type: 'compound'` requires one.
+`setup(...)` can supply those defaults, so the machine config may omit them.
+Existing setups that declare only schemas keep their permissive machine-config
+typing.
 
 Public schema event keys create typed methods on `actor.trigger`; internal
 schema keys do not appear in the public trigger namespace.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -128,7 +128,8 @@ export type {
   SystemConfig,
   SystemRuntime,
   SetupStateSchema,
-  SetupStateSchemas
+  SetupStateSchemas,
+  SetupStateType
 } from './setup.ts';
 export { getInitialSnapshot, getNextSnapshot } from './getNextSnapshot.ts';
 export type {

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -596,15 +596,23 @@ type SetupStateChildSchemas<TStateSchema extends SetupStateSchema> =
     ? TStateSchema['states']
     : Record<string, SetupStateSchema>;
 
-type SetupStateIds<TStateSchemas extends Record<string, SetupStateSchema>> = {
-  [K in keyof TStateSchemas & string]: TStateSchemas[K] extends {
-    id: infer TId extends string;
-  }
-    ? TId
-    : TStateSchemas[K]['states'] extends Record<string, SetupStateSchema>
-      ? SetupStateIds<TStateSchemas[K]['states']>
-      : never;
-}[keyof TStateSchemas & string];
+type SetupStateIds<TStateSchemas extends Record<string, SetupStateSchema>> =
+  | {
+      [K in keyof TStateSchemas & string]: TStateSchemas[K] extends {
+        id: infer TId extends string;
+      }
+        ? TId
+        : never;
+    }[keyof TStateSchemas & string]
+  | {
+      [K in keyof TStateSchemas &
+        string]: TStateSchemas[K]['states'] extends Record<
+        string,
+        SetupStateSchema
+      >
+        ? SetupStateIds<TStateSchemas[K]['states']>
+        : never;
+    }[keyof TStateSchemas & string];
 
 type SetupStateSchemaAtTarget<
   TStateSchemas extends Record<string, SetupStateSchema>,
@@ -1108,12 +1116,14 @@ type SetupTargetArrayInputConstraint<
     ? unknown
     : [TTargets[number]] extends [never]
       ? unknown
-      : Exclude<
-            TTargets[number],
-            KnownSetupStateTarget<TStateSchemas>
-          > extends never
-        ? SetupTargetArrayInputConfig<TStateSchemas, TTargets>
-        : unknown
+      : string extends StatePaths<TStateSchemas>
+        ? unknown
+        : Exclude<
+              TTargets[number],
+              KnownSetupStateTarget<TStateSchemas>
+            > extends never
+          ? SetupTargetArrayInputConfig<TStateSchemas, TTargets>
+          : never
   : unknown;
 
 type SetupTransitionValueTargetArrayInputConstraint<
@@ -1676,9 +1686,9 @@ type StateSchemaMetadataField<
   TSetup extends StateSchema,
   TKey extends keyof StateSchema
 > =
-  TSetup extends Record<TKey, infer TValue>
+  TConfig extends Record<TKey, infer TValue>
     ? { [K in TKey]: TValue }
-    : TConfig extends Record<TKey, infer TValue>
+    : TSetup extends Record<TKey, infer TValue>
       ? { [K in TKey]: TValue }
       : {};
 
@@ -3474,6 +3484,56 @@ function mergeMaps<TLeft, TRight>(
   return left || right ? ({ ...left, ...right } as TLeft & TRight) : undefined;
 }
 
+function mergeSetupStateSchemas(
+  left: Record<string, SetupStateSchema> | undefined,
+  right: Record<string, SetupStateSchema> | undefined
+): Record<string, SetupStateSchema> | undefined {
+  if (!left && !right) {
+    return undefined;
+  }
+
+  if (!left) {
+    return right;
+  }
+
+  if (!right) {
+    return left;
+  }
+
+  return Object.fromEntries(
+    Array.from(new Set([...Object.keys(left), ...Object.keys(right)])).map(
+      (key) => {
+        const leftState = left[key];
+        const rightState = right[key];
+
+        if (!leftState) {
+          return [key, rightState];
+        }
+
+        if (!rightState) {
+          return [key, leftState];
+        }
+
+        const schemas = mergeSchemas(leftState.schemas, rightState.schemas);
+        const states = mergeSetupStateSchemas(
+          leftState.states,
+          rightState.states
+        );
+
+        return [
+          key,
+          {
+            ...leftState,
+            ...rightState,
+            ...(schemas ? { schemas } : undefined),
+            ...(states ? { states } : undefined)
+          }
+        ];
+      }
+    )
+  );
+}
+
 function mergeSchemas(
   left: SetupSchemas | undefined,
   right: SetupSchemas | undefined
@@ -3554,7 +3614,7 @@ function mergeSetupConfigs<
     ...base,
     ...extension,
     schemas: mergeSchemas(base.schemas, extension.schemas),
-    states: mergeMaps(base.states, extension.states),
+    states: mergeSetupStateSchemas(base.states, extension.states),
     actions: mergeMaps(base.actions, extension.actions),
     actors: mergeMaps(base.actors, extension.actors),
     guards: mergeMaps(base.guards, extension.guards),

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -547,6 +547,12 @@ type SetupStateKey<TStateSchemas extends Record<string, SetupStateSchema>> =
       ? string
       : SetupStateKeys<TStateSchemas>;
 
+type StrictSetupStatePaths<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = [SetupStateKeys<TStateSchemas>] extends [never]
+  ? never
+  : StatePaths<TStateSchemas>;
+
 type SetupRelativeStateTarget<
   TStateSchemas extends Record<string, SetupStateSchema>
 > =
@@ -559,7 +565,7 @@ type SetupRelativeStateTarget<
 type SetupStateTarget<TStateSchemas extends Record<string, SetupStateSchema>> =
   TStateSchemas extends { readonly [strictSetupStateTargets]: true }
     ?
-        | StatePaths<TStateSchemas>
+        | StrictSetupStatePaths<TStateSchemas>
         | SetupRelativeStateTarget<RelativeSetupStateSchemas<TStateSchemas>>
         | `#${string}`
     : string extends SetupStateKeys<TStateSchemas>
@@ -572,15 +578,27 @@ type KnownSetupStateTarget<
   TStateSchemas extends Record<string, SetupStateSchema>
 > =
   string extends StatePaths<TStateSchemas>
-    ? never
+    ? string extends StatePaths<RelativeSetupStateSchemas<TStateSchemas>>
+      ? never
+      :
+          | SetupRelativeStateTarget<RelativeSetupStateSchemas<TStateSchemas>>
+          | SetupStateIdTarget<
+              SetupStateIds<RootSetupStateSchemas<TStateSchemas>>
+            >
+          | SetupStateIdTargets<RootSetupStateSchemas<TStateSchemas>>
     :
-        | (StatePaths<TStateSchemas> & string)
+        | (StrictSetupStatePaths<TStateSchemas> & string)
         | SetupRelativeStateTarget<RelativeSetupStateSchemas<TStateSchemas>>
-        | `#${SetupStateIds<RootSetupStateSchemas<TStateSchemas>> & string}`;
+        | SetupStateIdTarget<
+            SetupStateIds<RootSetupStateSchemas<TStateSchemas>>
+          >
+        | SetupStateIdTargets<RootSetupStateSchemas<TStateSchemas>>;
 
 declare const strictSetupStateTargets: unique symbol;
 declare const relativeSetupStateSchemas: unique symbol;
 declare const rootSetupStateSchemas: unique symbol;
+declare const currentSetupStateSchema: unique symbol;
+declare const parentSetupStateType: unique symbol;
 
 type StrictSetupStateSchemas<
   TStateSchemas extends Record<string, SetupStateSchema>,
@@ -589,11 +607,13 @@ type StrictSetupStateSchemas<
     SetupStateSchema
   >,
   TRootStateSchemas extends Record<string, SetupStateSchema> =
-    RootSetupStateSchemas<TStateSchemas>
+    RootSetupStateSchemas<TStateSchemas>,
+  TCurrentStateSchema extends SetupStateSchema = never
 > = TStateSchemas & {
   readonly [strictSetupStateTargets]: true;
   readonly [relativeSetupStateSchemas]: TRelativeStateSchemas;
   readonly [rootSetupStateSchemas]: TRootStateSchemas;
+  readonly [currentSetupStateSchema]: TCurrentStateSchema;
 };
 
 type RelativeSetupStateSchemas<
@@ -616,6 +636,58 @@ type RootSetupStateSchemas<
   ? TRootStateSchemas
   : TStateSchemas;
 
+type CurrentSetupStateSchema<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = TStateSchemas extends {
+  readonly [currentSetupStateSchema]: infer TCurrentStateSchema extends
+    SetupStateSchema;
+}
+  ? TCurrentStateSchema
+  : never;
+
+type SetupStateSelfSchema<TStateSchema extends SetupStateSchema> =
+  TStateSchema extends { schemas: infer TSchemas extends SetupStateSchemas }
+    ? { schemas: TSchemas }
+    : {};
+
+type SetupStateSchemasWithParentType<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TParentStateType extends SetupStateType | never
+> = TStateSchemas & {
+  readonly [parentSetupStateType]: TParentStateType;
+};
+
+type SetupStateParentType<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = TStateSchemas extends {
+  readonly [parentSetupStateType]: infer TParentStateType;
+}
+  ? TParentStateType
+  : never;
+
+type IsParallelSetupStateParent<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = [SetupStateParentType<TStateSchemas>] extends [never]
+  ? false
+  : SetupStateParentType<TStateSchemas> extends 'parallel'
+    ? true
+    : false;
+
+type ResolveStateSiblingsForPath<
+  TStates extends Record<string, SetupStateSchema>,
+  TPath extends string
+> =
+  SetupStateParentAtPath<TStates, TPath> extends infer TParent
+    ? [TParent] extends [SetupStateSchema]
+      ? SetupStateSchemasWithParentType<
+          ResolveStateSiblings<TStates, TPath>,
+          TParent extends { type: infer TType extends SetupStateType }
+            ? TType
+            : never
+        >
+      : ResolveStateSiblings<TStates, TPath>
+    : never;
+
 type WithRootSetupStateSchemas<
   TStateSchemas extends Record<string, SetupStateSchema>,
   TRootStateSchemas extends Record<string, SetupStateSchema>
@@ -623,31 +695,59 @@ type WithRootSetupStateSchemas<
   readonly [rootSetupStateSchemas]: TRootStateSchemas;
 };
 
-type UnknownSetupStateTarget<
+type RootSetupStateTransitionSchemas<
   TStateSchemas extends Record<string, SetupStateSchema>
-> = TStateSchemas extends { readonly [strictSetupStateTargets]: true }
-  ? never
-  : Exclude<
-      SetupStateTarget<TStateSchemas>,
-      KnownSetupStateTarget<TStateSchemas>
-    >;
+> = StrictSetupStateSchemas<{}, TStateSchemas, TStateSchemas>;
+
+type RootSetupStateTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> =
+  | SetupRelativeStateTarget<TStateSchemas>
+  | RootSetupStateIdTarget<TStateSchemas>;
+
+type RootSetupStateIdTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> =
+  | SetupStateIdTarget<SetupStateIds<TStateSchemas>>
+  | SetupStateIdTargets<TStateSchemas>;
+
+type SetupStateTransitionChildSchemas<TStateSchema extends SetupStateSchema> =
+  TStateSchema extends {
+    states: infer TChildStateSchemas extends Record<string, SetupStateSchema>;
+  }
+    ? TChildStateSchemas
+    : {};
 
 type SetupStateTransitionSchemas<
   TSiblingStateSchemas extends Record<string, SetupStateSchema>,
   TStateSchema extends SetupStateSchema
 > =
-  string extends SetupStateKeys<TSiblingStateSchemas>
-    ? TSiblingStateSchemas
-    : keyof SetupStateSchema extends keyof TStateSchema
+  IsParallelSetupStateParent<TSiblingStateSchemas> extends true
+    ? StrictSetupStateSchemas<
+        {},
+        SetupStateTransitionChildSchemas<TStateSchema>,
+        RootSetupStateSchemas<TSiblingStateSchemas>,
+        SetupStateSelfSchema<TStateSchema>
+      >
+    : string extends SetupStateKeys<TSiblingStateSchemas>
       ? TSiblingStateSchemas
-      : TStateSchema['states'] extends Record<string, SetupStateSchema>
-        ? TStateSchema extends { type: SetupStateType }
-          ? StrictSetupStateSchemas<
+      : keyof SetupStateSchema extends keyof TStateSchema
+        ? TSiblingStateSchemas
+        : TStateSchema extends { states: Record<string, SetupStateSchema> }
+          ? TStateSchema extends { type: SetupStateType }
+            ? StrictSetupStateSchemas<
+                TSiblingStateSchemas,
+                SetupStateTransitionChildSchemas<TStateSchema>,
+                RootSetupStateSchemas<TSiblingStateSchemas>,
+                SetupStateSelfSchema<TStateSchema>
+              >
+            : TSiblingStateSchemas
+          : StrictSetupStateSchemas<
               TSiblingStateSchemas,
-              TStateSchema['states']
-            >
-          : TSiblingStateSchemas
-        : StrictSetupStateSchemas<TSiblingStateSchemas, {}>;
+              {},
+              RootSetupStateSchemas<TSiblingStateSchemas>,
+              SetupStateSelfSchema<TStateSchema>
+            >;
 
 type SetupStateChildSchemas<TStateSchema extends SetupStateSchema> =
   TStateSchema['states'] extends Record<string, SetupStateSchema>
@@ -672,15 +772,49 @@ type SetupStateIds<TStateSchemas extends Record<string, SetupStateSchema>> =
         : never;
     }[keyof TStateSchemas & string];
 
+type SetupStateIdTarget<TId extends string> =
+  `#${EscapeSetupStatePathDots<TId>}`;
+
+type SetupStateIdTargets<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> =
+  string extends SetupStateKeys<TStateSchemas>
+    ? never
+    :
+        | {
+            [K in keyof TStateSchemas & string]: TStateSchemas[K] extends {
+              id: infer TId extends string;
+            }
+              ? TStateSchemas[K]['states'] extends infer TChildStateSchemas extends
+                  Record<string, SetupStateSchema>
+                ? string extends SetupStateKeys<TChildStateSchemas>
+                  ? never
+                  : `${SetupStateIdTarget<TId>}.${StatePaths<TChildStateSchemas> & string}`
+                : never
+              : never;
+          }[keyof TStateSchemas & string]
+        | {
+            [K in keyof TStateSchemas &
+              string]: TStateSchemas[K]['states'] extends infer TChildStateSchemas extends
+              Record<string, SetupStateSchema>
+              ? SetupStateIdTargets<TChildStateSchemas>
+              : never;
+          }[keyof TStateSchemas & string];
+
 type SetupStateSchemaAtTarget<
   TStateSchemas extends Record<string, SetupStateSchema>,
   TTarget extends string
 > = (
-  TTarget extends `.${infer TPath}`
-    ? ResolveStatePath<RelativeSetupStateSchemas<TStateSchemas>, TPath>
-    : TTarget extends `#${infer TId}`
-      ? SetupStateSchemaAtId<RootSetupStateSchemas<TStateSchemas>, TId>
-      : ResolveStatePath<TStateSchemas, TTarget>
+  TTarget extends '.'
+    ? CurrentSetupStateSchema<TStateSchemas>
+    : TTarget extends `.${infer TPath}`
+      ? ResolveStatePath<RelativeSetupStateSchemas<TStateSchemas>, TPath>
+      : TTarget extends `#${string}`
+        ? SetupStateSchemaAtIdTarget<
+            RootSetupStateSchemas<TStateSchemas>,
+            TTarget
+          >
+        : ResolveStatePath<TStateSchemas, TTarget>
 ) extends infer TStateSchema
   ? TStateSchema extends SetupStateSchema
     ? TStateSchema
@@ -700,12 +834,96 @@ type SetupStateSchemaAtId<
       : never;
 }[keyof TStateSchemas & string];
 
+type SetupStateSchemaAtIdTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TTarget extends string
+> = TTarget extends `#${infer TPath}`
+  ? SplitSetupStatePath<TPath> extends [
+      infer TId extends string,
+      ...infer TDescendant extends string[]
+    ]
+    ? SetupStateSchemaAtId<TStateSchemas, TId> extends infer TStateSchema
+      ? TDescendant extends []
+        ? TStateSchema
+        : TStateSchema extends {
+              states: infer TChildStateSchemas extends Record<
+                string,
+                SetupStateSchema
+              >;
+            }
+          ? ResolveStatePathSegments<TChildStateSchemas, TDescendant>
+          : never
+      : never
+    : never
+  : never;
+
 type StateSchemasWithKeys<
   TStateSchemas extends Record<string, SetupStateSchema>,
   TStateKeys extends string
 > = TStateSchemas & {
   [K in Exclude<TStateKeys, keyof TStateSchemas>]: {};
 };
+
+type EscapeSetupStatePathDots<TValue extends string> =
+  TValue extends `${infer THead}.${infer TTail}`
+    ? `${THead}\\.${EscapeSetupStatePathDots<TTail>}`
+    : TValue;
+
+type ProtectSetupStatePathDots<TValue extends string> =
+  TValue extends `${infer THead}\\.${infer TTail}`
+    ? `${THead}__XSTATE_ESCAPED_DOT__${ProtectSetupStatePathDots<TTail>}`
+    : TValue;
+
+type RestoreSetupStatePathDots<TValue extends string> =
+  TValue extends `${infer THead}__XSTATE_ESCAPED_DOT__${infer TTail}`
+    ? `${THead}.${RestoreSetupStatePathDots<TTail>}`
+    : TValue;
+
+type SplitSetupStatePath<TPath extends string> =
+  ProtectSetupStatePathDots<TPath> extends infer TProtected extends string
+    ? TProtected extends ''
+      ? []
+      : TProtected extends `${infer THead}.${infer TTail}`
+        ? [RestoreSetupStatePathDots<THead>, ...SplitSetupStatePath<TTail>]
+        : [RestoreSetupStatePathDots<TProtected>]
+    : never;
+
+type ResolveStatePathSegments<
+  TStates extends Record<string, SetupStateSchema>,
+  TSegments extends readonly string[]
+> = TSegments extends [
+  infer THead extends string,
+  ...infer TRest extends string[]
+]
+  ? THead extends keyof TStates
+    ? TRest extends []
+      ? TStates[THead]
+      : TStates[THead]['states'] extends Record<string, SetupStateSchema>
+        ? ResolveStatePathSegments<TStates[THead]['states'], TRest>
+        : never
+    : never
+  : never;
+
+type ResolveStatePath<
+  TStates extends Record<string, SetupStateSchema>,
+  TPath extends string
+> = ResolveStatePathSegments<TStates, SplitSetupStatePath<TPath>>;
+
+type ResolveStateSiblingsSegments<
+  TStates extends Record<string, SetupStateSchema>,
+  TSegments extends readonly string[]
+> = TSegments extends [
+  infer THead extends string,
+  ...infer TRest extends string[]
+]
+  ? TRest extends []
+    ? TStates
+    : THead extends keyof TStates
+      ? TStates[THead]['states'] extends Record<string, SetupStateSchema>
+        ? ResolveStateSiblingsSegments<TStates[THead]['states'], TRest>
+        : never
+      : never
+  : never;
 
 /**
  * The sibling state schemas of a dotted path: the children of the path's
@@ -716,37 +934,35 @@ type StateSchemasWithKeys<
 type ResolveStateSiblings<
   TStates extends Record<string, SetupStateSchema>,
   TPath extends string
-> = TPath extends `${infer Head}.${infer Rest}`
-  ? Head extends keyof TStates
-    ? TStates[Head]['states'] extends Record<string, SetupStateSchema>
-      ? ResolveStateSiblings<TStates[Head]['states'], Rest>
-      : never
-    : never
-  : TStates; // dotless path: siblings are the current level's states
+> = ResolveStateSiblingsSegments<TStates, SplitSetupStatePath<TPath>>;
 
-/**
- * Resolves a dotted state path (e.g. `'parent.child'`) into the leaf
- * `SetupStateSchema` it addresses, or `never` if any segment is missing.
- */
-type ResolveStatePath<
+type SetupStateParentAtSegments<
+  TStates extends Record<string, SetupStateSchema>,
+  TSegments extends readonly string[]
+> = TSegments extends [
+  infer THead extends string,
+  ...infer TRest extends string[]
+]
+  ? THead extends keyof TStates
+    ? TRest extends [string]
+      ? TStates[THead]
+      : TStates[THead]['states'] extends Record<string, SetupStateSchema>
+        ? SetupStateParentAtSegments<TStates[THead]['states'], TRest>
+        : never
+    : never
+  : never;
+
+type SetupStateParentAtPath<
   TStates extends Record<string, SetupStateSchema>,
   TPath extends string
-> = TPath extends `${infer Head}.${infer Rest}`
-  ? Head extends keyof TStates
-    ? TStates[Head]['states'] extends Record<string, SetupStateSchema>
-      ? ResolveStatePath<TStates[Head]['states'], Rest>
-      : never
-    : never
-  : TPath extends keyof TStates
-    ? TStates[TPath]
-    : never;
+> = SetupStateParentAtSegments<TStates, SplitSetupStatePath<TPath>>;
 
 /** Union of every addressable dotted path into a setup states tree */
 type StatePathsInner<TStates extends Record<string, SetupStateSchema>> = {
   [K in SetupStateKeys<TStates>]:
-    | K
+    | EscapeSetupStatePathDots<K>
     | (TStates[K]['states'] extends Record<string, SetupStateSchema>
-        ? `${K}.${StatePathsInner<TStates[K]['states']>}`
+        ? `${EscapeSetupStatePathDots<K>}.${StatePathsInner<TStates[K]['states']>}`
         : never);
 }[SetupStateKeys<TStates>];
 
@@ -756,6 +972,302 @@ type StatePaths<TStates extends Record<string, SetupStateSchema>> =
     : [SetupStateKeys<TStates>] extends [never]
       ? string
       : StatePathsInner<TStates>;
+
+type SetupStatePath = readonly string[];
+
+type SetupStatePathAtId<
+  TStates extends Record<string, SetupStateSchema>,
+  TId extends string,
+  TPrefix extends SetupStatePath = []
+> = {
+  [K in SetupStateKeys<TStates>]: TStates[K] extends { id: TId }
+    ? [...TPrefix, K]
+    : TStates[K]['states'] extends Record<string, SetupStateSchema>
+      ? SetupStatePathAtId<TStates[K]['states'], TId, [...TPrefix, K]>
+      : never;
+}[SetupStateKeys<TStates>];
+
+type SetupParentStatePath<TPath extends SetupStatePath> =
+  TPath extends readonly [...infer TParent extends string[], string]
+    ? TParent
+    : [];
+
+type SetupResolvedStatePath<
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TSourcePath extends string,
+  TTarget extends string
+> = TTarget extends `#${infer TIdPath}`
+  ? SplitSetupStatePath<TIdPath> extends [
+      infer TId extends string,
+      ...infer TDescendant extends string[]
+    ]
+    ? SetupStatePathAtId<TRootStateSchemas, TId> extends infer TIdStatePath
+      ? TIdStatePath extends SetupStatePath
+        ? [...TIdStatePath, ...TDescendant]
+        : never
+      : never
+    : never
+  : TTarget extends '.'
+    ? SplitSetupStatePath<TSourcePath>
+    : TTarget extends `.${infer TDescendant}`
+      ? [
+          ...SplitSetupStatePath<TSourcePath>,
+          ...SplitSetupStatePath<TDescendant>
+        ]
+      : [
+          ...SetupParentStatePath<SplitSetupStatePath<TSourcePath>>,
+          ...SplitSetupStatePath<TTarget>
+        ];
+
+type SetupCommonStatePath<
+  TLeft extends SetupStatePath,
+  TRight extends SetupStatePath,
+  TCommon extends SetupStatePath = []
+> = TLeft extends readonly [
+  infer TLeftHead extends string,
+  ...infer TLeftTail extends string[]
+]
+  ? TRight extends readonly [
+      infer TRightHead extends string,
+      ...infer TRightTail extends string[]
+    ]
+    ? TLeftHead extends TRightHead
+      ? SetupCommonStatePath<TLeftTail, TRightTail, [...TCommon, TLeftHead]>
+      : TCommon
+    : TCommon
+  : TCommon;
+
+type SetupIsParallelStatePath<
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TPath extends SetupStatePath
+> = TPath extends []
+  ? false
+  : ResolveStatePathSegments<
+        TRootStateSchemas,
+        TPath
+      > extends infer TStateSchema
+    ? TStateSchema extends { type: 'parallel' }
+      ? true
+      : TStateSchema extends { type: SetupStateType }
+        ? false
+        : 'unknown'
+    : 'unknown';
+
+type SetupInvalidTargetPair<
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TLeft extends SetupStatePath,
+  TRight extends SetupStatePath
+> = [TLeft] extends [never]
+  ? false
+  : [TRight] extends [never]
+    ? false
+    : TLeft extends TRight
+      ? true
+      : TRight extends TLeft
+        ? true
+        : SetupIsParallelStatePath<
+              TRootStateSchemas,
+              SetupCommonStatePath<TLeft, TRight>
+            > extends true
+          ? false
+          : SetupIsParallelStatePath<
+                TRootStateSchemas,
+                SetupCommonStatePath<TLeft, TRight>
+              > extends false
+            ? true
+            : false;
+
+type SetupInvalidTargetPairsWithHead<
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TSourcePath extends string,
+  THead,
+  TRest extends readonly unknown[]
+> = TRest extends readonly [infer TNext, ...infer TTail]
+  ? SetupInvalidTargetPair<
+      TRootStateSchemas,
+      SetupResolvedStatePath<
+        TRootStateSchemas,
+        TSourcePath,
+        Extract<THead, string>
+      >,
+      SetupResolvedStatePath<
+        TRootStateSchemas,
+        TSourcePath,
+        Extract<TNext, string>
+      >
+    > extends true
+    ? true
+    : SetupInvalidTargetPairsWithHead<
+        TRootStateSchemas,
+        TSourcePath,
+        THead,
+        TTail
+      >
+  : false;
+
+type SetupInvalidTargetSet<
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TSourcePath extends string,
+  TTargets
+> = TTargets extends readonly [infer THead, ...infer TRest]
+  ? SetupInvalidTargetPairsWithHead<
+      TRootStateSchemas,
+      TSourcePath,
+      THead,
+      TRest
+    > extends true
+    ? true
+    : SetupInvalidTargetSet<TRootStateSchemas, TSourcePath, TRest>
+  : false;
+
+type SetupTargetSetLegality<
+  TTransition,
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TSourcePath extends string
+> = TTransition extends (...args: infer TArgs) => infer TResult
+  ? (
+      ...args: TArgs
+    ) => TResult &
+      SetupTargetSetLegality<TResult, TRootStateSchemas, TSourcePath>
+  : TTransition extends readonly unknown[]
+    ? {
+        [K in keyof TTransition]: TTransition[K] &
+          SetupTargetSetLegality<
+            TTransition[K],
+            TRootStateSchemas,
+            TSourcePath
+          >;
+      }
+    : TTransition extends {
+          target: infer TTargets extends readonly string[];
+        }
+      ? string extends TTargets[number]
+        ? unknown
+        : SetupInvalidTargetSet<
+              TRootStateSchemas,
+              TSourcePath,
+              TTargets
+            > extends true
+          ? never
+          : unknown
+      : unknown;
+
+type SetupTargetSetMapLegality<
+  TMap,
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TSourcePath extends string
+> =
+  TMap extends Record<string, unknown>
+    ? {
+        [K in keyof TMap]?: TMap[K] &
+          SetupTargetSetLegality<TMap[K], TRootStateSchemas, TSourcePath>;
+      }
+    : unknown;
+
+type SetupInvokeTargetSetLegality<
+  TInvoke,
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TSourcePath extends string
+> = TInvoke extends readonly unknown[]
+  ? {
+      [K in keyof TInvoke]: TInvoke[K] &
+        SetupInvokeTargetSetLegality<
+          TInvoke[K],
+          TRootStateSchemas,
+          TSourcePath
+        >;
+    }
+  : TInvoke extends Record<string, unknown>
+    ? (TInvoke extends { onDone: infer TOnDone }
+        ? {
+            onDone?: TInvoke['onDone'] &
+              SetupTargetSetLegality<TOnDone, TRootStateSchemas, TSourcePath>;
+          }
+        : unknown) &
+        (TInvoke extends { onError: infer TOnError }
+          ? {
+              onError?: TInvoke['onError'] &
+                SetupTargetSetLegality<
+                  TOnError,
+                  TRootStateSchemas,
+                  TSourcePath
+                >;
+            }
+          : unknown) &
+        (TInvoke extends { onSnapshot: infer TOnSnapshot }
+          ? {
+              onSnapshot?: TInvoke['onSnapshot'] &
+                SetupTargetSetLegality<
+                  TOnSnapshot,
+                  TRootStateSchemas,
+                  TSourcePath
+                >;
+            }
+          : unknown) &
+        (TInvoke extends { onTimeout: infer TOnTimeout }
+          ? {
+              onTimeout?: TInvoke['onTimeout'] &
+                SetupTargetSetLegality<
+                  TOnTimeout,
+                  TRootStateSchemas,
+                  TSourcePath
+                >;
+            }
+          : unknown)
+    : unknown;
+
+type SetupStateTargetSetLegality<
+  TConfig,
+  TRootStateSchemas extends Record<string, SetupStateSchema>,
+  TSourcePath extends string
+> = (TConfig extends { on: infer TOn }
+  ? {
+      on?: TConfig['on'] &
+        SetupTargetSetMapLegality<TOn, TRootStateSchemas, TSourcePath>;
+    }
+  : unknown) &
+  (TConfig extends { always: infer TAlways }
+    ? {
+        always?: TConfig['always'] &
+          SetupTargetSetLegality<TAlways, TRootStateSchemas, TSourcePath>;
+      }
+    : unknown) &
+  (TConfig extends { after: infer TAfter }
+    ? {
+        after?: TConfig['after'] &
+          SetupTargetSetMapLegality<TAfter, TRootStateSchemas, TSourcePath>;
+      }
+    : unknown) &
+  (TConfig extends { onDone: infer TOnDone }
+    ? {
+        onDone?: TConfig['onDone'] &
+          SetupTargetSetLegality<TOnDone, TRootStateSchemas, TSourcePath>;
+      }
+    : unknown) &
+  (TConfig extends { onError: infer TOnError }
+    ? {
+        onError?: TConfig['onError'] &
+          SetupTargetSetLegality<TOnError, TRootStateSchemas, TSourcePath>;
+      }
+    : unknown) &
+  (TConfig extends { onTimeout: infer TOnTimeout }
+    ? {
+        onTimeout?: TConfig['onTimeout'] &
+          SetupTargetSetLegality<TOnTimeout, TRootStateSchemas, TSourcePath>;
+      }
+    : unknown) &
+  (TConfig extends { choice: infer TChoice }
+    ? {
+        choice?: TConfig['choice'] &
+          SetupTargetSetLegality<TChoice, TRootStateSchemas, TSourcePath>;
+      }
+    : unknown) &
+  (TConfig extends { invoke: infer TInvoke }
+    ? {
+        invoke?: TConfig['invoke'] &
+          SetupInvokeTargetSetLegality<TInvoke, TRootStateSchemas, TSourcePath>;
+      }
+    : unknown);
 
 /**
  * Shared body of both `createStateConfig` overloads: the
@@ -1154,6 +1666,58 @@ type SetupStateInputConfig<
           | ((args: TInputArgs) => Record<string, unknown>);
       };
 
+type SetupChoiceTargetConfig<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> =
+  | {
+      [K in KnownSetupStateTarget<TStateSchemas>]: {
+        target: K;
+      } & SetupStateInputConfig<
+        SetupStateSchemaAtTarget<TStateSchemas, K>,
+        TContext,
+        TEvent
+      >;
+    }[KnownSetupStateTarget<TStateSchemas>]
+  | (TStateSchemas extends { readonly [strictSetupStateTargets]: true }
+      ? {
+          target: KnownSetupStateTarget<TStateSchemas>[];
+          input?: Record<string, unknown>;
+        }
+      : {
+          target: SetupStateTarget<TStateSchemas>[];
+          input?: Record<string, unknown>;
+        });
+
+type SetupChoiceFunction<
+  TChoice,
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = TChoice extends (...args: infer TArgs) => infer TResult
+  ? (
+      ...args: TArgs
+    ) =>
+      | (TResult extends { target: unknown }
+          ? Omit<TResult, 'target' | 'input'> &
+              SetupChoiceTargetConfig<TStateSchemas, TContext, TEvent>
+          : TResult)
+      | void
+  : never;
+
+type SetupChoiceTargetArrayInputConstraint<
+  TChoice,
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = TChoice extends (...args: infer TArgs) => infer TResult
+  ? (
+      ...args: TArgs
+    ) => TResult &
+      SetupTargetArrayInputConstraint<TResult, TStateSchemas, TContext, TEvent>
+  : never;
+
 type SetupTargetInput<TStateSchema extends SetupStateSchema> =
   HasStateInputSchema<TStateSchema> extends true
     ? Exclude<StateInput<TStateSchema>, undefined>
@@ -1195,18 +1759,26 @@ type SetupTargetArrayRequiresInput<
 
 type SetupTargetArrayInputConfig<
   TStateSchemas extends Record<string, SetupStateSchema>,
-  TTargets extends readonly string[]
+  TTargets extends readonly string[],
+  TContext extends MachineContext = MachineContext,
+  TEvent extends EventObject = EventObject
 > =
   SetupTargetArrayRequiresInput<TStateSchemas, TTargets> extends true
     ? {
         input:
           | SetupTargetArrayInput<TStateSchemas, TTargets>
-          | ((args: any) => SetupTargetArrayInput<TStateSchemas, TTargets>);
+          | ((args: {
+              context: TContext;
+              event: TEvent;
+            }) => SetupTargetArrayInput<TStateSchemas, TTargets>);
       }
     : {
         input?:
           | SetupTargetArrayInput<TStateSchemas, TTargets>
-          | ((args: any) => SetupTargetArrayInput<TStateSchemas, TTargets>);
+          | ((args: {
+              context: TContext;
+              event: TEvent;
+            }) => SetupTargetArrayInput<TStateSchemas, TTargets>);
       };
 
 /**
@@ -1217,21 +1789,33 @@ type SetupTargetArrayInputConfig<
  */
 type SetupTargetArrayInputConstraint<
   TTransition,
-  TStateSchemas extends Record<string, SetupStateSchema>
-> = [TTransition] extends [{ target: infer TTargets extends readonly string[] }]
-  ? string extends TTargets[number]
-    ? unknown
-    : [TTargets[number]] extends [never]
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TContext extends MachineContext = MachineContext,
+  TEvent extends EventObject = EventObject
+> = TTransition extends (...args: infer TArgs) => infer TResult
+  ? (
+      ...args: TArgs
+    ) => TResult &
+      SetupTargetArrayInputConstraint<TResult, TStateSchemas, TContext, TEvent>
+  : [TTransition] extends [{ target: infer TTargets extends readonly string[] }]
+    ? string extends TTargets[number]
       ? unknown
-      : string extends StatePaths<TStateSchemas>
+      : [TTargets[number]] extends [never]
         ? unknown
-        : Exclude<
-              TTargets[number],
-              KnownSetupStateTarget<TStateSchemas>
-            > extends never
-          ? SetupTargetArrayInputConfig<TStateSchemas, TTargets>
-          : never
-  : unknown;
+        : KnownSetupStateTarget<TStateSchemas> extends never
+          ? unknown
+          : Exclude<
+                TTargets[number],
+                KnownSetupStateTarget<TStateSchemas>
+              > extends never
+            ? SetupTargetArrayInputConfig<
+                TStateSchemas,
+                TTargets,
+                TContext,
+                TEvent
+              >
+            : never
+    : unknown;
 
 type SetupTransitionValueTargetArrayInputConstraint<
   TValue,
@@ -1476,6 +2060,26 @@ type SetupInitialTransitionForStates<
     }[keyof TStates & string]
   : never;
 
+type SetupInitialTransitionForOtherStates<
+  TStateSchema extends SetupStateSchema,
+  TInitial extends string,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = TStateSchema['states'] extends infer TStates extends Record<
+  string,
+  SetupStateSchema
+>
+  ? {
+      [K in Exclude<keyof TStates & string, TInitial>]: SetupInitialTransition<
+        TStateSchema,
+        K,
+        unknown,
+        TContext,
+        TEvent
+      >;
+    }[Exclude<keyof TStates & string, TInitial>]
+  : never;
+
 type SetupStateInitial<
   TStateSchema extends SetupStateSchema,
   TContext extends MachineContext,
@@ -1485,22 +2089,36 @@ type SetupStateInitial<
       SetupStateSchemaForChild<TStateSchema, TInitial>
     > extends true
     ? {
-        initial: SetupInitialTransition<
-          TStateSchema,
-          TInitial,
-          unknown,
-          TContext,
-          TEvent
-        >;
+        initial:
+          | SetupInitialTransition<
+              TStateSchema,
+              TInitial,
+              unknown,
+              TContext,
+              TEvent
+            >
+          | SetupInitialTransitionForOtherStates<
+              TStateSchema,
+              TInitial,
+              TContext,
+              TEvent
+            >;
       }
     : {
-        initial?: SetupInitialTransition<
-          TStateSchema,
-          TInitial,
-          unknown,
-          TContext,
-          TEvent
-        >;
+        initial?:
+          | SetupInitialTransition<
+              TStateSchema,
+              TInitial,
+              unknown,
+              TContext,
+              TEvent
+            >
+          | SetupInitialTransitionForOtherStates<
+              TStateSchema,
+              TInitial,
+              TContext,
+              TEvent
+            >;
       }
   : TStateSchema['states'] extends Record<string, SetupStateSchema>
     ? HasRequiredStateInput<TStateSchema['states']> extends true
@@ -1623,7 +2241,24 @@ type SetupStateNodeContract<
                     TConfig,
                     { choice: (...args: any[]) => any }
                   > extends { choice: infer TChoice }
-                    ? TChoice
+                    ? SetupChoiceFunction<
+                        TChoice,
+                        SetupStateTransitionSchemas<
+                          TSiblingStateSchemas,
+                          TStateSchema
+                        >,
+                        TContext,
+                        TEvent
+                      > &
+                        SetupChoiceTargetArrayInputConstraint<
+                          TChoice,
+                          SetupStateTransitionSchemas<
+                            TSiblingStateSchemas,
+                            TStateSchema
+                          >,
+                          TContext,
+                          TEvent
+                        >
                     : (...args: any[]) => any;
                   states?: never;
                   initial?: never;
@@ -1660,8 +2295,17 @@ type SetupHistoryStateContract<
 } & (TStateSchema extends {
     target: infer TTarget extends string | readonly [string, ...string[]];
   }
-    ? { target?: TTarget | SetupStateTarget<TSiblingStateSchemas> }
-    : { target: SetupStateTarget<TSiblingStateSchemas> });
+    ? {
+        target?:
+          | TTarget
+          | KnownSetupStateTarget<TSiblingStateSchemas>
+          | readonly KnownSetupStateTarget<TSiblingStateSchemas>[];
+      }
+    : {
+        target:
+          | KnownSetupStateTarget<TSiblingStateSchemas>
+          | readonly KnownSetupStateTarget<TSiblingStateSchemas>[];
+      });
 
 type SetupStateChildrenContract<
   TStateSchema extends SetupStateSchema,
@@ -1937,7 +2581,7 @@ type SetupMachineStateSchema<
 
 /** Machine config without setup-declared state contracts. */
 type SetupMachineConfigBase<
-  TStateSchemas extends Record<string, SetupStateSchema>,
+  _TStateSchemas extends Record<string, SetupStateSchema>,
   TStateKeys extends string,
   TSchemas extends SetupSchemas,
   TContextSchema extends StandardSchemaV1,
@@ -2158,7 +2802,7 @@ type SetupMachineConfig<
       > & {
         initial?:
           | SetupInitialStateKey<TStateSchemas, TStateKeys>
-          | InitialTransitionWithInput<TStateSchemas, TContext, TEvent>
+          | RootInitialTransitionWithInput<TStateSchemas, TContext, TEvent>
           | undefined;
         on?: StateTransitions<
           TStateSchemas,
@@ -2172,7 +2816,10 @@ type SetupMachineConfig<
           TActorMap,
           TGuardMap,
           TDelayMap,
-          TSystemRegistry
+          TSystemRegistry,
+          undefined,
+          RootSetupStateTarget<TStateSchemas>,
+          RootSetupStateTarget<TStateSchemas>
         >;
         always?: StateTransitionConfigOrTarget<
           TStateSchemas,
@@ -2187,11 +2834,14 @@ type SetupMachineConfig<
           TActorMap,
           TGuardMap,
           TDelayMap,
-          TSystemRegistry
+          TSystemRegistry,
+          undefined,
+          RootSetupStateTarget<TStateSchemas>,
+          RootSetupStateTarget<TStateSchemas>
         >;
         invoke?: SingleOrArray<
           SetupInvokeConfig<
-            TStateSchemas,
+            RootSetupStateTransitionSchemas<TStateSchemas>,
             TContext,
             SetupContextShape<TSchemas, TContextSchema, TContext>,
             TEvent,
@@ -2479,9 +3129,14 @@ type StateNodeConfigWithNestedInputBase<
   },
   TStateSchema['states'] extends Record<string, SetupStateSchema>
     ? StatesWithInput<
-        WithRootSetupStateSchemas<
-          TStateSchema['states'],
-          RootSetupStateSchemas<TSiblingStateSchemas>
+        SetupStateSchemasWithParentType<
+          WithRootSetupStateSchemas<
+            TStateSchema['states'],
+            RootSetupStateSchemas<TSiblingStateSchemas>
+          >,
+          TStateSchema extends { type: infer TType extends SetupStateType }
+            ? TType
+            : never
         >,
         TStateSchema['states'],
         TContext,
@@ -2575,7 +3230,9 @@ type StateTransitions<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined
+  TInput = undefined,
+  TTarget extends string = SetupStateTarget<TStateSchemas>,
+  TKnownTarget extends string = KnownSetupStateTarget<TStateSchemas>
 > = {
   [K in EventDescriptor<TEvent>]?: StateTransitionConfigOrTarget<
     TStateSchemas,
@@ -2591,7 +3248,9 @@ type StateTransitions<
     TGuardMap,
     TDelayMap,
     TSystemRegistry,
-    TInput
+    TInput,
+    TTarget,
+    TKnownTarget
   >;
 };
 
@@ -2753,7 +3412,9 @@ type StateTransitionConfigOrTarget<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined
+  TInput = undefined,
+  TTarget extends string = SetupStateTarget<TStateSchemas>,
+  TKnownTarget extends string = KnownSetupStateTarget<TStateSchemas>
 > =
   | undefined
   | StateTransitionObjectConfig<
@@ -2767,7 +3428,10 @@ type StateTransitionConfigOrTarget<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TSystemRegistry
+      TSystemRegistry,
+      true,
+      TTarget,
+      TKnownTarget
     >
   | StateTransitionFunction<
       TStateSchemas,
@@ -2783,7 +3447,9 @@ type StateTransitionConfigOrTarget<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      TInput
+      TInput,
+      TTarget,
+      TKnownTarget
     >;
 
 type StateTransitionObjectConfig<
@@ -2798,7 +3464,9 @@ type StateTransitionObjectConfig<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TSystemRegistry extends SystemRegistry,
-  TAllowContextMapper extends boolean = true
+  TAllowContextMapper extends boolean = true,
+  TTarget extends string = SetupStateTarget<TStateSchemas>,
+  TKnownTarget extends string = KnownSetupStateTarget<TStateSchemas>
 > =
   | (StateTransitionResult<
       TStateSchemas,
@@ -2812,12 +3480,14 @@ type StateTransitionObjectConfig<
       TGuardMap,
       TDelayMap,
       TSystemRegistry,
-      TAllowContextMapper
+      TAllowContextMapper,
+      TTarget,
+      TKnownTarget
     > & {
       description?: string;
     })
   | {
-      target: SetupStateTarget<TStateSchemas>[];
+      target: TTarget[];
       context?: StateTransitionContext<
         TAllowContextMapper,
         TContext,
@@ -2944,7 +3614,9 @@ type StateTransitionFunction<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TSystemRegistry extends SystemRegistry,
-  TInput = undefined
+  TInput = undefined,
+  TTarget extends string = SetupStateTarget<TStateSchemas>,
+  TKnownTarget extends string = KnownSetupStateTarget<TStateSchemas>
 > = (
   args: {
     context: TContext;
@@ -2973,7 +3645,9 @@ type StateTransitionFunction<
   TGuardMap,
   TDelayMap,
   TSystemRegistry,
-  false
+  false,
+  TTarget,
+  TKnownTarget
 > | void;
 
 type StateTransitionResult<
@@ -2988,7 +3662,9 @@ type StateTransitionResult<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TSystemRegistry extends SystemRegistry,
-  TAllowContextMapper extends boolean
+  TAllowContextMapper extends boolean,
+  TTarget extends string = SetupStateTarget<TStateSchemas>,
+  TKnownTarget extends string = KnownSetupStateTarget<TStateSchemas>
 > =
   | {
       target?: never;
@@ -3010,7 +3686,7 @@ type StateTransitionResult<
       meta?: TMeta;
     }
   | {
-      [K in KnownSetupStateTarget<TStateSchemas>]: {
+      [K in TKnownTarget]: {
         target: K;
         reenter?: boolean;
         meta?: TMeta;
@@ -3073,9 +3749,13 @@ type StateTransitionResult<
                 TSystemRegistry
               >;
             });
-    }[KnownSetupStateTarget<TStateSchemas>]
+    }[TKnownTarget]
   | {
-      target: UnknownSetupStateTarget<TStateSchemas>;
+      target: TStateSchemas extends {
+        readonly [strictSetupStateTargets]: true;
+      }
+        ? never
+        : Exclude<TTarget, TKnownTarget>;
       context?: StateTransitionContext<
         TAllowContextMapper,
         TContext,
@@ -3141,6 +3821,22 @@ type InitialTransitionWithInput<
     target: K;
   } & SetupStateInputConfig<TStateSchemas[K], TContext, TEvent>;
 }[keyof TStateSchemas & string];
+
+type RootInitialTransitionWithInput<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> =
+  | InitialTransitionWithInput<TStateSchemas, TContext, TEvent>
+  | {
+      [K in RootSetupStateIdTarget<TStateSchemas>]: {
+        target: K;
+      } & SetupStateInputConfig<
+        SetupStateSchemaAtTarget<TStateSchemas, K>,
+        TContext,
+        TEvent
+      >;
+    }[RootSetupStateIdTarget<TStateSchemas>];
 
 /** Return type of setup() */
 export interface SetupReturn<
@@ -3407,9 +4103,10 @@ export interface SetupReturn<
     const TPath extends StatePaths<TStates>,
     const TConfig extends SetupStateNodeConfig<
       StrictSetupStateSchemas<
-        ResolveStateSiblings<TStates, TPath>,
-        SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>,
-        TStates
+        ResolveStateSiblingsForPath<TStates, TPath>,
+        SetupStateTransitionChildSchemas<ResolveStatePath<TStates, TPath>>,
+        TStates,
+        SetupStateSelfSchema<ResolveStatePath<TStates, TPath>>
       >,
       ResolveStatePath<TStates, TPath>,
       TSchemas,
@@ -3426,18 +4123,23 @@ export interface SetupReturn<
         SetupStateNodeTargetArrayInputConstraint<
           TConfig,
           StrictSetupStateSchemas<
-            ResolveStateSiblings<TStates, TPath>,
-            SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>,
-            TStates
+            ResolveStateSiblingsForPath<TStates, TPath>,
+            SetupStateTransitionChildSchemas<ResolveStatePath<TStates, TPath>>,
+            TStates,
+            SetupStateSelfSchema<ResolveStatePath<TStates, TPath>>
           >,
           ResolveStatePath<TStates, TPath>,
           SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>
         >
       > &
+      NoInfer<SetupStateTargetSetLegality<TConfig, TStates, TPath>> &
       ValidateSetupHistoryStateInput<
         TConfig,
         ResolveStatePath<TStates, TPath>,
-        WithRootSetupStateSchemas<ResolveStateSiblings<TStates, TPath>, TStates>
+        WithRootSetupStateSchemas<
+          ResolveStateSiblingsForPath<TStates, TPath>,
+          TStates
+        >
       >
   ): TConfig;
 

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -525,6 +525,21 @@ type SetupOrConfigSchemaMap<
 type SetupStateKeys<TStateSchemas extends Record<string, SetupStateSchema>> =
   keyof TStateSchemas & string;
 
+type HasExplicitSetupStateContracts<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = string extends keyof TStateSchemas
+  ? false
+  : [keyof TStateSchemas] extends [never]
+    ? false
+    : true;
+
+type UncheckedSetupStateSchema = {
+  schemas?: never;
+  states?: never;
+};
+
+type UncheckedSetupStateSchemas = Record<string, UncheckedSetupStateSchema>;
+
 type SetupStateKey<TStateSchemas extends Record<string, SetupStateSchema>> =
   string extends SetupStateKeys<TStateSchemas>
     ? string
@@ -1378,6 +1393,17 @@ type ValidateSetupTargetArrayInputs<
   TRootStateSchemas
 >;
 
+type ValidateSetupStateContracts<
+  TConfig,
+  TStateSchemas extends Record<string, SetupStateSchema>
+> =
+  HasExplicitSetupStateContracts<TStateSchemas> extends true
+    ? ValidateSetupHistoryInputs<TConfig, TStateSchemas> &
+        ValidateHistoryDefaults<MergeSetupConfig<TConfig, TStateSchemas>> &
+        ValidateStateTargets<MergeSetupConfig<TConfig, TStateSchemas>> &
+        NoInfer<ValidateSetupTargetArrayInputs<TConfig, TStateSchemas>>
+    : unknown;
+
 type SetupInitialTransitionConfig<
   TStateSchema extends SetupStateSchema,
   TTarget extends string,
@@ -1898,8 +1924,19 @@ type MergeStateSchema<
     : undefined;
 } & MergeStateSchemaMetadata<TConfig, TSetup>;
 
-/** Machine config with typed state input */
-type SetupMachineConfig<
+type SetupMachineStateSchema<
+  TConfig,
+  TStateSchemas extends Record<string, SetupStateSchema>
+> =
+  HasExplicitSetupStateContracts<TStateSchemas> extends true
+    ? MergeStateSchema<
+        Cast<TConfig, StateSchema>,
+        SetupStatesToStateSchema<TStateSchemas>
+      >
+    : Cast<TConfig, StateSchema>;
+
+/** Machine config without setup-declared state contracts. */
+type SetupMachineConfigBase<
   TStateSchemas extends Record<string, SetupStateSchema>,
   TStateKeys extends string,
   TSchemas extends SetupSchemas,
@@ -1979,11 +2016,14 @@ type SetupMachineConfig<
         }) => number);
   };
   initial?:
-    | SetupInitialStateKey<TStateSchemas, TStateKeys>
-    | InitialTransitionWithInput<TStateSchemas, TContext, TEvent>
+    | string
+    | {
+        target: string;
+        input?: unknown;
+      }
     | undefined;
   on?: StateTransitions<
-    TStateSchemas,
+    UncheckedSetupStateSchemas,
     TContext,
     SetupContextShape<TSchemas, TContextSchema, TContext>,
     TEvent,
@@ -1997,7 +2037,7 @@ type SetupMachineConfig<
     TSystemRegistry
   >;
   always?: StateTransitionConfigOrTarget<
-    TStateSchemas,
+    UncheckedSetupStateSchemas,
     TContext,
     SetupContextShape<TSchemas, TContextSchema, TContext>,
     TEvent,
@@ -2013,7 +2053,7 @@ type SetupMachineConfig<
   >;
   invoke?: SingleOrArray<
     SetupInvokeConfig<
-      TStateSchemas,
+      UncheckedSetupStateSchemas,
       TContext,
       SetupContextShape<TSchemas, TContextSchema, TContext>,
       TEvent,
@@ -2029,8 +2069,8 @@ type SetupMachineConfig<
     >
   >;
   states?: StatesWithInput<
-    TStateSchemas,
-    TStateSchemas,
+    UncheckedSetupStateSchemas,
+    UncheckedSetupStateSchemas,
     TContext,
     SetupContextShape<TSchemas, TContextSchema, TContext>,
     TEvent,
@@ -2048,6 +2088,175 @@ type SetupMachineConfig<
     TStateKeys
   >;
 };
+
+/** Machine config with typed state input */
+type SetupMachineConfig<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TStateKeys extends string,
+  TSchemas extends SetupSchemas,
+  TContextSchema extends StandardSchemaV1,
+  TEventSchemaMap extends Record<string, StandardSchemaV1>,
+  TInternalEventSchemaMap extends Record<string, StandardSchemaV1>,
+  TEmittedSchemaMap extends Record<string, StandardSchemaV1>,
+  TInputSchema extends StandardSchemaV1,
+  TOutputSchema extends StandardSchemaV1,
+  TMetaSchema extends StandardSchemaV1,
+  TTagSchema extends StandardSchemaV1,
+  TChildrenSchemaMap extends Record<string, StandardSchemaV1>,
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  TChildren extends Record<string, AnyActorRef | undefined>,
+  TDelays extends string,
+  TTag extends string,
+  TEmitted extends EventObject,
+  TMeta extends MetaObject,
+  TActionMap extends Sources['actions'],
+  TActorMap extends Sources['actors'],
+  TGuardMap extends Sources['guards'],
+  TDelayMap extends Sources['delays'],
+  TSystemRegistry extends SystemRegistry,
+  TContextRequired extends boolean,
+  TRootDelays extends string = TDelays,
+  TRootActionMap extends Sources['actions'] = TActionMap,
+  TRootActorMap extends Sources['actors'] = TActorMap,
+  TRootGuardMap extends Sources['guards'] = TGuardMap
+> =
+  HasExplicitSetupStateContracts<TStateSchemas> extends true
+    ? Omit<
+        SetupMachineConfigBase<
+          TStateSchemas,
+          TStateKeys,
+          TSchemas,
+          TContextSchema,
+          TEventSchemaMap,
+          TInternalEventSchemaMap,
+          TEmittedSchemaMap,
+          TInputSchema,
+          TOutputSchema,
+          TMetaSchema,
+          TTagSchema,
+          TChildrenSchemaMap,
+          TContext,
+          TEvent,
+          TChildren,
+          TDelays,
+          TTag,
+          TEmitted,
+          TMeta,
+          TActionMap,
+          TActorMap,
+          TGuardMap,
+          TDelayMap,
+          TSystemRegistry,
+          TContextRequired,
+          TRootDelays,
+          TRootActionMap,
+          TRootActorMap,
+          TRootGuardMap
+        >,
+        'states' | 'initial' | 'on' | 'always' | 'invoke'
+      > & {
+        initial?:
+          | SetupInitialStateKey<TStateSchemas, TStateKeys>
+          | InitialTransitionWithInput<TStateSchemas, TContext, TEvent>
+          | undefined;
+        on?: StateTransitions<
+          TStateSchemas,
+          TContext,
+          SetupContextShape<TSchemas, TContextSchema, TContext>,
+          TEvent,
+          TEmitted,
+          TChildren,
+          TMeta,
+          TActionMap,
+          TActorMap,
+          TGuardMap,
+          TDelayMap,
+          TSystemRegistry
+        >;
+        always?: StateTransitionConfigOrTarget<
+          TStateSchemas,
+          TContext,
+          SetupContextShape<TSchemas, TContextSchema, TContext>,
+          TEvent,
+          TEvent,
+          TEmitted,
+          TChildren,
+          TMeta,
+          TActionMap,
+          TActorMap,
+          TGuardMap,
+          TDelayMap,
+          TSystemRegistry
+        >;
+        invoke?: SingleOrArray<
+          SetupInvokeConfig<
+            TStateSchemas,
+            TContext,
+            SetupContextShape<TSchemas, TContextSchema, TContext>,
+            TEvent,
+            TEmitted,
+            TChildren,
+            TMeta,
+            TActionMap,
+            TActorMap,
+            TGuardMap,
+            TDelayMap,
+            TSystemRegistry,
+            SetupInput<TSchemas, TInputSchema>
+          >
+        >;
+        states?: StatesWithInput<
+          TStateSchemas,
+          TStateSchemas,
+          TContext,
+          SetupContextShape<TSchemas, TContextSchema, TContext>,
+          TEvent,
+          TChildren,
+          TDelays,
+          TTag,
+          SetupOutput<TSchemas, TOutputSchema>,
+          TEmitted,
+          TMeta,
+          TActionMap,
+          TActorMap,
+          TGuardMap,
+          TDelayMap,
+          TSystemRegistry,
+          TStateKeys
+        >;
+      }
+    : SetupMachineConfigBase<
+        TStateSchemas,
+        TStateKeys,
+        TSchemas,
+        TContextSchema,
+        TEventSchemaMap,
+        TInternalEventSchemaMap,
+        TEmittedSchemaMap,
+        TInputSchema,
+        TOutputSchema,
+        TMetaSchema,
+        TTagSchema,
+        TChildrenSchemaMap,
+        TContext,
+        TEvent,
+        TChildren,
+        TDelays,
+        TTag,
+        TEmitted,
+        TMeta,
+        TActionMap,
+        TActorMap,
+        TGuardMap,
+        TDelayMap,
+        TSystemRegistry,
+        TContextRequired,
+        TRootDelays,
+        TRootActionMap,
+        TRootActorMap,
+        TRootGuardMap
+      >;
 
 /** States config type that provides typed input for known states */
 type StatesWithInput<
@@ -3142,10 +3351,7 @@ export interface SetupReturn<
         TValidator
       > &
       ValidateSetupDelayReferences<TConfig, TSetupDelays> &
-      ValidateSetupHistoryInputs<TConfig, TStates> &
-      ValidateHistoryDefaults<MergeSetupConfig<TConfig, TStates>> &
-      ValidateStateTargets<MergeSetupConfig<TConfig, TStates>> &
-      NoInfer<ValidateSetupTargetArrayInputs<TConfig, TStates>> &
+      ValidateSetupStateContracts<TConfig, TStates> &
       ValidateRegistryKeys<
         TConfig,
         TSystemRegistry,
@@ -3154,34 +3360,19 @@ export interface SetupReturn<
   ): StateMachine<
     SetupContext<TSchemas, TContextSchema>,
     | SetupEvents<TSchemas, TEventSchemaMap, TInternalEventSchemaMap>
-    | ([
-        RoutableStateId<
-          MergeStateSchema<
-            Cast<TConfig, StateSchema>,
-            SetupStatesToStateSchema<TStates>
-          >
-        >
-      ] extends [never]
+    | ([RoutableStateId<SetupMachineStateSchema<TConfig, TStates>>] extends [
+        never
+      ]
         ? never
         : {
             type: 'xstate.route';
-            to: RoutableStateId<
-              MergeStateSchema<
-                Cast<TConfig, StateSchema>,
-                SetupStatesToStateSchema<TStates>
-              >
-            >;
+            to: RoutableStateId<SetupMachineStateSchema<TConfig, TStates>>;
           }),
     Cast<
       MergeChildren<SetupChildren<TSchemas, TChildrenSchemaMap>, TActor>,
       Record<string, AnyActorRef | undefined>
     >,
-    StateValueFromStateSchema<
-      MergeStateSchema<
-        Cast<TConfig, StateSchema>,
-        SetupStatesToStateSchema<TStates>
-      >
-    >,
+    StateValueFromStateSchema<SetupMachineStateSchema<TConfig, TStates>>,
     TTag & string,
     [SetupSchema<TSchemas, 'input'>] extends [never]
       ? TInput
@@ -3189,10 +3380,7 @@ export interface SetupReturn<
     SetupOrConfigOutput<TSchemas, TOutputSchema, TConfig>,
     SetupEmitted<TSchemas, TEmittedSchemaMap>,
     SetupMeta<TSchemas, TMetaSchema>,
-    MergeStateSchema<
-      Cast<TConfig, StateSchema>,
-      SetupStatesToStateSchema<TStates>
-    >,
+    SetupMachineStateSchema<TConfig, TStates>,
     MergeSourceMaps<
       SetupActions<TSchemas, TSetupActionMap>,
       MergeSourceMaps<InferActions<TActionSchemaMap>, TActionMap>

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -432,6 +432,15 @@ type ValidateRegistryKeys<
 
 export type { SetupStateSchemas };
 
+/** State node types that can be declared in a setup state contract. */
+export type SetupStateType =
+  | 'atomic'
+  | 'compound'
+  | 'parallel'
+  | 'final'
+  | 'history'
+  | 'choice';
+
 export type SetupSchemas = {
   context?: StandardSchemaV1;
   events?: Record<string, StandardSchemaV1>;
@@ -446,8 +455,20 @@ export type SetupSchemas = {
   children?: Record<string, StandardSchemaV1>;
 };
 
-/** State schema with optional input/output schemas and nested states */
+/**
+ * State schema with optional input/output schemas, structural metadata, and
+ * nested states.
+ *
+ * Structural fields are contracts/defaults for `createMachine(...)`; machine
+ * behavior remains authored in the machine config.
+ */
 export interface SetupStateSchema {
+  type?: SetupStateType;
+  id?: string;
+  initial?: string;
+  history?: 'shallow' | 'deep' | true;
+  target?: string | readonly [string, ...string[]];
+  route?: true;
   schemas?: SetupStateSchemas;
   states?: Record<string, SetupStateSchema>;
 }
@@ -516,7 +537,102 @@ type SetupStateTarget<TStateSchemas extends Record<string, SetupStateSchema>> =
     ? string
     : [SetupStateKeys<TStateSchemas>] extends [never]
       ? string
-      : SetupStateKeys<TStateSchemas> | `.${string}` | `#${string}`;
+      : StatePaths<TStateSchemas> | `.${string}` | `#${string}`;
+
+type KnownSetupStateTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> =
+  string extends StatePaths<TStateSchemas>
+    ? never
+    :
+        | (StatePaths<TStateSchemas> & string)
+        | `.${StatePaths<RelativeSetupStateSchemas<TStateSchemas>> & string}`
+        | `#${SetupStateIds<TStateSchemas> & string}`;
+
+declare const strictSetupStateTargets: unique symbol;
+declare const relativeSetupStateSchemas: unique symbol;
+
+type StrictSetupStateSchemas<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TRelativeStateSchemas extends Record<string, SetupStateSchema> = Record<
+    string,
+    SetupStateSchema
+  >
+> = TStateSchemas & {
+  readonly [strictSetupStateTargets]: true;
+  readonly [relativeSetupStateSchemas]: TRelativeStateSchemas;
+};
+
+type RelativeSetupStateSchemas<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = TStateSchemas extends {
+  readonly [relativeSetupStateSchemas]: infer TRelativeStateSchemas extends
+    Record<string, SetupStateSchema>;
+}
+  ? TRelativeStateSchemas
+  : TStateSchemas;
+
+type UnknownSetupStateTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = TStateSchemas extends { readonly [strictSetupStateTargets]: true }
+  ? never
+  : Exclude<
+      SetupStateTarget<TStateSchemas>,
+      KnownSetupStateTarget<TStateSchemas>
+    >;
+
+type SetupStateTransitionSchemas<
+  TSiblingStateSchemas extends Record<string, SetupStateSchema>,
+  TStateSchema extends SetupStateSchema
+> =
+  TStateSchema['states'] extends Record<string, SetupStateSchema>
+    ? TStateSchema extends { type: SetupStateType }
+      ? StrictSetupStateSchemas<TSiblingStateSchemas, TStateSchema['states']>
+      : TSiblingStateSchemas
+    : TSiblingStateSchemas;
+
+type SetupStateChildSchemas<TStateSchema extends SetupStateSchema> =
+  TStateSchema['states'] extends Record<string, SetupStateSchema>
+    ? TStateSchema['states']
+    : Record<string, SetupStateSchema>;
+
+type SetupStateIds<TStateSchemas extends Record<string, SetupStateSchema>> = {
+  [K in keyof TStateSchemas & string]: TStateSchemas[K] extends {
+    id: infer TId extends string;
+  }
+    ? TId
+    : TStateSchemas[K]['states'] extends Record<string, SetupStateSchema>
+      ? SetupStateIds<TStateSchemas[K]['states']>
+      : never;
+}[keyof TStateSchemas & string];
+
+type SetupStateSchemaAtTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TTarget extends string
+> = (
+  TTarget extends `.${infer TPath}`
+    ? ResolveStatePath<RelativeSetupStateSchemas<TStateSchemas>, TPath>
+    : TTarget extends `#${infer TId}`
+      ? SetupStateSchemaAtId<TStateSchemas, TId>
+      : ResolveStatePath<TStateSchemas, TTarget>
+) extends infer TStateSchema
+  ? TStateSchema extends SetupStateSchema
+    ? TStateSchema
+    : never
+  : never;
+
+type SetupStateSchemaAtId<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TId extends string
+> = {
+  [K in keyof TStateSchemas & string]: TStateSchemas[K] extends {
+    id: TId;
+  }
+    ? TStateSchemas[K]
+    : TStateSchemas[K]['states'] extends Record<string, SetupStateSchema>
+      ? SetupStateSchemaAtId<TStateSchemas[K]['states'], TId>
+      : never;
+}[keyof TStateSchemas & string];
 
 type StateSchemasWithKeys<
   TStateSchemas extends Record<string, SetupStateSchema>,
@@ -863,9 +979,611 @@ type WithNestedStates<TConfig, TNestedStates> = TConfig extends {
   ? TConfig
   : Omit<TConfig, 'states'> & { states?: TNestedStates };
 
+type HasStateInputSchema<TStateSchema extends SetupStateSchema> =
+  TStateSchema['schemas'] extends { input: infer TInputSchema }
+    ? TInputSchema extends StandardSchemaV1
+      ? true
+      : false
+    : false;
+
+type RequiresStateInput<TStateSchema extends SetupStateSchema> =
+  HasStateInputSchema<TStateSchema> extends true
+    ? undefined extends StateInput<TStateSchema>
+      ? false
+      : true
+    : false;
+
+type HasRequiredStateInput<TStates extends Record<string, SetupStateSchema>> =
+  true extends {
+    [K in keyof TStates]: RequiresStateInput<TStates[K]>;
+  }[keyof TStates]
+    ? true
+    : false;
+
+type SetupStateSchemaForChild<
+  TStateSchema extends SetupStateSchema,
+  TTarget extends string
+> = TStateSchema['states'] extends infer TStates extends Record<
+  string,
+  SetupStateSchema
+>
+  ? TTarget extends keyof TStates & string
+    ? TStates[TTarget]
+    : {}
+  : {};
+
+type SetupStateInputConfig<
+  TStateSchema extends SetupStateSchema,
+  TContext extends MachineContext,
+  TEvent extends EventObject,
+  TInputArgs extends { context: TContext; event: TEvent } = {
+    context: TContext;
+    event: TEvent;
+  }
+> =
+  HasStateInputSchema<TStateSchema> extends true
+    ? undefined extends StateInput<TStateSchema>
+      ? {
+          input?:
+            | StateInput<TStateSchema>
+            | ((args: TInputArgs) => StateInput<TStateSchema>);
+        }
+      : {
+          input:
+            | StateInput<TStateSchema>
+            | ((args: TInputArgs) => StateInput<TStateSchema>);
+        }
+    : {
+        input?:
+          | Record<string, unknown>
+          | ((args: TInputArgs) => Record<string, unknown>);
+      };
+
+type SetupTargetInput<TStateSchema extends SetupStateSchema> =
+  HasStateInputSchema<TStateSchema> extends true
+    ? Exclude<StateInput<TStateSchema>, undefined>
+    : Record<string, unknown>;
+
+type SetupUnionToIntersection<T> = (
+  T extends any ? (value: T) => void : never
+) extends (value: infer I) => void
+  ? I
+  : never;
+
+type SetupTargetArrayInput<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TTargets extends readonly string[]
+> = SetupUnionToIntersection<
+  SetupTargetInputForTarget<TStateSchemas, TTargets[number]>
+>;
+
+type SetupTargetInputForTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TTarget extends string
+> =
+  SetupStateSchemaAtTarget<TStateSchemas, TTarget> extends infer TStateSchema
+    ? TStateSchema extends SetupStateSchema
+      ? SetupTargetInput<TStateSchema>
+      : Record<string, unknown>
+    : Record<string, unknown>;
+
+type SetupTargetArrayRequiresInput<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TTargets extends readonly string[]
+> = true extends {
+  [K in TTargets[number]]: RequiresStateInput<
+    SetupStateSchemaAtTarget<TStateSchemas, K>
+  >;
+}[TTargets[number]]
+  ? true
+  : false;
+
+type SetupTargetArrayInputConfig<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TTargets extends readonly string[]
+> =
+  SetupTargetArrayRequiresInput<TStateSchemas, TTargets> extends true
+    ? {
+        input:
+          | SetupTargetArrayInput<TStateSchemas, TTargets>
+          | ((args: any) => SetupTargetArrayInput<TStateSchemas, TTargets>);
+      }
+    : {
+        input?:
+          | SetupTargetArrayInput<TStateSchemas, TTargets>
+          | ((args: any) => SetupTargetArrayInput<TStateSchemas, TTargets>);
+      };
+
+/**
+ * The runtime applies one transition input to every target in a target set.
+ * Keep the array's input correlated to its literal targets by requiring the
+ * intersection of their direct input types. Widened string arrays remain
+ * permissive for compatibility.
+ */
+type SetupTargetArrayInputConstraint<
+  TTransition,
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = [TTransition] extends [{ target: infer TTargets extends readonly string[] }]
+  ? string extends TTargets[number]
+    ? unknown
+    : [TTargets[number]] extends [never]
+      ? unknown
+      : Exclude<
+            TTargets[number],
+            KnownSetupStateTarget<TStateSchemas>
+          > extends never
+        ? SetupTargetArrayInputConfig<TStateSchemas, TTargets>
+        : unknown
+  : unknown;
+
+type SetupTransitionValueTargetArrayInputConstraint<
+  TValue,
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = [TValue] extends [readonly unknown[]]
+  ? {
+      [K in keyof TValue]: TValue[K] &
+        SetupTransitionValueTargetArrayInputConstraint<
+          TValue[K],
+          TStateSchemas
+        >;
+    }
+  : SetupTargetArrayInputConstraint<TValue, TStateSchemas>;
+
+type SetupTransitionMapTargetArrayInputConstraint<
+  TValue,
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = [TValue] extends [Record<string, unknown>]
+  ? {
+      [K in keyof TValue]?: TValue[K] &
+        SetupTransitionValueTargetArrayInputConstraint<
+          TValue[K],
+          TStateSchemas
+        >;
+    }
+  : unknown;
+
+type SetupTransitionPropertyTargetArrayInputConstraint<
+  TConfig,
+  TKey extends PropertyKey,
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TIsMap extends boolean = false
+> = TKey extends keyof TConfig
+  ? {
+      [K in TKey]?: TConfig[K] &
+        (TIsMap extends true
+          ? SetupTransitionMapTargetArrayInputConstraint<
+              TConfig[K],
+              TStateSchemas
+            >
+          : SetupTransitionValueTargetArrayInputConstraint<
+              TConfig[K],
+              TStateSchemas
+            >);
+    }
+  : unknown;
+
+type SetupInvokeTargetArrayInputConstraint<
+  TInvoke,
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = [TInvoke] extends [readonly unknown[]]
+  ? {
+      [K in keyof TInvoke]: TInvoke[K] &
+        SetupInvokeTargetArrayInputConstraint<TInvoke[K], TStateSchemas>;
+    }
+  : [TInvoke] extends [Record<string, unknown>]
+    ? SetupTransitionPropertyTargetArrayInputConstraint<
+        TInvoke,
+        'onDone',
+        TStateSchemas
+      > &
+        SetupTransitionPropertyTargetArrayInputConstraint<
+          TInvoke,
+          'onError',
+          TStateSchemas
+        > &
+        SetupTransitionPropertyTargetArrayInputConstraint<
+          TInvoke,
+          'onSnapshot',
+          TStateSchemas
+        > &
+        SetupTransitionPropertyTargetArrayInputConstraint<
+          TInvoke,
+          'onTimeout',
+          TStateSchemas
+        >
+    : unknown;
+
+type SetupStateNodeTargetArrayInputConstraint<
+  TConfig,
+  TSiblingStateSchemas extends Record<string, SetupStateSchema>,
+  TStateSchema extends SetupStateSchema,
+  TChildStateSchemas extends Record<string, SetupStateSchema>
+> = SetupTransitionPropertyTargetArrayInputConstraint<
+  TConfig,
+  'on',
+  SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
+  true
+> &
+  SetupTransitionPropertyTargetArrayInputConstraint<
+    TConfig,
+    'always',
+    SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>
+  > &
+  SetupTransitionPropertyTargetArrayInputConstraint<
+    TConfig,
+    'after',
+    SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
+    true
+  > &
+  SetupTransitionPropertyTargetArrayInputConstraint<
+    TConfig,
+    'onDone',
+    SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>
+  > &
+  SetupTransitionPropertyTargetArrayInputConstraint<
+    TConfig,
+    'onError',
+    SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>
+  > &
+  SetupTransitionPropertyTargetArrayInputConstraint<
+    TConfig,
+    'onTimeout',
+    SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>
+  > &
+  SetupTransitionPropertyTargetArrayInputConstraint<
+    TConfig,
+    'choice',
+    SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>
+  > &
+  (TConfig extends { invoke: infer TInvoke }
+    ? {
+        invoke?: TConfig['invoke'] &
+          SetupInvokeTargetArrayInputConstraint<
+            TInvoke,
+            SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>
+          >;
+      }
+    : unknown) &
+  (TConfig extends {
+    states: infer TChildren extends Record<string, unknown>;
+  }
+    ? {
+        states?: {
+          [K in keyof TChildren]?: TChildren[K] &
+            SetupStateNodeTargetArrayInputConstraint<
+              TChildren[K],
+              TChildStateSchemas,
+              K extends keyof TChildStateSchemas
+                ? TChildStateSchemas[K]
+                : SetupStateSchema,
+              SetupStateChildSchemas<
+                K extends keyof TChildStateSchemas
+                  ? TChildStateSchemas[K]
+                  : SetupStateSchema
+              >
+            >;
+        };
+      }
+    : unknown);
+
+type ValidateSetupTargetArrayInputs<
+  TConfig,
+  TRootStateSchemas extends Record<string, SetupStateSchema>
+> = SetupStateNodeTargetArrayInputConstraint<
+  TConfig,
+  TRootStateSchemas,
+  SetupStateSchema,
+  TRootStateSchemas
+>;
+
+type SetupInitialTransitionConfig<
+  TStateSchema extends SetupStateSchema,
+  TTarget extends string,
+  TConfig,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> =
+  Extract<
+    SetupConfigInitial<TConfig>,
+    { target: TTarget }
+  > extends infer TInitial
+    ? [TInitial] extends [never]
+      ? { target: TTarget } & SetupStateInputConfig<
+          SetupStateSchemaForChild<TStateSchema, TTarget>,
+          TContext,
+          TEvent
+        >
+      : Omit<TInitial, 'target' | 'input'> & {
+          target: TTarget;
+        } & SetupStateInputConfig<
+            SetupStateSchemaForChild<TStateSchema, TTarget>,
+            TContext,
+            TEvent
+          >
+    : never;
+
+type SetupConfigInitial<TConfig> = TConfig extends {
+  initial?: infer TInitial;
+}
+  ? NonNullable<TInitial>
+  : never;
+
+type SetupInitialTransition<
+  TStateSchema extends SetupStateSchema,
+  TTarget extends string = string,
+  TConfig = unknown,
+  TContext extends MachineContext = MachineContext,
+  TEvent extends EventObject = EventObject
+> =
+  | (RequiresStateInput<
+      SetupStateSchemaForChild<TStateSchema, TTarget>
+    > extends true
+      ? never
+      : TTarget)
+  | SetupInitialTransitionConfig<
+      TStateSchema,
+      TTarget,
+      TConfig,
+      TContext,
+      TEvent
+    >;
+
+type SetupInitialTransitionForStates<
+  TStateSchema extends SetupStateSchema,
+  TConfig,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = TStateSchema['states'] extends infer TStates extends Record<
+  string,
+  SetupStateSchema
+>
+  ? {
+      [K in keyof TStates & string]: SetupInitialTransition<
+        TStateSchema,
+        K,
+        TConfig,
+        TContext,
+        TEvent
+      >;
+    }[keyof TStates & string]
+  : never;
+
+type SetupStateInitial<
+  TStateSchema extends SetupStateSchema,
+  TContext extends MachineContext,
+  TEvent extends EventObject
+> = TStateSchema extends { initial: infer TInitial extends string }
+  ? RequiresStateInput<
+      SetupStateSchemaForChild<TStateSchema, TInitial>
+    > extends true
+    ? {
+        initial: SetupInitialTransition<
+          TStateSchema,
+          TInitial,
+          unknown,
+          TContext,
+          TEvent
+        >;
+      }
+    : {
+        initial?: SetupInitialTransition<
+          TStateSchema,
+          TInitial,
+          unknown,
+          TContext,
+          TEvent
+        >;
+      }
+  : TStateSchema['states'] extends Record<string, SetupStateSchema>
+    ? HasRequiredStateInput<TStateSchema['states']> extends true
+      ? {
+          initial: SetupInitialTransitionForStates<
+            TStateSchema,
+            unknown,
+            TContext,
+            TEvent
+          >;
+        }
+      : {
+          initial:
+            | string
+            | {
+                target: string;
+                input?: Record<string, unknown>;
+              };
+        }
+    : {
+        initial:
+          | string
+          | {
+              target: string;
+              input?: Record<string, unknown>;
+            };
+      };
+
+type SetupStateNodeContract<
+  TStateSchema extends SetupStateSchema,
+  TConfig,
+  TContext extends MachineContext = MachineContext,
+  TEvent extends EventObject = EventObject,
+  TSiblingStateSchemas extends Record<string, SetupStateSchema> = Record<
+    string,
+    SetupStateSchema
+  >
+> = TStateSchema extends { type: infer TType }
+  ? TType extends 'atomic'
+    ? Omit<TConfig, 'type' | 'states' | 'initial' | 'history' | 'target'> & {
+        type?: 'atomic';
+        states?: never;
+        initial?: never;
+        history?: never;
+        target?: never;
+      }
+    : TType extends 'compound'
+      ? Omit<TConfig, 'type' | 'initial'> &
+          ({ type?: 'compound' } & SetupStateChildrenContract<
+            TStateSchema,
+            TConfig
+          > &
+            SetupStateInitial<TStateSchema, TContext, TEvent>)
+      : TType extends 'parallel'
+        ? Omit<TConfig, 'type' | 'initial'> & {
+            type?: 'parallel';
+            initial?: never;
+            states: NonNullable<
+              TConfig extends { states?: infer TStates } ? TStates : unknown
+            >;
+          }
+        : TType extends 'final'
+          ? Omit<
+              TConfig,
+              | 'type'
+              | 'states'
+              | 'initial'
+              | 'history'
+              | 'target'
+              | 'invoke'
+              | 'on'
+              | 'always'
+              | 'after'
+              | 'timeout'
+              | 'onTimeout'
+              | 'onDone'
+              | 'onError'
+            > & {
+              type?: 'final';
+              states?: never;
+              initial?: never;
+              history?: never;
+              target?: never;
+              invoke?: never;
+              on?: never;
+              always?: never;
+              after?: never;
+              timeout?: never;
+              onTimeout?: never;
+              onDone?: never;
+              onError?: never;
+            }
+          : TType extends 'history'
+            ? SetupHistoryStateContract<
+                TStateSchema,
+                TConfig,
+                TSiblingStateSchemas
+              >
+            : TType extends 'choice'
+              ? Omit<
+                  TConfig,
+                  | 'type'
+                  | 'states'
+                  | 'initial'
+                  | 'history'
+                  | 'target'
+                  | 'invoke'
+                  | 'on'
+                  | 'entry'
+                  | 'exit'
+                  | 'onDone'
+                  | 'onError'
+                  | 'after'
+                  | 'timeout'
+                  | 'onTimeout'
+                  | 'always'
+                > & {
+                  type?: 'choice';
+                  choice: Extract<
+                    TConfig,
+                    { choice: (...args: any[]) => any }
+                  > extends { choice: infer TChoice }
+                    ? TChoice
+                    : (...args: any[]) => any;
+                  states?: never;
+                  initial?: never;
+                  history?: never;
+                  target?: never;
+                  invoke?: never;
+                  on?: never;
+                  entry?: never;
+                  exit?: never;
+                  onDone?: never;
+                  onError?: never;
+                  after?: never;
+                  timeout?: never;
+                  onTimeout?: never;
+                  always?: never;
+                }
+              : TStateSchema extends { history: unknown }
+                ? SetupHistoryStateContract<
+                    TStateSchema,
+                    TConfig,
+                    TSiblingStateSchemas
+                  >
+                : TConfig
+  : TConfig;
+
+type SetupHistoryStateContract<
+  TStateSchema extends SetupStateSchema,
+  TConfig,
+  TSiblingStateSchemas extends Record<string, SetupStateSchema>
+> = Omit<TConfig, 'type' | 'states' | 'initial' | 'target'> & {
+  type?: 'history';
+  states?: never;
+  initial?: never;
+} & (TStateSchema extends {
+    target: infer TTarget extends string | readonly string[];
+  }
+    ? HistoryTargetRequiresInput<TSiblingStateSchemas, TTarget> extends true
+      ? never
+      : { target?: TTarget }
+    : { target: string | [string, ...string[]] });
+
+type SetupStateChildrenContract<
+  TStateSchema extends SetupStateSchema,
+  TConfig
+> = TStateSchema extends {
+  states: Record<string, SetupStateSchema>;
+}
+  ? {
+      states: NonNullable<
+        TConfig extends { states?: infer TStates } ? TStates : unknown
+      >;
+    }
+  : {};
+
+type HistoryTargetRequiresInput<
+  TSiblingStateSchemas extends Record<string, SetupStateSchema>,
+  TTarget extends string | readonly string[]
+> = TTarget extends readonly (infer TTargets extends string)[]
+  ? true extends {
+      [K in TTargets]: RequiresStateInput<
+        SetupStateSchemaAtTarget<TSiblingStateSchemas, K>
+      >;
+    }[TTargets]
+    ? true
+    : false
+  : TTarget extends string
+    ? RequiresStateInput<
+        SetupStateSchemaAtTarget<TSiblingStateSchemas, TTarget>
+      >
+    : false;
+
 type DistributiveOmit<T, K extends keyof any> = T extends any
   ? Omit<T, K>
   : never;
+
+type SetupStateSchemaMetadata<TSetupSchema extends SetupStateSchema> =
+  (TSetupSchema extends { type: infer TType } ? { type: TType } : {}) &
+    (TSetupSchema extends { id: infer TId } ? { id: TId } : {}) &
+    (TSetupSchema extends { initial: infer TInitial }
+      ? { initial: TInitial }
+      : {}) &
+    (TSetupSchema extends { history: infer THistory }
+      ? { history: THistory }
+      : {}) &
+    (TSetupSchema extends { target: infer TTarget }
+      ? { target: TTarget }
+      : {}) &
+    (TSetupSchema extends { route: infer TRoute } ? { route: TRoute } : {});
 
 /**
  * Converts SetupStateSchema to StateSchema with input types included. This
@@ -893,7 +1611,7 @@ type SetupStateSchemaToStateSchema<TSetupSchema extends SetupStateSchema> = {
           string]: SetupStateSchemaToStateSchema<TSetupSchema['states'][K]>;
       }
     : undefined;
-};
+} & SetupStateSchemaMetadata<TSetupSchema>;
 
 /** Converts the root setup states config to a StateSchema. */
 type SetupStatesToStateSchema<
@@ -953,6 +1671,67 @@ type StateSchemaChild<
     : EmptyStateSchema
   : EmptyStateSchema;
 
+type StateSchemaMetadataField<
+  TConfig extends StateSchema,
+  TSetup extends StateSchema,
+  TKey extends keyof StateSchema
+> =
+  TSetup extends Record<TKey, infer TValue>
+    ? { [K in TKey]: TValue }
+    : TConfig extends Record<TKey, infer TValue>
+      ? { [K in TKey]: TValue }
+      : {};
+
+type MergeStateSchemaMetadata<
+  TConfig extends StateSchema,
+  TSetup extends StateSchema
+> = StateSchemaMetadataField<TConfig, TSetup, 'id'> &
+  StateSchemaMetadataField<TConfig, TSetup, 'route'> &
+  StateSchemaMetadataField<TConfig, TSetup, 'type'> &
+  StateSchemaMetadataField<TConfig, TSetup, 'initial'> &
+  StateSchemaMetadataField<TConfig, TSetup, 'history'> &
+  StateSchemaMetadataField<TConfig, TSetup, 'target'>;
+
+type StateConfigMetadataField<
+  TConfig,
+  TSetup extends StateSchema,
+  TKey extends keyof StateSchema
+> =
+  TConfig extends Record<TKey, infer TValue>
+    ? { [K in TKey]: TValue }
+    : TSetup extends Record<TKey, infer TValue>
+      ? { [K in TKey]: TValue }
+      : {};
+
+/** Adds setup-declared topology to authored config for structural validation. */
+type MergeSetupConfigState<TConfig, TSetup extends StateSchema> = Omit<
+  TConfig,
+  'id' | 'route' | 'type' | 'initial' | 'history' | 'target' | 'states'
+> &
+  StateConfigMetadataField<TConfig, TSetup, 'id'> &
+  StateConfigMetadataField<TConfig, TSetup, 'route'> &
+  StateConfigMetadataField<TConfig, TSetup, 'type'> &
+  StateConfigMetadataField<TConfig, TSetup, 'initial'> &
+  StateConfigMetadataField<TConfig, TSetup, 'history'> &
+  StateConfigMetadataField<TConfig, TSetup, 'target'> &
+  (TConfig extends { states: infer TStates }
+    ? TStates extends Record<string, unknown>
+      ? {
+          states: {
+            [K in keyof TStates & string]: MergeSetupConfigState<
+              TStates[K],
+              StateSchemaChild<TSetup, K>
+            >;
+          };
+        }
+      : { states: TStates }
+    : {});
+
+type MergeSetupConfig<
+  TConfig,
+  TStates extends Record<string, SetupStateSchema>
+> = MergeSetupConfigState<TConfig, SetupStatesToStateSchema<TStates>>;
+
 type MergeStateSchema<
   TConfig extends StateSchema,
   TSetup extends StateSchema
@@ -970,7 +1749,7 @@ type MergeStateSchema<
         }
       : undefined
     : undefined;
-};
+} & MergeStateSchemaMetadata<TConfig, TSetup>;
 
 /** Machine config with typed state input */
 type SetupMachineConfig<
@@ -1053,7 +1832,7 @@ type SetupMachineConfig<
         }) => number);
   };
   initial?:
-    | TStateKeys
+    | SetupInitialStateKey<TStateSchemas, TStateKeys>
     | InitialTransitionWithInput<TStateSchemas, TContext, TEvent>
     | undefined;
   on?: StateTransitions<
@@ -1098,7 +1877,8 @@ type SetupMachineConfig<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TSystemRegistry
+      TSystemRegistry,
+      SetupInput<TSchemas, TInputSchema>
     >
   >;
   states?: StatesWithInput<
@@ -1163,7 +1943,7 @@ type StatesWithInput<
 };
 
 /** State node config that recursively applies typed input for nested states */
-type StateNodeConfigWithNestedInput<
+type StateNodeConfigWithNestedInputBase<
   TSiblingStateSchemas extends Record<string, SetupStateSchema>,
   TStateSchema extends SetupStateSchema,
   TContext extends MachineContext,
@@ -1181,7 +1961,7 @@ type StateNodeConfigWithNestedInput<
   TDelayMap extends Sources['delays'],
   TSystemRegistry extends SystemRegistry
 > = WithNestedStates<
-  Omit<
+  DistributiveOmit<
     Next_StateNodeConfig<
       StateContext<TStateSchema, TContext>,
       TEvent,
@@ -1225,8 +2005,9 @@ type StateNodeConfigWithNestedInput<
               input?: Record<string, unknown>;
             }
           | undefined;
+  } & {
     on?: StateTransitions<
-      TSiblingStateSchemas,
+      SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
       StateContext<TStateSchema, TContext>,
       StateContextShape<TStateSchema, TContextShape>,
       TEvent,
@@ -1241,7 +2022,7 @@ type StateNodeConfigWithNestedInput<
       StateInput<TStateSchema>
     >;
     always?: StateTransitionConfigOrTarget<
-      TSiblingStateSchemas,
+      SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
       StateContext<TStateSchema, TContext>,
       StateContextShape<TStateSchema, TContextShape>,
       TEvent,
@@ -1258,7 +2039,7 @@ type StateNodeConfigWithNestedInput<
     >;
     invoke?: SingleOrArray<
       SetupInvokeConfig<
-        TSiblingStateSchemas,
+        SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
         StateContext<TStateSchema, TContext>,
         StateContextShape<TStateSchema, TContextShape>,
         TEvent,
@@ -1269,11 +2050,12 @@ type StateNodeConfigWithNestedInput<
         TActorMap,
         TGuardMap,
         TDelayMap,
-        TSystemRegistry
+        TSystemRegistry,
+        StateInput<TStateSchema>
       >
     >;
     onDone?: StateTransitionConfigOrTarget<
-      TSiblingStateSchemas,
+      SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
       StateContext<TStateSchema, TContext>,
       StateContextShape<TStateSchema, TContextShape>,
       DoneStateEvent<StateCompletionOutput<TStateSchema>>,
@@ -1289,7 +2071,7 @@ type StateNodeConfigWithNestedInput<
       StateInput<TStateSchema>
     >;
     onError?: StateTransitionConfigOrTarget<
-      TSiblingStateSchemas,
+      SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
       StateContext<TStateSchema, TContext>,
       StateContextShape<TStateSchema, TContextShape>,
       ErrorEvent,
@@ -1305,7 +2087,7 @@ type StateNodeConfigWithNestedInput<
       StateInput<TStateSchema>
     >;
     onTimeout?: StateTransitionConfigOrTarget<
-      TSiblingStateSchemas,
+      SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
       StateContext<TStateSchema, TContext>,
       StateContextShape<TStateSchema, TContextShape>,
       TimeoutEvent,
@@ -1322,7 +2104,7 @@ type StateNodeConfigWithNestedInput<
     >;
     after?: {
       [K in NoInfer<TDelays> | number]?: StateTransitionConfigOrTarget<
-        TSiblingStateSchemas,
+        SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
         StateContext<TStateSchema, TContext>,
         StateContextShape<TStateSchema, TContextShape>,
         AfterEvent,
@@ -1377,6 +2159,48 @@ type StateNodeConfigWithNestedInput<
           TSystemRegistry
         >;
       }
+>;
+
+type StateNodeConfigWithNestedInput<
+  TSiblingStateSchemas extends Record<string, SetupStateSchema>,
+  TStateSchema extends SetupStateSchema,
+  TContext extends MachineContext,
+  TContextShape,
+  TEvent extends EventObject,
+  TChildren extends Record<string, AnyActorRef | undefined>,
+  TDelays extends string,
+  TTag extends string,
+  TOutput,
+  TEmitted extends EventObject,
+  TMeta extends MetaObject,
+  TActionMap extends Sources['actions'],
+  TActorMap extends Sources['actors'],
+  TGuardMap extends Sources['guards'],
+  TDelayMap extends Sources['delays'],
+  TSystemRegistry extends SystemRegistry
+> = SetupStateNodeContract<
+  TStateSchema,
+  StateNodeConfigWithNestedInputBase<
+    TSiblingStateSchemas,
+    TStateSchema,
+    TContext,
+    TContextShape,
+    TEvent,
+    TChildren,
+    TDelays,
+    TTag,
+    TOutput,
+    TEmitted,
+    TMeta,
+    TActionMap,
+    TActorMap,
+    TGuardMap,
+    TDelayMap,
+    TSystemRegistry
+  >,
+  TContext,
+  TEvent,
+  TSiblingStateSchemas
 >;
 
 type StateTransitions<
@@ -1440,7 +2264,8 @@ type SetupInvokeConfig<
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TStateInput = undefined
 > =
   Next_InvokeConfig<
     TContext,
@@ -1452,7 +2277,8 @@ type SetupInvokeConfig<
     TGuardMap,
     TDelayMap,
     TMeta,
-    TSystemRegistry
+    TSystemRegistry,
+    TStateInput
   > extends infer TInvoke
     ? TInvoke extends any
       ? DistributiveOmit<
@@ -1825,59 +2651,72 @@ type StateTransitionResult<
       meta?: TMeta;
     }
   | {
-      [K in keyof TStateSchemas & string]: {
+      [K in KnownSetupStateTarget<TStateSchemas>]: {
         target: K;
         reenter?: boolean;
         meta?: TMeta;
-        input?:
-          | StateInput<TStateSchemas[K]>
-          | ((
-              args: {
-                context: TContext;
-                event: EventObject;
-              } & OutputArg<EventObject>
-            ) => StateInput<TStateSchemas[K]>);
-      } & ([TContextShape] extends [
-        StateContextShape<TStateSchemas[K], TContextShape>
-      ]
-        ? {
-            context?: StateTransitionContext<
-              TAllowContextMapper,
-              TContext,
-              TContextShape,
-              StateContextShape<TStateSchemas[K], TContextShape>,
-              StateContext<TStateSchemas[K], TContext>,
-              TExpressionEvent,
-              TChildren,
-              TActionMap,
-              TActorMap,
-              TGuardMap,
-              TDelayMap,
-              TSystemRegistry
-            >;
-          }
-        : {
-            context: StateTransitionContext<
-              TAllowContextMapper,
-              TContext,
-              TContextShape,
-              StateContextShape<TStateSchemas[K], TContextShape>,
-              StateContext<TStateSchemas[K], TContext>,
-              TExpressionEvent,
-              TChildren,
-              TActionMap,
-              TActorMap,
-              TGuardMap,
-              TDelayMap,
-              TSystemRegistry
-            >;
-          });
-    }[keyof TStateSchemas & string]
+      } & SetupStateInputConfig<
+        SetupStateSchemaAtTarget<TStateSchemas, K>,
+        TContext,
+        TExpressionEvent,
+        {
+          context: TContext;
+          event: TExpressionEvent;
+        } & OutputArg<TExpressionEvent>
+      > &
+        ([TContextShape] extends [
+          StateContextShape<
+            SetupStateSchemaAtTarget<TStateSchemas, K>,
+            TContextShape
+          >
+        ]
+          ? {
+              context?: StateTransitionContext<
+                TAllowContextMapper,
+                TContext,
+                TContextShape,
+                StateContextShape<
+                  SetupStateSchemaAtTarget<TStateSchemas, K>,
+                  TContextShape
+                >,
+                StateContext<
+                  SetupStateSchemaAtTarget<TStateSchemas, K>,
+                  TContext
+                >,
+                TExpressionEvent,
+                TChildren,
+                TActionMap,
+                TActorMap,
+                TGuardMap,
+                TDelayMap,
+                TSystemRegistry
+              >;
+            }
+          : {
+              context: StateTransitionContext<
+                TAllowContextMapper,
+                TContext,
+                TContextShape,
+                StateContextShape<
+                  SetupStateSchemaAtTarget<TStateSchemas, K>,
+                  TContextShape
+                >,
+                StateContext<
+                  SetupStateSchemaAtTarget<TStateSchemas, K>,
+                  TContext
+                >,
+                TExpressionEvent,
+                TChildren,
+                TActionMap,
+                TActorMap,
+                TGuardMap,
+                TDelayMap,
+                TSystemRegistry
+              >;
+            });
+    }[KnownSetupStateTarget<TStateSchemas>]
   | {
-      target: Exclude<
-        SetupStateTarget<TStateSchemas>,
-        keyof TStateSchemas & string
-      >;
+      target: UnknownSetupStateTarget<TStateSchemas>;
       context?: StateTransitionContext<
         TAllowContextMapper,
         TContext,
@@ -1921,6 +2760,19 @@ type RequiredContextKeys<TCurrentContext, TTargetContext> = {
 }[keyof TTargetContext];
 
 /** Initial transition with typed input based on target state */
+type SetupInitialStateKey<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TStateKeys extends string
+> = {
+  [K in TStateKeys]: K extends keyof TStateSchemas
+    ? TStateSchemas[K] extends { type: SetupStateType }
+      ? RequiresStateInput<TStateSchemas[K]> extends true
+        ? never
+        : K
+      : K
+    : K;
+}[TStateKeys];
+
 type InitialTransitionWithInput<
   TStateSchemas extends Record<string, SetupStateSchema>,
   TContext extends MachineContext,
@@ -1928,13 +2780,7 @@ type InitialTransitionWithInput<
 > = {
   [K in keyof TStateSchemas & string]: {
     target: K;
-    input?:
-      | StateInput<TStateSchemas[K]>
-      | ((args: {
-          context: TContext;
-          event: TEvent;
-        }) => StateInput<TStateSchemas[K]>);
-  };
+  } & SetupStateInputConfig<TStateSchemas[K], TContext, TEvent>;
 }[keyof TStateSchemas & string];
 
 /** Return type of setup() */
@@ -2146,8 +2992,9 @@ export interface SetupReturn<
         TValidator
       > &
       ValidateSetupDelayReferences<TConfig, TSetupDelays> &
-      ValidateHistoryDefaults<TConfig> &
-      ValidateStateTargets<TConfig> &
+      ValidateHistoryDefaults<MergeSetupConfig<TConfig, TStates>> &
+      ValidateStateTargets<MergeSetupConfig<TConfig, TStates>> &
+      NoInfer<ValidateSetupTargetArrayInputs<TConfig, TStates>> &
       ValidateRegistryKeys<
         TConfig,
         TSystemRegistry,
@@ -2156,11 +3003,23 @@ export interface SetupReturn<
   ): StateMachine<
     SetupContext<TSchemas, TContextSchema>,
     | SetupEvents<TSchemas, TEventSchemaMap, TInternalEventSchemaMap>
-    | ([RoutableStateId<Cast<TConfig, StateSchema>>] extends [never]
+    | ([
+        RoutableStateId<
+          MergeStateSchema<
+            Cast<TConfig, StateSchema>,
+            SetupStatesToStateSchema<TStates>
+          >
+        >
+      ] extends [never]
         ? never
         : {
             type: 'xstate.route';
-            to: RoutableStateId<Cast<TConfig, StateSchema>>;
+            to: RoutableStateId<
+              MergeStateSchema<
+                Cast<TConfig, StateSchema>,
+                SetupStatesToStateSchema<TStates>
+              >
+            >;
           }),
     Cast<
       MergeChildren<SetupChildren<TSchemas, TChildrenSchemaMap>, TActor>,
@@ -2208,7 +3067,10 @@ export interface SetupReturn<
   createStateConfig<
     const TPath extends StatePaths<TStates>,
     const TConfig extends SetupStateNodeConfig<
-      ResolveStateSiblings<TStates, TPath>,
+      StrictSetupStateSchemas<
+        ResolveStateSiblings<TStates, TPath>,
+        SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>
+      >,
       ResolveStatePath<TStates, TPath>,
       TSchemas,
       TSetupActionMap,
@@ -2219,7 +3081,18 @@ export interface SetupReturn<
     >
   >(
     path: TPath,
-    config: TConfig
+    config: TConfig &
+      NoInfer<
+        SetupStateNodeTargetArrayInputConstraint<
+          TConfig,
+          StrictSetupStateSchemas<
+            ResolveStateSiblings<TStates, TPath>,
+            SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>
+          >,
+          ResolveStatePath<TStates, TPath>,
+          SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>
+        >
+      >
   ): TConfig;
 
   /** Creates a state node config with the setup configuration */
@@ -2644,10 +3517,27 @@ function mergeStateSchemas(
       const schemas = mergeMaps(configState.schemas, setupState.schemas);
       const states = mergeStateSchemas(configState.states, setupState.states);
 
+      const structuralFields = [
+        'type',
+        'id',
+        'initial',
+        'history',
+        'target',
+        'route'
+      ] as const;
+      const structural = Object.fromEntries(
+        structuralFields.flatMap((field) =>
+          configState[field] === undefined && setupState[field] !== undefined
+            ? [[field, setupState[field]]]
+            : []
+        )
+      );
+
       return [
         key,
         {
           ...configState,
+          ...structural,
           ...(schemas ? { schemas } : undefined),
           ...(states ? { states } : undefined)
         }

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -547,20 +547,24 @@ type KnownSetupStateTarget<
     :
         | (StatePaths<TStateSchemas> & string)
         | `.${StatePaths<RelativeSetupStateSchemas<TStateSchemas>> & string}`
-        | `#${SetupStateIds<TStateSchemas> & string}`;
+        | `#${SetupStateIds<RootSetupStateSchemas<TStateSchemas>> & string}`;
 
 declare const strictSetupStateTargets: unique symbol;
 declare const relativeSetupStateSchemas: unique symbol;
+declare const rootSetupStateSchemas: unique symbol;
 
 type StrictSetupStateSchemas<
   TStateSchemas extends Record<string, SetupStateSchema>,
   TRelativeStateSchemas extends Record<string, SetupStateSchema> = Record<
     string,
     SetupStateSchema
-  >
+  >,
+  TRootStateSchemas extends Record<string, SetupStateSchema> =
+    RootSetupStateSchemas<TStateSchemas>
 > = TStateSchemas & {
   readonly [strictSetupStateTargets]: true;
   readonly [relativeSetupStateSchemas]: TRelativeStateSchemas;
+  readonly [rootSetupStateSchemas]: TRootStateSchemas;
 };
 
 type RelativeSetupStateSchemas<
@@ -571,6 +575,24 @@ type RelativeSetupStateSchemas<
 }
   ? TRelativeStateSchemas
   : TStateSchemas;
+
+type RootSetupStateSchemas<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> = TStateSchemas extends {
+  readonly [rootSetupStateSchemas]: infer TRootStateSchemas extends Record<
+    string,
+    SetupStateSchema
+  >;
+}
+  ? TRootStateSchemas
+  : TStateSchemas;
+
+type WithRootSetupStateSchemas<
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TRootStateSchemas extends Record<string, SetupStateSchema>
+> = TStateSchemas & {
+  readonly [rootSetupStateSchemas]: TRootStateSchemas;
+};
 
 type UnknownSetupStateTarget<
   TStateSchemas extends Record<string, SetupStateSchema>
@@ -621,7 +643,7 @@ type SetupStateSchemaAtTarget<
   TTarget extends `.${infer TPath}`
     ? ResolveStatePath<RelativeSetupStateSchemas<TStateSchemas>, TPath>
     : TTarget extends `#${infer TId}`
-      ? SetupStateSchemaAtId<TStateSchemas, TId>
+      ? SetupStateSchemaAtId<RootSetupStateSchemas<TStateSchemas>, TId>
       : ResolveStatePath<TStateSchemas, TTarget>
 ) extends infer TStateSchema
   ? TStateSchema extends SetupStateSchema
@@ -879,6 +901,55 @@ type MergeSourceMaps<
   TBase extends Record<string, unknown>,
   TExtension extends Record<string, unknown>
 > = Compute<TBase & TExtension>;
+
+type MergeSetupStateSchemaField<
+  TBase extends SetupStateSchema,
+  TExtension extends SetupStateSchema,
+  TKey extends 'schemas' | 'states'
+> = TKey extends keyof TExtension
+  ? TKey extends keyof TBase
+    ? TKey extends 'schemas'
+      ? {
+          [K in TKey]: MergeRecord<
+            NonNullable<TBase[TKey]>,
+            NonNullable<TExtension[TKey]>
+          >;
+        }
+      : NonNullable<TBase[TKey]> extends Record<string, SetupStateSchema>
+        ? NonNullable<TExtension[TKey]> extends Record<string, SetupStateSchema>
+          ? {
+              [K in TKey]: MergeSetupStateSchemas<
+                NonNullable<TBase[TKey]>,
+                NonNullable<TExtension[TKey]>
+              >;
+            }
+          : Pick<TExtension, TKey>
+        : Pick<TExtension, TKey>
+    : Pick<TExtension, TKey>
+  : TKey extends keyof TBase
+    ? Pick<TBase, TKey>
+    : {};
+
+type MergeSetupStateSchema<
+  TBase extends SetupStateSchema,
+  TExtension extends SetupStateSchema
+> = Omit<TBase, keyof TExtension> &
+  Omit<TExtension, 'schemas' | 'states'> &
+  MergeSetupStateSchemaField<TBase, TExtension, 'schemas'> &
+  MergeSetupStateSchemaField<TBase, TExtension, 'states'>;
+
+type MergeSetupStateSchemas<
+  TBase extends Record<string, SetupStateSchema>,
+  TExtension extends Record<string, SetupStateSchema>
+> = {
+  [K in keyof TBase | keyof TExtension]: K extends keyof TExtension
+    ? K extends keyof TBase
+      ? MergeSetupStateSchema<TBase[K], TExtension[K]>
+      : TExtension[K]
+    : K extends keyof TBase
+      ? TBase[K]
+      : never;
+};
 
 type DelayNamesFromConfigOrString<TConfig> = TConfig extends {
   delays: infer TDelays;
@@ -1540,12 +1611,10 @@ type SetupHistoryStateContract<
   states?: never;
   initial?: never;
 } & (TStateSchema extends {
-    target: infer TTarget extends string | readonly string[];
+    target: infer TTarget extends string | readonly [string, ...string[]];
   }
-    ? HistoryTargetRequiresInput<TSiblingStateSchemas, TTarget> extends true
-      ? never
-      : { target?: TTarget }
-    : { target: string | [string, ...string[]] });
+    ? { target?: TTarget | SetupStateTarget<TSiblingStateSchemas> }
+    : { target: SetupStateTarget<TSiblingStateSchemas> });
 
 type SetupStateChildrenContract<
   TStateSchema extends SetupStateSchema,
@@ -1576,6 +1645,64 @@ type HistoryTargetRequiresInput<
         SetupStateSchemaAtTarget<TSiblingStateSchemas, TTarget>
       >
     : false;
+
+type SetupHistoryTarget<
+  TStateSchema extends SetupStateSchema,
+  TConfig
+> = TConfig extends {
+  target: infer TTarget extends string | readonly [string, ...string[]];
+}
+  ? TTarget
+  : TStateSchema extends {
+        target: infer TTarget extends string | readonly [string, ...string[]];
+      }
+    ? TTarget
+    : never;
+
+type ValidateSetupHistoryStateInput<
+  TConfig,
+  TStateSchema extends SetupStateSchema,
+  TSiblingStateSchemas extends Record<string, SetupStateSchema>
+> = TStateSchema extends { type: 'history' } | { history: unknown }
+  ? SetupHistoryTarget<TStateSchema, TConfig> extends infer TTarget
+    ? [TTarget] extends [never]
+      ? unknown
+      : TTarget extends string | readonly [string, ...string[]]
+        ? HistoryTargetRequiresInput<TSiblingStateSchemas, TTarget> extends true
+          ? never
+          : unknown
+        : unknown
+    : unknown
+  : unknown;
+
+type ValidateSetupHistoryInputs<
+  TConfig,
+  TStateSchemas extends Record<string, SetupStateSchema>,
+  TRootStateSchemas extends Record<string, SetupStateSchema> = TStateSchemas
+> = TConfig extends { states: infer TStates extends Record<string, unknown> }
+  ? {
+      states: {
+        [K in keyof TStates & string]: K extends keyof TStateSchemas
+          ? TStates[K] &
+              ValidateSetupHistoryStateInput<
+                TStates[K],
+                TStateSchemas[K],
+                WithRootSetupStateSchemas<TStateSchemas, TRootStateSchemas>
+              > &
+              (TStateSchemas[K]['states'] extends Record<
+                string,
+                SetupStateSchema
+              >
+                ? ValidateSetupHistoryInputs<
+                    TStates[K],
+                    TStateSchemas[K]['states'],
+                    TRootStateSchemas
+                  >
+                : unknown)
+          : TStates[K];
+      };
+    }
+  : unknown;
 
 type DistributiveOmit<T, K extends keyof any> = T extends any
   ? Omit<T, K>
@@ -1681,8 +1808,8 @@ type StateSchemaChild<
     : EmptyStateSchema
   : EmptyStateSchema;
 
-type StateSchemaMetadataField<
-  TConfig extends StateSchema,
+type StateMetadataField<
+  TConfig,
   TSetup extends StateSchema,
   TKey extends keyof StateSchema
 > =
@@ -1695,35 +1822,24 @@ type StateSchemaMetadataField<
 type MergeStateSchemaMetadata<
   TConfig extends StateSchema,
   TSetup extends StateSchema
-> = StateSchemaMetadataField<TConfig, TSetup, 'id'> &
-  StateSchemaMetadataField<TConfig, TSetup, 'route'> &
-  StateSchemaMetadataField<TConfig, TSetup, 'type'> &
-  StateSchemaMetadataField<TConfig, TSetup, 'initial'> &
-  StateSchemaMetadataField<TConfig, TSetup, 'history'> &
-  StateSchemaMetadataField<TConfig, TSetup, 'target'>;
-
-type StateConfigMetadataField<
-  TConfig,
-  TSetup extends StateSchema,
-  TKey extends keyof StateSchema
-> =
-  TConfig extends Record<TKey, infer TValue>
-    ? { [K in TKey]: TValue }
-    : TSetup extends Record<TKey, infer TValue>
-      ? { [K in TKey]: TValue }
-      : {};
+> = StateMetadataField<TConfig, TSetup, 'id'> &
+  StateMetadataField<TConfig, TSetup, 'route'> &
+  StateMetadataField<TConfig, TSetup, 'type'> &
+  StateMetadataField<TConfig, TSetup, 'initial'> &
+  StateMetadataField<TConfig, TSetup, 'history'> &
+  StateMetadataField<TConfig, TSetup, 'target'>;
 
 /** Adds setup-declared topology to authored config for structural validation. */
 type MergeSetupConfigState<TConfig, TSetup extends StateSchema> = Omit<
   TConfig,
   'id' | 'route' | 'type' | 'initial' | 'history' | 'target' | 'states'
 > &
-  StateConfigMetadataField<TConfig, TSetup, 'id'> &
-  StateConfigMetadataField<TConfig, TSetup, 'route'> &
-  StateConfigMetadataField<TConfig, TSetup, 'type'> &
-  StateConfigMetadataField<TConfig, TSetup, 'initial'> &
-  StateConfigMetadataField<TConfig, TSetup, 'history'> &
-  StateConfigMetadataField<TConfig, TSetup, 'target'> &
+  StateMetadataField<TConfig, TSetup, 'id'> &
+  StateMetadataField<TConfig, TSetup, 'route'> &
+  StateMetadataField<TConfig, TSetup, 'type'> &
+  StateMetadataField<TConfig, TSetup, 'initial'> &
+  StateMetadataField<TConfig, TSetup, 'history'> &
+  StateMetadataField<TConfig, TSetup, 'target'> &
   (TConfig extends { states: infer TStates }
     ? TStates extends Record<string, unknown>
       ? {
@@ -2133,7 +2249,10 @@ type StateNodeConfigWithNestedInputBase<
   },
   TStateSchema['states'] extends Record<string, SetupStateSchema>
     ? StatesWithInput<
-        TStateSchema['states'],
+        WithRootSetupStateSchemas<
+          TStateSchema['states'],
+          RootSetupStateSchemas<TSiblingStateSchemas>
+        >,
         TStateSchema['states'],
         TContext,
         StateContextShape<TStateSchema, TContextShape>,
@@ -2834,7 +2953,7 @@ export interface SetupReturn<
       TExtendValidator
     >
   ): SetupReturn<
-    MergeSourceMaps<TStates, TExtendStates>,
+    MergeSetupStateSchemas<TStates, TExtendStates>,
     MergeSourceMaps<TSchemas, TExtendSchemas>,
     MergeSourceMaps<TSetupActionMap, TExtendActionMap>,
     MergeSourceMaps<TSetupActorMap, TExtendActorMap>,
@@ -3002,6 +3121,7 @@ export interface SetupReturn<
         TValidator
       > &
       ValidateSetupDelayReferences<TConfig, TSetupDelays> &
+      ValidateSetupHistoryInputs<TConfig, TStates> &
       ValidateHistoryDefaults<MergeSetupConfig<TConfig, TStates>> &
       ValidateStateTargets<MergeSetupConfig<TConfig, TStates>> &
       NoInfer<ValidateSetupTargetArrayInputs<TConfig, TStates>> &
@@ -3079,7 +3199,8 @@ export interface SetupReturn<
     const TConfig extends SetupStateNodeConfig<
       StrictSetupStateSchemas<
         ResolveStateSiblings<TStates, TPath>,
-        SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>
+        SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>,
+        TStates
       >,
       ResolveStatePath<TStates, TPath>,
       TSchemas,
@@ -3097,11 +3218,17 @@ export interface SetupReturn<
           TConfig,
           StrictSetupStateSchemas<
             ResolveStateSiblings<TStates, TPath>,
-            SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>
+            SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>,
+            TStates
           >,
           ResolveStatePath<TStates, TPath>,
           SetupStateChildSchemas<ResolveStatePath<TStates, TPath>>
         >
+      > &
+      ValidateSetupHistoryStateInput<
+        TConfig,
+        ResolveStatePath<TStates, TPath>,
+        WithRootSetupStateSchemas<ResolveStateSiblings<TStates, TPath>, TStates>
       >
   ): TConfig;
 
@@ -3351,7 +3478,7 @@ export const setup = function setupImplementation<
       return setup(
         mergeSetupConfigs(config, extension as AnySetupConfig) as any
       ) as unknown as SetupReturn<
-        MergeSourceMaps<TStates, TExtendStates>,
+        MergeSetupStateSchemas<TStates, TExtendStates>,
         MergeSourceMaps<TSchemas, TExtendSchemas>,
         MergeSourceMaps<TActionMap, TExtendActionMap>,
         MergeSourceMaps<TActorMap, TExtendActorMap>,

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -532,12 +532,26 @@ type SetupStateKey<TStateSchemas extends Record<string, SetupStateSchema>> =
       ? string
       : SetupStateKeys<TStateSchemas>;
 
-type SetupStateTarget<TStateSchemas extends Record<string, SetupStateSchema>> =
+type SetupRelativeStateTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> =
   string extends SetupStateKeys<TStateSchemas>
-    ? string
+    ? `.${string}`
     : [SetupStateKeys<TStateSchemas>] extends [never]
+      ? '.'
+      : '.' | `.${StatePaths<TStateSchemas> & string}`;
+
+type SetupStateTarget<TStateSchemas extends Record<string, SetupStateSchema>> =
+  TStateSchemas extends { readonly [strictSetupStateTargets]: true }
+    ?
+        | StatePaths<TStateSchemas>
+        | SetupRelativeStateTarget<RelativeSetupStateSchemas<TStateSchemas>>
+        | `#${string}`
+    : string extends SetupStateKeys<TStateSchemas>
       ? string
-      : StatePaths<TStateSchemas> | `.${string}` | `#${string}`;
+      : [SetupStateKeys<TStateSchemas>] extends [never]
+        ? string
+        : StatePaths<TStateSchemas> | `.${string}` | `#${string}`;
 
 type KnownSetupStateTarget<
   TStateSchemas extends Record<string, SetupStateSchema>
@@ -546,7 +560,7 @@ type KnownSetupStateTarget<
     ? never
     :
         | (StatePaths<TStateSchemas> & string)
-        | `.${StatePaths<RelativeSetupStateSchemas<TStateSchemas>> & string}`
+        | SetupRelativeStateTarget<RelativeSetupStateSchemas<TStateSchemas>>
         | `#${SetupStateIds<RootSetupStateSchemas<TStateSchemas>> & string}`;
 
 declare const strictSetupStateTargets: unique symbol;
@@ -607,11 +621,18 @@ type SetupStateTransitionSchemas<
   TSiblingStateSchemas extends Record<string, SetupStateSchema>,
   TStateSchema extends SetupStateSchema
 > =
-  TStateSchema['states'] extends Record<string, SetupStateSchema>
-    ? TStateSchema extends { type: SetupStateType }
-      ? StrictSetupStateSchemas<TSiblingStateSchemas, TStateSchema['states']>
-      : TSiblingStateSchemas
-    : TSiblingStateSchemas;
+  string extends SetupStateKeys<TSiblingStateSchemas>
+    ? TSiblingStateSchemas
+    : keyof SetupStateSchema extends keyof TStateSchema
+      ? TSiblingStateSchemas
+      : TStateSchema['states'] extends Record<string, SetupStateSchema>
+        ? TStateSchema extends { type: SetupStateType }
+          ? StrictSetupStateSchemas<
+              TSiblingStateSchemas,
+              TStateSchema['states']
+            >
+          : TSiblingStateSchemas
+        : StrictSetupStateSchemas<TSiblingStateSchemas, {}>;
 
 type SetupStateChildSchemas<TStateSchema extends SetupStateSchema> =
   TStateSchema['states'] extends Record<string, SetupStateSchema>

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -582,17 +582,11 @@ type KnownSetupStateTarget<
       ? never
       :
           | SetupRelativeStateTarget<RelativeSetupStateSchemas<TStateSchemas>>
-          | SetupStateIdTarget<
-              SetupStateIds<RootSetupStateSchemas<TStateSchemas>>
-            >
-          | SetupStateIdTargets<RootSetupStateSchemas<TStateSchemas>>
+          | RootSetupStateIdTarget<RootSetupStateSchemas<TStateSchemas>>
     :
         | (StrictSetupStatePaths<TStateSchemas> & string)
         | SetupRelativeStateTarget<RelativeSetupStateSchemas<TStateSchemas>>
-        | SetupStateIdTarget<
-            SetupStateIds<RootSetupStateSchemas<TStateSchemas>>
-          >
-        | SetupStateIdTargets<RootSetupStateSchemas<TStateSchemas>>;
+        | RootSetupStateIdTarget<RootSetupStateSchemas<TStateSchemas>>;
 
 declare const strictSetupStateTargets: unique symbol;
 declare const relativeSetupStateSchemas: unique symbol;
@@ -705,12 +699,6 @@ type RootSetupStateTarget<
   | SetupRelativeStateTarget<TStateSchemas>
   | RootSetupStateIdTarget<TStateSchemas>;
 
-type RootSetupStateIdTarget<
-  TStateSchemas extends Record<string, SetupStateSchema>
-> =
-  | SetupStateIdTarget<SetupStateIds<TStateSchemas>>
-  | SetupStateIdTargets<TStateSchemas>;
-
 type SetupStateTransitionChildSchemas<TStateSchema extends SetupStateSchema> =
   TStateSchema extends {
     states: infer TChildStateSchemas extends Record<string, SetupStateSchema>;
@@ -800,6 +788,15 @@ type SetupStateIdTargets<
               ? SetupStateIdTargets<TChildStateSchemas>
               : never;
           }[keyof TStateSchemas & string];
+
+type RootSetupStateIdTarget<
+  TStateSchemas extends Record<string, SetupStateSchema>
+> =
+  SetupStateIds<TStateSchemas> extends infer TIds extends string
+    ? [TIds] extends [never]
+      ? never
+      : SetupStateIdTarget<TIds> | SetupStateIdTargets<TStateSchemas>
+    : never;
 
 type SetupStateSchemaAtTarget<
   TStateSchemas extends Record<string, SetupStateSchema>,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1907,6 +1907,7 @@ function microstep(
                   self: actorScope.self,
                   context: nextState.context,
                   event,
+                  input: stateInputMap[stateNodeToEnter.id],
                   output: getEventOutput(event)
                 })
               : invokeDef.input;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1506,6 +1506,7 @@ export type Mapper<
   args: {
     context: _TCtx;
     event: TExpressionEvent;
+    input?: Record<string, unknown>;
     self: ActorSelf<
       MachineSnapshot<
         _TCtx & MachineContext,
@@ -2642,6 +2643,7 @@ export type StateSchema = {
   contextSchema?: StandardSchemaV1;
   outputSchema?: StandardSchemaV1;
   input?: unknown;
+  initial?: unknown;
 
   // Other types
   // Needed because TS treats objects with all optional properties as a "weak" object

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -2002,6 +2002,19 @@ type InvalidTransitionMapTargets<
       }[keyof TTransitionMap]
     : never;
 
+type InvalidInitialTarget<TRootConfig, TChildStates, TInitialTarget> =
+  TInitialTarget extends string
+    ? string extends TInitialTarget
+      ? never
+      : TInitialTarget extends keyof TChildStates
+        ? never
+        : TInitialTarget extends `#${string}`
+          ? TInitialTarget extends AuthoredIdTargets<TRootConfig>
+            ? never
+            : TInitialTarget
+          : TInitialTarget
+    : never;
+
 type InvalidInvokeTargets<
   TRootConfig,
   TSourcePath extends StatePath,
@@ -2042,13 +2055,7 @@ type InvalidNodeTargets<
                 ? TInitialTarget
                 : TInitial
             ) extends infer TInitialTarget
-            ? TInitialTarget extends string
-              ? string extends TInitialTarget
-                ? never
-                : TInitialTarget extends keyof TChildStates
-                  ? never
-                  : TInitialTarget
-              : never
+            ? InvalidInitialTarget<TRootConfig, TChildStates, TInitialTarget>
             : never
           : never)
       | (TNode extends { on: infer TOn }
@@ -2118,13 +2125,7 @@ export type ValidateStateTargets<TConfig> = 0 extends 1 & TConfig
                   ? TInitialTarget
                   : TInitial
               ) extends infer TInitialTarget
-              ? TInitialTarget extends string
-                ? string extends TInitialTarget
-                  ? never
-                  : TInitialTarget extends keyof TStates
-                    ? never
-                    : TInitialTarget
-                : never
+              ? InvalidInitialTarget<TConfig, TStates, TInitialTarget>
               : never
             : never)
         | InvalidNodeTargets<TConfig, TConfig, []>

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -442,10 +442,12 @@ type InvokeInputArgs<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TEmitted extends EventObject,
-  TChildren extends Record<string, AnyActorRef | undefined>
+  TChildren extends Record<string, AnyActorRef | undefined>,
+  TInput = undefined
 > = {
   context: TContext;
   event: TEvent;
+  input: TInput;
   self: ActorSelf<
     MachineSnapshot<
       TContext,
@@ -568,7 +570,8 @@ type InlineChildInvokeConfig<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TMeta extends MetaObject,
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TInput = undefined
 > = Values<{
   [K in keyof TChildren & string]: Omit<
     Next_InvokeConfigBase<
@@ -599,7 +602,7 @@ type InlineChildInvokeConfig<
     src: LogicForChildRef<TChildren[K]>;
     input?:
       | ((
-          args: InvokeInputArgs<TContext, TEvent, TEmitted, TChildren>
+          args: InvokeInputArgs<TContext, TEvent, TEmitted, TChildren, TInput>
         ) => unknown)
       | NonReducibleUnknown;
   };
@@ -615,7 +618,8 @@ type InlineInvokeConfig<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TMeta extends MetaObject,
-  TSystemRegistry extends SystemRegistry
+  TSystemRegistry extends SystemRegistry,
+  TInput = undefined
 > =
   HasExplicitChildren<TChildren> extends true
     ? InlineChildInvokeConfig<
@@ -628,7 +632,8 @@ type InlineInvokeConfig<
         TGuardMap,
         TDelayMap,
         TMeta,
-        TSystemRegistry
+        TSystemRegistry,
+        TInput
       >
     : Omit<
         Next_InvokeConfigBase<
@@ -658,7 +663,13 @@ type InlineInvokeConfig<
         src: AnyActorLogic;
         input?:
           | ((
-              args: InvokeInputArgs<TContext, TEvent, TEmitted, TChildren>
+              args: InvokeInputArgs<
+                TContext,
+                TEvent,
+                TEmitted,
+                TChildren,
+                TInput
+              >
             ) => unknown)
           | NonReducibleUnknown;
       };
@@ -683,7 +694,8 @@ export type Next_InvokeConfig<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TMeta extends MetaObject,
-  TSystemRegistry extends SystemRegistry = SystemRegistry
+  TSystemRegistry extends SystemRegistry = SystemRegistry,
+  TInput = undefined
 > = string extends keyof TActorMap
   ? // No registered actor sources (permissive map): `src`/`input` cannot be
     // correlated. A mapped type over `string` would also defer resolution and
@@ -699,7 +711,8 @@ export type Next_InvokeConfig<
         TGuardMap,
         TDelayMap,
         TMeta,
-        TSystemRegistry
+        TSystemRegistry,
+        TInput
       >
     : Next_InvokeConfigBase<
         TContext,
@@ -721,7 +734,13 @@ export type Next_InvokeConfig<
             ) => string | AnyActorLogic);
         input?:
           | ((
-              args: InvokeInputArgs<TContext, TEvent, TEmitted, TChildren>
+              args: InvokeInputArgs<
+                TContext,
+                TEvent,
+                TEmitted,
+                TChildren,
+                TInput
+              >
             ) => unknown)
           | NonReducibleUnknown;
       }
@@ -743,7 +762,13 @@ export type Next_InvokeConfig<
             id?: ChildIdForLogic<TActorMap[K], TChildren>;
             input?:
               | ((
-                  args: InvokeInputArgs<TContext, TEvent, TEmitted, TChildren>
+                  args: InvokeInputArgs<
+                    TContext,
+                    TEvent,
+                    TEmitted,
+                    TChildren,
+                    TInput
+                  >
                 ) => InputFrom<TActorMap[K]>)
               | InputFrom<TActorMap[K]>;
           } & (
@@ -770,7 +795,8 @@ export type Next_InvokeConfig<
           TGuardMap,
           TDelayMap,
           TMeta,
-          TSystemRegistry
+          TSystemRegistry,
+          TInput
         >;
 
 interface Next_InvokeConfigBase<
@@ -1201,7 +1227,8 @@ interface Next_RegularStateNodeConfig<
       TGuardMap,
       TDelayMap,
       TMeta,
-      TSystemRegistry
+      TSystemRegistry,
+      TInput
     >
   >;
   /** The mapping of event types to their potential transition(s). */

--- a/packages/core/test/setup.test.ts
+++ b/packages/core/test/setup.test.ts
@@ -164,6 +164,47 @@ describe('setup', () => {
     expect(machine.states.done.schemas).toBeUndefined();
   });
 
+  it('deep-merges repeated nested state contracts through extend', () => {
+    const leftInput = types<{ left: number }>();
+    const rightInput = types<{ right: boolean }>();
+
+    const s = setup({
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'left',
+          states: {
+            left: { schemas: { input: leftInput } }
+          }
+        }
+      }
+    }).extend({
+      states: {
+        parent: {
+          states: {
+            right: { schemas: { input: rightInput } }
+          }
+        }
+      }
+    });
+
+    expect(s.states.parent.states?.left.schemas?.input).toBe(leftInput);
+    expect(s.states.parent.states?.right.schemas?.input).toBe(rightInput);
+
+    const machine = s.createMachine({
+      initial: 'parent',
+      states: {
+        parent: {
+          initial: { target: 'left', input: { left: 1 } },
+          states: { left: {}, right: {} }
+        }
+      }
+    });
+
+    expect(machine.states.parent.states.left.schemas?.input).toBe(leftInput);
+    expect(machine.states.parent.states.right.schemas?.input).toBe(rightInput);
+  });
+
   it('extends sources', () => {
     const calls: string[] = [];
 

--- a/packages/core/test/setup.test.ts
+++ b/packages/core/test/setup.test.ts
@@ -205,6 +205,42 @@ describe('setup', () => {
     expect(machine.states.parent.states.right.schemas?.input).toBe(rightInput);
   });
 
+  it('uses extension state metadata while preserving base descendants', () => {
+    const s = setup({
+      states: {
+        parent: {
+          type: 'compound',
+          id: 'base-parent',
+          initial: 'left',
+          states: { left: {} }
+        }
+      }
+    }).extend({
+      states: {
+        parent: {
+          type: 'compound',
+          id: 'extension-parent',
+          initial: 'right',
+          states: { right: {} }
+        }
+      }
+    });
+
+    s.states.parent.type satisfies 'compound';
+    s.states.parent.id satisfies 'extension-parent';
+    s.states.parent.initial satisfies 'right';
+    s.states.parent.states?.left;
+    s.states.parent.states?.right;
+
+    const machine = s.createMachine({
+      initial: 'parent',
+      states: { parent: { states: { left: {}, right: {} } } }
+    });
+
+    expect(machine.states.parent.id).toBe('extension-parent');
+    expect(machine.states.parent.config.initial).toBe('right');
+  });
+
   it('extends sources', () => {
     const calls: string[] = [];
 

--- a/packages/core/test/setupStateContracts.test.ts
+++ b/packages/core/test/setupStateContracts.test.ts
@@ -1,0 +1,1115 @@
+import { createActor, createAsyncLogic, setup, types } from '../src/index.ts';
+import type { StateValueFrom } from '../src/types.ts';
+
+describe('setup state contracts', () => {
+  it('carries declared state types through machine state values and runtime nodes', () => {
+    const s = setup({
+      states: {
+        active: {
+          type: 'parallel',
+          id: 'active-state',
+          states: {
+            playback: {
+              type: 'compound',
+              initial: 'stopped',
+              states: {
+                stopped: {},
+                playing: {}
+              }
+            },
+            volume: {
+              type: 'compound',
+              initial: 'audible',
+              states: {
+                audible: {},
+                muted: {}
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const machine = s.createMachine({
+      initial: 'active',
+      states: {
+        active: {
+          states: {
+            playback: {
+              states: {
+                stopped: {},
+                playing: {}
+              }
+            },
+            volume: {
+              states: {
+                audible: {},
+                muted: {}
+              }
+            }
+          }
+        }
+      }
+    });
+
+    type MachineStateValue = StateValueFrom<typeof machine>;
+    const stateValue = {
+      active: { playback: 'stopped', volume: 'audible' }
+    } satisfies MachineStateValue;
+
+    expect(machine.states.active.type).toBe('parallel');
+    expect(machine.states.active.id).toBe('active-state');
+    expect(machine.states.active.states.playback.type).toBe('compound');
+    expect(machine.states.active.states.playback.config.initial).toBe(
+      'stopped'
+    );
+    expect(stateValue).toEqual({
+      active: { playback: 'stopped', volume: 'audible' }
+    });
+  });
+
+  it('inherits history defaults from setup state contracts', () => {
+    const machine = setup({
+      states: {
+        parent: {
+          initial: 'idle',
+          states: {
+            idle: {},
+            hist: {
+              type: 'history',
+              target: 'idle'
+            }
+          }
+        }
+      }
+    }).createMachine({
+      initial: 'parent',
+      states: {
+        parent: {
+          states: {
+            idle: {},
+            hist: {}
+          }
+        }
+      }
+    });
+
+    expect(machine.states.parent.states.hist.type).toBe('history');
+    expect(machine.states.parent.states.hist.config.target).toBe('idle');
+  });
+
+  it('treats setup history metadata as a history node without a type', () => {
+    const s = setup({
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'idle',
+          states: {
+            idle: {},
+            hist: { history: true, target: 'idle' }
+          }
+        }
+      }
+    });
+
+    const machine = s.createMachine({
+      initial: 'parent',
+      states: {
+        parent: {
+          states: { idle: {}, hist: {} }
+        }
+      }
+    });
+
+    expect(machine.states.parent.states.hist.type).toBe('history');
+  });
+
+  it('keeps child input typing on setup-declared compound initials', () => {
+    const s = setup({
+      schemas: { context: types<{ value: number }>() },
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'child',
+          states: {
+            child: { schemas: { input: types<{ id: number }>() } }
+          }
+        }
+      }
+    });
+
+    s.createMachine({
+      context: { value: 1 },
+      initial: 'parent',
+      states: {
+        parent: {
+          initial: {
+            target: 'child',
+            input: ({ context }) => {
+              context.value satisfies number;
+              // @ts-expect-error - initial context is not a string
+              const value: string = context.value;
+              void value;
+              return { id: context.value };
+            }
+          },
+          states: { child: {} }
+        }
+      }
+    });
+
+    if (false) {
+      s.createMachine({
+        context: { value: 1 },
+        initial: 'parent',
+        states: {
+          parent: {
+            initial: {
+              target: 'child',
+              // @ts-expect-error - the setup child input requires a number
+              input: { id: 'wrong' }
+            },
+            states: { child: {} }
+          }
+        }
+      });
+    }
+  });
+
+  it('requires input for every explicitly entered composite state', () => {
+    const s = setup({
+      schemas: { events: { GO: types<{}>() } },
+      states: {
+        idle: {},
+        parent: {
+          type: 'compound',
+          initial: 'child',
+          schemas: { input: types<{ parentId: string }>() },
+          states: {
+            child: { schemas: { input: types<{ childId: number }>() } }
+          }
+        },
+        active: {
+          type: 'parallel',
+          schemas: { input: types<{ sessionId: string }>() },
+          states: {
+            left: {
+              type: 'compound',
+              initial: 'leaf',
+              states: {
+                leaf: { schemas: { input: types<{ leftId: number }>() } }
+              }
+            },
+            right: {
+              type: 'compound',
+              initial: 'leaf',
+              states: {
+                leaf: { schemas: { input: types<{ rightId: boolean }>() } }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            GO: { target: 'parent', input: { parentId: 'p1' } }
+          }
+        },
+        parent: {
+          initial: { target: 'child', input: { childId: 1 } },
+          states: { child: {} }
+        },
+        active: {
+          states: {
+            left: {
+              initial: { target: 'leaf', input: { leftId: 1 } },
+              states: { leaf: {} }
+            },
+            right: {
+              initial: { target: 'leaf', input: { rightId: true } },
+              states: { leaf: {} }
+            }
+          }
+        }
+      }
+    });
+
+    if (false as boolean) {
+      s.createMachine({
+        // @ts-expect-error - a root initial transition to parent needs parentId
+        initial: { target: 'parent' },
+        states: {
+          parent: {
+            initial: { target: 'child', input: { childId: 1 } },
+            states: { child: {} }
+          }
+        }
+      });
+
+      s.createMachine({
+        // @ts-expect-error - a structural parent with required input cannot use a bare initial target
+        initial: 'parent',
+        states: {
+          parent: {
+            initial: { target: 'child', input: { childId: 1 } },
+            states: { child: {} }
+          }
+        }
+      });
+    }
+
+    if (false as boolean) {
+      s.createMachine({
+        initial: 'idle',
+        states: {
+          idle: {
+            on: {
+              // @ts-expect-error - entering parent requires parentId
+              GO: {
+                target: 'parent',
+                input: {}
+              }
+            }
+          },
+          parent: {
+            // @ts-expect-error - the initial child requires childId
+            initial: 'child',
+            states: { child: {} }
+          }
+        }
+      });
+
+      s.createMachine({
+        initial: 'idle',
+        states: {
+          idle: {
+            on: {
+              GO: { target: 'active', input: { sessionId: 's1' } }
+            }
+          },
+          active: {
+            states: {
+              left: {
+                // @ts-expect-error - the left initial child requires leftId
+                initial: 'leaf',
+                states: { leaf: {} }
+              },
+              right: {
+                initial: { target: 'leaf', input: { rightId: true } },
+                states: { leaf: {} }
+              }
+            }
+          }
+        }
+      });
+    }
+  });
+
+  it('validates setup-declared history targets and ids', () => {
+    const valid = setup({
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'idle',
+          states: {
+            idle: {},
+            hist: { type: 'history', target: 'idle' },
+            done: { id: 'done-state' }
+          }
+        }
+      }
+    });
+
+    valid.createMachine({
+      initial: 'parent',
+      states: {
+        parent: {
+          states: {
+            idle: {},
+            hist: {},
+            done: { on: { RESET: { target: '#done-state' } } }
+          }
+        }
+      }
+    });
+
+    if (false) {
+      valid.createMachine({
+        initial: 'parent',
+        states: {
+          parent: {
+            states: {
+              idle: {},
+              // @ts-expect-error - history nodes cannot have child states
+              hist: { type: 'history', states: { child: {} } }
+            }
+          }
+        }
+      });
+    }
+
+    const invalid = setup({
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'idle',
+          states: {
+            idle: {},
+            hist: { type: 'history', target: 'missing' }
+          }
+        }
+      }
+    });
+
+    if (false) {
+      // @ts-expect-error - setup history defaults must target a real state
+      invalid.createMachine({
+        initial: 'parent',
+        states: {
+          parent: { states: { idle: {}, hist: {} } }
+        }
+      });
+    }
+
+    const historyWithInputTarget = setup({
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'idle',
+          states: {
+            idle: {},
+            loaded: {
+              schemas: { input: types<{ token: string }>() }
+            },
+            hist: { type: 'history', target: 'loaded' }
+          }
+        }
+      }
+    });
+
+    if (false as boolean) {
+      historyWithInputTarget.createMachine({
+        initial: 'parent',
+        states: {
+          parent: {
+            states: {
+              idle: {},
+              // @ts-expect-error - history defaults cannot provide loaded input
+              hist: {},
+              loaded: {}
+            }
+          }
+        }
+      });
+    }
+
+    const historyWithNestedInitialInputs = setup({
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'idle',
+          states: {
+            idle: {},
+            active: {
+              type: 'parallel',
+              states: {
+                left: {
+                  type: 'compound',
+                  initial: 'leaf',
+                  states: {
+                    leaf: { schemas: { input: types<{ id: number }>() } }
+                  }
+                },
+                right: {
+                  type: 'compound',
+                  initial: 'leaf',
+                  states: {
+                    leaf: { schemas: { input: types<{ ready: boolean }>() } }
+                  }
+                }
+              }
+            },
+            hist: { type: 'history', target: 'active' }
+          }
+        }
+      }
+    });
+
+    historyWithNestedInitialInputs.createMachine({
+      initial: 'parent',
+      states: {
+        parent: {
+          states: {
+            idle: {},
+            active: {
+              states: {
+                left: {
+                  initial: { target: 'leaf', input: { id: 1 } },
+                  states: { leaf: {} }
+                },
+                right: {
+                  initial: { target: 'leaf', input: { ready: true } },
+                  states: { leaf: {} }
+                }
+              }
+            },
+            hist: {}
+          }
+        }
+      }
+    });
+  });
+
+  it('requires the structural fields declared by setup', () => {
+    const parallel = setup({
+      states: {
+        active: {
+          type: 'parallel'
+        }
+      }
+    });
+
+    if (false) {
+      parallel.createMachine({
+        initial: 'active',
+        states: {
+          active: {
+            // @ts-expect-error - parallel states cannot have an initial state
+            initial: 'left',
+            states: { left: {} }
+          }
+        }
+      });
+    }
+
+    const compound = setup({
+      states: {
+        active: {
+          type: 'compound'
+        }
+      }
+    });
+
+    if (false) {
+      compound.createMachine({
+        initial: 'active',
+        states: {
+          // @ts-expect-error - a declared compound state needs an initial
+          active: { states: { idle: {} } }
+        }
+      });
+    }
+
+    const compoundWithChildren = setup({
+      states: {
+        active: {
+          type: 'compound',
+          initial: 'idle',
+          states: { idle: {} }
+        }
+      }
+    });
+
+    if (false) {
+      compoundWithChildren.createMachine({
+        initial: 'active',
+        states: {
+          // @ts-expect-error - declared compound children must be authored
+          active: {}
+        }
+      });
+    }
+
+    const incompatible = setup({
+      states: {
+        active: {
+          type: 'parallel'
+        }
+      }
+    });
+
+    if (false) {
+      incompatible.createMachine({
+        initial: 'active',
+        states: {
+          active: {
+            // @ts-expect-error - the machine config cannot contradict setup
+            type: 'compound',
+            states: { idle: {} }
+          }
+        }
+      });
+    }
+
+    const final = setup({
+      states: { done: { type: 'final' } }
+    });
+
+    final.createMachine({
+      initial: 'done',
+      states: { done: { output: { ok: true } } }
+    });
+
+    if (false) {
+      final.createMachine({
+        initial: 'done',
+        states: {
+          done: {
+            // @ts-expect-error - final states cannot have child states
+            states: { child: {} }
+          }
+        }
+      });
+    }
+
+    const choice = setup({
+      schemas: { context: types<{ value: number }>() },
+      states: { route: { type: 'choice' } }
+    });
+
+    choice.createMachine({
+      context: { value: 0 },
+      initial: 'route',
+      states: {
+        route: {
+          choice: ({ context }) => {
+            context.value satisfies number;
+            // @ts-expect-error - choice context is not a string
+            const value: string = context.value;
+            void value;
+            return { target: 'done' };
+          }
+        },
+        done: { type: 'final' }
+      }
+    });
+
+    if (false) {
+      choice.createMachine({
+        initial: 'route',
+        states: {
+          // @ts-expect-error - choice states require a choice function
+          route: {
+            type: 'choice'
+          },
+          done: { type: 'final' }
+        }
+      });
+    }
+
+    expect(true).toBe(true);
+  });
+
+  it('retains current permissive setup schemas without structural metadata', () => {
+    setup({
+      states: {
+        active: {
+          schemas: {}
+        }
+      }
+    }).createMachine({
+      initial: 'active',
+      states: {
+        active: {}
+      }
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('uses setup parallel metadata when validating authored target sets', () => {
+    const s = setup({
+      schemas: { events: { RESET: types<{}>() } },
+      states: {
+        active: {
+          type: 'parallel',
+          states: {
+            left: {
+              type: 'compound',
+              initial: 'idle',
+              states: { idle: {}, done: {} }
+            },
+            right: {
+              type: 'compound',
+              initial: 'idle',
+              states: { idle: {}, done: {} }
+            }
+          }
+        }
+      }
+    });
+
+    const machine = s.createMachine({
+      initial: 'active',
+      on: {
+        RESET: { target: ['.active.left.done', '.active.right.done'] }
+      },
+      states: {
+        active: {
+          states: {
+            left: { states: { idle: {}, done: {} } },
+            right: { states: { idle: {}, done: {} } }
+          }
+        }
+      }
+    });
+
+    expect(machine.states.active.type).toBe('parallel');
+  });
+
+  it('correlates nested setup targets with their context and input schemas', () => {
+    const s = setup({
+      schemas: {
+        context: types<{ mode: 'idle' }>(),
+        events: {
+          GO: types<{}>(),
+          CHILD: types<{}>(),
+          GRANDCHILD: types<{}>()
+        }
+      },
+      states: {
+        parent: {
+          initial: 'idle',
+          states: {
+            idle: {},
+            child: {
+              schemas: { input: types<{ childToken: number }>() }
+            },
+            flow: {
+              type: 'compound',
+              initial: 'ready',
+              states: {
+                ready: {},
+                done: {
+                  id: 'done-state',
+                  schemas: {
+                    context: types<{ mode: 'done'; code: number }>(),
+                    input: types<{ token: string }>()
+                  }
+                }
+              }
+            },
+            foo: {
+              type: 'compound',
+              initial: 'grandchild',
+              states: {
+                grandchild: {
+                  schemas: { input: types<{ grandchildToken: boolean }>() }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    s.createStateConfig('parent', {
+      on: {
+        CHILD: {
+          target: '.child',
+          input: { childToken: 1 }
+        },
+        GRANDCHILD: {
+          target: '.foo.grandchild',
+          input: { grandchildToken: true }
+        },
+        GO: {
+          target: '.flow.done',
+          context: { mode: 'done', code: 1 },
+          input: { token: 'ready' }
+        }
+      }
+    });
+
+    const machineSetup = setup({
+      schemas: {
+        events: {
+          CHILD: types<{}>(),
+          GRANDCHILD: types<{}>()
+        }
+      },
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'idle',
+          states: {
+            idle: {},
+            child: {
+              schemas: { input: types<{ childToken: number }>() }
+            },
+            foo: {
+              type: 'compound',
+              initial: 'grandchild',
+              states: {
+                grandchild: {
+                  schemas: { input: types<{ grandchildToken: boolean }>() }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    machineSetup.createMachine({
+      initial: 'parent',
+      states: {
+        parent: {
+          initial: 'idle',
+          on: {
+            CHILD: { target: '.child', input: { childToken: 1 } },
+            GRANDCHILD: {
+              target: '.foo.grandchild',
+              input: { grandchildToken: true }
+            }
+          },
+          states: {
+            idle: {},
+            child: {},
+            foo: {
+              initial: {
+                target: 'grandchild',
+                input: { grandchildToken: true }
+              },
+              states: { grandchild: {} }
+            }
+          }
+        }
+      }
+    });
+
+    s.createStateConfig('parent', {
+      on: {
+        GO: {
+          target: '#done-state',
+          context: { mode: 'done', code: 1 },
+          input: { token: 'ready' }
+        }
+      }
+    });
+
+    if (false as boolean) {
+      s.createStateConfig('parent', {
+        on: {
+          // @ts-expect-error - nested target input is required to be typed
+          GO: {
+            target: '.flow.done',
+            input: { token: 1 },
+            context: { mode: 'done', code: 1 }
+          }
+        }
+      });
+
+      s.createStateConfig('parent', {
+        on: {
+          // @ts-expect-error - `.child` requires childToken to be a number
+          CHILD: { target: '.child', input: { childToken: 'wrong' } },
+          // @ts-expect-error - `.foo.grandchild` requires grandchildToken
+          GRANDCHILD: { target: '.foo.grandchild', input: {} }
+        }
+      });
+
+      machineSetup.createMachine({
+        initial: 'parent',
+        states: {
+          parent: {
+            on: {
+              // @ts-expect-error - machine relative targets use the source state's input schema
+              CHILD: { target: '.child', input: { childToken: 'wrong' } }
+            },
+            states: {
+              idle: {},
+              child: {},
+              foo: {
+                initial: {
+                  target: 'grandchild',
+                  input: { grandchildToken: true }
+                },
+                states: { grandchild: {} }
+              }
+            }
+          }
+        }
+      });
+    }
+
+    expect(true).toBe(true);
+  });
+
+  it('passes state input to invoke input callbacks', () => {
+    const seen: Array<{ token: string }> = [];
+    const worker = createAsyncLogic<undefined, { token: string }>({
+      run: async ({ input }) => {
+        seen.push(input);
+        return undefined;
+      }
+    });
+
+    const machine = setup({
+      actors: { worker },
+      states: {
+        working: {
+          schemas: { input: types<{ token: string }>() }
+        }
+      }
+    }).createMachine({
+      initial: { target: 'working', input: { token: 'abc' } },
+      states: {
+        working: {
+          invoke: {
+            src: 'worker',
+            input: ({ input }) => {
+              input.token satisfies string;
+              return input;
+            }
+          }
+        }
+      }
+    });
+
+    createActor(machine).start();
+
+    expect(seen).toEqual([{ token: 'abc' }]);
+  });
+
+  it('requires shared input for every target in a target set', () => {
+    const s = setup({
+      schemas: { events: { GO: types<{}>() } },
+      states: {
+        idle: {},
+        active: {
+          type: 'parallel',
+          states: {
+            left: {
+              type: 'compound',
+              initial: 'ready',
+              states: {
+                ready: { schemas: { input: types<{ leftId: number }>() } }
+              }
+            },
+            right: {
+              type: 'compound',
+              initial: 'ready',
+              states: {
+                ready: {
+                  schemas: { input: types<{ rightId: boolean }>() }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const machine = s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            GO: {
+              target: ['active.left.ready', 'active.right.ready'],
+              input: { leftId: 1, rightId: true }
+            }
+          }
+        },
+        active: {
+          states: {
+            left: {
+              initial: { target: 'ready', input: { leftId: 1 } },
+              states: {
+                ready: {
+                  entry: ({ input }) => {
+                    input.leftId satisfies number;
+                  }
+                }
+              }
+            },
+            right: {
+              initial: { target: 'ready', input: { rightId: true } },
+              states: {
+                ready: {
+                  entry: ({ input }) => {
+                    input.rightId satisfies boolean;
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    s.createStateConfig('idle', {
+      on: {
+        GO: {
+          target: ['active.left.ready', 'active.right.ready'],
+          input: { leftId: 1, rightId: true }
+        }
+      }
+    });
+
+    if (false as boolean) {
+      s.createMachine({
+        initial: 'idle',
+        states: {
+          idle: {
+            on: {
+              GO: {
+                target: ['active.left.ready', 'active.right.ready'],
+                // @ts-expect-error - every target's required input is needed
+                input: { leftId: 1 }
+              }
+            }
+          },
+          active: {
+            states: {
+              left: {
+                initial: { target: 'ready', input: { leftId: 1 } },
+                states: { ready: {} }
+              },
+              right: {
+                initial: { target: 'ready', input: { rightId: true } },
+                states: { ready: {} }
+              }
+            }
+          }
+        }
+      });
+    }
+
+    s.createStateConfig('idle', {
+      on: {
+        GO: {
+          target: ['active.left.ready', 'active.right.ready'],
+          // @ts-expect-error - every target's required input is needed
+          input: { leftId: 1 }
+        }
+      }
+    });
+
+    s.createStateConfig('idle', {
+      on: {
+        GO: {
+          target: ['active.left.ready', 'active.right.ready'],
+          // @ts-expect-error - each target input keeps its own field type
+          input: { leftId: 1, rightId: 'wrong' }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'GO' });
+
+    expect(actor.getSnapshot().value).toEqual({
+      active: { left: 'ready', right: 'ready' }
+    });
+  });
+
+  it('passes nested initial inputs through a history default into parallel regions', () => {
+    const seen: Array<string | number | boolean> = [];
+    const machine = setup({
+      schemas: { events: { RESTORE: types<{}>() } },
+      states: {
+        parent: {
+          type: 'compound',
+          initial: 'idle',
+          states: {
+            idle: {},
+            active: {
+              type: 'parallel',
+              states: {
+                left: {
+                  type: 'compound',
+                  initial: 'leaf',
+                  states: {
+                    leaf: { schemas: { input: types<{ id: number }>() } }
+                  }
+                },
+                right: {
+                  type: 'compound',
+                  initial: 'leaf',
+                  states: {
+                    leaf: {
+                      schemas: { input: types<{ ready: boolean }>() }
+                    }
+                  }
+                }
+              }
+            },
+            hist: { type: 'history', target: 'active' }
+          }
+        }
+      }
+    }).createMachine({
+      initial: 'parent',
+      states: {
+        parent: {
+          initial: 'idle',
+          states: {
+            idle: { on: { RESTORE: { target: 'hist' } } },
+            active: {
+              states: {
+                left: {
+                  initial: { target: 'leaf', input: { id: 7 } },
+                  states: {
+                    leaf: {
+                      entry: ({ input }) => {
+                        seen.push(input.id);
+                      }
+                    }
+                  }
+                },
+                right: {
+                  initial: { target: 'leaf', input: { ready: true } },
+                  states: {
+                    leaf: {
+                      entry: ({ input }) => {
+                        seen.push(input.ready);
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            hist: {}
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'RESTORE' });
+
+    expect(actor.getSnapshot().value).toEqual({
+      parent: { active: { left: 'leaf', right: 'leaf' } }
+    });
+    expect(seen).toEqual([7, true]);
+  });
+
+  it('carries setup route metadata into the machine event contract', () => {
+    const machine = setup({
+      states: { home: { id: 'home', route: true } }
+    }).createMachine({
+      initial: 'home',
+      states: { home: {} }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'xstate.route', to: '#home' });
+
+    if (false) {
+      actor.send({
+        type: 'xstate.route',
+        // @ts-expect-error - only setup states with ids and routes are targets
+        to: '#missing'
+      });
+    }
+
+    expect(actor.getSnapshot().value).toBe('home');
+  });
+});

--- a/packages/core/test/setupStateContracts.test.ts
+++ b/packages/core/test/setupStateContracts.test.ts
@@ -408,6 +408,35 @@ describe('setup state contracts', () => {
       });
     }
 
+    historyWithInputTarget.createMachine({
+      initial: 'parent',
+      states: {
+        parent: {
+          states: {
+            idle: {},
+            hist: { target: 'idle' },
+            loaded: {}
+          }
+        }
+      }
+    });
+
+    if (false as boolean) {
+      historyWithInputTarget.createMachine({
+        initial: 'parent',
+        states: {
+          parent: {
+            states: {
+              idle: {},
+              // @ts-expect-error - authored history targets still require input
+              hist: { target: 'loaded' },
+              loaded: {}
+            }
+          }
+        }
+      });
+    }
+
     const historyWithNestedInitialInputs = setup({
       states: {
         parent: {
@@ -839,6 +868,63 @@ describe('setup state contracts', () => {
     }
 
     expect(true).toBe(true);
+  });
+
+  it('resolves root IDs from nested state transitions', () => {
+    const s = setup({
+      schemas: { events: { GO: types<{}>() } },
+      states: {
+        one: {
+          type: 'compound',
+          initial: 'idle',
+          states: { idle: {} }
+        },
+        two: {
+          type: 'compound',
+          initial: 'idle',
+          states: {
+            idle: {},
+            done: {
+              id: 'two-done',
+              schemas: { input: types<{ token: string }>() }
+            }
+          }
+        }
+      }
+    });
+
+    s.createStateConfig('one.idle', {
+      on: { GO: { target: '#two-done', input: { token: 'ready' } } }
+    });
+
+    const machine = s.createMachine({
+      initial: 'one',
+      states: {
+        one: {
+          states: {
+            idle: {
+              on: {
+                GO: { target: '#two-done', input: { token: 'ready' } }
+              }
+            }
+          }
+        },
+        two: {
+          states: { idle: {}, done: {} }
+        }
+      }
+    });
+
+    if (false as boolean) {
+      s.createStateConfig('one.idle', {
+        on: {
+          // @ts-expect-error - root IDs must be declared in the setup tree
+          GO: { target: '#missing', input: { token: 'ready' } }
+        }
+      });
+    }
+
+    expect(machine.states.two.states.done.id).toBe('two-done');
   });
 
   it('passes state input to invoke input callbacks', () => {

--- a/packages/core/test/setupStateContracts.test.ts
+++ b/packages/core/test/setupStateContracts.test.ts
@@ -1112,4 +1112,128 @@ describe('setup state contracts', () => {
 
     expect(actor.getSnapshot().value).toBe('home');
   });
+
+  it('uses the authored machine ID when it overrides a setup ID', () => {
+    const machine = setup({
+      states: { home: { id: 'setup-home', route: true } }
+    }).createMachine({
+      initial: 'home',
+      states: { home: { id: 'machine-home' as const } }
+    });
+
+    expect(machine.states.home.id).toBe('machine-home');
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'xstate.route', to: '#machine-home' });
+
+    if (false as boolean) {
+      actor.send({
+        type: 'xstate.route',
+        // @ts-expect-error - the setup ID is overridden by the machine ID
+        to: '#setup-home'
+      });
+    }
+
+    expect(actor.getSnapshot().value).toBe('home');
+  });
+
+  it('keeps descendant IDs in strict target contracts when parents have IDs', () => {
+    const s = setup({
+      schemas: {
+        events: {
+          TO_LEFT: types<{}>(),
+          TO_BOTH: types<{}>()
+        }
+      },
+      states: {
+        idle: {},
+        active: {
+          type: 'parallel',
+          id: 'active-state',
+          states: {
+            left: {
+              type: 'compound',
+              initial: 'ready',
+              states: {
+                ready: {
+                  id: 'left-ready',
+                  schemas: { input: types<{ leftId: number }>() }
+                }
+              }
+            },
+            right: {
+              type: 'compound',
+              initial: 'ready',
+              states: {
+                ready: {
+                  id: 'right-ready',
+                  schemas: { input: types<{ rightId: boolean }>() }
+                }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    s.createStateConfig('idle', {
+      on: {
+        TO_LEFT: { target: '#left-ready', input: { leftId: 1 } },
+        TO_BOTH: {
+          target: ['#left-ready', '#right-ready'],
+          input: { leftId: 1, rightId: true }
+        }
+      }
+    });
+
+    const machine = s.createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            TO_LEFT: { target: '#left-ready', input: { leftId: 1 } },
+            TO_BOTH: {
+              target: ['#left-ready', '#right-ready'],
+              input: { leftId: 1, rightId: true }
+            }
+          }
+        },
+        active: {
+          states: {
+            left: {
+              initial: { target: 'ready', input: { leftId: 1 } },
+              states: { ready: {} }
+            },
+            right: {
+              initial: { target: 'ready', input: { rightId: true } },
+              states: { ready: {} }
+            }
+          }
+        }
+      }
+    });
+
+    if (false as boolean) {
+      s.createStateConfig('idle', {
+        on: {
+          // @ts-expect-error - the descendant ID must be known
+          TO_LEFT: { target: '#missing', input: { leftId: 1 } }
+        }
+      });
+
+      s.createStateConfig('idle', {
+        on: {
+          // @ts-expect-error - the descendant ID must be known in the target set
+          TO_BOTH: {
+            target: ['#left-ready', '#missing'],
+            input: { leftId: 1, rightId: true }
+          }
+        }
+      });
+    }
+
+    expect(machine.states.active.states.left.states.ready.id).toBe(
+      'left-ready'
+    );
+  });
 });

--- a/packages/core/test/setupStateContracts.test.ts
+++ b/packages/core/test/setupStateContracts.test.ts
@@ -1877,4 +1877,186 @@ describe('setup state contracts', () => {
       'left-ready'
     );
   });
+
+  it('handles a larger explicit parallel topology', () => {
+    const s = setup({
+      schemas: { events: { NEXT: types<{}>() } },
+      states: {
+        app: {
+          type: 'parallel',
+          id: 'workflow',
+          states: {
+            regionOne: {
+              type: 'compound',
+              initial: 's1',
+              states: {
+                s1: {},
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionTwo: {
+              type: 'compound',
+              initial: 's1',
+              states: {
+                s1: {},
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionThree: {
+              type: 'compound',
+              initial: 's1',
+              states: {
+                s1: {},
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionFour: {
+              type: 'compound',
+              initial: 's1',
+              states: {
+                s1: {},
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionFive: {
+              type: 'compound',
+              initial: 's1',
+              states: {
+                s1: {},
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionSix: {
+              type: 'compound',
+              initial: 's1',
+              states: {
+                s1: {},
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const machine = s.createMachine({
+      initial: 'app',
+      states: {
+        app: {
+          states: {
+            regionOne: {
+              states: {
+                s1: { on: { NEXT: { target: '#workflow.regionOne.s2' } } },
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionTwo: {
+              states: {
+                s1: { on: { NEXT: { target: 's2' } } },
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionThree: {
+              states: {
+                s1: { on: { NEXT: { target: 's2' } } },
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionFour: {
+              states: {
+                s1: { on: { NEXT: { target: 's2' } } },
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionFive: {
+              states: {
+                s1: { on: { NEXT: { target: 's2' } } },
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            },
+            regionSix: {
+              states: {
+                s1: { on: { NEXT: { target: 's2' } } },
+                s2: {},
+                s3: {},
+                s4: {},
+                s5: {},
+                s6: {},
+                s7: {},
+                s8: {}
+              }
+            }
+          }
+        }
+      }
+    });
+
+    expect(machine.states.app.states.regionSix.states.s8).toBeDefined();
+  });
 });

--- a/packages/core/test/setupStateContracts.test.ts
+++ b/packages/core/test/setupStateContracts.test.ts
@@ -340,6 +340,15 @@ describe('setup state contracts', () => {
       }
     });
 
+    valid.createStateConfig('parent.hist', { target: 'idle' });
+
+    if (false) {
+      valid.createStateConfig('parent.hist', {
+        // @ts-expect-error - history targets must use declared state IDs
+        target: '#missing'
+      });
+    }
+
     if (false) {
       valid.createMachine({
         initial: 'parent',
@@ -693,6 +702,309 @@ describe('setup state contracts', () => {
     expect(true).toBe(true);
   });
 
+  it('requires root transitions to use root-relative targets', () => {
+    const s = setup({
+      schemas: { events: { GO: types<{}>() } },
+      states: { active: {}, inactive: {} }
+    });
+
+    s.createMachine({
+      initial: 'active',
+      on: { GO: { target: '.inactive' } },
+      states: { active: {}, inactive: {} }
+    });
+
+    if (false) {
+      s.createMachine({
+        initial: 'active',
+        on: {
+          // @ts-expect-error - root transitions require a dot-relative target
+          GO: {
+            target: 'inactive'
+          }
+        },
+        states: { active: {}, inactive: {} }
+      });
+    }
+
+    expect(true).toBe(true);
+  });
+
+  it('types root invoke completion targets as root-relative targets', () => {
+    const s = setup({
+      actors: {
+        worker: createAsyncLogic({ run: async () => undefined })
+      },
+      states: {
+        idle: {},
+        done: { schemas: { input: types<{ id: number }>() } }
+      }
+    });
+
+    s.createMachine({
+      initial: 'idle',
+      invoke: {
+        src: 'worker',
+        onDone: { target: '.done', input: { id: 1 } }
+      },
+      states: { idle: {}, done: {} }
+    });
+
+    if (false) {
+      s.createMachine({
+        initial: 'idle',
+        // @ts-expect-error - root invoke completion targets are dot-relative
+        invoke: {
+          src: 'worker',
+          onDone: { target: 'done', input: { id: 1 } }
+        },
+        states: { idle: {}, done: {} }
+      });
+    }
+  });
+
+  it('preserves escaped dots in setup state paths', () => {
+    const s = setup({
+      schemas: { events: { GO: types<{}>(), ID: types<{}>() } },
+      states: {
+        active: {
+          type: 'compound',
+          initial: 'idle',
+          id: 'active.id',
+          states: {
+            'foo.bar': {
+              type: 'atomic',
+              id: 'node.id',
+              schemas: { input: types<{ id: number }>() }
+            },
+            idle: { type: 'atomic' }
+          }
+        }
+      }
+    });
+
+    s.createStateConfig('active.idle', {
+      on: {
+        GO: {
+          target: 'foo\\.bar',
+          input: { id: 1 }
+        },
+        ID: {
+          target: '#node\\.id',
+          input: { id: 1 }
+        }
+      }
+    });
+
+    s.createStateConfig('active.foo\\.bar', {
+      entry: ({ input }) => {
+        input.id satisfies number;
+      }
+    });
+
+    if (false) {
+      s.createStateConfig('active.idle', {
+        on: {
+          // @ts-expect-error - a literal dot in a state key must be escaped
+          GO: { target: '.foo.bar', input: { id: 1 } }
+        }
+      });
+    }
+
+    s.createMachine({
+      initial: 'active',
+      states: {
+        active: {
+          initial: 'idle',
+          states: {
+            'foo.bar': {},
+            idle: {
+              on: {
+                ID: { target: '#node\\.id', input: { id: 1 } }
+              }
+            }
+          }
+        }
+      }
+    });
+
+    s.createMachine({
+      initial: { target: '#active\\.id' },
+      states: {
+        active: {
+          initial: 'idle',
+          states: {
+            'foo.bar': {},
+            idle: {}
+          }
+        }
+      }
+    });
+
+    if (false) {
+      s.createMachine({
+        initial: 'active',
+        states: {
+          active: {
+            initial: 'idle',
+            states: {
+              'foo.bar': {},
+              idle: {
+                on: {
+                  // @ts-expect-error - dots in IDs must be escaped
+                  ID: { target: '#node.id', input: { id: 1 } }
+                }
+              }
+            }
+          }
+        }
+      });
+    }
+  });
+
+  it('types choice targets and their target inputs from setup', () => {
+    const s = setup({
+      schemas: { context: types<{ value: number }>() },
+      states: {
+        route: { type: 'choice' },
+        done: { schemas: { input: types<{ token: string }>() } },
+        active: {
+          type: 'parallel',
+          states: {
+            left: { schemas: { input: types<{ leftId: number }>() } },
+            right: { schemas: { input: types<{ rightId: boolean }>() } }
+          }
+        },
+        other: { schemas: { input: types<{ otherId: string }>() } }
+      }
+    });
+
+    s.createMachine({
+      context: { value: 1 },
+      initial: 'route',
+      states: {
+        route: {
+          choice: ({ context }) => {
+            context.value satisfies number;
+            return { target: 'done', input: { token: 'ok' } };
+          }
+        },
+        done: {},
+        active: {
+          states: {
+            left: {},
+            right: {}
+          }
+        },
+        other: {}
+      }
+    });
+
+    s.createMachine({
+      context: { value: 1 },
+      initial: 'route',
+      states: {
+        route: {
+          choice: () => ({
+            target: ['active.left', 'active.right'],
+            input: { leftId: 1, rightId: true }
+          })
+        },
+        active: { states: { left: {}, right: {} } },
+        other: {},
+        done: {}
+      }
+    });
+
+    if (false) {
+      s.createMachine({
+        context: { value: 1 },
+        initial: 'route',
+        states: {
+          route: {
+            // @ts-expect-error - choice targets must exist in setup
+            choice: () => ({
+              target: 'missing'
+            })
+          },
+          done: {}
+        }
+      });
+
+      s.createMachine({
+        context: { value: 1 },
+        initial: 'route',
+        states: {
+          route: {
+            // @ts-expect-error - the choice target requires its input
+            choice: () => ({
+              target: 'done'
+            })
+          },
+          done: {}
+        }
+      });
+
+      s.createMachine({
+        context: { value: 1 },
+        initial: 'route',
+        states: {
+          route: {
+            // @ts-expect-error - choice target sets require every target input
+            choice: () => ({
+              target: ['active.left', 'active.right'],
+              input: { leftId: 1 }
+            })
+          },
+          active: { states: { left: {}, right: {} } },
+          other: {},
+          done: {}
+        }
+      });
+    }
+
+    expect(true).toBe(true);
+  });
+
+  it('requires self-reentry transitions to provide current state input', () => {
+    const s = setup({
+      schemas: { events: { GO: types<{}>() } },
+      states: {
+        active: { schemas: { input: types<{ id: number }>() } }
+      }
+    });
+
+    s.createMachine({
+      initial: { target: 'active', input: { id: 0 } },
+      states: {
+        active: {
+          on: {
+            GO: { target: '.', reenter: true, input: { id: 1 } }
+          }
+        }
+      }
+    });
+
+    if (false) {
+      s.createMachine({
+        initial: { target: 'active', input: { id: 0 } },
+        states: {
+          active: {
+            on: {
+              // @ts-expect-error - self-reentry requires the current state input
+              GO: {
+                target: '.',
+                reenter: true
+              }
+            }
+          }
+        }
+      });
+    }
+
+    expect(true).toBe(true);
+  });
+
   it('uses setup parallel metadata when validating authored target sets', () => {
     const s = setup({
       schemas: { events: { RESET: types<{}>() } },
@@ -733,6 +1045,168 @@ describe('setup state contracts', () => {
     expect(machine.states.active.type).toBe('parallel');
   });
 
+  it('keeps standalone target sets aligned with statechart topology', () => {
+    const s = setup({
+      schemas: { events: { DONE: types<{}>() } },
+      states: {
+        active: {
+          type: 'parallel',
+          states: {
+            left: {
+              type: 'compound',
+              initial: 'idle',
+              states: { idle: {}, done: {} }
+            },
+            right: {
+              type: 'compound',
+              initial: 'idle',
+              states: { idle: {}, done: {} }
+            }
+          }
+        }
+      }
+    });
+
+    s.createStateConfig('active', {
+      on: {
+        DONE: { target: ['.left.idle', '.right.idle'] }
+      },
+      states: {
+        left: { states: { idle: {}, done: {} } },
+        right: { states: { idle: {}, done: {} } }
+      }
+    });
+
+    if (false) {
+      s.createStateConfig('active.left', {
+        on: {
+          // @ts-expect-error - target sets cannot select two children of one compound state
+          DONE: { target: ['.idle', '.done'] }
+        },
+        states: { idle: {}, done: {} }
+      });
+
+      s.createStateConfig('active.left', {
+        on: {
+          // @ts-expect-error - an invalid target set cannot hide in a transition array
+          DONE: [{ target: ['.idle', '.done'] }, { target: '.idle' }]
+        },
+        states: { idle: {}, done: {} }
+      });
+    }
+  });
+
+  it('keeps transitions on parallel regions scoped to their own children', () => {
+    const s = setup({
+      schemas: { events: { DONE: types<{}>() } },
+      states: {
+        active: {
+          type: 'parallel',
+          states: {
+            left: {
+              type: 'compound',
+              initial: 'idle',
+              states: { idle: {}, done: {} }
+            },
+            right: {
+              type: 'compound',
+              initial: 'idle',
+              states: { idle: {}, done: {} }
+            }
+          }
+        }
+      }
+    });
+
+    s.createMachine({
+      initial: 'active',
+      states: {
+        active: {
+          states: {
+            left: {
+              on: { DONE: { target: '.done' } },
+              states: { idle: {}, done: {} }
+            },
+            right: { states: { idle: {}, done: {} } }
+          }
+        }
+      }
+    });
+
+    if (false) {
+      s.createMachine({
+        initial: 'active',
+        states: {
+          active: {
+            states: {
+              left: {
+                on: {
+                  // @ts-expect-error - a parallel region cannot target its sibling region by name
+                  DONE: { target: 'right' }
+                },
+                states: { idle: {}, done: {} }
+              },
+              right: { states: { idle: {}, done: {} } }
+            }
+          }
+        }
+      });
+    }
+  });
+
+  it('keeps target-set input typing for parallel-region self targets', () => {
+    const s = setup({
+      schemas: { events: { REFRESH: types<{}>() } },
+      states: {
+        active: {
+          type: 'parallel',
+          states: {
+            left: { schemas: { input: types<{ id: number }>() } },
+            right: {}
+          }
+        }
+      }
+    });
+
+    s.createMachine({
+      initial: 'active',
+      states: {
+        active: {
+          states: {
+            left: {
+              on: {
+                REFRESH: { target: ['.'], input: { id: 1 } }
+              }
+            },
+            right: {}
+          }
+        }
+      }
+    });
+
+    if (false) {
+      s.createMachine({
+        initial: 'active',
+        states: {
+          active: {
+            states: {
+              left: {
+                on: {
+                  REFRESH: {
+                    target: ['.'],
+                    // @ts-expect-error - the self target still requires its input
+                    input: {}
+                  }
+                }
+              },
+              right: {}
+            }
+          }
+        }
+      });
+    }
+  });
+
   it('correlates nested setup targets with their context and input schemas', () => {
     const s = setup({
       schemas: {
@@ -740,11 +1214,13 @@ describe('setup state contracts', () => {
         events: {
           GO: types<{}>(),
           CHILD: types<{}>(),
-          GRANDCHILD: types<{}>()
+          GRANDCHILD: types<{}>(),
+          NESTED_ID: types<{}>()
         }
       },
       states: {
         parent: {
+          id: 'parent-id',
           initial: 'idle',
           states: {
             idle: {},
@@ -752,6 +1228,7 @@ describe('setup state contracts', () => {
               schemas: { input: types<{ childToken: number }>() }
             },
             flow: {
+              id: 'flow-id',
               type: 'compound',
               initial: 'ready',
               states: {
@@ -790,12 +1267,26 @@ describe('setup state contracts', () => {
           input: { grandchildToken: true }
         },
         GO: {
-          target: '.flow.done',
+          target: '#parent-id.flow.done',
+          context: { mode: 'done', code: 1 },
+          input: { token: 'ready' }
+        },
+        NESTED_ID: {
+          target: '#flow-id.done',
           context: { mode: 'done', code: 1 },
           input: { token: 'ready' }
         }
       }
     });
+
+    if (false) {
+      s.createStateConfig('parent', {
+        on: {
+          // @ts-expect-error - descendants after nested IDs must be known
+          NESTED_ID: { target: '#flow-id.missing' }
+        }
+      });
+    }
 
     const machineSetup = setup({
       schemas: {
@@ -1129,6 +1620,28 @@ describe('setup state contracts', () => {
         }
       }
     });
+
+    if (false) {
+      s.createStateConfig('idle', {
+        on: {
+          GO: {
+            target: ['active.left.ready', 'active.right.ready'],
+            // @ts-expect-error - input mappers must provide every target field
+            input: () => ({ leftId: 1 })
+          }
+        }
+      });
+
+      s.createStateConfig('idle', {
+        on: {
+          // @ts-expect-error - function results must provide every target field
+          GO: () => ({
+            target: ['active.left.ready', 'active.right.ready'],
+            input: { leftId: 1 }
+          })
+        }
+      });
+    }
 
     const actor = createActor(machine).start();
     actor.send({ type: 'GO' });

--- a/packages/core/test/setupStateContracts.test.ts
+++ b/packages/core/test/setupStateContracts.test.ts
@@ -13,6 +13,8 @@ describe('setup state contracts', () => {
               type: 'compound',
               initial: 'stopped',
               states: {
+                // Preserved local autocomplete probe (no target selected):
+                // always: { target: }
                 stopped: {},
                 playing: {}
               }
@@ -647,6 +649,46 @@ describe('setup state contracts', () => {
         active: {}
       }
     });
+
+    expect(true).toBe(true);
+  });
+
+  it('narrows relative targets for atomic states', () => {
+    const s = setup({
+      states: {
+        active: {},
+        inactive: {}
+      }
+    });
+
+    s.createMachine({
+      initial: 'active',
+      states: {
+        active: {
+          on: {
+            SELF: { target: '.' },
+            TO_ACTIVE: { target: 'active' },
+            TO_INACTIVE: { target: 'inactive' }
+          }
+        },
+        inactive: {}
+      }
+    });
+
+    if (false) {
+      s.createMachine({
+        initial: 'active',
+        states: {
+          active: {
+            on: {
+              // @ts-expect-error - an atomic state has no relative children
+              EVENT: { target: '.inactive' }
+            }
+          },
+          inactive: {}
+        }
+      });
+    }
 
     expect(true).toBe(true);
   });

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -339,13 +339,7 @@ describe('setup', () => {
     expect(true).toBe(true);
   });
 
-  // KNOWN SOUNDNESS GAP: in a parallel state, targeting a sibling region
-  // (e.g. `target: 'r2'` from inside `r1`) type-checks but is a runtime no-op.
-  // There is no way to tell whether a state is parallel from the setup `states`
-  // schema alone, so sibling regions are indistinguishable from ordinary
-  // siblings. Tripwire: when `target: 'r2'` stops compiling, the gap is
-  // fixed — flip that line to a `@ts-expect-error`.
-  it('createStateConfig (path, config) currently accepts a sibling-region target in a parallel state (known limitation)', () => {
+  it('createStateConfig (path, config) rejects sibling-region targets in parallel states', () => {
     const s = setup({
       schemas: {
         events: {
@@ -354,6 +348,7 @@ describe('setup', () => {
       },
       states: {
         p: {
+          type: 'parallel',
           states: {
             r1: {},
             r2: {}
@@ -364,8 +359,9 @@ describe('setup', () => {
 
     s.createStateConfig('p.r1', {
       on: {
+        // @ts-expect-error - parallel regions cannot target sibling regions by name
         E: {
-          target: 'r2' // known gap: should be rejected; flip to @ts-expect-error when it is
+          target: 'r2'
         }
       }
     });

--- a/packages/core/test/strictTargets.types.test.ts
+++ b/packages/core/test/strictTargets.types.test.ts
@@ -87,12 +87,18 @@ describe('strict authored targets', () => {
     });
 
     if (false) {
-      // @ts-expect-error - no state declares the ID `missing`
       s.createMachine({
         id: 'root',
         initial: 'idle',
         states: {
-          idle: { on: { GO: { target: '#missing' } } },
+          idle: {
+            on: {
+              // @ts-expect-error - no state declares the ID `missing`
+              GO: {
+                target: '#missing'
+              }
+            }
+          },
           done: { id: 'finished' }
         }
       });


### PR DESCRIPTION
## Summary

- strengthen `setup(...)` state contracts for recursive parent, compound, parallel, and history input semantics
- type known relative, dotted, ID, and literal target-set inputs
- require shared target-set input to satisfy every direct target schema while preserving widened-array compatibility
- add compiler/runtime coverage, docs, and a changeset

## Validation

- `pnpm test:core`
- `./node_modules/.bin/tsc --noEmit --pretty false`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`

Base: latest `origin/next` (`0b52534e`).

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5690" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger TypeScript validation for state structure, targets, routes, history states, parallel states, and state inputs.
  * Added support for propagating typed input through transitions, nested states, and invoked actors.
  * Exported the `SetupStateType` type for public use.

* **Documentation**
  * Expanded guidance and examples for state contracts, history, parallel states, routes, inputs, and TypeScript usage.

* **Tests**
  * Added comprehensive coverage for state contracts, input propagation, target validation, history restoration, and route typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->