### PR TITLE
Add separate transition metadata typing

### DIFF
--- a/.changeset/quiet-maps-dream.md
+++ b/.changeset/quiet-maps-dream.md
@@ -7,7 +7,7 @@ State and transition metadata can now use separate types:
 ```ts
 const machine = setup({
   types: {
-    stateMeta: {} as { label: string },
+    meta: {} as { label: string },
     transitionMeta: {} as { trackingId: number }
   }
 }).createMachine({
@@ -18,5 +18,5 @@ const machine = setup({
 });
 ```
 
-The existing `types.meta` field remains supported and applies its type to both
-state and transition metadata.
+When `transitionMeta` is omitted, `types.meta` continues to apply its type to
+both state and transition metadata.

--- a/.changeset/quiet-maps-dream.md
+++ b/.changeset/quiet-maps-dream.md
@@ -1,0 +1,22 @@
+---
+'xstate': minor
+---
+
+State and transition metadata can now use separate types:
+
+```ts
+const machine = setup({
+  types: {
+    stateMeta: {} as { label: string },
+    transitionMeta: {} as { trackingId: number }
+  }
+}).createMachine({
+  meta: { label: 'Root' },
+  on: {
+    NEXT: { meta: { trackingId: 42 } }
+  }
+});
+```
+
+The existing `types.meta` field remains supported and applies its type to both
+state and transition metadata.

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -69,8 +69,9 @@ export class StateMachine<
   TInput,
   TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
-  TStateSchema extends StateSchema
+  TStateMeta extends MetaObject,
+  TStateSchema extends StateSchema,
+  TTransitionMeta extends MetaObject = TStateMeta
 > implements ActorLogic<
   MachineSnapshot<
     TContext,
@@ -79,7 +80,7 @@ export class StateMachine<
     TStateValue,
     TTag,
     TOutput,
-    TMeta,
+    TStateMeta,
     TStateSchema
   >,
   TEvent,
@@ -101,13 +102,21 @@ export class StateMachine<
   public __xstatenode = true as const;
 
   /** @internal */
-  public idMap: Map<string, StateNode<TContext, TEvent>> = new Map();
+  public idMap: Map<
+    string,
+    StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>
+  > = new Map();
 
-  public root: StateNode<TContext, TEvent>;
+  public root: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>;
 
   public id: string;
 
