### PR TITLE
Add separate transition metadata schemas to v6

### DIFF
--- a/.changeset/quiet-pandas-track.md
+++ b/.changeset/quiet-pandas-track.md
@@ -1,0 +1,21 @@
+---
+'xstate': minor
+---
+
+State and transition metadata can now use separate schemas:
+
+```ts
+const machine = createMachine({
+  schemas: {
+    meta: z.object({ label: z.string() }),
+    transitionMeta: z.object({ trackingId: z.number() })
+  },
+  meta: { label: 'Root' },
+  on: {
+    NEXT: { meta: { trackingId: 42 } }
+  }
+});
+```
+
+When `transitionMeta` is omitted, `schemas.meta` continues to apply its type to
+both state and transition metadata.

--- a/docs/transitions.md
+++ b/docs/transitions.md
@@ -11,6 +11,8 @@ idle: { on: { start: { target: 'active' } } }
 
 ## Transition properties
 
+<!-- transition config properties from packages/core/src/types.v6.ts -->
+
 | Property | Description |
 | --- | --- |
 | `target` | Target state or states. |
@@ -20,6 +22,17 @@ idle: { on: { start: { target: 'active' } } }
 | `reenter` | Re-enter the source state when targeting it. |
 | `meta` | Per-transition metadata. |
 | `description` | Human-readable description. |
+
+Use `schemas.transitionMeta` to type transition metadata separately from state
+metadata. If omitted, transition metadata uses `schemas.meta` for backwards
+compatibility.
+
+```ts
+schemas: {
+  meta: z.object({ label: z.string() }),
+  transitionMeta: z.object({ trackingId: z.number() })
+}
+```
 
 There is no `guard` property. Conditions live inside the transition function, which returns `undefined` to reject the event. See [guards](guards.md).
 

--- a/docs/xstate-v5-to-v6.md
+++ b/docs/xstate-v5-to-v6.md
@@ -386,6 +386,7 @@ schemas: {
   input:    ZodSchema,                                  // machine input
   output:   ZodSchema,                                  // machine output
   meta:     ZodSchema,                                  // per-state meta
+  transitionMeta: ZodSchema,                            // per-transition meta
   tags:     z.enum([...]),                              // tag values
   children: { [childId: string]: ZodSchema }            // invoked/spawned child schemas
 }

--- a/packages/core/src/StateMachine.ts
+++ b/packages/core/src/StateMachine.ts
@@ -212,7 +212,8 @@ export class StateMachine<
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
   TDelayMap extends Sources['delays'],
-  TInternalEvent extends EventObject = never
+  TInternalEvent extends EventObject = never,
+  TTransitionMeta extends MetaObject = TMeta
 > implements ActorLogic<
   MachineSnapshot<
     TContext,
@@ -235,6 +236,8 @@ export class StateMachine<
    * one `undefined` property this emits per machine instance is inert.
    */
   readonly _internalEventType!: TInternalEvent;
+  /** @internal Type-only marker for transition metadata. */
+  readonly _transitionMetaType!: TTransitionMeta;
 
   /** The machine's own version. */
   public version?: string;
@@ -258,11 +261,11 @@ export class StateMachine<
   /** @internal */
   public idMap: Map<string, AnyStateNode> = new Map();
 
-  public root: StateNode<TContext, TEvent>;
+  public root: StateNode<TContext, TEvent, TMeta, TTransitionMeta>;
 
   public id: string;
 
-  public states: StateNode<TContext, TEvent>['states'];
+  public states: StateNode<TContext, TEvent, TMeta, TTransitionMeta>['states'];
   public events: Array<EventDescriptor<TEvent>>;
   public internalEventDescriptors: ReadonlyArray<string>;
   /** @internal Skips eventless-selection scans for machines without `always`. */
@@ -270,6 +273,7 @@ export class StateMachine<
   constructor(
     /** The raw config used to create the machine. */
     public config: Next_MachineConfig<
+      any,
       any,
       any,
       any,
@@ -458,10 +462,13 @@ export class StateMachine<
     this.restoreSnapshot = this.restoreSnapshot.bind(this);
     this.start = this.start.bind(this);
 
-    this.root = new StateNode(config as any, {
-      _key: this.id,
-      _machine: this as any
-    });
+    this.root = new StateNode<TContext, TEvent, TMeta, TTransitionMeta>(
+      config as any,
+      {
+        _key: this.id,
+        _machine: this as any
+      }
+    );
 
     this.root._initialize();
     formatRouteTransitions(this.root);
@@ -1281,7 +1288,9 @@ export class StateMachine<
     }
   }
 
-  public getStateNodeById(stateId: string): StateNode<TContext, TEvent> {
+  public getStateNodeById(
+    stateId: string
+  ): StateNode<TContext, TEvent, TMeta, TTransitionMeta> {
     const fullPath = toStatePath(stateId);
     const relativePath = fullPath.slice(1);
     const resolvedStateId = isStateId(fullPath[0])
@@ -1296,7 +1305,9 @@ export class StateMachine<
     }
     return getStateNodeByPath(stateNode, relativePath) as StateNode<
       TContext,
-      TEvent
+      TEvent,
+      TMeta,
+      TTransitionMeta
     >;
   }
 

