### PR TITLE
Allow sending to typed child IDs

### DIFF
--- a/.changeset/typed-child-id-send-to.md
+++ b/.changeset/typed-child-id-send-to.md
@@ -1,0 +1,21 @@
+---
+'xstate': patch
+---
+
+Send events to statically declared children by id. Events are checked against
+the actor-ref protocol declared in `schemas.children`.
+
+```ts
+createMachine({
+  schemas: {
+    children: {
+      worker: types<ActorRefFromLogic<typeof workerLogic>>()
+    }
+  },
+  on: {
+    notify: (_, enq) => {
+      enq.sendTo('worker', { type: 'notify' });
+    }
+  }
+});
+```

--- a/docs/actions.md
+++ b/docs/actions.md
@@ -19,7 +19,7 @@ entry: ({ context }, enq) => {
 | --- | --- |
 | `enq(...)` | Enqueue an effect function. |
 | `enq.raise(...)` | Send an event to the same actor. |
-| `enq.sendTo(...)` | Send an event to another actor. |
+| `enq.sendTo(...)` | Send an event to an actor ref or a statically declared child id. |
 | `enq.spawn(...)` | Spawn a child from actor logic or its typed registered name. |
 | `enq.stop(...)` | Stop an actor. |
 | `enq.cancel(...)` | Cancel a delayed event. |
@@ -40,7 +40,9 @@ Use actions for work such as:
 
 ## TypeScript
 
-Action arguments are inferred from context and event schemas.
+Action arguments are inferred from context and event schemas. A child declared
+in `schemas.children` can be addressed by id; its actor-ref schema determines
+which events are accepted.
 
 ## Actions cheatsheet
 
@@ -48,8 +50,8 @@ Action arguments are inferred from context and event schemas.
 entry: (_, enq) => enq(() => startEffect())
 exit: (_, enq) => enq(() => stopEffect())
 on: {
-  ping: ({ children }, enq) => {
-    enq.sendTo(children.worker, { type: 'ping' });
+  ping: (_, enq) => {
+    enq.sendTo('worker', { type: 'ping' });
   }
 }
 ```

--- a/docs/invoke.md
+++ b/docs/invoke.md
@@ -232,7 +232,15 @@ setup({}).createMachine({
 });
 ```
 
-`children.payment` is then typed, `children.other` is a type error, and invoking incompatible logic under `id: 'payment'` is rejected.
+`children.payment` is then typed, `children.other` is a type error, and invoking incompatible logic under `id: 'payment'` is rejected. The id can also be used directly with `enq.sendTo`; the event is checked against the declared actor ref:
+
+```ts
+on: {
+  retry: (_, enq) => {
+    enq.sendTo('payment', { type: 'retry' });
+  }
+}
+```
 
 ## Invoke cheatsheet
 

--- a/docs/spawn.md
+++ b/docs/spawn.md
@@ -203,7 +203,10 @@ schemas: {
 }
 ```
 
-`children.connection` is then typed, and unknown keys are type errors. Dynamic children keyed by a runtime id stay typed through the context array instead.
+`children.connection` is then typed, unknown keys are type errors, and
+`enq.sendTo('connection', event)` checks the event against the declared actor
+ref. Dynamic children keyed by a runtime id stay typed through their returned
+refs or refs stored in context.
 
 ## Spawn cheatsheet
 
@@ -211,6 +214,7 @@ schemas: {
 const child = enq.spawn(logic, { id, input, registryKey, syncSnapshot: true });
 const durableChild = enq.spawn('registeredSource', { id, input });
 enq.sendTo(child, { type: 'start' });
+enq.sendTo('connection', { type: 'start' });
 enq.subscribeTo(child, { done: (output) => ({ type: 'finished', output }) });
 enq.stop(child);
 ```

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -3644,7 +3644,7 @@ type StateTransitionFunction<
     delays: TDelayMap;
     input: TInput;
   } & OutputArg<TExpressionEvent>,
-  enq: EnqueueObject<TEvent, TEmitted, TSystemRegistry, TActorMap>
+  enq: EnqueueObject<TEvent, TEmitted, TSystemRegistry, TActorMap, TChildren>
 ) => StateTransitionResult<
   TStateSchemas,
   TContext,

