### PR TITLE
Fix v6 production integration friction

### DIFF
--- a/.changeset/tall-cows-send.md
+++ b/.changeset/tall-cows-send.md
@@ -1,0 +1,7 @@
+---
+"@xstate/react": patch
+"xstate": patch
+---
+
+Fixed delayed transitions and other built-in effects in minified bundles, preserved hook-owned actors across React StrictMode effect reconnects, and allowed graph utilities to accept machines from duplicate XState package copies.
+  

--- a/.changeset/tall-cows-send.md
+++ b/.changeset/tall-cows-send.md
@@ -4,4 +4,3 @@
 ---
 
 Fixed delayed transitions and other built-in effects in minified bundles, preserved hook-owned actors across React StrictMode effect reconnects, and allowed graph utilities to accept machines from duplicate XState package copies.
-  

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ Both packages were removed. Instead of `@xstate/immer`, return an updated `conte
 
 ## Can I run v5 and v6 side by side?
 
-There is no supported dual-install story, and none is documented. If you want to migrate one machine at a time in a single application, the generic npm alias technique applies: install the second copy under another name, for example `npm install xstate5@npm:xstate@5`, and import from that alias in the modules that still use v5. Treat the two as separate libraries. Actors, snapshots and types are not interchangeable across them, so do not pass a v5 actor into a v6 machine or the reverse.
+There is no supported dual-install story. If you want to migrate one machine at a time in a single application, the generic npm alias technique applies: install the second copy under another name, for example `npm install xstate5@npm:xstate@5`, and import from that alias in the modules that still use v5. Treat the two as separate libraries. Actors, snapshots and types are not interchangeable across them, so do not pass a v5 actor into a v6 machine or the reverse. Keep framework bindings and other integration packages on the same major as the core instance they consume; an alias changes your import specifier, not the runtime protocol or peer dependency expected by an integration.
 
 ## Do v5 persisted snapshots work in v6?
 

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -1,7 +1,6 @@
 import {
   EventObject,
   AnyStateMachine,
-  StateMachine,
   StateNode,
   AnyActorLogic,
   EventFromLogic,
@@ -122,7 +121,7 @@ export function toDirectedGraph(
   stateMachine: AnyStateNode | AnyStateMachine
 ): DirectedGraphNode {
   const stateNode = (
-    stateMachine instanceof StateMachine ? stateMachine.root : stateMachine
+    isMachineLogic(stateMachine) ? stateMachine.root : stateMachine
   ) as AnyStateNode; // TODO: accept only machines
 
   const edges: DirectedGraphEdge[] = [...stateNode.transitions.values()]
@@ -165,8 +164,8 @@ export function toDirectedGraph(
   return graph;
 }
 
-function isMachineLogic(logic: AnyActorLogic): logic is AnyStateMachine {
-  return 'getStateNodeById' in logic;
+export function isMachineLogic(logic: unknown): logic is AnyStateMachine {
+  return !!logic && typeof logic === 'object' && 'getStateNodeById' in logic;
 }
 
 export function resolveTraversalOptions<TLogic extends AnyActorLogic>(

--- a/packages/core/src/graph/graph.ts
+++ b/packages/core/src/graph/graph.ts
@@ -165,7 +165,23 @@ export function toDirectedGraph(
 }
 
 export function isMachineLogic(logic: unknown): logic is AnyStateMachine {
-  return !!logic && typeof logic === 'object' && 'getStateNodeById' in logic;
+  if (!logic || typeof logic !== 'object') {
+    return false;
+  }
+
+  const machine = logic as Partial<AnyStateMachine>;
+  const root = machine.root as Partial<AnyStateNode> | undefined;
+
+  return (
+    !!root &&
+    typeof root === 'object' &&
+    typeof root.id === 'string' &&
+    typeof root.states === 'object' &&
+    typeof root.transitions?.values === 'function' &&
+    typeof machine.getStateNodeById === 'function' &&
+    typeof machine.resolveState === 'function' &&
+    typeof machine.getTransitionData === 'function'
+  );
 }
 
 export function resolveTraversalOptions<TLogic extends AnyActorLogic>(

--- a/packages/core/src/graph/pathFromEvents.ts
+++ b/packages/core/src/graph/pathFromEvents.ts
@@ -2,10 +2,8 @@ import {
   ActorScope,
   ActorLogic,
   ActorSystem,
-  AnyStateMachine,
   EventObject,
-  Snapshot,
-  StateMachine
+  Snapshot
 } from '../index.ts';
 import { getAdjacencyMap } from './adjacency.ts';
 import {
@@ -18,14 +16,11 @@ import {
 import {
   resolveTraversalOptions,
   createDefaultMachineOptions,
-  createDefaultLogicOptions
+  createDefaultLogicOptions,
+  isMachineLogic
 } from './graph.ts';
 import { alterPath } from './alterPath.ts';
 import { createMockActorScope } from './actorScope.ts';
-
-function isMachine(value: any): value is AnyStateMachine {
-  return !!value && value instanceof StateMachine;
-}
 
 export function getPathsFromEvents<
   TSnapshot extends Snapshot<unknown>,
@@ -43,7 +38,7 @@ export function getPathsFromEvents<
       events,
       ...options
     },
-    (isMachine(logic)
+    (isMachineLogic(logic)
       ? createDefaultMachineOptions(logic)
       : createDefaultLogicOptions()) as TraversalOptions<
       TSnapshot,

--- a/packages/core/src/graph/test/graph.test.ts
+++ b/packages/core/src/graph/test/graph.test.ts
@@ -613,6 +613,27 @@ describe('@xstate/graph', () => {
 
       expect(digraph).toMatchSnapshot();
     });
+
+    it('does not rely on StateMachine constructor identity', () => {
+      const machine = createMachine({
+        id: 'light',
+        initial: 'green',
+        states: {
+          green: { on: { TIMER: { target: 'yellow' } } },
+          yellow: {}
+        }
+      });
+      const machineFromAnotherPackageInstance = new Proxy(machine, {
+        getPrototypeOf: () => null
+      });
+
+      expect(machineFromAnotherPackageInstance).not.toBeInstanceOf(
+        machine.constructor
+      );
+      expect(toDirectedGraph(machineFromAnotherPackageInstance).id).toBe(
+        'light'
+      );
+    });
   });
 });
 

--- a/packages/core/src/graph/test/graph.test.ts
+++ b/packages/core/src/graph/test/graph.test.ts
@@ -586,6 +586,26 @@ describe('@xstate/graph', () => {
 
       expect(path.state.matches('red')).toBeTruthy();
     });
+
+    it('does not treat custom logic with a getStateNodeById property as a machine', () => {
+      const logic = Object.assign(
+        createLogic({
+          context: 0,
+          run: ({ context, event }) => {
+            if (event.type === 'INC') {
+              return { context: context + 1 };
+            }
+          }
+        }),
+        { getStateNodeById: () => 'custom metadata' }
+      );
+
+      const path = getPathsFromEvents(logic, [{ type: 'INC' }], {
+        toState: (state) => state.context === 1
+      })[0];
+
+      expect(path.state.context).toBe(1);
+    });
   });
 
   describe('toDirectedGraph', () => {

--- a/packages/core/src/schema.types.ts
+++ b/packages/core/src/schema.types.ts
@@ -38,13 +38,15 @@ export interface TypeSchema<T> extends StandardSchemaV1<T, T> {
  *     context: types<{ count: number }>(),
  *     events: {
  *       inc: types<{ by: number }>(),
- *       reset: types<{}>()
+ *       reset: types<void>()
  *     }
  *   },
  *   context: { count: 0 }
  *   // ...
  * });
  * ```
