### PR TITLE
Fix framework adapter inference with exact optional types

### DIFF
--- a/.changeset/tidy-adapters-type.md
+++ b/.changeset/tidy-adapters-type.md
@@ -1,0 +1,10 @@
+---
+'xstate': patch
+---
+
+Fixed framework adapter snapshot inference in projects that enable `exactOptionalPropertyTypes`.
+
+```ts
+const actor = createActor(machine);
+const count = useSelector(actor, (snapshot) => snapshot.context.count);
+```

--- a/.github/actions/ci-checks/action.yml
+++ b/.github/actions/ci-checks/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
 
     - name: Typecheck
-      run: pnpm typecheck
+      run: pnpm typecheck && pnpm typecheck:adapter-consumers
       shell: bash
 
     - name: Test

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "lint": "oxlint --quiet --report-unused-disable-directives-severity=error",
     "lint:fix": "oxlint --fix --report-unused-disable-directives-severity=error",
     "typecheck": "tsc",
+    "typecheck:adapter-consumers": "tsc -p tsconfig.exact-optional.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:core": "vitest run --project xstate",

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1152,8 +1152,8 @@ export interface AnyStateMachine extends AnyActorLogic {
   events: Array<EventDescriptor<any>>;
   sources: Sources;
   config: any;
-  version?: string;
-  schemas?: import('./types.v6.ts').AnyMachineSchemas;
+  version?: string | undefined;
+  schemas?: import('./types.v6.ts').AnyMachineSchemas | undefined;
   snapshotSchema: import('./machineVersion.types.ts').MachineSnapshotSchema;
   eventSchema: import('./machineVersion.types.ts').MachineEventSchema;
   provide(sources: any): AnyStateMachine;
@@ -2301,7 +2301,7 @@ export interface ActorLogic<
   /** The initial setup/configuration used to create the actor logic. */
   config?: unknown;
   /** Optional runtime validator for pure calculation boundaries. */
-  validator?: import('./validation.types.ts').ActorLogicValidator;
+  validator?: import('./validation.types.ts').ActorLogicValidator | undefined;
   /**
    * Transition function that processes the current state and an incoming event
    * to produce a new state and effects.
@@ -2388,7 +2388,7 @@ export interface ActorLogic<
 
 export interface AnyActorLogic {
   config?: unknown;
-  validator?: import('./validation.types.ts').ActorLogicValidator;
+  validator?: import('./validation.types.ts').ActorLogicValidator | undefined;
   transition(
     snapshot: any,
     event: any,

--- a/scripts/typecheck-fixtures/exact-optional-adapters.ts
+++ b/scripts/typecheck-fixtures/exact-optional-adapters.ts
@@ -1,0 +1,63 @@
+import {
+  createActor,
+  setup,
+  types
+} from '../../packages/core/dist/xstate.cjs.mjs';
+import {
+  useActor as useReactActor,
+  useActorRef as useReactActorRef,
+  useMachine as useReactMachine,
+  useSelector as useReactSelector
+} from '../../packages/xstate-react/dist/xstate-react.cjs.mjs';
+import {
+  useActor as useSolidActor,
+  useActorRef as useSolidActorRef,
+  useMachine as useSolidMachine
+} from '../../packages/xstate-solid/dist/xstate-solid.cjs.mjs';
+import {
+  useActor as useSvelteActor,
+  useActorRef as useSvelteActorRef,
+  useMachine as useSvelteMachine,
+  useSelector as useSvelteSelector
+} from '../../packages/xstate-svelte/dist/xstate-svelte.cjs.mjs';
+import {
+  useActor as useVueActor,
+  useActorRef as useVueActorRef,
+  useMachine as useVueMachine,
+  useSelector as useVueSelector
+} from '../../packages/xstate-vue/dist/xstate-vue.cjs.mjs';
+
+const machine = setup({
+  schemas: {
+    context: types<{ count: number }>()
+  }
+}).createMachine({
+  context: { count: 0 }
+});
+
+const actor = createActor(machine);
+declare function expectNumber(value: number): void;
+
+useVueSelector(actor, (snapshot) => snapshot.context.count);
+useReactSelector(actor, (snapshot) => snapshot.context.count);
+useSvelteSelector(actor, (snapshot) => snapshot.context.count);
+
+expectNumber(useVueActor(machine).snapshot.value.context.count);
+expectNumber(useVueMachine(machine).snapshot.value.context.count);
+expectNumber(useVueActorRef(machine).getSnapshot().context.count);
+
+expectNumber(useReactActor(machine)[0].context.count);
+expectNumber(useReactMachine(machine)[0].context.count);
+expectNumber(useReactActorRef(machine).getSnapshot().context.count);
+
+useSvelteActor(machine).snapshot.subscribe(
+  (snapshot) => snapshot.context.count
+);
+useSvelteMachine(machine).snapshot.subscribe(
+  (snapshot) => snapshot.context.count
+);
+expectNumber(useSvelteActorRef(machine).getSnapshot().context.count);
+
+expectNumber(useSolidActor(machine)[0].context.count);
+expectNumber(useSolidMachine(machine)[0].context.count);
+expectNumber(useSolidActorRef(machine).getSnapshot().context.count);

--- a/tsconfig.exact-optional.json
+++ b/tsconfig.exact-optional.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": true
+  },
+  "include": ["scripts/typecheck-fixtures/exact-optional-adapters.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Summary

- make core's erased actor-logic and machine interfaces accept concrete runtime fields under `exactOptionalPropertyTypes`
- cover `useSelector`, `useActor`, `useMachine`, and `useActorRef` through built Vue, React, Svelte, and Solid declarations
- run the cross-framework consumer fixture in CI

## Root cause

The adapter declarations were still structurally compatible with current core. The failure came from concrete core logic exposing optional runtime fields as `T | undefined` while `AnyActorLogic` and `AnyStateMachine` accepted only optional `T`. With `exactOptionalPropertyTypes`, machines no longer satisfied the adapters' generic constraints and snapshot inference degraded.

## Validation

- `pnpm build`
- `pnpm typecheck`
- `pnpm typecheck:adapter-consumers`
- `pnpm lint`
- `pnpm format:check`
- `pnpm test --silent` (3,042 passed; 35 skipped; 3 todo)
- `pnpm --filter @xstate/svelte svelte-check`
- `pnpm knip`
- packed-package consumer repro against TypeScript 5.4–6.0