--- a/packages/core/src/stateUtils.ts
+++ b/packages/core/src/stateUtils.ts
@@ -1593,7 +1593,8 @@ function microstep(
           nextState,
           event,
           actorScope,
-          exitActions
+          exitActions,
+          internalQueue
         );
         nextState = resolvedState;
         executableActions.push(...resolvedActions);
@@ -1607,7 +1608,8 @@ function microstep(
             nextState,
             event,
             actorScope,
-            invokeStopActions
+            invokeStopActions,
+            internalQueue
           );
           nextState = stoppedState;
           executableActions.push(...stopEffects);
@@ -2011,7 +2013,8 @@ function microstep(
           nextState,
           event,
           actorScope,
-          actions
+          actions,
+          internalQueue
         );
         nextState = resolvedState;
         actions.length = 0;
@@ -2118,7 +2121,8 @@ function microstep(
         nextState,
         event,
         actorScope,
-        transitionActions
+        transitionActions,
+        internalQueue
       );
     nextState = resolvedTransitionState;
     executableActions.push(...transitionExecutableActions);
@@ -2159,7 +2163,8 @@ function microstep(
         nextState,
         event,
         actorScope,
-        allExitActions
+        allExitActions,
+        internalQueue
       );
       nextState = resolvedState;
       executableActions.push(...resolvedActions);

