### PR TITLE
Fix partial per-state context schema inference

### DIFF
--- a/.changeset/wise-items-refine.md
+++ b/.changeset/wise-items-refine.md
@@ -5,6 +5,8 @@
 State-level context schemas now refine the root context schema instead of
 replacing it. Declare only the fields narrowed by a state while retaining all
 root context fields in state actions, transitions, and narrowed snapshots.
+Nested states retain active ancestor refinements, and `xstate/fsm` uses the
+same refinement semantics.
 
 ```ts
 const machine = setup({

--- a/.changeset/wise-items-refine.md
+++ b/.changeset/wise-items-refine.md
@@ -1,0 +1,26 @@
+---
+'xstate': minor
+---
+
+State-level context schemas now refine the root context schema instead of
+replacing it. Declare only the fields narrowed by a state while retaining all
+root context fields in state actions, transitions, and narrowed snapshots.
+
+```ts
+const machine = setup({
+  schemas: {
+    context: z.object({
+      requestId: z.string(),
+      draft: z.string().optional()
+    })
+  },
+  states: {
+    reviewing: {
+      schemas: { context: z.object({ draft: z.string() }) }
+    }
+  }
+}).createMachine({
+  context: { requestId: 'req-1' },
+  // ...
+});
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ Every non-root state node accepts the following. All are optional.
 | `tags` | `string[]` | Tags read with `snapshot.hasTag(...)`. |
 | `description` | `string` | Human-readable description. |
 | `order` | `number` | Document order override. |
-| `schemas` | `{ input, ... }` | Per-state schemas, usually declared in `setup({ states })`. |
+| `schemas` | `{ context, input, output }` | Per-state schemas, usually declared in `setup({ states })`. A context schema refines the root context schema. |
 
 A [choice state](choice-states.md) is a different shape: it requires `type: 'choice'` and a `choice` function, and accepts only `id`, `tags`, `meta`, `description` and `route`. It cannot have `states`, `on`, `entry`, `exit`, `invoke`, `after`, `always` or `output`.
 

