### PR TITLE
Fix state input on non-reentering transitions

### DIFF
--- a/.changeset/tidy-state-input-reentry.md
+++ b/.changeset/tidy-state-input-reentry.md
@@ -1,0 +1,6 @@
+---
+'xstate': patch
+---
+
+Preserve a state's existing input when a transition targets that state without
+reentering it. Reentering transitions continue to replace the state input.

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1859,7 +1859,9 @@ function microstep(
       for (const transition of filteredTransitions) {
         const { targets, input } = getCurrentTransitionResult(transition);
         if (input && targets) {
-          for (const targetNode of targets) {
+          for (const targetNode of targets.filter((targetNode) =>
+            statesToEnter.has(targetNode)
+          )) {
             stateInputMap[targetNode.id] = input;
             stateInputsChanged = true;
           }

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1801,6 +1801,10 @@ function microstep(
         }
       };
 
+      const enteredTargetsByTransition = new Map<
+        AnyTransitionDefinition,
+        Set<AnyStateNode>
+      >();
       for (const transition of filteredTransitions) {
         const domain = getTransitionDomain(
           transition,
@@ -1809,6 +1813,8 @@ function microstep(
         );
 
         const { targets, reenter } = getCurrentTransitionResult(transition);
+        const enteredTargets = new Set<AnyStateNode>();
+        enteredTargetsByTransition.set(transition, enteredTargets);
 
         for (const targetNode of targets ?? []) {
           if (
@@ -1817,6 +1823,7 @@ function microstep(
               transition.source !== domain ||
               reenter)
           ) {
+            enteredTargets.add(targetNode);
             statesToEnter.add(targetNode);
             statesForDefaultEntry.add(targetNode);
           }
@@ -1860,7 +1867,7 @@ function microstep(
         const { targets, input } = getCurrentTransitionResult(transition);
         if (input && targets) {
           for (const targetNode of targets.filter((targetNode) =>
-            statesToEnter.has(targetNode)
+            enteredTargetsByTransition.get(transition)?.has(targetNode)
           )) {
             stateInputMap[targetNode.id] = input;
             stateInputsChanged = true;

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1664,6 +1664,79 @@ describe('setup', () => {
     expect(actor.getSnapshot().context.count).toBe(90);
   });
 
+  it("a non-reentering self-transition cannot overwrite a concurrent transition's input", () => {
+    const s = setup({
+      schemas: {
+        events: {
+          GO: z.object({})
+        }
+      },
+      states: {
+        receiver: {
+          states: {
+            active: {
+              schemas: {
+                input: z.object({ value: z.number() })
+              }
+            }
+          }
+        },
+        sender: {
+          states: {
+            idle: {}
+          }
+        }
+      }
+    });
+    const entryInputs: Array<{ value: number }> = [];
+    const machine = s.createMachine({
+      type: 'parallel',
+      states: {
+        sender: {
+          initial: 'idle',
+          states: {
+            idle: {
+              on: {
+                GO: {
+                  target: '#active',
+                  input: { value: 2 }
+                } as any
+              }
+            }
+          }
+        },
+        receiver: {
+          initial: {
+            target: 'active',
+            input: { value: 1 }
+          },
+          states: {
+            active: {
+              id: 'active',
+              entry: ({ input }) => {
+                entryInputs.push(input);
+              },
+              on: {
+                GO: {
+                  target: '#active',
+                  input: { value: 99 }
+                } as any
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'GO' });
+
+    expect(entryInputs).toEqual([{ value: 1 }, { value: 2 }]);
+    expect(
+      (actor.getSnapshot().getInputs() as Record<string, unknown>)['active']
+    ).toEqual({ value: 2 });
+  });
+
   it("a compound state's input is replaced only when the state is re-entered", () => {
     const s = setup({
       schemas: {

--- a/packages/core/test/stateInput.test.ts
+++ b/packages/core/test/stateInput.test.ts
@@ -1595,6 +1595,148 @@ describe('setup', () => {
     });
   });
 
+  it("a self-transition's input only takes effect when the state is re-entered", () => {
+    const s = setup({
+      schemas: {
+        context: z.object({ count: z.number() }),
+        events: {
+          SET_MULTIPLIER_NO_REENTER: z.object({}),
+          SET_MULTIPLIER_REENTER: z.object({}),
+          MULTIPLY: z.object({})
+        }
+      },
+      states: {
+        active: {
+          schemas: {
+            input: z.object({ multiplier: z.number() })
+          }
+        }
+      }
+    });
+    const entryInputs: Array<{ multiplier: number }> = [];
+    const machine = s.createMachine({
+      context: { count: 1 },
+      initial: {
+        target: 'active',
+        input: { multiplier: 3 }
+      },
+      states: {
+        active: {
+          entry: ({ input }) => {
+            entryInputs.push(input);
+          },
+          on: {
+            SET_MULTIPLIER_NO_REENTER: {
+              target: 'active',
+              input: { multiplier: 99 }
+            },
+            SET_MULTIPLIER_REENTER: {
+              target: 'active',
+              reenter: true,
+              input: { multiplier: 10 }
+            },
+            MULTIPLY: ({ context, input }) => ({
+              context: { count: context.count * input.multiplier }
+            })
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    actor.send({ type: 'MULTIPLY' });
+    expect(actor.getSnapshot().context.count).toBe(3);
+
+    actor.send({ type: 'SET_MULTIPLIER_NO_REENTER' });
+    expect(entryInputs).toEqual([{ multiplier: 3 }]);
+    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
+      multiplier: 3
+    });
+    actor.send({ type: 'MULTIPLY' });
+    expect(actor.getSnapshot().context.count).toBe(9);
+
+    actor.send({ type: 'SET_MULTIPLIER_REENTER' });
+    expect(entryInputs).toEqual([{ multiplier: 3 }, { multiplier: 10 }]);
+    expect(actor.getSnapshot().getInputs()['(machine).active']).toEqual({
+      multiplier: 10
+    });
+    actor.send({ type: 'MULTIPLY' });
+    expect(actor.getSnapshot().context.count).toBe(90);
+  });
+
+  it("a compound state's input is replaced only when the state is re-entered", () => {
+    const s = setup({
+      schemas: {
+        events: {
+          PING: z.object({}),
+          PING_REENTER: z.object({})
+        }
+      },
+      states: {
+        parent: {
+          schemas: {
+            input: z.object({ value: z.number() })
+          },
+          states: {
+            child: {}
+          }
+        }
+      }
+    });
+    const parentInputs: Array<{ value: number }> = [];
+    const childEntries: string[] = [];
+    const machine = s.createMachine({
+      initial: {
+        target: 'parent',
+        input: { value: 1 }
+      },
+      states: {
+        parent: {
+          initial: 'child',
+          entry: ({ input }) => {
+            parentInputs.push(input);
+          },
+          on: {
+            PING: {
+              target: 'parent',
+              input: { value: 2 }
+            },
+            PING_REENTER: {
+              target: 'parent',
+              reenter: true,
+              input: { value: 3 }
+            }
+          },
+          states: {
+            child: {
+              entry: () => {
+                childEntries.push('child');
+              }
+            }
+          }
+        }
+      }
+    });
+
+    const actor = createActor(machine).start();
+    expect(parentInputs).toEqual([{ value: 1 }]);
+    expect(childEntries).toEqual(['child']);
+
+    actor.send({ type: 'PING' });
+    expect(parentInputs).toEqual([{ value: 1 }]);
+    expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+      value: 1
+    });
+    expect(childEntries).toEqual(['child', 'child']);
+
+    actor.send({ type: 'PING_REENTER' });
+    expect(parentInputs).toEqual([{ value: 1 }, { value: 3 }]);
+    expect(actor.getSnapshot().getInputs()['(machine).parent']).toEqual({
+      value: 3
+    });
+    expect(childEntries).toEqual(['child', 'child', 'child']);
+  });
+
   it('invoke transitions should require context for incompatible targets', () => {
     const s = setup({
       schemas: {


### PR DESCRIPTION
Redo of #5601 on current `next`.

Most of #5601's type-level behavior is already covered by #5690. This PR restores the remaining runtime guarantee: transition input only replaces stored state input when the target state is actually entered.

A non-reentering self-transition now preserves the active state's existing input. A reentering transition still resolves and replaces it.

Regression coverage includes atomic and compound states.

## Verification

- `pnpm exec vitest run packages/core/test/stateInput.test.ts`
- `pnpm test:core`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->