--- a/packages/core/src/transitionActions.ts
+++ b/packages/core/src/transitionActions.ts
@@ -1043,7 +1043,9 @@ export function resolveActionsWithContext(
       typeof actionRecord.args[1] === 'string'
     ) {
       const childId = actionRecord.args[1];
-      const target = intermediateSnapshot.children[childId];
+      const target = Object.hasOwn(intermediateSnapshot.children, childId)
+        ? intermediateSnapshot.children[childId]
+        : undefined;
       if (!target) {
         internalEvents?.push(
           createErrorPlatformEvent('communication', {

--- a/packages/core/src/transitionActions.ts
+++ b/packages/core/src/transitionActions.ts
@@ -1003,7 +1003,8 @@ export function resolveActionsWithContext(
   currentSnapshot: AnyMachineSnapshot,
   event: AnyEventObject,
   actorScope: AnyActorScope,
-  actions: AnyAction[]
+  actions: AnyAction[],
+  internalEvents?: EventObject[]
 ): [AnyMachineSnapshot, ExecutableActionObject[]] {
   let intermediateSnapshot = currentSnapshot;
   const executableActions: ExecutableActionObject[] = [];
@@ -1035,11 +1036,34 @@ export function resolveActionsWithContext(
 
     const isInline = typeof action === 'function';
     const actionRecord = getTransitionActionRecord(action);
+    let resolvedActionArgs = actionRecord?.args;
+
+    if (
+      actionRecord?.action === builtInActions['@xstate.sendTo'] &&
+      typeof actionRecord.args[1] === 'string'
+    ) {
+      const childId = actionRecord.args[1];
+      const target = intermediateSnapshot.children[childId];
+      if (!target) {
+        internalEvents?.push(
+          createErrorPlatformEvent('communication', {
+            message: `Unable to send event to unknown child '${childId}'`,
+            event: actionRecord.args[2]
+          })
+        );
+        continue;
+      }
+      resolvedActionArgs = [
+        actionRecord.args[0],
+        target,
+        ...actionRecord.args.slice(2)
+      ];
+    }
 
     const resolvedAction = isInline
       ? action
       : actionRecord
-        ? actionRecord.action.bind(null, ...actionRecord.args)
+        ? actionRecord.action.bind(null, ...resolvedActionArgs!)
         : false;
 
     let actionParams = undefined;
@@ -1114,7 +1138,7 @@ export function resolveActionsWithContext(
         action !== null &&
         'action' in action &&
         typeof action.action === 'function'
-          ? getBuiltInActionFields(action.action, action.args)
+          ? getBuiltInActionFields(action.action, resolvedActionArgs!)
           : undefined;
       const isEmittedEvent =
         typeof action === 'object' && action !== null && !actionRecord;
@@ -1133,7 +1157,9 @@ export function resolveActionsWithContext(
             : action.name || '(anonymous)',
         params: builtInFields ? undefined : actionParams,
         args:
-          typeof action === 'object' && 'action' in action ? action.args : [],
+          typeof action === 'object' && 'action' in action
+            ? resolvedActionArgs!
+            : [],
         ...(builtInFields
           ? {}
           : isEmittedEvent

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -593,7 +593,8 @@ export type TransitionConfigFunction<
   TDelayMap extends Sources['delays'],
   TMeta extends MetaObject,
   TInput = undefined,
-  _TCtx extends MachineContext = [TContext] extends [never] ? any : TContext
+  _TCtx extends MachineContext = [TContext] extends [never] ? any : TContext,
+  TChildren extends Record<string, AnyActorRef | undefined> = {}
 > = (
   args: TransitionFunctionArgs<
     _TCtx,
@@ -602,9 +603,10 @@ export type TransitionConfigFunction<
     TActionMap,
     TActorMap,
     TGuardMap,
-    TDelayMap
+    TDelayMap,
+    TChildren
   > & { input: TInput },
-  enq: EnqueueObject<TEvent, TEmitted, SystemRegistry, TActorMap>
+  enq: EnqueueObject<TEvent, TEmitted, SystemRegistry, TActorMap, TChildren>
 ) => {
   target?: string | string[];
   // target?: keyof TSS['states'];
@@ -621,7 +623,11 @@ type TransitionFunctionArgs<
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
-  TDelayMap extends Sources['delays']
+  TDelayMap extends Sources['delays'],
+  TChildren extends Record<string, AnyActorRef | undefined> = Record<
+    string,
+    AnyActor
+  >
 > = {
   context: TContext;
   event: TCurrentEvent;
@@ -640,7 +646,7 @@ type TransitionFunctionArgs<
   >;
   parent: UnknownActorRef | undefined;
   value: StateValue;
-  children: Record<string, AnyActor>;
+  children: TChildren;
   system: AnyActorSystem;
   actions: TActionMap;
   actors: TActorMap;
@@ -3106,7 +3112,8 @@ export type EnqueueObject<
   TEvent extends EventObject,
   TEmittedEvent extends EventObject,
   TSystemRegistry extends SystemRegistry = SystemRegistry,
-  TActorMap extends Sources['actors'] = Sources['actors']
+  TActorMap extends Sources['actors'] = Sources['actors'],
+  TChildren extends Record<string, AnyActorRef | undefined> = {}
 > = {
   cancel: (id: string) => void;
   raise: (ev: TEvent, options?: { id?: string; delay?: number }) => void;
@@ -3120,9 +3127,18 @@ export type EnqueueObject<
   emit: (emittedEvent: TEmittedEvent) => void;
   <T extends (...args: any[]) => any>(fn: T, ...args: Parameters<T>): void;
   log: (...args: any[]) => void;
-  sendTo: <TActorRef extends { send: (...args: any[]) => void } | undefined>(
-    actorRef: TActorRef,
-    event: SendableEventFromActorRef<NoInfer<TActorRef>>,
+  sendTo: <
+    TTarget extends
+      | { send: (...args: any[]) => void }
+      | undefined
+      | (keyof TChildren & string)
+  >(
+    target: TTarget,
+    event: SendableEventFromActorRef<
+      NoInfer<
+        TTarget extends keyof TChildren & string ? TChildren[TTarget] : TTarget
+      >
+    >,
     options?: { id?: string; delay?: number }
   ) => void;
   stop: (actor?: AnyActorRef) => void;

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -18,6 +18,7 @@ import {
   DoneActorEvent,
   DoNotInfer,
   ErrorActorEvent,
+  EnqueueObject,
   EventDescriptor,
   ErrorEvent,
   EventObject,
@@ -518,7 +519,8 @@ type InlineInvokeOnDone<
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
-  TMeta extends MetaObject
+  TMeta extends MetaObject,
+  TChildren extends Record<string, AnyActorRef | undefined>
 > = [keyof TActorMap & string] extends [never]
   ? Next_TransitionConfigOrTarget<
       TContext,
@@ -529,7 +531,9 @@ type InlineInvokeOnDone<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TMeta
+      TMeta,
+      undefined,
+      TChildren
     >
   : string extends keyof TActorMap
     ? Next_TransitionConfigOrTarget<
@@ -541,7 +545,9 @@ type InlineInvokeOnDone<
         TActorMap,
         TGuardMap,
         TDelayMap,
-        TMeta
+        TMeta,
+        undefined,
+        TChildren
       >
     :
         | undefined
@@ -596,7 +602,8 @@ type InlineChildInvokeConfig<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TMeta
+      TMeta,
+      TChildren
     >;
     id: K;
     src: LogicForChildRef<TChildren[K]>;
@@ -658,7 +665,8 @@ type InlineInvokeConfig<
           TActorMap,
           TGuardMap,
           TDelayMap,
-          TMeta
+          TMeta,
+          TChildren
         >;
         src: AnyActorLogic;
         input?:
@@ -803,7 +811,7 @@ interface Next_InvokeConfigBase<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TEmitted extends EventObject,
-  _TChildren extends Record<string, AnyActorRef | undefined>,
+  TChildren extends Record<string, AnyActorRef | undefined>,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
@@ -825,7 +833,9 @@ interface Next_InvokeConfigBase<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TMeta,
+    undefined,
+    TChildren
   >;
   onError?: Next_TransitionConfigOrTarget<
     TContext,
@@ -836,7 +846,9 @@ interface Next_InvokeConfigBase<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TMeta,
+    undefined,
+    TChildren
   >;
   onSnapshot?: Next_TransitionConfigOrTarget<
     TContext,
@@ -847,7 +859,9 @@ interface Next_InvokeConfigBase<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TMeta,
+    undefined,
+    TChildren
   >;
   /**
    * The duration (in ms) after which this invocation will time out if it has
@@ -870,7 +884,9 @@ interface Next_InvokeConfigBase<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TMeta,
+    undefined,
+    TChildren
   >;
 }
 
@@ -888,7 +904,8 @@ type StateAction<
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
-  TInput = Record<string, unknown> | undefined
+  TInput = Record<string, unknown> | undefined,
+  TChildren extends Record<string, AnyActorRef | undefined> = {}
 > = (
   _: Omit<
     Parameters<
@@ -905,18 +922,13 @@ type StateAction<
     >[0],
     'params'
   > & { input: TInput },
-  enqueue: Parameters<
-    Action<
-      TContext,
-      TEvent,
-      TEmittedEvent,
-      TActionMap,
-      TActorMap,
-      TGuardMap,
-      TDelayMap,
-      never
-    >
-  >[1]
+  enqueue: EnqueueObject<
+    TEvent,
+    TEmittedEvent,
+    SystemRegistry,
+    TActorMap,
+    TChildren
+  >
 ) => ReturnType<
   Action<
     TContext,
@@ -1243,7 +1255,8 @@ interface Next_RegularStateNodeConfig<
       TGuardMap,
       TDelayMap,
       TMeta,
-      TInput
+      TInput,
+      TChildren
     >;
   };
   /**
@@ -1269,7 +1282,8 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TInput
+    TInput,
+    TChildren
   >;
   exit?: StateAction<
     TContext,
@@ -1279,7 +1293,8 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TInput
+    TInput,
+    TChildren
   >;
   /**
    * The potential transition(s) to be taken upon reaching a final child state
@@ -1297,7 +1312,9 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TMeta,
+    undefined,
+    TChildren
   >;
   /**
    * The transition to take when an `xstate.error.*` event is raised while this
@@ -1312,7 +1329,9 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TMeta,
+    undefined,
+    TChildren
   >;
   /**
    * The mapping (or array) of delays (in milliseconds) to their potential
@@ -1332,7 +1351,9 @@ interface Next_RegularStateNodeConfig<
           TGuardMap,
           TDelayMap,
           TMeta,
-          TInput
+          TInput,
+          [TContext] extends [never] ? any : TContext,
+          TChildren
         >;
   };
 
@@ -1365,7 +1386,8 @@ interface Next_RegularStateNodeConfig<
     TGuardMap,
     TDelayMap,
     TMeta,
-    TInput
+    TInput,
+    TChildren
   >;
 
   /**
@@ -1381,7 +1403,9 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TMeta,
+    undefined,
+    TChildren
   >;
   choice?: never;
   /**
@@ -1430,7 +1454,8 @@ export type Next_TransitionConfigOrTarget<
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
   TMeta extends MetaObject,
-  TInput = undefined
+  TInput = undefined,
+  TChildren extends Record<string, AnyActorRef | undefined> = {}
 > =
   | undefined
   | {
@@ -1466,7 +1491,9 @@ export type Next_TransitionConfigOrTarget<
         TGuardMap,
         TDelayMap,
         TMeta,
-        TInput
+        TInput,
+        [TContext] extends [never] ? any : TContext,
+        TChildren
       >;
       context?:
         | TransitionContextPatch<TContext>
@@ -1496,7 +1523,9 @@ export type Next_TransitionConfigOrTarget<
       TGuardMap,
       TDelayMap,
       TMeta,
-      TInput
+      TInput,
+      [TContext] extends [never] ? any : TContext,
+      TChildren
     >;
 
 export type WithDefault<T, Default> = IsNever<T> extends true ? Default : T;

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2867,6 +2867,49 @@ describe('sendTo', () => {
     );
   });
 
+  it('should not resolve inherited properties as declared child ids', () => {
+    const errorSpy = vi.fn();
+    const childMachine = createMachine({
+      schemas: {
+        events: {
+          PING: z.object({})
+        }
+      }
+    });
+    const parentMachine = createMachine({
+      schemas: {
+        children: {
+          toString: z.custom<ActorRefFromLogic<typeof childMachine>>()
+        }
+      },
+      initial: 'active',
+      states: {
+        active: {
+          on: {
+            SEND: (_, enq) => {
+              enq.sendTo('toString', { type: 'PING' });
+            }
+          },
+          onError: ({ event }) => {
+            errorSpy(event.error);
+            return { target: 'failed' };
+          }
+        },
+        failed: {}
+      }
+    });
+
+    const parent = createActor(parentMachine).start();
+    parent.send({ type: 'SEND' });
+
+    expect(parent.getSnapshot().value).toBe('failed');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Unable to send event to unknown child 'toString'"
+      })
+    );
+  });
+
   it('should be able to send an event to an actor', () => {
     const { resolve, promise } = Promise.withResolvers<void>();
     const childMachine = createMachine({

--- a/packages/core/test/actions.test.ts
+++ b/packages/core/test/actions.test.ts
@@ -2753,6 +2753,120 @@ describe('sendParent', () => {
   });
 });
 describe('sendTo', () => {
+  it('should send to an invoked child by its declared id', async () => {
+    const received = vi.fn();
+    const childMachine = createMachine({
+      schemas: {
+        events: {
+          PING: z.object({ value: z.number() })
+        }
+      },
+      on: {
+        PING: ({ event }) => {
+          received(event.value);
+        }
+      }
+    });
+    const parentMachine = createMachine({
+      schemas: {
+        children: {
+          worker: z.custom<ActorRefFromLogic<typeof childMachine>>()
+        }
+      },
+      invoke: {
+        id: 'worker',
+        src: childMachine
+      },
+      on: {
+        SEND: (_, enq) => {
+          enq.sendTo('worker', { type: 'PING', value: 42 });
+        }
+      }
+    });
+
+    const parent = createActor(parentMachine).start();
+    parent.send({ type: 'SEND' });
+
+    expect(received).toHaveBeenCalledWith(42);
+  });
+
+  it('should resolve a child spawned earlier in the same transition', () => {
+    const received = vi.fn();
+    const childMachine = createMachine({
+      schemas: {
+        events: {
+          PING: z.object({})
+        }
+      },
+      on: {
+        PING: () => {
+          received();
+        }
+      }
+    });
+    const parentMachine = createMachine({
+      schemas: {
+        children: {
+          worker: z.custom<ActorRefFromLogic<typeof childMachine>>()
+        }
+      },
+      on: {
+        START: (_, enq) => {
+          enq.spawn(childMachine, { id: 'worker' });
+          enq.sendTo('worker', { type: 'PING' });
+        }
+      }
+    });
+
+    const parent = createActor(parentMachine).start();
+    parent.send({ type: 'START' });
+
+    expect(received).toHaveBeenCalledOnce();
+  });
+
+  it('should raise a communication error for an unknown declared child id', () => {
+    const errorSpy = vi.fn();
+    const childMachine = createMachine({
+      schemas: {
+        events: {
+          PING: z.object({})
+        }
+      }
+    });
+    const parentMachine = createMachine({
+      schemas: {
+        children: {
+          worker: z.custom<ActorRefFromLogic<typeof childMachine>>()
+        }
+      },
+      initial: 'active',
+      states: {
+        active: {
+          on: {
+            SEND: (_, enq) => {
+              enq.sendTo('worker', { type: 'PING' });
+            }
+          },
+          onError: ({ event }) => {
+            errorSpy(event.error);
+            return { target: 'failed' };
+          }
+        },
+        failed: {}
+      }
+    });
+
+    const parent = createActor(parentMachine).start();
+    parent.send({ type: 'SEND' });
+
+    expect(parent.getSnapshot().value).toBe('failed');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "Unable to send event to unknown child 'worker'"
+      })
+    );
+  });
+
   it('should be able to send an event to an actor', () => {
     const { resolve, promise } = Promise.withResolvers<void>();
     const childMachine = createMachine({

--- a/packages/core/test/types.test.ts
+++ b/packages/core/test/types.test.ts
@@ -5851,6 +5851,42 @@ describe('delays', () => {
     });
   });
 
+  it('should type enq.sendTo events against declared child ids', () => {
+    const child = createMachine({
+      schemas: {
+        events: {
+          PING: z.object({
+            type: z.literal('PING'),
+            value: z.number()
+          })
+        }
+      }
+    });
+
+    createMachine({
+      schemas: {
+        children: {
+          worker: z.custom<ActorRefFromLogic<typeof child>>()
+        }
+      },
+      invoke: {
+        id: 'worker',
+        src: child
+      },
+      on: {
+        SEND: (_, enq) => {
+          enq.sendTo('worker', { type: 'PING', value: 42 });
+          // @ts-expect-error unknown child id
+          enq.sendTo('missing', { type: 'PING', value: 42 });
+          // @ts-expect-error incompatible child event
+          enq.sendTo('worker', { type: 'PONG' });
+          // @ts-expect-error missing child event payload
+          enq.sendTo('worker', { type: 'PING' });
+        }
+      }
+    });
+  });
+
   it('should return typed actor refs from enq.spawn', () => {
     const child = createMachine({
       schemas: {


### PR DESCRIPTION
## Summary

- allow `enq.sendTo('childId', event)` for statically typed children
- infer accepted events from the actor ref declared in `schemas.children`
- resolve IDs against transition-ordered children, including children spawned earlier in the same transition
- raise a communication error when a declared child is unavailable
- document the API and add a patch changeset

## Verification

- `pnpm test:core` (2,490 passed; 33 skipped; 3 todo)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5707" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Send events directly to statically declared child actors by ID.
  * Receive type checking and event suggestions based on each child actor’s supported events.
  * Child actors created during a transition can also be targeted.

* **Bug Fixes**
  * Sending to an unknown child ID now reports a communication error that can be handled by the machine.

* **Documentation**
  * Updated action, invocation, and spawning guides with child-ID usage examples and typing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->