### PR TITLE
Fix `xstate/fsm` standalone typechecking and slim its type-import chain

### DIFF
--- a/.changeset/spotty-crabs-shave.md
+++ b/.changeset/spotty-crabs-shave.md
@@ -1,0 +1,5 @@
+---
+'xstate': patch
+---
+
+Importing only `xstate/fsm` now typechecks on its own. Previously, an fsm-only program failed with `Property 'observable' does not exist on type 'SymbolConstructor'` errors because the `Symbol.observable` type augmentation lived in the main entry. The `xstate/fsm` entry also no longer pulls the main entry's full type surface into the program, so editors and `tsc` check far less code for fsm-only consumers.

--- a/.github/actions/ci-checks/action.yml
+++ b/.github/actions/ci-checks/action.yml
@@ -15,7 +15,7 @@ runs:
       shell: bash
 
     - name: Typecheck
-      run: pnpm typecheck && pnpm typecheck:adapter-consumers
+      run: pnpm typecheck && pnpm typecheck:adapter-consumers && pnpm typecheck:fsm-only
       shell: bash
 
     - name: Test

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lint:fix": "oxlint --fix --report-unused-disable-directives-severity=error",
     "typecheck": "tsc",
     "typecheck:adapter-consumers": "tsc -p tsconfig.exact-optional.json",
+    "typecheck:fsm-only": "node scripts/typecheck-fsm-only.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:core": "vitest run --project xstate",

--- a/packages/core/src/base.types.ts
+++ b/packages/core/src/base.types.ts
@@ -1,0 +1,121 @@
+/**
+ * Lean type primitives shared by the main `xstate` entry and the compact
+ * `xstate/fsm` entry. This module (plus `schema.types.ts`) must stay free of
+ * imports from the rest of the package so that `xstate/fsm` consumers do not
+ * pull the full type surface into their program.
+ */
+import type {
+  SetupStateSchemas,
+  StandardSchemaV1,
+  TypeSchema
+} from './schema.types.ts';
+
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
+/** The full definition of an event, with a string `type`. */
+export type EventObject = {
+  /** The type of event that is sent. */
+  type: string;
+};
+
+export type MachineContext = Record<string, any>;
+
+export type Values<T> = T[keyof T];
+
+export type ActionSchemas = Record<string, { params: StandardSchemaV1 }>;
+
+export type GuardSchemas = Record<string, { params: StandardSchemaV1 }>;
+
+/** State node types that can be declared in a setup state contract. */
+export type SetupStateType =
+  | 'atomic'
+  | 'compound'
+  | 'parallel'
+  | 'final'
+  | 'history'
+  | 'choice';
+
+export type SetupSchemas = {
+  context?: StandardSchemaV1;
+  events?: Record<string, StandardSchemaV1>;
+  internalEvents?: Record<string, StandardSchemaV1>;
+  actions?: ActionSchemas;
+  guards?: GuardSchemas;
+  emitted?: Record<string, StandardSchemaV1>;
+  input?: StandardSchemaV1;
+  output?: StandardSchemaV1;
+  meta?: StandardSchemaV1;
+  tags?: StandardSchemaV1;
+  children?: Record<string, StandardSchemaV1>;
+};
+
+/**
+ * State schema with optional input/output schemas, structural metadata, and
+ * nested states.
+ *
+ * Structural fields are contracts/defaults for `createMachine(...)`; machine
+ * behavior remains authored in the machine config.
+ */
+export interface SetupStateSchema {
+  type?: SetupStateType;
+  id?: string;
+  initial?: string;
+  history?: 'shallow' | 'deep' | true;
+  target?: string | readonly [string, ...string[]];
+  route?: true;
+  schemas?: SetupStateSchemas;
+  states?: Record<string, SetupStateSchema>;
+}
+
+/**
+ * Event payloads from schemas (e.g. Zod) are often inferred as optional in
+ * output types. Wrapping in Required<> ensures properties defined in the schema
+ * are required on the event. Type-only schemas created with the `types()`
+ * helper are exempt: their declared type is authoritative, so optional
+ * properties stay optional.
+ */
+export type InferEvents<
+  TEventSchemaMap extends Record<string, StandardSchemaV1>
+> = Values<{
+  [K in keyof TEventSchemaMap & string]: StandardSchemaV1.InferOutput<
+    TEventSchemaMap[K]
+  > extends infer O
+    ? [O] extends [never]
+      ? never
+      : unknown extends O
+        ? O & { type: K }
+        : [O] extends [void]
+          ? { type: K }
+          : string extends keyof O
+            ? [O[string]] extends [never]
+              ? { type: EventTypeFromSchemaKey<K> }
+              : NormalizeEventPayload<TEventSchemaMap[K], O> & {
+                  type: EventTypeFromSchemaKey<K>;
+                }
+            : NormalizeEventPayload<TEventSchemaMap[K], O> & {
+                type: EventTypeFromSchemaKey<K>;
+              }
+    : never;
+}>;
+
+/** Infers internal events only from explicitly declared schema keys. */
+export type InferInternalEvents<
+  TEventSchemaMap extends Record<string, StandardSchemaV1>
+> = string extends keyof TEventSchemaMap ? never : InferEvents<TEventSchemaMap>;
+
+type EventTypeFromSchemaKey<TKey extends string> = TKey extends '*'
+  ? string
+  : TKey extends `${infer TLeading}.*`
+    ? `${TLeading}.${string}`
+    : TKey;
+
+/**
+ * Keeps a type-only schema's payload verbatim; applies Required<> to payloads
+ * from validator libraries (see {@link InferEvents}).
+ */
+type NormalizeEventPayload<TSchema extends StandardSchemaV1, O> =
+  TSchema extends TypeSchema<any> ? O : Required<O>;