+ *
+ * Use `types<void>()` for events without a payload.
  */
 export function types<T>(): TypeSchema<T> {
   return {

--- a/packages/core/src/transitionActions.ts
+++ b/packages/core/src/transitionActions.ts
@@ -757,6 +757,7 @@ function getBuiltInActionFields(
         (typeof builtInActions)['@xstate.spawn']
       >;
       return {
+        type: '@xstate.spawn',
         kind: 'builtin',
         exec: execSpawnEffect,
         source: actor._parent,
@@ -772,6 +773,7 @@ function getBuiltInActionFields(
         (typeof builtInActions)['@xstate.raise']
       >;
       return {
+        type: '@xstate.raise',
         kind: 'builtin',
         exec: execRaiseEffect,
         source: (
@@ -787,6 +789,7 @@ function getBuiltInActionFields(
         (typeof builtInActions)['@xstate.sendTo']
       >;
       return {
+        type: '@xstate.sendTo',
         kind: 'builtin',
         exec: execSendToEffect,
         source: (
@@ -803,6 +806,7 @@ function getBuiltInActionFields(
         (typeof builtInActions)['@xstate.cancel']
       >;
       return {
+        type: '@xstate.cancel',
         kind: 'builtin',
         exec: execCancelEffect,
         source: (
@@ -816,6 +820,7 @@ function getBuiltInActionFields(
         (typeof builtInActions)['@xstate.stop']
       >;
       return {
+        type: '@xstate.stop',
         kind: 'builtin',
         exec: execStopEffect,
         source: (args as Parameters<(typeof builtInActions)['@xstate.stop']>)[0]

--- a/packages/core/test/after.test.ts
+++ b/packages/core/test/after.test.ts
@@ -1,5 +1,6 @@
 import { setTimeout as sleep } from 'node:timers/promises';
 import { createMachine, createActor } from '../src/index.ts';
+import { builtInActions } from '../src/actions.ts';
 import z from 'zod';
 
 const lightMachine = createMachine({
@@ -37,6 +38,30 @@ afterEach(() => {
 });
 
 describe('delayed transitions', () => {
+  it('does not rely on inferred function names for built-in timer effects', () => {
+    vi.useFakeTimers();
+    const raise = builtInActions['@xstate.raise'];
+    const originalName = Object.getOwnPropertyDescriptor(raise, 'name')!;
+    Object.defineProperty(raise, 'name', { ...originalName, value: 'a' });
+
+    try {
+      const actor = createActor(
+        createMachine({
+          initial: 'waiting',
+          states: {
+            waiting: { after: { 10: { target: 'done' } } },
+            done: {}
+          }
+        })
+      ).start();
+
+      vi.advanceTimersByTime(10);
+      expect(actor.getSnapshot().value).toBe('done');
+    } finally {
+      Object.defineProperty(raise, 'name', originalName);
+    }
+  });
+
   it('uses a canonical after event with delay and state identity', () => {
     vi.useFakeTimers();
     const spy = vi.fn();

--- a/packages/core/test/vizTypeFriction.types.test.ts
+++ b/packages/core/test/vizTypeFriction.types.test.ts
@@ -1,0 +1,67 @@
+import { setup, types } from '../src/index.ts';
+
+describe('Viz v6 type ergonomics', () => {
+  it('preserves an inline machine id for ID targets without as const', () => {
+    const machine = setup({
+      schemas: {
+        events: {
+          NEXT: types<void>()
+        }
+      }
+    }).createMachine({
+      id: 'gesture',
+      initial: 'idle',
+      states: {
+        idle: {
+          on: {
+            NEXT: { target: 'pressed' }
+          }
+        },
+        pressed: {
+          initial: 'pending',
+          states: {
+            pending: {
+              on: {
+                NEXT: () => ({ target: '#gesture.idle' })
+              }
+            }
+          }
+        }
+      }
+    });
+
+    machine.id satisfies 'gesture';
+  });
+
+  it('accepts setup-provided named delays in nested states', () => {
+    const machine = setup({
+      delays: {
+        doubleTap: 300,
+        dragHold: 120
+      }
+    }).createMachine({
+      id: 'gesture',
+      initial: 'idle',
+      states: {
+        idle: {
+          after: {
+            doubleTap: { target: 'pressed' }
+          }
+        },
+        pressed: {
+          initial: 'pending',
+          states: {
+            pending: {
+              after: {
+                dragHold: { target: 'held' }
+              }
+            },
+            held: {}
+          }
+        }
+      }
+    });
+
+    machine.id satisfies 'gesture';
+  });
+});

--- a/packages/xstate-react/docs/use-machine.md
+++ b/packages/xstate-react/docs/use-machine.md
@@ -89,9 +89,7 @@ If the actor reaches an `error` snapshot, `useActor` throws the error during ren
 
 One actor is created per component instance. It starts in an effect after mount and is stopped on unmount.
 
-React StrictMode mounts, unmounts and remounts a component in development. The second mount would otherwise leave the component holding a stopped actor, so `useActor` and `useActorRef` detect an externally stopped actor and create a fresh one from the same logic and options, starting from the initial state. An actor that completed naturally (`done` or `error`) is left alone and is not restarted.
-
-That development-only stop and restart does not currently restart invoked or spawned children. If a child actor appears inert only under StrictMode, that is why; the behavior in production builds is unaffected.
+React StrictMode disconnects and immediately reconnects effects in development. `useActor` and `useActorRef` defer cleanup by one microtask, so that immediate reconnect cancels the pending stop and preserves the actor and its children. A real unmount still stops the actor. If an actor was stopped externally before an effect reconnects, the hooks create a fresh actor from the same logic and options; an actor that completed naturally (`done` or `error`) is left alone.
 
 Changing the logic identity between renders is handled separately: when the config of the logic passed in differs from the running actor's, a new actor is created from the current logic and seeded with the previous actor's persisted snapshot, so the component keeps its state. Implementations swapped with `machine.provide({ ... })` in the component body keep the same config, so they update the running actor in place rather than replacing it. A guard or action defined in render always sees the latest props.
 

--- a/packages/xstate-react/src/useActor.ts
+++ b/packages/xstate-react/src/useActor.ts
@@ -1,5 +1,5 @@
 import isDevelopment from '#is-development';
-import { useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
 import { useSyncExternalStore } from 'use-sync-external-store/shim';
 import {
   Actor,
@@ -12,7 +12,7 @@ import {
   type IsNotNever,
   type RequiredActorOptionsKeys
 } from 'xstate';
-import { useIdleActorRef } from './useActorRef.ts';
+import { useActorLifecycle, useIdleActorRef } from './useActorRef.ts';
 
 export function useActor<TLogic extends AnyActorLogic>(
   logic: TLogic,
@@ -67,22 +67,7 @@ export function useActor<TLogic extends AnyActorLogic>(
     throw snapshotWithStatus.error;
   }
 
-  useEffect(() => {
-    if (
-      (actorRef as any)._processingStatus ===
-        2 /* ProcessingStatus.Stopped */ &&
-      (actorRef.getSnapshot() as any)?.status === 'stopped'
-    ) {
-      const newActor = createActor(logic, options);
-      newActor.start();
-      setActorRef(newActor);
-      return;
-    }
-    actorRef.start();
-    return () => {
-      actorRef.stop();
-    };
-  }, [actorRef]);
+  useActorLifecycle(actorRef, setActorRef, () => createActor(logic, options));
 
   return [actorSnapshot, actorRef.send, actorRef];
 }

--- a/packages/xstate-react/src/useActorRef.ts
+++ b/packages/xstate-react/src/useActorRef.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import useIsomorphicLayoutEffect from 'use-isomorphic-layout-effect';
 import {
   Actor,
@@ -50,6 +50,53 @@ export function useIdleActorRef<TLogic extends AnyActorLogic>(
   return [actorRef, setActorRef];
 }
 
+export function useActorLifecycle<TLogic extends AnyActorLogic>(
+  actorRef: Actor<TLogic>,
+  setActorRef: (actorRef: Actor<TLogic>) => void,
+  createReplacement: () => Actor<TLogic>
+): void {
+  const pendingStopsRef = useRef(new Map<Actor<TLogic>, () => void>());
+
+  useEffect(() => {
+    const cancelPendingStop = pendingStopsRef.current.get(actorRef);
+    if (cancelPendingStop) {
+      cancelPendingStop();
+      pendingStopsRef.current.delete(actorRef);
+    }
+
+    // If the actor was stopped before this effect reconnected, create a fresh
+    // actor. A stopped actor cannot be restarted.
+    if (
+      (actorRef as any)._processingStatus ===
+        2 /* ProcessingStatus.Stopped */ &&
+      (actorRef.getSnapshot() as any)?.status === 'stopped'
+    ) {
+      const newActor = createReplacement();
+      newActor.start();
+      setActorRef(newActor);
+      return;
+    }
+
+    actorRef.start();
+    return () => {
+      let canceled = false;
+      const cancel = () => {
+        canceled = true;
+      };
+      pendingStopsRef.current.set(actorRef, cancel);
+
+      queueMicrotask(() => {
+        if (!canceled) {
+          actorRef.stop();
+        }
+        if (pendingStopsRef.current.get(actorRef) === cancel) {
+          pendingStopsRef.current.delete(actorRef);
+        }
+      });
+    };
+  }, [actorRef]);
+}
+
 export function useActorRef<TLogic extends AnyActorLogic>(
   machine: TLogic,
   ...[options, observerOrListener]: IsNotNever<
@@ -82,29 +129,9 @@ export function useActorRef<TLogic extends AnyActorLogic>(
     };
   }, [observerOrListener]);
 
-  useEffect(() => {
-    // If the actor was stopped by a previous cleanup (e.g. strict mode),
-    // create a fresh actor. The setActorRef triggers a re-render so
-    // useSyncExternalStore re-subscribes to the new actor.
-    // Only recreate if externally stopped ('stopped' status from XSTATE_STOP),
-    // not if it completed naturally ('done'/'error' status).
-    if (
-      (actorRef as any)._processingStatus ===
-        2 /* ProcessingStatus.Stopped */ &&
-      (actorRef.getSnapshot() as any)?.status === 'stopped'
-    ) {
-      const newActor = createActor(machine, actorRef.options);
-      newActor.start();
-      setActorRef(newActor);
-      // No cleanup — the re-render will run this effect again with the
-      // new actorRef (which is Running), registering the stop cleanup then.
-      return;
-    }
-    actorRef.start();
-    return () => {
-      actorRef.stop();
-    };
-  }, [actorRef]);
+  useActorLifecycle(actorRef, setActorRef, () =>
+    createActor(machine, actorRef.options)
+  );
 
   return actorRef;
 }

--- a/packages/xstate-react/test/useActorRef.test.tsx
+++ b/packages/xstate-react/test/useActorRef.test.tsx
@@ -19,6 +19,59 @@ afterEach(() => {
 });
 
 describeEachReactMode('useActorRef (%s)', ({ suiteKey, render }) => {
+  it('should accept events from effects when mounted in strict mode', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let received = 0;
+    const machine = createMachine({
+      actions: {
+        record: () => {
+          received++;
+        }
+      },
+      on: {
+        INC: ({ actions }, enq) => enq(actions.record)
+      }
+    });
+
+    const App = () => {
+      const actorRef = useActorRef(machine);
+
+      React.useEffect(() => {
+        actorRef.send({ type: 'INC' });
+      }, [actorRef]);
+
+      return null;
+    };
+
+    render(<App />);
+
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('was not delivered (stopped)')
+    );
+    expect(received).toBe(suiteKey === 'strict' ? 2 : 1);
+  });
+
+  it('should still warn when sending to an actor after unmount', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const machine = createMachine({});
+    let actorRef: ActorRefFrom<typeof machine>;
+
+    const App = () => {
+      actorRef = useActorRef(machine);
+      return null;
+    };
+
+    const { unmount } = render(<App />);
+    unmount();
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    actorRef!.send({ type: 'INC' });
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('was not delivered (stopped)')
+    );
+  });
+
   it('observer should be called with next state', () => {
     const { resolve, promise } = Promise.withResolvers<void>();
     const machine = createMachine({


### PR DESCRIPTION
## Summary

- keep built-in effect types stable through production minification so delayed transitions and other built-in effects retain runtime semantics
- preserve hook-owned actors across React StrictMode's immediate effect reconnect while still stopping on real unmount
- accept machines from duplicate same-major XState copies in graph utilities without relying on constructor identity
- add regressions for Viz-shaped target/delay inference and document payload-free events as `types<void>()`
- document v5/v6 alias boundaries and aligned integration peer requirements

## Classification

- production `after` failure: XState core bug exposed by production minification, not Turbopack-specific
- StrictMode stopped-actor warning: `@xstate/react` lifecycle bug
- alpha.50 target and named-delay `never` errors: core type bug already fixed on `next` by #5690; regressions added here
- payload-free events: documentation gap; `types<void>()` is the precise API
- dual v5/v6 aliases: supported only as isolated libraries; cross-major actor/machine mixing remains unsupported
- duplicate same-major graph machines: preventable constructor-identity leak fixed here

## Verification

- `pnpm test:core` — 2,480 passed, 33 skipped, 3 todo
- React `useActorRef` + `useActor` suites — 70 passed
- focused core regressions — 40 passed, 4 skipped
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- minimal Next 16.2.4 production reproduction:
  - alpha.50 + Turbopack: timer transition remained in `waiting`
  - alpha.50 + webpack minification: remained in `waiting`
  - webpack without minification: transitioned to `done`
  - fixed source + minified webpack and Turbopack: transitioned to `done`