-  public states: StateNode<TContext, TEvent>['states'];
+  public states: StateNode<
+    TContext,
+    TEvent,
+    TStateMeta,
+    TTransitionMeta
+  >['states'];
   public events: Array<EventDescriptor<TEvent>>;
 
   constructor(
@@ -123,7 +132,8 @@ export class StateMachine<
       any,
       TOutput,
       any, // TEmitted
-      any // TMeta
+      any, // TStateMeta
+      any // TTransitionMeta
     > & {
       schemas?: unknown;
     },
@@ -206,8 +216,9 @@ export class StateMachine<
     TInput,
     TOutput,
     TEmitted,
-    TMeta,
-    TStateSchema
+    TStateMeta,
+    TStateSchema,
+    TTransitionMeta
   > {
     const { actions, guards, actors, delays } = this.implementations;
 
@@ -237,7 +248,7 @@ export class StateMachine<
     TStateValue,
     TTag,
     TOutput,
-    TMeta,
+    TStateMeta,
     TStateSchema
   > {
     const resolvedStateValue = resolveStateValue(this.root, config.value);
@@ -265,7 +276,7 @@ export class StateMachine<
       TStateValue,
       TTag,
       TOutput,
-      TMeta,
+      TStateMeta,
       TStateSchema
     >;
   }
@@ -285,7 +296,7 @@ export class StateMachine<
       TStateValue,
       TTag,
       TOutput,
-      TMeta,
+      TStateMeta,
       TStateSchema
     >,
     event: TEvent,
@@ -297,7 +308,7 @@ export class StateMachine<
     TStateValue,
     TTag,
     TOutput,
-    TMeta,
+    TStateMeta,
     TStateSchema
   > {
     return macrostep(snapshot, event, actorScope, [])
@@ -319,7 +330,7 @@ export class StateMachine<
       TStateValue,
       TTag,
       TOutput,
-      TMeta,
+      TStateMeta,
       TStateSchema
     >,
     event: TEvent,
@@ -332,7 +343,7 @@ export class StateMachine<
       TStateValue,
       TTag,
       TOutput,
-      TMeta,
+      TStateMeta,
       TStateSchema
     >
   > {
@@ -349,12 +360,13 @@ export class StateMachine<
       TStateValue,
       TTag,
       TOutput,
-      TMeta,
+      TStateMeta,
       TStateSchema
     >,
     event: TEvent
-  ): Array<TransitionDefinition<TContext, TEvent>> {
-    return transitionNode(this.root, snapshot.value, snapshot, event) || [];
+  ): Array<TransitionDefinition<TContext, TEvent, TTransitionMeta>> {
+    return (transitionNode(this.root, snapshot.value, snapshot, event) ||
+      []) as Array<TransitionDefinition<TContext, TEvent, TTransitionMeta>>;
   }
 
   /**
@@ -374,7 +386,7 @@ export class StateMachine<
     TStateValue,
     TTag,
     TOutput,
-    TMeta,
+    TStateMeta,
     TStateSchema
   > {
     const { context } = this.config;
@@ -419,7 +431,7 @@ export class StateMachine<
         TStateValue,
         TTag,
         TOutput,
-        TMeta,
+        TStateMeta,
         TStateSchema
       >,
       TEvent,
@@ -434,7 +446,7 @@ export class StateMachine<
     TStateValue,
     TTag,
     TOutput,
-    TMeta,
+    TStateMeta,
     TStateSchema
   > {
     const initEvent = createInitEvent(input) as unknown as TEvent; // TODO: fix;
@@ -486,7 +498,7 @@ export class StateMachine<
       TStateValue,
       TTag,
       TOutput,
-      TMeta,
+      TStateMeta,
       TStateSchema
     >
   ): void {
@@ -499,7 +511,9 @@ export class StateMachine<
     );
   }
 
-  public getStateNodeById(stateId: string): StateNode<TContext, TEvent> {
+  public getStateNodeById(
+    stateId: string
+  ): StateNode<TContext, TEvent, TStateMeta, TTransitionMeta> {
     const fullPath = toStatePath(stateId);
     const relativePath = fullPath.slice(1);
     const resolvedStateId = isStateId(fullPath[0])
@@ -512,10 +526,20 @@ export class StateMachine<
         `Child state node '#${resolvedStateId}' does not exist on machine '${this.id}'`
       );
     }
-    return getStateNodeByPath(stateNode, relativePath);
+    return getStateNodeByPath(stateNode, relativePath) as StateNode<
+      TContext,
+      TEvent,
+      TStateMeta,
+      TTransitionMeta
+    >;
   }
 
-  public get definition(): StateMachineDefinition<TContext, TEvent> {
+  public get definition(): StateMachineDefinition<
+    TContext,
+    TEvent,
+    TStateMeta,
+    TTransitionMeta
+  > {
     return this.root.definition;
   }
 
@@ -531,7 +555,7 @@ export class StateMachine<
       TStateValue,
       TTag,
       TOutput,
-      TMeta,
+      TStateMeta,
       TStateSchema
     >,
     options?: unknown
@@ -549,7 +573,7 @@ export class StateMachine<
         TStateValue,
         TTag,
         TOutput,
-        TMeta,
+        TStateMeta,
         TStateSchema
       >,
       TEvent,
@@ -563,7 +587,7 @@ export class StateMachine<
     TStateValue,
     TTag,
     TOutput,
-    TMeta,
+    TStateMeta,
     TStateSchema
   > {
     const children: Record<string, AnyActorRef> = {};
@@ -602,8 +626,10 @@ export class StateMachine<
     });
 
     function resolveHistoryReferencedState(
-      root: StateNode<TContext, TEvent>,
-      referenced: { id: string } | StateNode<TContext, TEvent>
+      root: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>,
+      referenced:
+        | { id: string }
+        | StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>
     ) {
       if (referenced instanceof StateNode) {
         return referenced;
@@ -618,10 +644,13 @@ export class StateMachine<
     }
 
     function reviveHistoryValue(
-      root: StateNode<TContext, TEvent>,
+      root: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>,
       historyValue: Record<
         string,
-        ({ id: string } | StateNode<TContext, TEvent>)[]
+        (
+          | { id: string }
+          | StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>
+        )[]
       >
     ): HistoryValue<TContext, TEvent> {
       if (!historyValue || typeof historyValue !== 'object') {
@@ -667,7 +696,7 @@ export class StateMachine<
       TStateValue,
       TTag,
       TOutput,
-      TMeta,
+      TStateMeta,
       TStateSchema
     >;
 

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -31,7 +31,8 @@ import type {
   AnyStateNodeConfig,
   ProvidedActor,
   NonReducibleUnknown,
-  EventDescriptor
+  EventDescriptor,
+  MetaObject
 } from './types.ts';
 import {
   createInvokeId,
@@ -59,16 +60,20 @@ const toSerializableAction = (action: UnknownAction) => {
 
 interface StateNodeOptions<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject
 > {
   _key: string;
-  _parent?: StateNode<TContext, TEvent>;
+  _parent?: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>;
   _machine: AnyStateMachine;
 }
 
 export class StateNode<
   TContext extends MachineContext = MachineContext,
-  TEvent extends EventObject = EventObject
+  TEvent extends EventObject = EventObject,
+  TStateMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > {
   /**
    * The relative key of the state node, which represents its location in the
@@ -90,7 +95,12 @@ export class StateNode<
   /** The string path from the root machine node to this node. */
   public path: string[];
   /** The child state nodes. */
-  public states: StateNodesConfig<TContext, TEvent>;
+  public states: StateNodesConfig<
+    TContext,
+    TEvent,
+    TStateMeta,
+    TTransitionMeta
+  >;
   /**
    * The type of history on this state node. Can be:
    *
@@ -103,7 +113,7 @@ export class StateNode<
   /** The action(s) to be executed upon exiting the state node. */
   public exit: UnknownAction[];
   /** The parent state node. */
-  public parent?: StateNode<TContext, TEvent>;
+  public parent?: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>;
   /** The root machine node. */
   public machine: StateMachine<
     TContext,
@@ -118,14 +128,15 @@ export class StateNode<
     any, // input
     any, // output
     any, // emitted
-    any, // meta
-    any // state schema
+    TStateMeta,
+    any, // state schema
+    TTransitionMeta
   >;
   /**
    * The meta data associated with this state node, which will be returned in
    * State instances.
    */
-  public meta?: any;
+  public meta?: TStateMeta;
   /**
    * The output data sent with the "xstate.done.state._id_" event if this is a
    * final state node.
@@ -143,8 +154,13 @@ export class StateNode<
   public description?: string;
 
   public tags: string[] = [];
-  public transitions!: Map<string, TransitionDefinition<TContext, TEvent>[]>;
-  public always?: Array<TransitionDefinition<TContext, TEvent>>;
+  public transitions!: Map<
+    string,
+    TransitionDefinition<TContext, TEvent, TTransitionMeta>[]
+  >;
+  public always?: Array<
+    TransitionDefinition<TContext, TEvent, TTransitionMeta>
+  >;
 
   constructor(
     /** The raw config used to create the machine. */
@@ -158,9 +174,10 @@ export class StateNode<
       TODO, // tags
       TODO, // output
       TODO, // emitted
-      TODO // meta
+      TStateMeta,
+      TTransitionMeta
     >,
-    options: StateNodeOptions<TContext, TEvent>
+    options: StateNodeOptions<TContext, TEvent, TStateMeta, TTransitionMeta>
   ) {
     this.parent = options._parent;
     this.key = options._key;
@@ -221,7 +238,7 @@ export class StateNode<
 
   /** @internal */
   public _initialize() {
-    this.transitions = formatTransitions(this);
+    this.transitions = formatTransitions(this) as typeof this.transitions;
     if (this.config.always) {
       this.always = toTransitionConfigArray(this.config.always).map((t) =>
         formatTransition(this, NULL_EVENT, t)
@@ -234,7 +251,12 @@ export class StateNode<
   }
 
   /** The well-structured state node definition. */
-  public get definition(): StateNodeDefinition<TContext, TEvent> {
+  public get definition(): StateNodeDefinition<
+    TContext,
+    TEvent,
+    TStateMeta,
+    TTransitionMeta
+  > {
     return {
       id: this.id,
       key: this.key,
@@ -247,18 +269,24 @@ export class StateNode<
             actions: this.initial.actions.map(toSerializableAction),
             eventType: null as any,
             reenter: false,
+            meta: this.initial.meta,
+            description: this.initial.description,
             toJSON: () => ({
               target: this.initial.target.map((t) => `#${t.id}`),
               source: `#${this.id}`,
               actions: this.initial.actions.map(toSerializableAction),
-              eventType: null as any
+              eventType: null as any,
+              meta: this.initial.meta,
+              description: this.initial.description
             })
           }
         : undefined,
       history: this.history,
-      states: mapValues(this.states, (state: StateNode<TContext, TEvent>) => {
-        return state.definition;
-      }) as StatesDefinition<TContext, TEvent>,
+      states: mapValues(
+        this.states,
+        (state: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>) =>
+          state.definition
+      ) as StatesDefinition<TContext, TEvent, TStateMeta, TTransitionMeta>,
       on: this.on,
       transitions: [...this.transitions.values()].flat().map((t) => ({
         ...t,
@@ -290,7 +318,7 @@ export class StateNode<
       ParameterizedObject,
       string,
       TODO, // TEmitted
-      TODO // TMeta
+      TTransitionMeta
     >
   > {
     return memo(this, 'invoke', () =>
@@ -324,14 +352,14 @@ export class StateNode<
           ParameterizedObject,
           string,
           TODO, // TEmitted
-          TODO // TMeta
+          TTransitionMeta
         >;
       })
     );
   }
 
   /** The mapping of events to transitions. */
-  public get on(): TransitionDefinitionMap<TContext, TEvent> {
+  public get on(): TransitionDefinitionMap<TContext, TEvent, TTransitionMeta> {
     return memo(this, 'on', () => {
       const transitions = this.transitions;
 
@@ -343,12 +371,14 @@ export class StateNode<
             map[descriptor].push(transition);
             return map;
           },
-          {} as TransitionDefinitionMap<TContext, TEvent>
+          {} as TransitionDefinitionMap<TContext, TEvent, TTransitionMeta>
         );
     });
   }
 
-  public get after(): Array<DelayedTransitionDefinition<TContext, TEvent>> {
+  public get after(): Array<
+    DelayedTransitionDefinition<TContext, TEvent, TTransitionMeta>
+  > {
     return memo(
       this,
       'delayedTransitions',
@@ -356,9 +386,19 @@ export class StateNode<
     );
   }
 
-  public get initial(): InitialTransitionDefinition<TContext, TEvent> {
-    return memo(this, 'initial', () =>
-      formatInitialTransition(this, this.config.initial)
+  public get initial(): InitialTransitionDefinition<
+    TContext,
+    TEvent,
+    TTransitionMeta
+  > {
+    return memo(
+      this,
+      'initial',
+      () =>
+        formatInitialTransition(
+          this,
+          this.config.initial
+        ) as typeof this.initial
     );
   }
 
@@ -375,16 +415,23 @@ export class StateNode<
       any // TStateSchema
     >,
     event: TEvent
-  ): TransitionDefinition<TContext, TEvent>[] | undefined {
+  ): TransitionDefinition<TContext, TEvent, TTransitionMeta>[] | undefined {
     const eventType = event.type;
     const actions: UnknownAction[] = [];
 
-    let selectedTransition: TransitionDefinition<TContext, TEvent> | undefined;
+    let selectedTransition:
+      | TransitionDefinition<TContext, TEvent, TTransitionMeta>
+      | undefined;
 
-    const candidates: Array<TransitionDefinition<TContext, TEvent>> = memo(
+    const candidates: Array<
+      TransitionDefinition<TContext, TEvent, TTransitionMeta>
+    > = memo(
       this,
       `candidates-${eventType}`,
-      () => getCandidates(this, eventType)
+      () =>
+        getCandidates(this, eventType) as Array<
+          TransitionDefinition<TContext, TEvent, TTransitionMeta>
+        >
     );
 
     for (const candidate of candidates) {

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -84,7 +84,8 @@ export function createMachine<
   TInput,
   TOutput extends NonReducibleUnknown,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject = any,
+  TTransitionMeta extends MetaObject = TStateMeta,
   // it's important to have at least one default type parameter here
   // it allows us to benefit from contextual type instantiation as it makes us to pass the hasInferenceCandidatesOrDefault check in the compiler
   // we should be able to remove this when we start inferring TConfig, with it we'll always have an inference candidate
@@ -102,7 +103,8 @@ export function createMachine<
       TInput,
       TOutput,
       TEmitted,
-      TMeta
+      TStateMeta,
+      TTransitionMeta
     >;
     schemas?: unknown;
   } & MachineConfig<
@@ -116,7 +118,8 @@ export function createMachine<
     TInput,
     TOutput,
     TEmitted,
-    TMeta
+    TStateMeta,
+    TTransitionMeta
   >,
   implementations?: InternalMachineImplementations<
     ResolvedStateMachineTypes<
@@ -143,8 +146,9 @@ export function createMachine<
   TInput,
   TOutput,
   TEmitted,
-  TMeta, // TMeta
-  TODO // TStateSchema
+  TStateMeta,
+  TODO, // TStateSchema
+  TTransitionMeta
 > {
   return new StateMachine<
     any,
@@ -159,7 +163,8 @@ export function createMachine<
     any,
     any,
     any, // TEmitted
-    any, // TMeta
-    any // TStateSchema
+    any, // TStateMeta
+    any, // TStateSchema
+    any // TTransitionMeta
   >(config as any, implementations as any);
 }

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -123,7 +123,7 @@ export type SetupReturn<
   TOutput extends NonReducibleUnknown,
   TEmitted extends EventObject,
   TStateMeta extends MetaObject,
-  TTransitionMeta extends MetaObject
+  TTransitionMeta extends MetaObject = TStateMeta
 > = {
   extend: <
     TExtendActions extends Record<

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -122,7 +122,8 @@ export type SetupReturn<
   TInput,
   TOutput extends NonReducibleUnknown,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject
 > = {
   extend: <
     TExtendActions extends Record<
@@ -180,7 +181,8 @@ export type SetupReturn<
     TInput,
     TOutput,
     TEmitted,
-    TMeta
+    TStateMeta,
+    TTransitionMeta
   >;
   /**
    * Creates a state config that is strongly typed. This state config can be
@@ -222,7 +224,8 @@ export type SetupReturn<
       TTag,
       unknown,
       TEmitted,
-      TMeta
+      TStateMeta,
+      TTransitionMeta
     >
   >(
     config: TStateConfig
@@ -277,7 +280,8 @@ export type SetupReturn<
       TInput,
       TOutput,
       TEmitted,
-      TMeta
+      TStateMeta,
+      TTransitionMeta
     >,
     TResolvedChildren extends Record<string, string> = MergeChildrenMap<
       TChildrenMap,
@@ -307,8 +311,9 @@ export type SetupReturn<
     TInput,
     TOutput,
     TEmitted,
-    TMeta,
-    ToStateSchema<TConfig>
+    TStateMeta,
+    ToStateSchema<TConfig>,
+    TTransitionMeta
   >;
 
   assign: typeof assign<
@@ -380,7 +385,8 @@ export function setup<
   TInput = NonReducibleUnknown,
   TOutput extends NonReducibleUnknown = NonReducibleUnknown,
   TEmitted extends EventObject = EventObject,
-  TMeta extends MetaObject = MetaObject
+  TStateMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 >({
   schemas,
   actors,
@@ -397,7 +403,8 @@ export function setup<
     TInput,
     TOutput,
     TEmitted,
-    TMeta
+    TStateMeta,
+    TTransitionMeta
   >;
   actors?: {
     // union here enforces that all configured children have to be provided in actors
@@ -449,7 +456,8 @@ export function setup<
   TInput,
   TOutput,
   TEmitted,
-  TMeta
+  TStateMeta,
+  TTransitionMeta
 > {
   return {
     assign,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -39,7 +39,8 @@ import {
   AnyTransitionConfig,
   AnyActorScope,
   ActionExecutor,
-  AnyStateMachine
+  AnyStateMachine,
+  MetaObject
 } from './types.ts';
 import {
   resolveOutput,
@@ -424,14 +425,24 @@ export function formatRouteTransitions(rootStateNode: AnyStateNode): void {
 
 export function formatInitialTransition<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TTransitionMeta extends MetaObject
 >(
-  stateNode: AnyStateNode,
+  stateNode: StateNode<TContext, TEvent, any, TTransitionMeta>,
   _target:
     | string
     | undefined
-    | InitialTransitionConfig<TContext, TEvent, TODO, TODO, TODO, TODO>
-): InitialTransitionDefinition<TContext, TEvent> {
+    | InitialTransitionConfig<
+        TContext,
+        TEvent,
+        TODO,
+        TODO,
+        TODO,
+        TODO,
+        TODO,
+        TTransitionMeta
+      >
+): InitialTransitionDefinition<TContext, TEvent, TTransitionMeta> {
   const resolvedTarget =
     typeof _target === 'string'
       ? stateNode.states[_target]
@@ -444,13 +455,19 @@ export function formatInitialTransition<
       `Initial state node "${_target}" not found on parent state node #${stateNode.id}`
     );
   }
-  const transition: InitialTransitionDefinition<TContext, TEvent> = {
+  const transition: InitialTransitionDefinition<
+    TContext,
+    TEvent,
+    TTransitionMeta
+  > = {
     source: stateNode,
     actions:
       !_target || typeof _target === 'string' ? [] : toArray(_target.actions),
     eventType: null as any,
     reenter: false,
     target: resolvedTarget ? [resolvedTarget] : [],
+    meta: typeof _target === 'object' ? _target.meta : undefined,
+    description: typeof _target === 'object' ? _target.description : undefined,
     toJSON: () => ({
       ...transition,
       source: `#${stateNode.id}`,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1520,10 +1520,11 @@ export interface SetupTypes<
   input?: TInput;
   output?: TOutput;
   emitted?: TEmitted;
-  /** State-node metadata. Retained as the shared metadata declaration for compatibility. */
+  /**
+   * State-node metadata. Also used for transition metadata when
+   * `transitionMeta` is not specified.
+   */
   meta?: TStateMeta;
-  /** State-node metadata. */
-  stateMeta?: TStateMeta;
   /** Transition metadata. */
   transitionMeta?: TTransitionMeta;
 }
@@ -1559,7 +1560,6 @@ export interface MachineTypes<
   guards?: TGuard;
   delays?: TDelay;
   meta?: TStateMeta;
-  stateMeta?: TStateMeta;
   transitionMeta?: TTransitionMeta;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,7 +151,8 @@ export type InputFrom<T> =
     infer _TOutput,
     infer _TEmitted,
     infer _TMeta,
-    infer _TStateSchema
+    infer _TStateSchema,
+    infer _TTransitionMeta
   >
     ? TInput
     : T extends ActorLogic<
@@ -347,7 +348,9 @@ export interface InitialTransitionConfig<
   TActor extends ProvidedActor,
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
-  TDelay extends string
+  TDelay extends string,
+  TEmitted extends EventObject = EventObject,
+  TTransitionMeta extends MetaObject = MetaObject
 > extends TransitionConfig<
   TContext,
   TEvent,
@@ -356,8 +359,8 @@ export interface InitialTransitionConfig<
   TAction,
   TGuard,
   TDelay,
-  TODO, // TEmitted
-  TODO // TMeta
+  TEmitted,
+  TTransitionMeta
 > {
   target: string;
 }
@@ -471,7 +474,9 @@ export type DelayedTransitions<
   TActor extends ProvidedActor,
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
-  TDelay extends string
+  TDelay extends string,
+  TEmitted extends EventObject = EventObject,
+  TTransitionMeta extends MetaObject = MetaObject
 > = {
   [K in Delay<TDelay>]?:
     | string
@@ -484,8 +489,8 @@ export type DelayedTransitions<
           TAction,
           TGuard,
           TDelay,
-          TODO, // TEmitted
-          TODO // TMeta
+          TEmitted,
+          TTransitionMeta
         >
       >;
 };
@@ -502,9 +507,11 @@ export type SingleOrArray<T> = readonly T[] | T;
 
 export type StateNodesConfig<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > = {
-  [K in string]: StateNode<TContext, TEvent>;
+  [K in string]: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>;
 };
 
 export type StatesConfig<
@@ -517,7 +524,8 @@ export type StatesConfig<
   TTag extends string,
   TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > = {
   [K in string]: StateNodeConfig<
     TContext,
@@ -529,15 +537,23 @@ export type StatesConfig<
     TTag,
     TOutput,
     TEmitted,
-    TMeta
+    TStateMeta,
+    TTransitionMeta
   >;
 };
 
 export type StatesDefinition<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > = {
-  [K in string]: StateNodeDefinition<TContext, TEvent>;
+  [K in string]: StateNodeDefinition<
+    TContext,
+    TEvent,
+    TStateMeta,
+    TTransitionMeta
+  >;
 };
 
 export type TransitionConfigTarget = string | undefined;
@@ -551,7 +567,7 @@ export type TransitionConfigOrTarget<
   TGuard extends ParameterizedObject,
   TDelay extends string,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > = SingleOrArray<
   | TransitionConfigTarget
   | TransitionConfig<
@@ -563,7 +579,7 @@ export type TransitionConfigOrTarget<
       TGuard,
       TDelay,
       TEmitted,
-      TMeta
+      TTransitionMeta
     >
 >;
 
@@ -575,7 +591,7 @@ export type TransitionsConfig<
   TGuard extends ParameterizedObject,
   TDelay extends string,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > = {
   [K in EventDescriptor<TEvent>]?: TransitionConfigOrTarget<
     TContext,
@@ -586,7 +602,7 @@ export type TransitionsConfig<
     TGuard,
     TDelay,
     TEmitted,
-    TMeta
+    TTransitionMeta
   >;
 };
 
@@ -616,7 +632,7 @@ type DistributeActors<
   TGuard extends ParameterizedObject,
   TDelay extends string,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TSpecificActor extends ProvidedActor
 > = TSpecificActor extends { src: infer TSrc }
   ?
@@ -659,7 +675,7 @@ type DistributeActors<
                     TGuard,
                     TDelay,
                     TEmitted,
-                    TMeta
+                    TTransitionMeta
                   >
                 >;
             /**
@@ -678,7 +694,7 @@ type DistributeActors<
                     TGuard,
                     TDelay,
                     TEmitted,
-                    TMeta
+                    TTransitionMeta
                   >
                 >;
 
@@ -694,7 +710,7 @@ type DistributeActors<
                     TGuard,
                     TDelay,
                     TEmitted,
-                    TMeta
+                    TTransitionMeta
                   >
                 >;
           } & { [K in RequiredActorOptions<TSpecificActor>]: unknown }
@@ -718,7 +734,7 @@ type DistributeActors<
                   TGuard,
                   TDelay,
                   TEmitted,
-                  TMeta
+                  TTransitionMeta
                 >
               >;
           onError?:
@@ -733,7 +749,7 @@ type DistributeActors<
                   TGuard,
                   TDelay,
                   TEmitted,
-                  TMeta
+                  TTransitionMeta
                 >
               >;
 
@@ -749,7 +765,7 @@ type DistributeActors<
                   TGuard,
                   TDelay,
                   TEmitted,
-                  TMeta
+                  TTransitionMeta
                 >
               >;
         }
@@ -763,7 +779,7 @@ export type InvokeConfig<
   TGuard extends ParameterizedObject,
   TDelay extends string,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > =
   IsLiteralString<TActor['src']> extends true
     ? DistributeActors<
@@ -774,7 +790,7 @@ export type InvokeConfig<
         TGuard,
         TDelay,
         TEmitted,
-        TMeta,
+        TTransitionMeta,
         TActor
       >
     : {
@@ -807,7 +823,7 @@ export type InvokeConfig<
                 TGuard,
                 TDelay,
                 TEmitted,
-                TMeta
+                TTransitionMeta
               >
             >;
         /**
@@ -826,7 +842,7 @@ export type InvokeConfig<
                 TGuard,
                 TDelay,
                 TEmitted,
-                TMeta
+                TTransitionMeta
               >
             >;
 
@@ -842,7 +858,7 @@ export type InvokeConfig<
                 TGuard,
                 TDelay,
                 TEmitted,
-                TMeta
+                TTransitionMeta
               >
             >;
       };
@@ -855,7 +871,7 @@ export type AnyInvokeConfig = InvokeConfig<
   any,
   any,
   any,
-  any // TMeta
+  any // TTransitionMeta
 >;
 
 export interface StateNodeConfig<
@@ -868,11 +884,21 @@ export interface StateNodeConfig<
   TTag extends string,
   _TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > {
   /** The initial state transition. */
   initial?:
-    | InitialTransitionConfig<TContext, TEvent, TActor, TAction, TGuard, TDelay>
+    | InitialTransitionConfig<
+        TContext,
+        TEvent,
+        TActor,
+        TAction,
+        TGuard,
+        TDelay,
+        TEmitted,
+        TTransitionMeta
+      >
     | string
     | undefined;
   /**
@@ -905,7 +931,8 @@ export interface StateNodeConfig<
         TTag,
         NonReducibleUnknown,
         TEmitted,
-        TMeta
+        TStateMeta,
+        TTransitionMeta
       >
     | undefined;
   /**
@@ -921,7 +948,7 @@ export interface StateNodeConfig<
       TGuard,
       TDelay,
       TEmitted,
-      TMeta
+      TTransitionMeta
     >
   >;
   /** The mapping of event types to their potential transition(s). */
@@ -933,7 +960,7 @@ export interface StateNodeConfig<
     TGuard,
     TDelay,
     TEmitted,
-    TMeta
+    TTransitionMeta
   >;
   /** The action(s) to be executed upon entering the state node. */
   entry?: Actions<
@@ -978,7 +1005,7 @@ export interface StateNodeConfig<
           TGuard,
           TDelay,
           TEmitted,
-          TMeta
+          TTransitionMeta
         >
       >
     | undefined;
@@ -987,7 +1014,16 @@ export interface StateNodeConfig<
    * transition(s). The delayed transitions are taken after the specified delay
    * in an interpreter.
    */
-  after?: DelayedTransitions<TContext, TEvent, TActor, TAction, TGuard, TDelay>;
+  after?: DelayedTransitions<
+    TContext,
+    TEvent,
+    TActor,
+    TAction,
+    TGuard,
+    TDelay,
+    TEmitted,
+    TTransitionMeta
+  >;
 
   /**
    * An eventless transition that is always taken when this state node is
@@ -1002,14 +1038,14 @@ export interface StateNodeConfig<
     TGuard,
     TDelay,
     TEmitted,
-    TMeta
+    TTransitionMeta
   >;
-  parent?: StateNode<TContext, TEvent>;
+  parent?: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>;
   /**
    * The meta data associated with this state node, which will be returned in
    * State instances.
    */
-  meta?: TMeta;
+  meta?: TStateMeta;
   /**
    * The output data sent with the "xstate.done.state._id_" event if this is a
    * final state node.
@@ -1047,7 +1083,8 @@ export interface StateNodeConfig<
     TAction,
     TGuard,
     TDelay,
-    TEmitted
+    TEmitted,
+    TTransitionMeta
   >;
 }
 
@@ -1059,7 +1096,8 @@ export interface RouteTransitionConfig<
   TAction extends ParameterizedObject,
   TGuard extends ParameterizedObject,
   TDelay extends string,
-  TEmitted extends EventObject
+  TEmitted extends EventObject,
+  TTransitionMeta extends MetaObject = MetaObject
 > {
   guard?: Guard<TContext, TExpressionEvent, undefined, TGuard>;
   actions?: Actions<
@@ -1073,7 +1111,7 @@ export interface RouteTransitionConfig<
     TDelay,
     TEmitted
   >;
-  meta?: Record<string, any>;
+  meta?: TTransitionMeta;
   description?: string;
 }
 
@@ -1087,26 +1125,31 @@ export type AnyStateNodeConfig = StateNodeConfig<
   any,
   any,
   any, // emitted
-  any // meta
+  any, // state meta
+  any // transition meta
 >;
 
 export interface StateNodeDefinition<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TStateMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > {
   id: string;
   version?: string | undefined;
   key: string;
   type: 'atomic' | 'compound' | 'parallel' | 'final' | 'history';
-  initial: InitialTransitionDefinition<TContext, TEvent> | undefined;
+  initial:
+    | InitialTransitionDefinition<TContext, TEvent, TTransitionMeta>
+    | undefined;
   history: boolean | 'shallow' | 'deep' | undefined;
-  states: StatesDefinition<TContext, TEvent>;
-  on: TransitionDefinitionMap<TContext, TEvent>;
-  transitions: Array<TransitionDefinition<TContext, TEvent>>;
+  states: StatesDefinition<TContext, TEvent, TStateMeta, TTransitionMeta>;
+  on: TransitionDefinitionMap<TContext, TEvent, TTransitionMeta>;
+  transitions: Array<TransitionDefinition<TContext, TEvent, TTransitionMeta>>;
   // TODO: establish what a definition really is
   entry: UnknownAction[];
   exit: UnknownAction[];
-  meta: any;
+  meta: TStateMeta | undefined;
   order: number;
   output?: StateNodeConfig<
     TContext,
@@ -1118,7 +1161,8 @@ export interface StateNodeDefinition<
     string,
     unknown,
     EventObject, // TEmitted
-    any // TMeta
+    any, // TStateMeta
+    any // TTransitionMeta
   >['output'];
   invoke: Array<
     InvokeDefinition<
@@ -1138,8 +1182,10 @@ export interface StateNodeDefinition<
 
 export interface StateMachineDefinition<
   TContext extends MachineContext,
-  TEvent extends EventObject
-> extends StateNodeDefinition<TContext, TEvent> {}
+  TEvent extends EventObject,
+  TStateMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
+> extends StateNodeDefinition<TContext, TEvent, TStateMeta, TTransitionMeta> {}
 
 export type AnyStateNode = StateNode<any, any>;
 
@@ -1173,7 +1219,8 @@ export type AnyStateMachine = StateMachine<
   any, // output
   any, // emitted
   any, // TMeta
-  any // TStateSchema
+  any, // TStateSchema
+  any // TTransitionMeta
 >;
 
 export type AnyStateConfig = StateConfig<any, AnyEventObject>;
@@ -1417,7 +1464,8 @@ export type MachineConfig<
   TInput = any,
   TOutput = unknown,
   TEmitted extends EventObject = EventObject,
-  TMeta extends MetaObject = MetaObject
+  TStateMeta extends MetaObject = MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > = (Omit<
   StateNodeConfig<
     DoNotInfer<TContext>,
@@ -1429,7 +1477,8 @@ export type MachineConfig<
     DoNotInfer<TTag>,
     DoNotInfer<TOutput>,
     DoNotInfer<TEmitted>,
-    DoNotInfer<TMeta>
+    DoNotInfer<TStateMeta>,
+    DoNotInfer<TTransitionMeta>
   >,
   'output'
 > & {
@@ -1461,7 +1510,8 @@ export interface SetupTypes<
   TInput,
   TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > {
   context?: TContext;
   events?: TEvent;
@@ -1470,7 +1520,12 @@ export interface SetupTypes<
   input?: TInput;
   output?: TOutput;
   emitted?: TEmitted;
-  meta?: TMeta;
+  /** State-node metadata. Retained as the shared metadata declaration for compatibility. */
+  meta?: TStateMeta;
+  /** State-node metadata. */
+  stateMeta?: TStateMeta;
+  /** Transition metadata. */
+  transitionMeta?: TTransitionMeta;
 }
 
 export interface MachineTypes<
@@ -1484,7 +1539,8 @@ export interface MachineTypes<
   TInput,
   TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject = TStateMeta
 > extends SetupTypes<
   TContext,
   TEvent,
@@ -1495,13 +1551,16 @@ export interface MachineTypes<
   TInput,
   TOutput,
   TEmitted,
-  TMeta
+  TStateMeta,
+  TTransitionMeta
 > {
   actors?: TActor;
   actions?: TAction;
   guards?: TGuard;
   delays?: TDelay;
-  meta?: TMeta;
+  meta?: TStateMeta;
+  stateMeta?: TStateMeta;
+  transitionMeta?: TTransitionMeta;
 }
 
 export interface HistoryStateNode<
@@ -1722,7 +1781,8 @@ export type Mapper<
 
 export interface TransitionDefinition<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TTransitionMeta extends MetaObject = MetaObject
 > extends Omit<
   TransitionConfig<
     TContext,
@@ -1733,7 +1793,7 @@ export interface TransitionDefinition<
     TODO,
     TODO,
     TODO, // TEmitted
-    TODO // TMeta
+    TTransitionMeta
   >,
   | 'target'
   // `guard` is correctly rejected by `extends` here and `actions` should be too
@@ -1741,8 +1801,10 @@ export interface TransitionDefinition<
   // it doesn't exactly have to be incorrect, we are overriding this here anyway but it looks like a lucky accident rather than smth done on purpose
   | 'guard'
 > {
-  target: ReadonlyArray<StateNode<TContext, TEvent>> | undefined;
-  source: StateNode<TContext, TEvent>;
+  target:
+    | ReadonlyArray<StateNode<TContext, TEvent, any, TTransitionMeta>>
+    | undefined;
+  source: StateNode<TContext, TEvent, any, TTransitionMeta>;
   actions: readonly UnknownAction[];
   reenter: boolean;
   guard?: UnknownGuard;
@@ -1753,33 +1815,36 @@ export interface TransitionDefinition<
     actions: readonly UnknownAction[];
     guard?: UnknownGuard;
     eventType: EventDescriptor<TEvent>;
-    meta?: Record<string, any>;
+    meta?: TTransitionMeta;
   };
 }
 
-export type AnyTransitionDefinition = TransitionDefinition<any, any>;
+export type AnyTransitionDefinition = TransitionDefinition<any, any, any>;
 
 export interface InitialTransitionDefinition<
   TContext extends MachineContext,
-  TEvent extends EventObject
-> extends TransitionDefinition<TContext, TEvent> {
-  target: ReadonlyArray<StateNode<TContext, TEvent>>;
+  TEvent extends EventObject,
+  TTransitionMeta extends MetaObject = MetaObject
+> extends TransitionDefinition<TContext, TEvent, TTransitionMeta> {
+  target: ReadonlyArray<StateNode<TContext, TEvent, any, TTransitionMeta>>;
   guard?: never;
 }
 
 export type TransitionDefinitionMap<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TTransitionMeta extends MetaObject = MetaObject
 > = {
   [K in EventDescriptor<TEvent>]: Array<
-    TransitionDefinition<TContext, ExtractEvent<TEvent, K>>
+    TransitionDefinition<TContext, ExtractEvent<TEvent, K>, TTransitionMeta>
   >;
 };
 
 export interface DelayedTransitionDefinition<
   TContext extends MachineContext,
-  TEvent extends EventObject
-> extends TransitionDefinition<TContext, TEvent> {
+  TEvent extends EventObject,
+  TTransitionMeta extends MetaObject = MetaObject
+> extends TransitionDefinition<TContext, TEvent, TTransitionMeta> {
   delay: number | string | DelayExpr<TContext, TEvent, undefined, TEvent>;
 }
 
@@ -1815,7 +1880,8 @@ export interface StateConfig<
     any,
     any,
     any, // TMeta
-    any // TStateSchema
+    any, // TStateSchema
+    any // TTransitionMeta
   >;
 }
 
@@ -2099,7 +2165,8 @@ export type ActorLogicFrom<T> =
         any,
         any,
         any, // TMeta
-        any // TStateSchema
+        any, // TStateSchema
+        any // TTransitionMeta
       >
       ? R
       : R extends Promise<infer U>
@@ -2124,7 +2191,8 @@ export type ActorRefFrom<T> =
         infer TOutput,
         infer TEmitted,
         infer TMeta,
-        infer TStateSchema
+        infer TStateSchema,
+        infer _TTransitionMeta
       >
       ? ActorRef<
           MachineSnapshot<
@@ -2179,7 +2247,8 @@ export type InterpreterFrom<
     infer TOutput,
     infer TEmitted,
     infer TMeta,
-    infer TStateSchema
+    infer TStateSchema,
+    infer _TTransitionMeta
   >
     ? Actor<
         ActorLogic<
@@ -2218,7 +2287,8 @@ export type MachineImplementationsFrom<
     infer _TOutput,
     infer TEmitted,
     infer _TMeta,
-    infer _TStateSchema
+    infer _TStateSchema,
+    infer _TTransitionMeta
   >
     ? InternalMachineImplementations<
         ResolvedStateMachineTypes<
@@ -2438,7 +2508,8 @@ type ResolveEventType<T> =
         infer _TOutput,
         infer _TEmitted,
         infer _TMeta,
-        infer _TStateSchema
+        infer _TStateSchema,
+        infer _TTransitionMeta
       >
       ? TEvent
       : R extends MachineSnapshot<
@@ -2479,7 +2550,8 @@ export type ContextFrom<T> =
         infer _TOutput,
         infer _TEmitted,
         infer _TMeta,
-        infer _TStateSchema
+        infer _TStateSchema,
+        infer _TTransitionMeta
       >
       ? TContext
       : R extends MachineSnapshot<
@@ -2508,7 +2580,8 @@ export type ContextFrom<T> =
               infer _TOutput,
               infer _TEmitted,
               infer _TMeta,
-              infer _TStateSchema
+              infer _TStateSchema,
+              infer _TTransitionMeta
             >
             ? TContext
             : never
@@ -2621,7 +2694,8 @@ export type StateSchemaFrom<T extends AnyStateMachine> =
     infer _TOutput,
     infer _TEmitted,
     infer _TMeta,
-    infer TStateSchema
+    infer TStateSchema,
+    infer _TTransitionMeta
   >
     ? TStateSchema
     : never;
@@ -2788,7 +2862,8 @@ export type ExecutableActionsFrom<T extends AnyActorLogic> =
     infer _TOutput,
     infer _TEmitted,
     infer _TMeta,
-    infer _TStateSchema
+    infer _TStateSchema,
+    infer _TTransitionMeta
   >
     ?
         | SpecialExecutableAction

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -385,7 +385,7 @@ export interface InvokeDefinition<
   TGuard extends ParameterizedObject,
   TDelay extends string,
   TEmitted extends EventObject,
-  TMeta extends MetaObject
+  TTransitionMeta extends MetaObject
 > {
   id: string;
 
@@ -412,7 +412,7 @@ export interface InvokeDefinition<
           TGuard,
           TDelay,
           TEmitted,
-          TMeta
+          TTransitionMeta
         >
       >;
   /**
@@ -431,7 +431,7 @@ export interface InvokeDefinition<
           TGuard,
           TDelay,
           TEmitted,
-          TMeta
+          TTransitionMeta
         >
       >;
 
@@ -447,7 +447,7 @@ export interface InvokeDefinition<
           TGuard,
           TDelay,
           TEmitted,
-          TMeta
+          TTransitionMeta
         >
       >;
 
@@ -460,7 +460,7 @@ export interface InvokeDefinition<
       TGuard,
       TDelay,
       TEmitted,
-      TMeta
+      TTransitionMeta
     >,
     'onDone' | 'onError' | 'toJSON'
   >;
@@ -1173,7 +1173,7 @@ export interface StateNodeDefinition<
       TODO,
       TODO,
       TODO, // TEmitted
-      TODO // TMeta
+      TTransitionMeta
     >
   >;
   description?: string;

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -420,7 +420,7 @@ describe('transition meta data', () => {
   it('infers distinct metadata types with createMachine', () => {
     const machine = createMachine({
       types: {
-        stateMeta: {} as { label: string },
+        meta: {} as { label: string },
         transitionMeta: {} as { trackingId: number }
       },
       meta: { label: 'root' },
@@ -438,7 +438,7 @@ describe('transition meta data', () => {
   it('supports distinct state and transition meta types', () => {
     const machine = setup({
       types: {
-        stateMeta: {} as { view: 'compact' | 'full' },
+        meta: {} as { view: 'compact' | 'full' },
         transitionMeta: {} as { analyticsEvent: string }
       }
     }).createMachine({
@@ -477,7 +477,7 @@ describe('transition meta data', () => {
   it('rejects state and transition metadata in the wrong positions', () => {
     setup({
       types: {
-        stateMeta: {} as { state: string },
+        meta: {} as { state: string },
         transitionMeta: {} as { transition: string }
       }
     }).createMachine({

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -536,7 +536,9 @@ describe('transition meta data', () => {
           },
           invoke: {
             src: 'child',
-            onDone: { meta: { source: 'invoke' } }
+            onDone: { meta: { source: 'invoke.done' } },
+            onError: { meta: { source: 'invoke.error' } },
+            onSnapshot: { meta: { source: 'invoke.snapshot' } }
           }
         }
       }
@@ -551,6 +553,27 @@ describe('transition meta data', () => {
       | { source: string }
       | undefined;
 
+    type InvokeDefinition = (typeof machine.definition.states.idle.invoke)[0];
+    type SingleTransition<T> = Exclude<
+      NonNullable<T>,
+      string | readonly unknown[]
+    >;
+
+    (({}) as SingleTransition<InvokeDefinition['onDone']>).meta satisfies
+      | { source: string }
+      | undefined;
+    (({}) as SingleTransition<InvokeDefinition['onError']>).meta satisfies
+      | { source: string }
+      | undefined;
+    (({}) as SingleTransition<InvokeDefinition['onSnapshot']>).meta satisfies
+      | { source: string }
+      | undefined;
+
+    // @ts-expect-error invoke callback metadata is transition metadata
+    (({}) as SingleTransition<InvokeDefinition['onDone']>).meta satisfies
+      | { unknown: string }
+      | undefined;
+
     expect(machine.root.initial.meta).toEqual({ source: 'initial' });
     expect(machine.definition.initial?.meta).toEqual({ source: 'initial' });
     expect(JSON.parse(JSON.stringify(machine)).initial.meta).toEqual({
@@ -562,7 +585,13 @@ describe('transition meta data', () => {
       [...machine.states.idle.transitions.values()]
         .flat()
         .map((transition) => transition.meta)
-    ).toContainEqual({ source: 'invoke' });
+    ).toEqual(
+      expect.arrayContaining([
+        { source: 'invoke.done' },
+        { source: 'invoke.error' },
+        { source: 'invoke.snapshot' }
+      ])
+    );
   });
 
   it('TS should error with unexpected transition meta property', () => {

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -417,6 +417,154 @@ describe('state meta data', () => {
 });
 
 describe('transition meta data', () => {
+  it('infers distinct metadata types with createMachine', () => {
+    const machine = createMachine({
+      types: {
+        stateMeta: {} as { label: string },
+        transitionMeta: {} as { trackingId: number }
+      },
+      meta: { label: 'root' },
+      on: {
+        NEXT: { meta: { trackingId: 42 } }
+      }
+    });
+
+    machine.root.meta satisfies { label: string } | undefined;
+    machine.root.transitions.get('NEXT')![0].meta satisfies
+      | { trackingId: number }
+      | undefined;
+  });
+
+  it('supports distinct state and transition meta types', () => {
+    const machine = setup({
+      types: {
+        stateMeta: {} as { view: 'compact' | 'full' },
+        transitionMeta: {} as { analyticsEvent: string }
+      }
+    }).createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          meta: { view: 'compact' },
+          on: {
+            NEXT: {
+              target: 'done',
+              meta: { analyticsEvent: 'next' }
+            }
+          }
+        },
+        done: {}
+      }
+    });
+
+    createActor(machine).getSnapshot().getMeta()['(machine).idle'] satisfies
+      | { view: 'compact' | 'full' }
+      | undefined;
+
+    machine.states.idle.transitions.get('NEXT')![0].meta satisfies
+      | { analyticsEvent: string }
+      | undefined;
+    machine.definition.states.idle.transitions[0].meta satisfies
+      | { analyticsEvent: string }
+      | undefined;
+
+    // @ts-expect-error state metadata is not transition metadata
+    machine.states.idle.transitions.get('NEXT')![0].meta satisfies
+      | { view: 'compact' | 'full' }
+      | undefined;
+  });
+
+  it('rejects state and transition metadata in the wrong positions', () => {
+    setup({
+      types: {
+        stateMeta: {} as { state: string },
+        transitionMeta: {} as { transition: string }
+      }
+    }).createMachine({
+      initial: 'idle',
+      states: {
+        idle: {
+          // @ts-expect-error transition metadata is invalid on a state node
+          meta: { transition: 'idle' },
+          on: {
+            NEXT: {
+              // @ts-expect-error state metadata is invalid on a transition
+              meta: { state: 'next' }
+            }
+          }
+        }
+      }
+    });
+  });
+
+  it('keeps types.meta as the shared metadata type for compatibility', () => {
+    const machine = setup({
+      types: {
+        meta: {} as { legacy: string }
+      }
+    }).createMachine({
+      meta: { legacy: 'state' },
+      on: {
+        NEXT: { meta: { legacy: 'transition' } }
+      }
+    });
+
+    machine.root.meta satisfies { legacy: string } | undefined;
+    machine.root.transitions.get('NEXT')![0].meta satisfies
+      | { legacy: string }
+      | undefined;
+  });
+
+  it('preserves transition meta on all transition definitions', () => {
+    const machine = setup({
+      types: {
+        transitionMeta: {} as { source: string }
+      },
+      actors: {
+        child: createMachine({})
+      }
+    }).createMachine({
+      initial: {
+        target: 'idle',
+        meta: { source: 'initial' }
+      },
+      states: {
+        idle: {
+          always: { meta: { source: 'always' } },
+          after: {
+            100: { meta: { source: 'after' } }
+          },
+          invoke: {
+            src: 'child',
+            onDone: { meta: { source: 'invoke' } }
+          }
+        }
+      }
+    });
+
+    machine.root.initial.meta satisfies { source: string } | undefined;
+    machine.states.idle.always![0].meta satisfies
+      | { source: string }
+      | undefined;
+    machine.states.idle.after[0].meta satisfies { source: string } | undefined;
+    [...machine.states.idle.transitions.values()].flat()[0].meta satisfies
+      | { source: string }
+      | undefined;
+
+    expect(machine.root.initial.meta).toEqual({ source: 'initial' });
+    expect(machine.definition.initial?.meta).toEqual({ source: 'initial' });
+    expect(JSON.parse(JSON.stringify(machine)).initial.meta).toEqual({
+      source: 'initial'
+    });
+    expect(machine.states.idle.always![0].meta).toEqual({ source: 'always' });
+    expect(machine.states.idle.after[0].meta).toEqual({ source: 'after' });
+    expect(
+      [...machine.states.idle.transitions.values()]
+        .flat()
+        .map((transition) => transition.meta)
+    ).toContainEqual({ source: 'invoke' });
+  });
+
   it('TS should error with unexpected transition meta property', () => {
     setup({
       types: {


### PR DESCRIPTION
## Summary

- add `types.transitionMeta` as an optional override for transition metadata
- keep `types.meta` as state metadata and the transition metadata fallback for backward compatibility
- preserve transition metadata types through `setup`, `createMachine`, state nodes, machine definitions, transition definitions, and invoke callbacks (`onDone`, `onError`, and `onSnapshot`)
- retain initial-transition metadata and descriptions in definitions and serialized output
- keep heterogeneous global inspection events on `AnyTransitionDefinition`

## Example

```ts
const machine = setup({
  types: {
    meta: {} as { label: string },
    transitionMeta: {} as { trackingId: number }
  }
}).createMachine({
  meta: { label: 'Root' },
  on: {
    NEXT: { meta: { trackingId: 42 } }
  }
});
```

When `transitionMeta` is omitted, `types.meta` continues to type both state and transition metadata.

## Verification

- `pnpm typecheck --pretty false`
- `pnpm test:core` (1,753 passed; 13 skipped; 1 todo)
- `pnpm lint`
- `pnpm format:check`
- `git diff --check origin/main...HEAD`