--- a/packages/core/src/fsm.ts
+++ b/packages/core/src/fsm.ts
@@ -1,7 +1,11 @@
-import type { EventObject, MachineContext } from './types.ts';
+import type {
+  EventObject,
+  InferEvents,
+  MachineContext,
+  SetupSchemas,
+  SetupStateSchema
+} from './base.types.ts';
 import type { StandardSchemaV1 } from './schema.types.ts';
-import type { SetupSchemas, SetupStateSchema } from './setup.ts';
-import type { InferEvents } from './types.v6.ts';
 
 export type FSMArgs<
   TContext extends MachineContext,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -195,9 +195,3 @@ export {
   terminateActor
 } from './runtimeHelpers.ts';
 export { waitFor } from './waitFor.ts';
-
-declare global {
-  interface SymbolConstructor {
-    readonly observable: symbol;
-  }
-}

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -1,4 +1,9 @@
 import { SetupStateSchemas, StandardSchemaV1 } from './schema.types.ts';
+import type {
+  SetupSchemas,
+  SetupStateSchema,
+  SetupStateType
+} from './base.types.ts';
 import type { ActorLogicValidator } from './validation.types.ts';
 import { StateMachine } from './StateMachine.ts';
 import {
@@ -432,46 +437,11 @@ type ValidateRegistryKeys<
 
 export type { SetupStateSchemas };
 
-/** State node types that can be declared in a setup state contract. */
-export type SetupStateType =
-  | 'atomic'
-  | 'compound'
-  | 'parallel'
-  | 'final'
-  | 'history'
-  | 'choice';
-
-export type SetupSchemas = {
-  context?: StandardSchemaV1;
-  events?: Record<string, StandardSchemaV1>;
-  internalEvents?: Record<string, StandardSchemaV1>;
-  actions?: ActionSchemas;
-  guards?: GuardSchemas;
-  emitted?: Record<string, StandardSchemaV1>;
-  input?: StandardSchemaV1;
-  output?: StandardSchemaV1;
-  meta?: StandardSchemaV1;
-  tags?: StandardSchemaV1;
-  children?: Record<string, StandardSchemaV1>;
-};
-
-/**
- * State schema with optional input/output schemas, structural metadata, and
- * nested states.
- *
- * Structural fields are contracts/defaults for `createMachine(...)`; machine
- * behavior remains authored in the machine config.
- */
-export interface SetupStateSchema {
-  type?: SetupStateType;
-  id?: string;
-  initial?: string;
-  history?: 'shallow' | 'deep' | true;
-  target?: string | readonly [string, ...string[]];
-  route?: true;
-  schemas?: SetupStateSchemas;
-  states?: Record<string, SetupStateSchema>;
-}
+export type {
+  SetupSchemas,
+  SetupStateSchema,
+  SetupStateType
+} from './base.types.ts';
 
 type SetupSchema<
   TSchemas,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,6 +20,9 @@ import type { SimulatedClock } from './SimulatedClock.ts';
 import { Sources, Next_StateNodeConfig } from './types.v6.ts';
 import { StandardSchemaV1 } from './schema.types.ts';
 import { builtInActions } from './actions.ts';
+import type { EventObject, MachineContext, Values } from './base.types.ts';
+
+export type { EventObject, MachineContext, Values };
 
 export type Identity<T> = { [K in keyof T]: T[K] };
 
@@ -64,7 +67,6 @@ export type IsNotNever<T> = [T] extends [never] ? false : true;
 
 export type Compute<A> = { [K in keyof A]: A[K] } & unknown;
 export type Prop<T, K> = K extends keyof T ? T[K] : never;
-export type Values<T> = T[keyof T];
 export type Elements<T> = T[keyof T & `${number}`];
 export type Merge<M, N> = Omit<M, keyof N> & N;
 export type IndexByProp<T extends Record<P, string>, P extends keyof T> = {
@@ -96,12 +98,6 @@ export type MetaObject = Record<string, any>;
 
 export type Lazy<T> = () => T;
 export type MaybeLazy<T> = T | Lazy<T>;
-
-/** The full definition of an event, with a string `type`. */
-export type EventObject = {
-  /** The type of event that is sent. */
-  type: string;
-};
 
 export type EventPayloadPattern<TEvent extends EventObject> = TEvent extends any
   ? Partial<Omit<TEvent, 'type'>>
@@ -139,8 +135,6 @@ export type UnifiedArg<
   >;
   system: AnyActorSystem;
 } & OutputArg<TExpressionEvent>;
-
-export type MachineContext = Record<string, any>;
 
 type DoneEventType = 'xstate.done.actor' | 'xstate.done.state';
 

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -1,8 +1,12 @@
-import {
-  SetupStateSchemas,
-  StandardSchemaV1,
-  TypeSchema
-} from './schema.types.ts';
+import { SetupStateSchemas, StandardSchemaV1 } from './schema.types.ts';
+import type {
+  ActionSchemas,
+  GuardSchemas,
+  InferEvents,
+  InferInternalEvents
+} from './base.types.ts';
+
+export type { ActionSchemas, GuardSchemas, InferEvents, InferInternalEvents };
 import { MachineSnapshot } from './State';
 import {
   Action,
@@ -76,55 +80,6 @@ export type SchemaOrConfigOutput<
   ? OutputFromConfig<TConfig, InferOutput<TOutputSchema, unknown>>
   : InferOutput<TOutputSchema, unknown>;
 
-/**
- * Event payloads from schemas (e.g. Zod) are often inferred as optional in
- * output types. Wrapping in Required<> ensures properties defined in the schema
- * are required on the event. Type-only schemas created with the `types()`
- * helper are exempt: their declared type is authoritative, so optional
- * properties stay optional.
- */
-export type InferEvents<
-  TEventSchemaMap extends Record<string, StandardSchemaV1>
-> = Values<{
-  [K in keyof TEventSchemaMap & string]: StandardSchemaV1.InferOutput<
-    TEventSchemaMap[K]
-  > extends infer O
-    ? [O] extends [never]
-      ? never
-      : unknown extends O
-        ? O & { type: K }
-        : [O] extends [void]
-          ? { type: K }
-          : string extends keyof O
-            ? [O[string]] extends [never]
-              ? { type: EventTypeFromSchemaKey<K> }
-              : NormalizeEventPayload<TEventSchemaMap[K], O> & {
-                  type: EventTypeFromSchemaKey<K>;
-                }
-            : NormalizeEventPayload<TEventSchemaMap[K], O> & {
-                type: EventTypeFromSchemaKey<K>;
-              }
-    : never;
-}>;
-
-/** Infers internal events only from explicitly declared schema keys. */
-export type InferInternalEvents<
-  TEventSchemaMap extends Record<string, StandardSchemaV1>
-> = string extends keyof TEventSchemaMap ? never : InferEvents<TEventSchemaMap>;
-
-type EventTypeFromSchemaKey<TKey extends string> = TKey extends '*'
-  ? string
-  : TKey extends `${infer TLeading}.*`
-    ? `${TLeading}.${string}`
-    : TKey;
-
-/**
- * Keeps a type-only schema's payload verbatim; applies Required<> to payloads
- * from validator libraries (see {@link InferEvents}).
- */
-type NormalizeEventPayload<TSchema extends StandardSchemaV1, O> =
-  TSchema extends TypeSchema<any> ? O : Required<O>;
-
 export type InferChildren<
   TChildrenSchemaMap extends Record<string, StandardSchemaV1>
 > = string extends keyof TChildrenSchemaMap
@@ -136,10 +91,6 @@ export type InferChildren<
         ? NormalizeActorRef<StandardSchemaV1.InferOutput<TChildrenSchemaMap[K]>>
         : never;
     };
-
-export type ActionSchemas = Record<string, { params: StandardSchemaV1 }>;
-
-export type GuardSchemas = Record<string, { params: StandardSchemaV1 }>;
 
 export type InferActions<TActionSchemaMap extends ActionSchemas> =
   string extends keyof TActionSchemaMap

--- a/scripts/typecheck-fixtures/fsm-only-consumer.ts
+++ b/scripts/typecheck-fixtures/fsm-only-consumer.ts
@@ -1,0 +1,52 @@
+// Compiled in isolation by `pnpm typecheck:fsm-only` (tsconfig.fsm-only.json)
+// to guarantee that a consumer importing only `xstate/fsm` typechecks without
+// the main entry in the program — no `Symbol.observable` augmentation errors
+// and no dependency on the full `types.ts` surface.
+import { createFSM, setup, types } from '../../packages/core/src/fsm/index.ts';
+
+type Context = { count: number };
+type Event = { type: 'inc'; by: number } | { type: 'reset' };
+
+const machine = createFSM<Context, Event, { active: unknown }>({
+  initial: 'active',
+  context: { count: 0 },
+  states: {
+    active: {
+      on: {
+        inc: ({ context, event }) => ({
+          context: { count: context.count + event.by }
+        }),
+        reset: { context: { count: 0 } }
+      }
+    }
+  }
+});
+
+const next = machine.transition(machine.initialState, { type: 'inc', by: 1 });
+const _count: number = next.context.count;
+
+const machineWithSchemas = setup({
+  schemas: {
+    context: types<Context>(),
+    events: {
+      inc: types<{ by: number }>()
+    }
+  }
+}).createFSM({
+  initial: 'active',
+  context: { count: 0 },
+  states: {
+    active: {
+      on: {
+        inc: ({ context, event }) => ({
+          context: { count: context.count + event.by }
+        })
+      }
+    }
+  }
+});
+
+machineWithSchemas.transition(machineWithSchemas.initialState, {
+  type: 'inc',
+  by: 2
+});

--- a/scripts/typecheck-fsm-only.mjs
+++ b/scripts/typecheck-fsm-only.mjs
@@ -1,0 +1,49 @@
+// Compiles an fsm-only consumer in isolation (tsconfig.fsm-only.json) and
+// asserts the resulting program stays lean: the `xstate/fsm` entry must not
+// pull the main entry's type surface (types.ts, setup.ts, etc.) back in.
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const allowedProgramFiles = new Set([
+  'packages/core/src/schema.types.ts',
+  'packages/core/src/base.types.ts',
+  'packages/core/src/fsm.ts',
+  'packages/core/src/fsm/index.ts',
+  'scripts/typecheck-fixtures/fsm-only-consumer.ts'
+]);
+
+let stdout;
+try {
+  stdout = execFileSync(
+    'npx',
+    ['tsc', '-p', 'tsconfig.fsm-only.json', '--listFiles'],
+    { cwd: root, encoding: 'utf8' }
+  );
+} catch (error) {
+  process.stderr.write(error.stdout ?? '');
+  process.stderr.write(error.stderr ?? '');
+  console.error('\nfsm-only typecheck failed.');
+  process.exit(1);
+}
+
+const unexpected = stdout
+  .split('\n')
+  .filter((line) => line.trim() !== '' && !line.includes('node_modules'))
+  .map((line) => path.relative(root, line.trim()))
+  .filter((file) => !allowedProgramFiles.has(file));
+
+if (unexpected.length > 0) {
+  console.error(
+    'The xstate/fsm entry pulled unexpected files into an fsm-only program:\n' +
+      unexpected.map((file) => `  ${file}`).join('\n') +
+      '\n\nKeep the fsm type-import chain limited to base.types.ts and ' +
+      'schema.types.ts (or update the allowlist in scripts/typecheck-fsm-only.mjs ' +
+      'if a new lean module is intentional).'
+  );
+  process.exit(1);
+}
+
+console.log('fsm-only typecheck passed with a lean program.');

--- a/tsconfig.fsm-only.json
+++ b/tsconfig.fsm-only.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "include": ["scripts/typecheck-fixtures/fsm-only-consumer.ts"],
+  "exclude": []
+}