--- a/docs/fsm.md
+++ b/docs/fsm.md
@@ -59,7 +59,8 @@ const machine = machineSetup.createFSM({
 ```
 
 Declare per-state context schemas when the snapshot should be a discriminated
-union:
+union. They refine an existing root context schema in the same way as full
+XState machines, so root fields remain available:
 
 ```ts
 type User = { id: string };

--- a/docs/setup-and-provide.md
+++ b/docs/setup-and-provide.md
@@ -52,7 +52,8 @@ const editorSetup = setup({
 In `reviewing`, both `context.requestId` and the narrowed
 `context.draft: string` are available. With runtime validation enabled, XState
 validates the complete context against both the root schema and every active
-state schema.
+state schema. Nested states also retain refinements from their active ancestor
+states.
 
 State contracts can also declare structural metadata: `type`, `initial`,
 `history`, `target`, and `id` (plus `route: true` for a routable state).

--- a/docs/setup-and-provide.md
+++ b/docs/setup-and-provide.md
@@ -29,6 +29,31 @@ const orderMachine = orderSetup.createMachine({
 
 `setup(...)` also accepts `states`, where each state declares its own schemas. That is what types the `initial: { target, input }` form and transitions carrying [state input](state-input.md).
 
+A state-level `schemas.context` refines the root context schema. It only needs
+to declare the fields narrowed in that state; XState intersects its inferred
+type with the root context type:
+
+```ts
+const editorSetup = setup({
+  schemas: {
+    context: z.object({
+      requestId: z.string(),
+      draft: z.string().optional()
+    })
+  },
+  states: {
+    reviewing: {
+      schemas: { context: z.object({ draft: z.string() }) }
+    }
+  }
+});
+```
+
+In `reviewing`, both `context.requestId` and the narrowed
+`context.draft: string` are available. With runtime validation enabled, XState
+validates the complete context against both the root schema and every active
+state schema.
+
 State contracts can also declare structural metadata: `type`, `initial`,
 `history`, `target`, and `id` (plus `route: true` for a routable state).
 `createMachine(...)` may omit those defaults, and the resulting state value and

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -33,7 +33,8 @@ Structural state contracts are checked only when declared. For example,
 `type: 'parallel'` forbids `initial`, while `type: 'compound'` requires one.
 `setup(...)` can supply those defaults, so the machine config may omit them.
 Existing setups that declare only schemas keep their permissive machine-config
-typing.
+typing. A state-level `schemas.context` is intersected with the root context
+schema, so it can declare only the fields that state narrows.
 
 Public schema event keys create typed methods on `actor.trigger`; internal
 schema keys do not appear in the public trigger namespace.

--- a/packages/core/src/fsm.ts
+++ b/packages/core/src/fsm.ts
@@ -156,21 +156,26 @@ type FSMStateContext<
   ? TSchemas extends {
       context?: infer TSchema extends StandardSchemaV1;
     }
-    ? FSMSchemaContext<TSchema>
+    ? FSMSchemaContext<TSchema> &
+        ([MachineContext] extends [TGlobalContext] ? unknown : TGlobalContext)
     : TGlobalContext
   : TGlobalContext;
+
+type FSMContextFromDeclaredStates<
+  TStates extends FSMSetupStates,
+  TGlobalContext extends MachineContext
+> = {
+  [K in keyof TStates & string]: FSMStateContext<TStates[K], TGlobalContext>;
+}[keyof TStates & string];
 
 type FSMContextFromStates<
   TStates extends FSMSetupStates,
   TGlobalContext extends MachineContext
 > = [keyof TStates] extends [never]
   ? TGlobalContext
-  : {
-      [K in keyof TStates & string]: FSMStateContext<
-        TStates[K],
-        TGlobalContext
-      >;
-    }[keyof TStates & string];
+  : [MachineContext] extends [TGlobalContext]
+    ? FSMContextFromDeclaredStates<TStates, TGlobalContext>
+    : TGlobalContext | FSMContextFromDeclaredStates<TStates, TGlobalContext>;
 
 type FSMSetupStateContext<
   TState extends string,
@@ -197,12 +202,35 @@ type FSMSetupTargetTransitionConfig<
   TSourceContext extends MachineContext,
   TTarget extends string,
   TTargetContext extends MachineContext
-> = [TSourceContext] extends [TTargetContext]
-  ? { target: TTarget; context?: FSMContextPatch<TSourceContext> }
+> = [FSMRequiredTargetContextKeys<TSourceContext, TTargetContext>] extends [
+  never
+]
+  ? {
+      target: TTarget;
+      context?: FSMTargetContextPatch<TSourceContext, TTargetContext>;
+    }
   : {
       target: TTarget;
-      context: TTargetContext;
+      context: FSMTargetContextPatch<TSourceContext, TTargetContext>;
     };
+
+type FSMRequiredTargetContextKeys<TSourceContext, TTargetContext> = {
+  [K in keyof TTargetContext]-?: K extends keyof TSourceContext
+    ? [TSourceContext[K]] extends [TTargetContext[K]]
+      ? never
+      : K
+    : K;
+}[keyof TTargetContext];
+
+type FSMTargetContextPatch<TSourceContext, TTargetContext> =
+  Partial<TTargetContext> &
+    Pick<
+      TTargetContext,
+      Extract<
+        FSMRequiredTargetContextKeys<TSourceContext, TTargetContext>,
+        string
+      >
+    >;
 
 type FSMSetupTransitionConfig<
   TSourceContext extends MachineContext,

--- a/packages/core/src/schema.types.ts
+++ b/packages/core/src/schema.types.ts
@@ -6,6 +6,7 @@ export interface StandardSchemaV1<Input = unknown, Output = Input> {
 
 /** Schemas that can be declared for an individual state node. */
 export type SetupStateSchemas = {
+  /** Refines the machine's root context schema while this state is active. */
   context?: StandardSchemaV1;
   input?: StandardSchemaV1;
   /** The output emitted when this state node completes. */

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1572,6 +1572,7 @@ type StateContext<
 > = TStateSchema['schemas'] extends { context: infer TContextSchema }
   ? TContextSchema extends StandardSchemaV1
     ? StandardSchemaV1.InferOutput<TContextSchema> &
+        RootContext<TFallbackContext> &
         MachineContext &
         RootContextMarker<TFallbackContext>
     : RootContext<TFallbackContext>
@@ -1593,6 +1594,7 @@ type StateContextShape<
 > = TStateSchema['schemas'] extends { context: infer TContextSchema }
   ? TContextSchema extends StandardSchemaV1
     ? StandardSchemaV1.InferOutput<TContextSchema> &
+        RootContext<TFallbackContext> &
         RootContextMarker<TFallbackContext>
     : RootContext<TFallbackContext>
   : RootContext<TFallbackContext>;

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1599,6 +1599,19 @@ type StateContextShape<
     : RootContext<TFallbackContext>
   : RootContext<TFallbackContext>;
 
+type ActiveStateContext<
+  TStateSchema extends SetupStateSchema,
+  TRootContext extends MachineContext,
+  TAncestorContext
+> = StateContext<TStateSchema, TRootContext> &
+  TAncestorContext &
+  MachineContext;
+
+type ActiveStateContextShape<
+  TStateSchema extends SetupStateSchema,
+  TAncestorContext
+> = StateContextShape<TStateSchema, TAncestorContext> & TAncestorContext;
+
 type WithNestedStates<TConfig, TNestedStates> = TConfig extends {
   type: 'choice';
 }
@@ -2968,7 +2981,7 @@ type StateNodeConfigWithNestedInputBase<
 > = WithNestedStates<
   DistributiveOmit<
     Next_StateNodeConfig<
-      StateContext<TStateSchema, TContext>,
+      ActiveStateContext<TStateSchema, TContext, TContextShape>,
       TEvent,
       TDelays,
       TTag,
@@ -3000,7 +3013,7 @@ type StateNodeConfigWithNestedInputBase<
           | (string & {})
           | InitialTransitionWithInput<
               TStateSchema['states'],
-              StateContext<TStateSchema, TContext>,
+              ActiveStateContext<TStateSchema, TContext, TContextShape>,
               TEvent
             >
       :
@@ -3013,8 +3026,8 @@ type StateNodeConfigWithNestedInputBase<
   } & {
     on?: StateTransitions<
       SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
-      StateContext<TStateSchema, TContext>,
-      StateContextShape<TStateSchema, TContextShape>,
+      ActiveStateContext<TStateSchema, TContext, TContextShape>,
+      ActiveStateContextShape<TStateSchema, TContextShape>,
       TEvent,
       TEmitted,
       TChildren,
@@ -3028,8 +3041,8 @@ type StateNodeConfigWithNestedInputBase<
     >;
     always?: StateTransitionConfigOrTarget<
       SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
-      StateContext<TStateSchema, TContext>,
-      StateContextShape<TStateSchema, TContextShape>,
+      ActiveStateContext<TStateSchema, TContext, TContextShape>,
+      ActiveStateContextShape<TStateSchema, TContextShape>,
       TEvent,
       TEvent,
       TEmitted,
@@ -3045,8 +3058,8 @@ type StateNodeConfigWithNestedInputBase<
     invoke?: SingleOrArray<
       SetupInvokeConfig<
         SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
-        StateContext<TStateSchema, TContext>,
-        StateContextShape<TStateSchema, TContextShape>,
+        ActiveStateContext<TStateSchema, TContext, TContextShape>,
+        ActiveStateContextShape<TStateSchema, TContextShape>,
         TEvent,
         TEmitted,
         TChildren,
@@ -3061,8 +3074,8 @@ type StateNodeConfigWithNestedInputBase<
     >;
     onDone?: StateTransitionConfigOrTarget<
       SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
-      StateContext<TStateSchema, TContext>,
-      StateContextShape<TStateSchema, TContextShape>,
+      ActiveStateContext<TStateSchema, TContext, TContextShape>,
+      ActiveStateContextShape<TStateSchema, TContextShape>,
       DoneStateEvent<StateCompletionOutput<TStateSchema>>,
       TEvent,
       TEmitted,
@@ -3077,8 +3090,8 @@ type StateNodeConfigWithNestedInputBase<
     >;
     onError?: StateTransitionConfigOrTarget<
       SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
-      StateContext<TStateSchema, TContext>,
-      StateContextShape<TStateSchema, TContextShape>,
+      ActiveStateContext<TStateSchema, TContext, TContextShape>,
+      ActiveStateContextShape<TStateSchema, TContextShape>,
       ErrorEvent,
       TEvent,
       TEmitted,
@@ -3093,8 +3106,8 @@ type StateNodeConfigWithNestedInputBase<
     >;
     onTimeout?: StateTransitionConfigOrTarget<
       SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
-      StateContext<TStateSchema, TContext>,
-      StateContextShape<TStateSchema, TContextShape>,
+      ActiveStateContext<TStateSchema, TContext, TContextShape>,
+      ActiveStateContextShape<TStateSchema, TContextShape>,
       TimeoutEvent,
       TEvent,
       TEmitted,
@@ -3110,8 +3123,8 @@ type StateNodeConfigWithNestedInputBase<
     after?: {
       [K in NoInfer<TDelays> | number]?: StateTransitionConfigOrTarget<
         SetupStateTransitionSchemas<TSiblingStateSchemas, TStateSchema>,
-        StateContext<TStateSchema, TContext>,
-        StateContextShape<TStateSchema, TContextShape>,
+        ActiveStateContext<TStateSchema, TContext, TContextShape>,
+        ActiveStateContextShape<TStateSchema, TContextShape>,
         AfterEvent,
         TEvent,
         TEmitted,
@@ -3139,7 +3152,7 @@ type StateNodeConfigWithNestedInputBase<
         >,
         TStateSchema['states'],
         TContext,
-        StateContextShape<TStateSchema, TContextShape>,
+        ActiveStateContextShape<TStateSchema, TContextShape>,
         TEvent,
         TChildren,
         TDelays,
@@ -3155,7 +3168,7 @@ type StateNodeConfigWithNestedInputBase<
       >
     : {
         [K in string]?: Next_StateNodeConfig<
-          TContext,
+          ActiveStateContext<TStateSchema, TContext, TContextShape>,
           TEvent,
           TDelays,
           TTag,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2751,7 +2751,9 @@ type ContextFromStateSchema<
   TSchema extends StateSchema,
   TFallbackContext extends MachineContext
 > = TSchema['contextSchema'] extends StandardSchemaV1
-  ? StandardSchemaV1.InferOutput<TSchema['contextSchema']> & MachineContext
+  ? StandardSchemaV1.InferOutput<TSchema['contextSchema']> &
+      TFallbackContext &
+      MachineContext
   : TFallbackContext;
 
 type ContextFromChildStateValue<

--- a/packages/core/test/fsm.setup.test.ts
+++ b/packages/core/test/fsm.setup.test.ts
@@ -155,4 +155,60 @@ describe('xstate/fsm setup', () => {
       }
     });
   });
+
+  it('combines root context with a partial state context schema', () => {
+    const app = setup({
+      schemas: {
+        context: types<{ requestId: string; draft?: string }>(),
+        events: {
+          review: types<{ draft: string }>(),
+          skip: types<{}>()
+        }
+      },
+      states: {
+        reviewing: { schemas: { context: types<{ draft: string }>() } }
+      }
+    });
+
+    const machine = app.createFSM({
+      initial: 'editing',
+      context: { requestId: 'req-1' },
+      states: {
+        editing: {
+          on: {
+            review: ({ event }) => ({
+              target: 'reviewing',
+              context: { draft: event.draft }
+            }),
+            // @ts-expect-error - the refinement requires a draft
+            skip: { target: 'reviewing' }
+          }
+        },
+        reviewing: {
+          on: {
+            review: ({ context }) => {
+              context.requestId satisfies string;
+              context.draft satisfies string;
+              return { context: { draft: context.draft } };
+            }
+          }
+        }
+      }
+    });
+
+    const next = machine.transition(machine.initialState, {
+      type: 'review',
+      draft: 'Ready'
+    });
+
+    if (next.value === 'reviewing') {
+      next.context.requestId satisfies string;
+      next.context.draft satisfies string;
+    }
+
+    expect(next).toEqual({
+      value: 'reviewing',
+      context: { requestId: 'req-1', draft: 'Ready' }
+    });
+  });
 });

--- a/packages/core/test/runtimeValidation.test.ts
+++ b/packages/core/test/runtimeValidation.test.ts
@@ -614,6 +614,48 @@ describe('runtime schema validation', () => {
     );
   });
 
+  it('validates root and partial state context schemas independently', () => {
+    const createPartialContextMachine = (context: unknown) =>
+      setup({
+        validator: standardSchemaValidator(),
+        schemas: {
+          context: z.object({
+            requestId: z.string(),
+            draft: z.string().optional()
+          })
+        },
+        states: {
+          reviewing: {
+            schemas: { context: z.object({ draft: z.string() }) }
+          }
+        }
+      }).createMachine({
+        context: context as any,
+        initial: 'reviewing',
+        states: { reviewing: {} }
+      });
+
+    expect(() =>
+      initialTransition(
+        createPartialContextMachine({ requestId: 'req-1', draft: 'Ready' })
+      )
+    ).not.toThrow();
+    expectValidationError(
+      getThrown(() =>
+        initialTransition(
+          createPartialContextMachine({ requestId: 1, draft: 'Ready' })
+        )
+      ),
+      'context'
+    );
+    expectValidationError(
+      getThrown(() =>
+        initialTransition(createPartialContextMachine({ requestId: 'req-1' }))
+      ),
+      'state.context'
+    );
+  });
+
   it('does not validate named action and guard params in v1', () => {
     const action = vi.fn();
     const actionMachine = setup({

--- a/packages/core/test/setupStateContracts.test.ts
+++ b/packages/core/test/setupStateContracts.test.ts
@@ -1210,7 +1210,7 @@ describe('setup state contracts', () => {
   it('correlates nested setup targets with their context and input schemas', () => {
     const s = setup({
       schemas: {
-        context: types<{ mode: 'idle' }>(),
+        context: types<{ mode: 'idle' } | { mode: 'done'; code: number }>(),
         events: {
           GO: types<{}>(),
           CHILD: types<{}>(),

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1837,6 +1837,87 @@ describe('setup', () => {
     expect(true).toBe(true);
   });
 
+  it('state context schemas should refine part of the root context', () => {
+    const machine = setup({
+      schemas: {
+        context: z.object({
+          requestId: z.string(),
+          draft: z.string().optional()
+        }),
+        events: { REVIEW: z.object({ draft: z.string() }) }
+      },
+      states: {
+        workflow: {
+          type: 'compound',
+          initial: 'editing',
+          states: {
+            editing: {},
+            reviewing: {
+              schemas: { context: z.object({ draft: z.string() }) }
+            }
+          }
+        }
+      }
+    }).createMachine({
+      context: { requestId: 'req-1' },
+      initial: 'workflow',
+      states: {
+        workflow: {
+          initial: 'editing',
+          states: {
+            editing: {
+              on: {
+                REVIEW: ({ event }) => ({
+                  target: 'reviewing',
+                  context: { draft: event.draft }
+                })
+              }
+            },
+            reviewing: {
+              entry: ({ context }) => {
+                false satisfies IsAny<typeof context>;
+                false satisfies IsAny<typeof context.requestId>;
+                context.requestId satisfies string;
+                context.draft satisfies string;
+                // @ts-expect-error - root context fields keep their declared type
+                context.requestId satisfies number;
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'REVIEW', draft: 'Ready' });
+
+    type ReviewingContext = StateContextFromStateValue<
+      StateSchemaFrom<typeof machine>,
+      { requestId: string; draft?: string },
+      { workflow: 'reviewing' }
+    >;
+    false satisfies IsAny<ReviewingContext['requestId']>;
+    (({}) as ReviewingContext).requestId satisfies string;
+    (({}) as ReviewingContext).draft satisfies string;
+    // @ts-expect-error - the root field remains a string in the refinement
+    (({}) as ReviewingContext).requestId satisfies number;
+
+    const snapshot = actor.getSnapshot();
+    if (snapshot.matches({ workflow: 'reviewing' })) {
+      false satisfies IsAny<typeof snapshot.context>;
+      false satisfies IsAny<typeof snapshot.context.requestId>;
+      snapshot.context.requestId satisfies string;
+      snapshot.context.draft satisfies string;
+      // @ts-expect-error - root context fields keep their declared type
+      snapshot.context.requestId satisfies number;
+    }
+
+    expect(snapshot.context).toEqual({
+      requestId: 'req-1',
+      draft: 'Ready'
+    });
+  });
+
   it('state schemas should allow undeclared sibling states', () => {
     setup({
       states: {

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1842,24 +1842,26 @@ describe('setup', () => {
       schemas: {
         context: z.object({
           requestId: z.string(),
-          draft: z.string().optional()
+          draft: z.string().optional(),
+          approved: z.literal(true).optional()
         }),
-        events: { REVIEW: z.object({ draft: z.string() }) }
+        events: { REVIEW: z.object({ approved: z.literal(true) }) }
       },
       states: {
         workflow: {
           type: 'compound',
           initial: 'editing',
+          schemas: { context: z.object({ draft: z.string() }) },
           states: {
             editing: {},
             reviewing: {
-              schemas: { context: z.object({ draft: z.string() }) }
+              schemas: { context: z.object({ approved: z.literal(true) }) }
             }
           }
         }
       }
     }).createMachine({
-      context: { requestId: 'req-1' },
+      context: { requestId: 'req-1', draft: 'Ready' },
       initial: 'workflow',
       states: {
         workflow: {
@@ -1869,7 +1871,7 @@ describe('setup', () => {
               on: {
                 REVIEW: ({ event }) => ({
                   target: 'reviewing',
-                  context: { draft: event.draft }
+                  context: { approved: event.approved }
                 })
               }
             },
@@ -1879,8 +1881,16 @@ describe('setup', () => {
                 false satisfies IsAny<typeof context.requestId>;
                 context.requestId satisfies string;
                 context.draft satisfies string;
+                context.approved satisfies true;
                 // @ts-expect-error - root context fields keep their declared type
                 context.requestId satisfies number;
+              },
+              on: {
+                REVIEW: ({ context }) => {
+                  context.requestId satisfies string;
+                  context.draft satisfies string;
+                  context.approved satisfies true;
+                }
               }
             }
           }
@@ -1889,16 +1899,17 @@ describe('setup', () => {
     });
 
     const actor = createActor(machine).start();
-    actor.send({ type: 'REVIEW', draft: 'Ready' });
+    actor.send({ type: 'REVIEW', approved: true });
 
     type ReviewingContext = StateContextFromStateValue<
       StateSchemaFrom<typeof machine>,
-      { requestId: string; draft?: string },
+      { requestId: string; draft?: string; approved?: true },
       { workflow: 'reviewing' }
     >;
     false satisfies IsAny<ReviewingContext['requestId']>;
     (({}) as ReviewingContext).requestId satisfies string;
     (({}) as ReviewingContext).draft satisfies string;
+    (({}) as ReviewingContext).approved satisfies true;
     // @ts-expect-error - the root field remains a string in the refinement
     (({}) as ReviewingContext).requestId satisfies number;
 
@@ -1908,13 +1919,15 @@ describe('setup', () => {
       false satisfies IsAny<typeof snapshot.context.requestId>;
       snapshot.context.requestId satisfies string;
       snapshot.context.draft satisfies string;
+      snapshot.context.approved satisfies true;
       // @ts-expect-error - root context fields keep their declared type
       snapshot.context.requestId satisfies number;
     }
 
     expect(snapshot.context).toEqual({
       requestId: 'req-1',
-      draft: 'Ready'
+      draft: 'Ready',
+      approved: true
     });
   });
 


### PR DESCRIPTION
## Summary

- treat a state-level `schemas.context` as a refinement of the root context type
- retain root context fields in state actions and `StateContextFromStateValue`, including nested states
- document the native partial-schema pattern and add a minor changeset

## Rationale

Runtime validation already checks the complete context against the machine root schema and then every active state schema. Type inference instead replaced the root type with the state-local output, forcing callers to repeat the full root object schema to retain its fields.

Intersecting the two inferred outputs aligns types with runtime semantics and lets a state declare only its narrower fields:

```ts
states: {
  reviewing: {
    schemas: { context: z.object({ draft: z.string() }) }
  }
}
```

This intentionally keeps the Standard Schema-native `schemas.context` shape. A shorthand such as `context: { draft: z.string() }` would be library-specific schema-object syntax rather than a Standard Schema and would introduce a second meaning for state context.

One existing type fixture declared mutually exclusive root/state schemas (`mode: 'idle'` versus `mode: 'done'`). The root fixture now describes the actual machine-wide union, because validated runtime contexts must satisfy both root and active-state schemas.

## Verification

- `pnpm exec vitest run --project xstate packages/core/test/stateInput.test.ts packages/core/test/runtimeValidation.test.ts`
- `pnpm test:core` — 2,476 passed, 33 skipped, 3 todo
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm changeset status`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * State-level context schemas now refine the root context while preserving root fields.
  * Context narrowing is reflected in state actions, transitions, and snapshots.
  * Runtime validation checks both the complete root context and active state context.

* **Documentation**
  * Added guidance for state-level context and output schemas.
  * Clarified context refinement, runtime validation, and TypeScript behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->