--- a/packages/core/src/StateNode.ts
+++ b/packages/core/src/StateNode.ts
@@ -18,7 +18,6 @@ import type {
   InitialTransitionDefinition,
   MachineContext,
   Mapper,
-  StateNodesConfig,
   TransitionDefinition,
   TransitionDefinitionMap,
   AnyStateMachine,
@@ -32,7 +31,9 @@ import type {
   AnyTransitionConfig,
   AnyTransitionDefinition,
   AnyMachineSnapshot,
-  AnyInvokeDefinition
+  AnyInvokeDefinition,
+  InvokeDefinition,
+  MetaObject
 } from './types.ts';
 import {
   createInvokeId,
@@ -60,17 +61,19 @@ const CHOICE_CONFIG_KEYS = [
 ] as const;
 
 interface StateNodeOptions<
-  TContext extends MachineContext,
-  TEvent extends EventObject
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject
 > {
   _key: string;
-  _parent?: StateNode<TContext, TEvent>;
+  _parent?: StateNode<any, any, TStateMeta, TTransitionMeta>;
   _machine: AnyStateMachine;
 }
 
 export class StateNode<
   TContext extends MachineContext = MachineContext,
-  TEvent extends EventObject = EventObject
+  TEvent extends EventObject = EventObject,
+  TStateMeta extends MetaObject = any,
+  TTransitionMeta extends MetaObject = TStateMeta
 > {
   /**
    * The relative key of the state node, which represents its location in the
@@ -99,7 +102,10 @@ export class StateNode<
   /** The string path from the root machine node to this node. */
   public path: string[];
   /** The child state nodes. */
-  public states: StateNodesConfig<any, any>;
+  public states: Record<
+    string,
+    StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>
+  >;
   /**
    * The type of history on this state node. Can be:
    *
@@ -112,14 +118,14 @@ export class StateNode<
   /** The action(s) to be executed upon exiting the state node. */
   public exit: AnyAction | undefined;
   /** The parent state node. */
-  public parent?: StateNode<any, any>;
+  public parent?: StateNode<TContext, TEvent, TStateMeta, TTransitionMeta>;
   /** The root machine node. */
   public machine: AnyStateMachine;
   /**
    * The meta data associated with this state node, which will be returned in
    * State instances.
    */
-  public meta?: any;
+  public meta?: TStateMeta;
   /**
    * The output data sent with the `xstate.done.state` event if this is a final
    * state node.
@@ -139,11 +145,16 @@ export class StateNode<
   public schemas: SetupStateSchemas | undefined;
 
   public tags: string[] = [];
-  public transitions!: Map<string, AnyTransitionDefinition[]>;
-  public always?: Array<AnyTransitionDefinition>;
-  public invoke: Array<AnyInvokeDefinition>;
-  public on!: TransitionDefinitionMap<any, any>;
-  public after!: Array<DelayedTransitionDefinition<any, any>>;
+  public transitions!: Map<
+    string,
+    TransitionDefinition<any, any, TTransitionMeta>[]
+  >;
+  public always?: Array<TransitionDefinition<any, any, TTransitionMeta>>;
+  public invoke: Array<
+    InvokeDefinition<any, any, any, TTransitionMeta, any, any, any, any>
+  >;
+  public on!: TransitionDefinitionMap<any, any, TTransitionMeta>;
+  public after!: Array<DelayedTransitionDefinition<any, any, TTransitionMeta>>;
   public events!: Array<EventDescriptor<any>>;
   public ownEvents!: Array<EventDescriptor<any>>;
   private _candidateCache?: Map<string, AnyTransitionDefinition[]>;
@@ -151,7 +162,7 @@ export class StateNode<
   constructor(
     /** The raw config used to create the machine. */
     public config: AnyStateNodeConfig,
-    options: StateNodeOptions<TContext, TEvent>
+    options: StateNodeOptions<TStateMeta, TTransitionMeta>
   ) {
     this.parent = options._parent;
     this.key = options._key;
@@ -182,7 +193,12 @@ export class StateNode<
         ? mapValues(
             this.config.states,
             (stateConfig: AnyStateNodeConfig, key) => {
-              const stateNode = new StateNode(stateConfig, {
+              const stateNode = new StateNode<
+                any,
+                any,
+                TStateMeta,
+                TTransitionMeta
+              >(stateConfig, {
                 _parent: this,
                 _key: key,
                 _machine: this.machine
@@ -191,7 +207,7 @@ export class StateNode<
             }
           )
         : EMPTY_OBJECT
-    ) as StateNodesConfig<TContext, TEvent>;
+    ) as typeof this.states;
 
     if (this.type === 'compound' && !this.config.initial) {
       throw new Error(
@@ -241,19 +257,19 @@ export class StateNode<
         id: resolvedId,
         registryKey
       } as AnyInvokeDefinition;
-    });
+    }) as typeof this.invoke;
   }
 
   /** @internal */
   public _initialize() {
     this.after = getDelayedTransitions(this) as any;
-    this.transitions = formatTransitions(this);
+    this.transitions = formatTransitions(this) as typeof this.transitions;
     if (this.type === 'choice') {
-      this.always = formatChoiceTransitions(this);
+      this.always = formatChoiceTransitions(this) as typeof this.always;
     } else if (this.config.always) {
       this.always = mapTransitionConfigs(this.config.always, (transition) =>
         formatTransition(this, NULL_EVENT, transition)
-      );
+      ) as typeof this.always;
     }
 
     for (const key of Object.keys(this.states)) {
@@ -265,7 +281,7 @@ export class StateNode<
 
   /** @internal */
   public _refreshEventMetadata() {
-    const on = {} as TransitionDefinitionMap<TContext, TEvent>;
+    const on = {} as TransitionDefinitionMap<any, any, TTransitionMeta>;
     const ownEvents: EventDescriptor<any>[] = [];
     for (const [descriptor, transitions] of this.transitions) {
       (on as any)[descriptor] = transitions.slice();
@@ -290,10 +306,10 @@ export class StateNode<
     this.events = Array.from(events);
   }
 
-  public get initial(): InitialTransitionDefinition {
+  public get initial(): InitialTransitionDefinition<TTransitionMeta> {
     return memo(this, 'initial', () =>
       formatInitialTransition(this, this.config.initial)
-    );
+    ) as InitialTransitionDefinition<TTransitionMeta>;
   }
 
   /** @internal */
@@ -636,7 +652,13 @@ function formatInitialTransition(
   stateNode: AnyStateNode,
   _target:
     | string
-    | { target: string | string[]; input?: any; to?: (...args: any[]) => any }
+    | {
+        target: string | string[];
+        input?: any;
+        to?: (...args: any[]) => any;
+        meta?: any;
+        description?: string;
+      }
     | undefined
 ): InitialTransitionDefinition {
   const targetString =
@@ -645,6 +667,12 @@ function formatInitialTransition(
     typeof _target === 'object' && _target !== null ? _target.input : undefined;
   const to =
     typeof _target === 'object' && _target !== null ? _target.to : undefined;
+  const meta =
+    typeof _target === 'object' && _target !== null ? _target.meta : undefined;
+  const description =
+    typeof _target === 'object' && _target !== null
+      ? _target.description
+      : undefined;
   const targetStrings = Array.isArray(targetString)
     ? targetString
     : targetString
@@ -668,7 +696,9 @@ function formatInitialTransition(
       ? (resolvedTargets as AnyStateNode[])
       : undefined,
     input,
-    to
+    to,
+    meta,
+    description
   };
 
   return transition;

--- a/packages/core/src/createMachine.ts
+++ b/packages/core/src/createMachine.ts
@@ -49,6 +49,13 @@ type MachineIdentity<TConfig> = {
     : undefined;
 };
 
+type TransitionMetaFromSchemas<
+  TMetaSchema extends StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1
+> = StandardSchemaV1 extends TTransitionMetaSchema
+  ? InferOutput<TMetaSchema, MetaObject>
+  : InferOutput<TTransitionMetaSchema, MetaObject>;
+
 type TestValue =
   | string
   | {
@@ -113,6 +120,7 @@ export function createMachine<
   TInputSchema extends StandardSchemaV1,
   const TOutputSchema extends StandardSchemaV1,
   TMetaSchema extends StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1,
   TTagSchema extends StandardSchemaV1,
   const TChildrenSchemaMap extends Record<string, StandardSchemaV1>,
   _TEvent extends EventObject,
@@ -138,6 +146,7 @@ export function createMachine<
       TInputSchema,
       TOutputSchema,
       TMetaSchema,
+      TTransitionMetaSchema,
       TTagSchema,
       TChildrenSchemaMap,
       InferOutput<TContextSchema, MachineContext>,
@@ -188,7 +197,8 @@ export function createMachine<
   TActorMap,
   TGuardMap,
   DelayMapFromNames<TDelays, TDelayMap>,
-  InferInternalEvents<TInternalEventSchemaMap>
+  InferInternalEvents<TInternalEventSchemaMap>,
+  TransitionMetaFromSchemas<TMetaSchema, TTransitionMetaSchema>
 > & {
   states: TSS;
 } & MachineIdentity<TSS>;
@@ -207,6 +217,7 @@ export function createMachine<
   TInputSchema extends StandardSchemaV1 = StandardSchemaV1,
   const TOutputSchema extends StandardSchemaV1 = StandardSchemaV1,
   TMetaSchema extends StandardSchemaV1 = StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1 = TMetaSchema,
   TTagSchema extends StandardSchemaV1 = StandardSchemaV1,
   const TChildrenSchemaMap extends Record<string, StandardSchemaV1> = Record<
     string,
@@ -237,6 +248,7 @@ export function createMachine<
       TInputSchema,
       TOutputSchema,
       TMetaSchema,
+      TTransitionMetaSchema,
       TTagSchema,
       TChildrenSchemaMap,
       WidenLiterals<TContext>,
@@ -299,7 +311,8 @@ export function createMachine<
   TActorMap,
   TGuardMap,
   DelayMapFromNames<TDelays, TDelayMap>,
-  InferInternalEvents<TInternalEventSchemaMap>
+  InferInternalEvents<TInternalEventSchemaMap>,
+  TransitionMetaFromSchemas<TMetaSchema, TTransitionMetaSchema>
 > & {
   states: TSS;
 } & MachineIdentity<TSS>;
@@ -320,6 +333,7 @@ export function createMachine(config: any): any {
     any,
     any,
     any,
+    any,
     any
   >(config) as any;
 }
@@ -331,6 +345,7 @@ export function createStateConfig<
   _TInputSchema extends StandardSchemaV1,
   const TOutputSchema extends StandardSchemaV1,
   TMetaSchema extends StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1,
   TTagSchema extends StandardSchemaV1,
   // TContext extends MachineContext,
   _TEvent extends StandardSchemaV1.InferOutput<TEventSchema> & EventObject, // TODO: consider using a stricter `EventObject` here
@@ -357,7 +372,12 @@ export function createStateConfig<
       DoNotInfer<TActionMap>,
       DoNotInfer<TActorMap>,
       DoNotInfer<TGuardMap>,
-      DoNotInfer<TDelayMap>
+      DoNotInfer<TDelayMap>,
+      any,
+      any,
+      any,
+      any,
+      DoNotInfer<TransitionMetaFromSchemas<TMetaSchema, TTransitionMetaSchema>>
     >
 ): typeof config {
   return config;

--- a/packages/core/src/setup.ts
+++ b/packages/core/src/setup.ts
@@ -302,6 +302,7 @@ type InlineMachineSchemas<
   TInputSchema,
   TOutputSchema,
   TMetaSchema,
+  TTransitionMetaSchema,
   TTagSchema,
   TChildrenSchemaMap
 > = {
@@ -314,6 +315,7 @@ type InlineMachineSchemas<
   input?: TInputSchema;
   output?: TOutputSchema;
   meta?: TMetaSchema;
+  transitionMeta?: TTransitionMetaSchema;
   tags?: TTagSchema;
   children?: TChildrenSchemaMap;
 };
@@ -451,6 +453,7 @@ export type SetupSchemas = {
   input?: StandardSchemaV1;
   output?: StandardSchemaV1;
   meta?: StandardSchemaV1;
+  transitionMeta?: StandardSchemaV1;
   tags?: StandardSchemaV1;
   children?: Record<string, StandardSchemaV1>;
 };
@@ -1299,6 +1302,7 @@ type SetupStateNodeConfig<
   SetupOutput<TSchemas, StandardSchemaV1>,
   SetupEmitted<TSchemas, Record<string, StandardSchemaV1>>,
   SetupMeta<TSchemas, StandardSchemaV1>,
+  SetupTransitionMeta<TSchemas, StandardSchemaV1, StandardSchemaV1>,
   SetupActions<TSchemas, TSetupActionMap>,
   TSetupActorMap,
   SetupGuards<TSchemas, TSetupGuardMap>,
@@ -1415,6 +1419,16 @@ type SetupMeta<TSchemas, TMetaSchema extends StandardSchemaV1> = [
 ] extends [never]
   ? InferOutput<TMetaSchema, MetaObject>
   : InferOutput<SetupSchema<TSchemas, 'meta'>, MetaObject>;
+
+type SetupTransitionMeta<
+  TSchemas,
+  TMetaSchema extends StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1
+> = [SetupSchema<TSchemas, 'transitionMeta'>] extends [never]
+  ? StandardSchemaV1 extends TTransitionMetaSchema
+    ? SetupMeta<TSchemas, TMetaSchema>
+    : InferOutput<TTransitionMetaSchema, MetaObject>
+  : InferOutput<SetupSchema<TSchemas, 'transitionMeta'>, MetaObject>;
 
 type SetupChildren<
   TSchemas,
@@ -2603,6 +2617,7 @@ type SetupMachineConfigBase<
   TInputSchema extends StandardSchemaV1,
   TOutputSchema extends StandardSchemaV1,
   TMetaSchema extends StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1,
   TTagSchema extends StandardSchemaV1,
   TChildrenSchemaMap extends Record<string, StandardSchemaV1>,
   TContext extends MachineContext,
@@ -2611,7 +2626,8 @@ type SetupMachineConfigBase<
   TDelays extends string,
   TTag extends string,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
@@ -2631,6 +2647,7 @@ type SetupMachineConfigBase<
     SetupOrConfigSchema<TSchemas, 'input', TInputSchema>,
     SetupOrConfigSchema<TSchemas, 'output', TOutputSchema>,
     SetupOrConfigSchema<TSchemas, 'meta', TMetaSchema>,
+    SetupOrConfigSchema<TSchemas, 'transitionMeta', TTransitionMetaSchema>,
     SetupOrConfigSchema<TSchemas, 'tags', TTagSchema>,
     SetupOrConfigSchemaMap<TSchemas, 'children', TChildrenSchemaMap>,
     TContext,
@@ -2675,6 +2692,8 @@ type SetupMachineConfigBase<
     | string
     | {
         target: string;
+        meta?: TTransitionMeta;
+        description?: string;
         input?: unknown;
       }
     | undefined;
@@ -2685,7 +2704,7 @@ type SetupMachineConfigBase<
     TEvent,
     TEmitted,
     TChildren,
-    TMeta,
+    TTransitionMeta,
     TActionMap,
     TActorMap,
     TGuardMap,
@@ -2700,7 +2719,7 @@ type SetupMachineConfigBase<
     TEvent,
     TEmitted,
     TChildren,
-    TMeta,
+    TTransitionMeta,
     TActionMap,
     TActorMap,
     TGuardMap,
@@ -2715,7 +2734,7 @@ type SetupMachineConfigBase<
       TEvent,
       TEmitted,
       TChildren,
-      TMeta,
+      TTransitionMeta,
       TActionMap,
       TActorMap,
       TGuardMap,
@@ -2735,7 +2754,8 @@ type SetupMachineConfigBase<
     TTag,
     SetupOutput<TSchemas, TOutputSchema>,
     TEmitted,
-    TMeta,
+    TStateMeta,
+    TTransitionMeta,
     TActionMap,
     TActorMap,
     TGuardMap,
@@ -2757,6 +2777,7 @@ type SetupMachineConfig<
   TInputSchema extends StandardSchemaV1,
   TOutputSchema extends StandardSchemaV1,
   TMetaSchema extends StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1,
   TTagSchema extends StandardSchemaV1,
   TChildrenSchemaMap extends Record<string, StandardSchemaV1>,
   TContext extends MachineContext,
@@ -2765,7 +2786,8 @@ type SetupMachineConfig<
   TDelays extends string,
   TTag extends string,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
@@ -2790,6 +2812,7 @@ type SetupMachineConfig<
           TInputSchema,
           TOutputSchema,
           TMetaSchema,
+          TTransitionMetaSchema,
           TTagSchema,
           TChildrenSchemaMap,
           TContext,
@@ -2798,7 +2821,8 @@ type SetupMachineConfig<
           TDelays,
           TTag,
           TEmitted,
-          TMeta,
+          TStateMeta,
+          TTransitionMeta,
           TActionMap,
           TActorMap,
           TGuardMap,
@@ -2814,7 +2838,12 @@ type SetupMachineConfig<
       > & {
         initial?:
           | SetupInitialStateKey<TStateSchemas, TStateKeys>
-          | RootInitialTransitionWithInput<TStateSchemas, TContext, TEvent>
+          | RootInitialTransitionWithInput<
+              TStateSchemas,
+              TContext,
+              TEvent,
+              TTransitionMeta
+            >
           | undefined;
         on?: StateTransitions<
           TStateSchemas,
@@ -2823,7 +2852,7 @@ type SetupMachineConfig<
           TEvent,
           TEmitted,
           TChildren,
-          TMeta,
+          TTransitionMeta,
           TActionMap,
           TActorMap,
           TGuardMap,
@@ -2841,7 +2870,7 @@ type SetupMachineConfig<
           TEvent,
           TEmitted,
           TChildren,
-          TMeta,
+          TTransitionMeta,
           TActionMap,
           TActorMap,
           TGuardMap,
@@ -2859,7 +2888,7 @@ type SetupMachineConfig<
             TEvent,
             TEmitted,
             TChildren,
-            TMeta,
+            TTransitionMeta,
             TActionMap,
             TActorMap,
             TGuardMap,
@@ -2879,7 +2908,8 @@ type SetupMachineConfig<
           TTag,
           SetupOutput<TSchemas, TOutputSchema>,
           TEmitted,
-          TMeta,
+          TStateMeta,
+          TTransitionMeta,
           TActionMap,
           TActorMap,
           TGuardMap,
@@ -2899,6 +2929,7 @@ type SetupMachineConfig<
         TInputSchema,
         TOutputSchema,
         TMetaSchema,
+        TTransitionMetaSchema,
         TTagSchema,
         TChildrenSchemaMap,
         TContext,
@@ -2907,7 +2938,8 @@ type SetupMachineConfig<
         TDelays,
         TTag,
         TEmitted,
-        TMeta,
+        TStateMeta,
+        TTransitionMeta,
         TActionMap,
         TActorMap,
         TGuardMap,
@@ -2932,7 +2964,8 @@ type StatesWithInput<
   TTag extends string,
   TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
@@ -2951,7 +2984,8 @@ type StatesWithInput<
     TTag,
     TOutput,
     TEmitted,
-    TMeta,
+    TStateMeta,
+    TTransitionMeta,
     TActionMap,
     TActorMap,
     TGuardMap,
@@ -2972,7 +3006,8 @@ type StateNodeConfigWithNestedInputBase<
   TTag extends string,
   TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
@@ -2987,7 +3022,7 @@ type StateNodeConfigWithNestedInputBase<
       TTag,
       StateOutput<TStateSchema, TOutput>,
       TEmitted,
-      TMeta,
+      TStateMeta,
       TChildren,
       TActionMap,
       TActorMap,
@@ -2996,7 +3031,8 @@ type StateNodeConfigWithNestedInputBase<
       StateInput<TStateSchema>,
       Record<string, unknown>,
       TSystemRegistry,
-      StateCompletionOutput<TStateSchema>
+      StateCompletionOutput<TStateSchema>,
+      TTransitionMeta
     >,
     | 'on'
     | 'always'
@@ -3014,12 +3050,15 @@ type StateNodeConfigWithNestedInputBase<
           | InitialTransitionWithInput<
               TStateSchema['states'],
               ActiveStateContext<TStateSchema, TContext, TContextShape>,
-              TEvent
+              TEvent,
+              TTransitionMeta
             >
       :
           | string
           | {
               target: string;
+              meta?: TTransitionMeta;
+              description?: string;
               input?: Record<string, unknown>;
             }
           | undefined;
@@ -3031,7 +3070,7 @@ type StateNodeConfigWithNestedInputBase<
       TEvent,
       TEmitted,
       TChildren,
-      TMeta,
+      TTransitionMeta,
       TActionMap,
       TActorMap,
       TGuardMap,
@@ -3047,7 +3086,7 @@ type StateNodeConfigWithNestedInputBase<
       TEvent,
       TEmitted,
       TChildren,
-      TMeta,
+      TTransitionMeta,
       TActionMap,
       TActorMap,
       TGuardMap,
@@ -3063,7 +3102,7 @@ type StateNodeConfigWithNestedInputBase<
         TEvent,
         TEmitted,
         TChildren,
-        TMeta,
+        TTransitionMeta,
         TActionMap,
         TActorMap,
         TGuardMap,
@@ -3080,7 +3119,7 @@ type StateNodeConfigWithNestedInputBase<
       TEvent,
       TEmitted,
       TChildren,
-      TMeta,
+      TTransitionMeta,
       TActionMap,
       TActorMap,
       TGuardMap,
@@ -3096,7 +3135,7 @@ type StateNodeConfigWithNestedInputBase<
       TEvent,
       TEmitted,
       TChildren,
-      TMeta,
+      TTransitionMeta,
       TActionMap,
       TActorMap,
       TGuardMap,
@@ -3112,7 +3151,7 @@ type StateNodeConfigWithNestedInputBase<
       TEvent,
       TEmitted,
       TChildren,
-      TMeta,
+      TTransitionMeta,
       TActionMap,
       TActorMap,
       TGuardMap,
@@ -3129,7 +3168,7 @@ type StateNodeConfigWithNestedInputBase<
         TEvent,
         TEmitted,
         TChildren,
-        TMeta,
+        TTransitionMeta,
         TActionMap,
         TActorMap,
         TGuardMap,
@@ -3159,7 +3198,8 @@ type StateNodeConfigWithNestedInputBase<
         TTag,
         TOutput,
         TEmitted,
-        TMeta,
+        TStateMeta,
+        TTransitionMeta,
         TActionMap,
         TActorMap,
         TGuardMap,
@@ -3174,7 +3214,7 @@ type StateNodeConfigWithNestedInputBase<
           TTag,
           TOutput,
           TEmitted,
-          TMeta,
+          TStateMeta,
           TChildren,
           TActionMap,
           TActorMap,
@@ -3182,7 +3222,9 @@ type StateNodeConfigWithNestedInputBase<
           TDelayMap,
           undefined,
           Record<string, unknown>,
-          TSystemRegistry
+          TSystemRegistry,
+          unknown,
+          TTransitionMeta
         >;
       }
 >;
@@ -3198,7 +3240,8 @@ type StateNodeConfigWithNestedInput<
   TTag extends string,
   TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
@@ -3217,7 +3260,8 @@ type StateNodeConfigWithNestedInput<
     TTag,
     TOutput,
     TEmitted,
-    TMeta,
+    TStateMeta,
+    TTransitionMeta,
     TActionMap,
     TActorMap,
     TGuardMap,
@@ -3827,22 +3871,28 @@ type SetupInitialStateKey<
 type InitialTransitionWithInput<
   TStateSchemas extends Record<string, SetupStateSchema>,
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TTransitionMeta extends MetaObject
 > = {
   [K in keyof TStateSchemas & string]: {
     target: K;
+    meta?: TTransitionMeta;
+    description?: string;
   } & SetupStateInputConfig<TStateSchemas[K], TContext, TEvent>;
 }[keyof TStateSchemas & string];
 
 type RootInitialTransitionWithInput<
   TStateSchemas extends Record<string, SetupStateSchema>,
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TTransitionMeta extends MetaObject
 > =
-  | InitialTransitionWithInput<TStateSchemas, TContext, TEvent>
+  | InitialTransitionWithInput<TStateSchemas, TContext, TEvent, TTransitionMeta>
   | {
       [K in RootSetupStateIdTarget<TStateSchemas>]: {
         target: K;
+        meta?: TTransitionMeta;
+        description?: string;
       } & SetupStateInputConfig<
         SetupStateSchemaAtTarget<TStateSchemas, K>,
         TContext,
@@ -3917,6 +3967,7 @@ export interface SetupReturn<
     TInputSchema extends StandardSchemaV1 = StandardSchemaV1,
     TOutputSchema extends StandardSchemaV1 = StandardSchemaV1,
     TMetaSchema extends StandardSchemaV1 = StandardSchemaV1,
+    TTransitionMetaSchema extends StandardSchemaV1 = TMetaSchema,
     TTagSchema extends StandardSchemaV1 = StandardSchemaV1,
     const TChildrenSchemaMap extends Record<string, StandardSchemaV1> = Record<
       string,
@@ -3948,6 +3999,7 @@ export interface SetupReturn<
       TInputSchema,
       TOutputSchema,
       TMetaSchema,
+      TTransitionMetaSchema,
       TTagSchema,
       TChildrenSchemaMap,
       SetupContext<TSchemas, TContextSchema>,
@@ -3960,6 +4012,7 @@ export interface SetupReturn<
       TTag,
       SetupEmitted<TSchemas, TEmittedSchemaMap>,
       SetupMeta<TSchemas, TMetaSchema>,
+      SetupTransitionMeta<TSchemas, TMetaSchema, TTransitionMetaSchema>,
       MergeSourceMaps<
         SetupActions<TSchemas, TSetupActionMap>,
         MergeSourceMaps<InferActions<TActionSchemaMap>, TActionMap>
@@ -3987,6 +4040,7 @@ export interface SetupReturn<
       TInputSchema,
       TOutputSchema,
       TMetaSchema,
+      TTransitionMetaSchema,
       TTagSchema,
       TChildrenSchemaMap,
       SetupContext<TSchemas, TContextSchema>,
@@ -3999,6 +4053,7 @@ export interface SetupReturn<
       TTag,
       SetupEmitted<TSchemas, TEmittedSchemaMap>,
       SetupMeta<TSchemas, TMetaSchema>,
+      SetupTransitionMeta<TSchemas, TMetaSchema, TTransitionMetaSchema>,
       MergeSourceMaps<
         SetupActions<TSchemas, TSetupActionMap>,
         MergeSourceMaps<InferActions<TActionSchemaMap>, TActionMap>
@@ -4028,6 +4083,7 @@ export interface SetupReturn<
         input?: TInputSchema;
         output?: TOutputSchema;
         meta?: TMetaSchema;
+        transitionMeta?: TTransitionMetaSchema;
         tags?: TTagSchema;
         children?: TChildrenSchemaMap;
       } & ([TValidator] extends [ActorLogicValidator]
@@ -4042,6 +4098,7 @@ export interface SetupReturn<
               TInputSchema,
               TOutputSchema,
               TMetaSchema,
+              TTransitionMetaSchema,
               TTagSchema,
               TChildrenSchemaMap
             >
@@ -4102,7 +4159,8 @@ export interface SetupReturn<
       TSetupDelays | TDelays,
       MergeSourceMaps<TSetupDelayMap, TDelayMap>
     >,
-    SetupInternalEvents<TSchemas, TInternalEventSchemaMap>
+    SetupInternalEvents<TSchemas, TInternalEventSchemaMap>,
+    SetupTransitionMeta<TSchemas, TMetaSchema, TTransitionMetaSchema>
   > &
     MachineIdentity<TConfig>;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1532,18 +1532,19 @@ export type Mapper<
 
 export interface TransitionDefinition<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TMeta extends MetaObject = any
 > extends Omit<
   TransitionConfig<
     TContext,
     TEvent,
     TEvent,
     TODO,
+    TMeta,
     TODO,
     TODO,
     TODO,
-    TODO, // TEmitted
-    TODO // TMeta
+    TODO
   >,
   'target' | 'to'
 > {
@@ -1565,11 +1566,13 @@ export interface TransitionDefinition<
 
 export type AnyTransitionDefinition = TransitionDefinition<any, any>;
 
-export type InitialTransitionDefinition = {
+export type InitialTransitionDefinition<TMeta extends MetaObject = any> = {
   source: AnyStateNode;
   target: AnyStateNode[] | undefined;
   reenter?: boolean;
   eventType?: EventDescriptor<any>;
+  meta?: TMeta;
+  description?: string;
   input?:
     | Record<string, unknown>
     | ((args: {
@@ -1581,10 +1584,11 @@ export type InitialTransitionDefinition = {
 
 export type TransitionDefinitionMap<
   TContext extends MachineContext,
-  TEvent extends EventObject
+  TEvent extends EventObject,
+  TMeta extends MetaObject = any
 > = {
   [K in EventDescriptor<TEvent>]: Array<
-    TransitionDefinition<TContext, ExtractEvent<TEvent, K>>
+    TransitionDefinition<TContext, ExtractEvent<TEvent, K>, TMeta>
   >;
 };
 
@@ -1599,8 +1603,9 @@ export type DelayExpr<
 
 export interface DelayedTransitionDefinition<
   TContext extends MachineContext,
-  TEvent extends EventObject
-> extends TransitionDefinition<TContext, TEvent> {
+  TEvent extends EventObject,
+  TMeta extends MetaObject = any
+> extends TransitionDefinition<TContext, TEvent, TMeta> {
   delay: number | string | DelayExpr<TContext, TEvent>;
 }
 

--- a/packages/core/src/types.v6.ts
+++ b/packages/core/src/types.v6.ts
@@ -259,6 +259,7 @@ type MachineSchemas<
   TInputSchema extends StandardSchemaV1,
   TOutputSchema extends StandardSchemaV1,
   TMetaSchema extends StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1,
   TTagSchema extends StandardSchemaV1,
   TChildrenSchemaMap extends Record<string, StandardSchemaV1>
 > = {
@@ -271,6 +272,7 @@ type MachineSchemas<
   input?: TInputSchema;
   output?: TOutputSchema;
   meta?: TMetaSchema;
+  transitionMeta?: TTransitionMetaSchema;
   tags?: TTagSchema;
   children?: TChildrenSchemaMap;
 };
@@ -280,6 +282,7 @@ export type AnyMachineSchemas = MachineSchemas<
   Record<string, StandardSchemaV1>,
   Record<string, StandardSchemaV1>,
   Record<string, StandardSchemaV1>,
+  StandardSchemaV1,
   StandardSchemaV1,
   StandardSchemaV1,
   StandardSchemaV1,
@@ -295,6 +298,7 @@ export type Next_MachineConfig<
   TInputSchema extends StandardSchemaV1,
   TOutputSchema extends StandardSchemaV1,
   TMetaSchema extends StandardSchemaV1,
+  TTransitionMetaSchema extends StandardSchemaV1,
   TTagSchema extends StandardSchemaV1,
   TChildrenSchemaMap extends Record<string, StandardSchemaV1>,
   TContext extends MachineContext = InferOutput<TContextSchema, MachineContext>,
@@ -330,7 +334,8 @@ export type Next_MachineConfig<
     Record<string, unknown> | undefined,
     Record<string, unknown>,
     DoNotInfer<TSystemRegistry>,
-    DoNotInfer<InferOutput<TOutputSchema, unknown>>
+    DoNotInfer<InferOutput<TOutputSchema, unknown>>,
+    DoNotInfer<InferOutput<TTransitionMetaSchema, MetaObject>>
   >,
   'output' | 'schemas'
 > & {
@@ -344,6 +349,7 @@ export type Next_MachineConfig<
     TInputSchema,
     TOutputSchema,
     TMetaSchema,
+    TTransitionMetaSchema,
     TTagSchema,
     TChildrenSchemaMap
   >;
@@ -1055,7 +1061,7 @@ export type Next_StateNodeConfig<
   TTag extends string,
   _TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject,
   TChildren extends Record<string, AnyActorRef | undefined>,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
@@ -1064,7 +1070,8 @@ export type Next_StateNodeConfig<
   TInput = Record<string, unknown> | undefined,
   TInputMap extends Record<string, unknown> = Record<string, unknown>,
   TSystemRegistry extends SystemRegistry = SystemRegistry,
-  TChildOutput = unknown
+  TChildOutput = unknown,
+  TTransitionMeta extends MetaObject = TStateMeta
 > =
   | Next_RegularStateNodeConfig<
       TContext,
@@ -1073,7 +1080,8 @@ export type Next_StateNodeConfig<
       TTag,
       _TOutput,
       TEmitted,
-      TMeta,
+      TStateMeta,
+      TTransitionMeta,
       TChildren,
       TActionMap,
       TActorMap,
@@ -1088,7 +1096,8 @@ export type Next_StateNodeConfig<
       TContext,
       TEvent,
       TTag,
-      TMeta,
+      TStateMeta,
+      TTransitionMeta,
       TActionMap,
       TActorMap,
       TGuardMap,
@@ -1099,7 +1108,8 @@ interface Next_ChoiceStateNodeConfig<
   TContext extends MachineContext,
   TEvent extends EventObject,
   TTag extends string,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
   TGuardMap extends Sources['guards'],
@@ -1117,18 +1127,18 @@ interface Next_ChoiceStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta
+    TTransitionMeta
   >;
   id?: string | undefined;
   order?: number;
   tags?: TTag[];
   description?: string;
-  meta?: TMeta;
+  meta?: TStateMeta;
   route?:
     | Next_RouteConfig<
         TContext,
         TEvent,
-        TMeta,
+        TTransitionMeta,
         TActionMap,
         TActorMap,
         TGuardMap,
@@ -1159,7 +1169,8 @@ interface Next_RegularStateNodeConfig<
   TTag extends string,
   TOutput,
   TEmitted extends EventObject,
-  TMeta extends MetaObject,
+  TStateMeta extends MetaObject,
+  TTransitionMeta extends MetaObject,
   TChildren extends Record<string, AnyActorRef | undefined>,
   TActionMap extends Sources['actions'],
   TActorMap extends Sources['actors'],
@@ -1177,6 +1188,8 @@ interface Next_RegularStateNodeConfig<
     | string
     | {
         target: string;
+        meta?: TTransitionMeta;
+        description?: string;
         input?:
           | Record<string, unknown>
           | ((args: {
@@ -1212,7 +1225,7 @@ interface Next_RegularStateNodeConfig<
       TTag,
       any, // TOutput,
       TEmitted,
-      TMeta,
+      TStateMeta,
       TChildren,
       TActionMap,
       TActorMap,
@@ -1221,7 +1234,8 @@ interface Next_RegularStateNodeConfig<
       LookupInput<TInputMap, K>,
       TInputMap,
       TSystemRegistry,
-      TChildOutput
+      TChildOutput,
+      TTransitionMeta
     >;
   };
   /**
@@ -1238,7 +1252,7 @@ interface Next_RegularStateNodeConfig<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TMeta,
+      TTransitionMeta,
       TSystemRegistry,
       TInput
     >
@@ -1254,7 +1268,7 @@ interface Next_RegularStateNodeConfig<
       TActorMap,
       TGuardMap,
       TDelayMap,
-      TMeta,
+      TTransitionMeta,
       TInput,
       TChildren
     >;
@@ -1267,7 +1281,7 @@ interface Next_RegularStateNodeConfig<
     | Next_RouteConfig<
         TContext,
         TEvent,
-        TMeta,
+        TTransitionMeta,
         TActionMap,
         TActorMap,
         TGuardMap,
@@ -1312,7 +1326,7 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta,
+    TTransitionMeta,
     undefined,
     TChildren
   >;
@@ -1329,7 +1343,7 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta,
+    TTransitionMeta,
     undefined,
     TChildren
   >;
@@ -1350,7 +1364,7 @@ interface Next_RegularStateNodeConfig<
           TActorMap,
           TGuardMap,
           TDelayMap,
-          TMeta,
+          TTransitionMeta,
           TInput,
           [TContext] extends [never] ? any : TContext,
           TChildren
@@ -1385,7 +1399,7 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta,
+    TTransitionMeta,
     TInput,
     TChildren
   >;
@@ -1403,7 +1417,7 @@ interface Next_RegularStateNodeConfig<
     TActorMap,
     TGuardMap,
     TDelayMap,
-    TMeta,
+    TTransitionMeta,
     undefined,
     TChildren
   >;
@@ -1412,7 +1426,7 @@ interface Next_RegularStateNodeConfig<
    * The meta data associated with this state node, which will be returned in
    * State instances.
    */
-  meta?: TMeta;
+  meta?: TStateMeta;
   /**
    * The output data sent with the `xstate.done.state` event if this is a final
    * state node.

--- a/packages/core/test/meta.test.ts
+++ b/packages/core/test/meta.test.ts
@@ -1,5 +1,11 @@
 import { z } from 'zod';
-import { createMachine, createActor, StateId } from '../src/index.ts';
+import {
+  createMachine,
+  createActor,
+  serializeMachine,
+  setup,
+  StateId
+} from '../src/index.ts';
 
 describe('state meta data', () => {
   const enter_walk = () => {};
@@ -475,6 +481,148 @@ describe('state meta data', () => {
 });
 
 describe('transition meta data', () => {
+  it('supports distinct state and transition metadata schemas', () => {
+    const machine = createMachine({
+      schemas: {
+        meta: z.object({ label: z.string() }),
+        transitionMeta: z.object({ trackingId: z.number() })
+      },
+      meta: { label: 'root' },
+      on: {
+        NEXT: { meta: { trackingId: 42 } }
+      }
+    });
+
+    machine.root.meta satisfies { label: string } | undefined;
+    machine.root.transitions.get('NEXT')![0].meta satisfies
+      | { trackingId: number }
+      | undefined;
+  });
+
+  it('rejects state and transition metadata in the wrong positions', () => {
+    createMachine({
+      schemas: {
+        meta: z.object({ state: z.string() }),
+        transitionMeta: z.object({ transition: z.string() })
+      },
+      // @ts-expect-error transition metadata is invalid on a state node
+      meta: { transition: 'root' }
+    });
+
+    createMachine({
+      schemas: {
+        meta: z.object({ state: z.string() }),
+        transitionMeta: z.object({ transition: z.string() })
+      },
+      // @ts-expect-error state metadata is invalid on a transition
+      on: {
+        NEXT: {
+          meta: { state: 'next' }
+        }
+      }
+    });
+  });
+
+  it('uses the state metadata schema for transitions by default', () => {
+    const machine = createMachine({
+      schemas: {
+        meta: z.object({ legacy: z.string() })
+      },
+      meta: { legacy: 'state' },
+      on: {
+        NEXT: { meta: { legacy: 'transition' } }
+      }
+    });
+
+    machine.root.meta satisfies { legacy: string } | undefined;
+    machine.root.transitions.get('NEXT')![0].meta satisfies
+      | { legacy: string }
+      | undefined;
+  });
+
+  it('preserves transition metadata on v6 transition definitions', () => {
+    const machine = setup({
+      schemas: {
+        meta: z.object({ state: z.string() }),
+        transitionMeta: z.object({ source: z.string() })
+      },
+      actors: {
+        child: createMachine({})
+      }
+    }).createMachine({
+      initial: {
+        target: 'idle',
+        meta: { source: 'initial' },
+        description: 'start idle'
+      },
+      states: {
+        idle: {
+          meta: { state: 'idle' },
+          route: { meta: { source: 'route' } },
+          always: { meta: { source: 'always' } },
+          after: {
+            100: () => ({ meta: { source: 'after' } })
+          },
+          timeout: 200,
+          onTimeout: { meta: { source: 'state.timeout' } },
+          invoke: {
+            src: 'child',
+            timeout: 300,
+            onDone: { meta: { source: 'invoke.done' } },
+            onError: { meta: { source: 'invoke.error' } },
+            onSnapshot: { meta: { source: 'invoke.snapshot' } },
+            onTimeout: { meta: { source: 'invoke.timeout' } }
+          }
+        },
+        routing: {
+          type: 'choice',
+          meta: { state: 'routing' },
+          choice: () => ({
+            target: 'idle',
+            meta: { source: 'choice' }
+          })
+        }
+      }
+    });
+
+    machine.root.initial.meta satisfies { source: string } | undefined;
+    machine.root.states.idle.meta satisfies { state: string } | undefined;
+    machine.root.states.idle.always![0].meta satisfies
+      | { source: string }
+      | undefined;
+    machine.root.states.idle.after[0].meta satisfies
+      | { source: string }
+      | undefined;
+
+    const invoke = machine.root.states.idle.invoke[0];
+    type SingleTransition<T> = Exclude<
+      NonNullable<T>,
+      string | readonly unknown[]
+    >;
+
+    (({}) as SingleTransition<typeof invoke.onDone>).meta satisfies
+      | { source: string }
+      | undefined;
+    (({}) as SingleTransition<typeof invoke.onError>).meta satisfies
+      | { source: string }
+      | undefined;
+    (({}) as SingleTransition<typeof invoke.onSnapshot>).meta satisfies
+      | { source: string }
+      | undefined;
+    (({}) as SingleTransition<typeof invoke.onTimeout>).meta satisfies
+      | { source: string }
+      | undefined;
+
+    expect(machine.root.initial.meta).toEqual({ source: 'initial' });
+    expect(machine.root.initial.description).toBe('start idle');
+    expect(
+      JSON.parse(JSON.stringify(serializeMachine(machine))).initial
+    ).toMatchObject({
+      meta: { source: 'initial' },
+      description: 'start idle'
+    });
+  });
+
   it('TS should error with unexpected transition meta property', () => {
     createMachine({
       schemas: {


### PR DESCRIPTION
Ports #5700 to the v6 schema-first API.

- adds `schemas.transitionMeta`, falling back to `schemas.meta`
- propagates the transition schema through event, initial, delayed, eventless, route, choice, timeout, and invoke transitions
- preserves initial-transition metadata and descriptions in runtime definitions/serialization
- documents the schema and adds a changeset

Verification:
- `pnpm exec vitest run packages/core/test/meta.test.ts`
- `pnpm test:core` (2,495 passed; 33 skipped; 3 todo)
- `pnpm typecheck --pretty false`
- `pnpm lint`
- `pnpm format:check`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/statelyai/xstate/pull/5711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->