### PR DESCRIPTION
## Problem

1. A consumer importing only `xstate/fsm` failed typechecking with `TS2339: Property 'observable' does not exist on type 'SymbolConstructor'` (×3): the fsm type chain reached `types.ts`, which uses `Symbol.observable`, but the `declare global` augmentation lived only in the main entry's `index.ts`.
2. The `xstate/fsm` entry pulled the entire `types.ts` surface (and everything it imports — `State`, `StateMachine`, `createActor`, …) into the program at type level, undercutting the compact entry's editor/tsc cost story.

## Changes

- New `packages/core/src/base.types.ts`: holds the `Symbol.observable` global augmentation plus the lean shared types (`EventObject`, `MachineContext`, `Values`, `SetupSchemas`, `SetupStateSchema`, `SetupStateType`, `ActionSchemas`, `GuardSchemas`, `InferEvents`, `InferInternalEvents`). It imports only `schema.types.ts`. The previous homes (`types.ts`, `setup.ts`, `types.v6.ts`) re-export them, so the public API is unchanged.
- `fsm.ts` imports types only from `base.types.ts` + `schema.types.ts`. An fsm-only program now contains just 4 small package files (`schema.types.ts`, `base.types.ts`, `fsm.ts`, `fsm/index.ts`) instead of the full type surface (verified with `tsc --listFiles`).
- New `pnpm typecheck:fsm-only` (wired into CI): compiles an isolated fsm-only consumer fixture and fails if the program pulls in files outside the lean allowlist.

## Notes

- `pnpm typecheck:adapter-consumers` fails on `main` too (pre-existing `exactOptionalPropertyTypes` errors); untouched here.
- The commented `xstate-fsm-env.d.ts` workaround in `examples/compact-fsm` (on the examples-corpus branch, not this one) can be removed once this merges.

## Verification

`pnpm typecheck`, `pnpm typecheck:fsm-only`, `pnpm test:core` (2481 passed), `pnpm lint`, `pnpm format:check`, `pnpm knip` all green.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5703" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->